### PR TITLE
feat(#2): emit structured proxy.started log event

### DIFF
--- a/internal/adapters/caddy/adapter.go
+++ b/internal/adapters/caddy/adapter.go
@@ -37,14 +37,23 @@ func (a *Adapter) Start(ctx context.Context) error {
 		return fmt.Errorf("building caddy config: %w", err)
 	}
 
-	a.logger.Info("starting caddy proxy",
-		slog.String("listen", a.config.ListenAddr),
-		slog.String("upstream", a.config.UpstreamAddr),
-	)
-
 	if err := caddy.Load(cfgJSON, true); err != nil {
 		return fmt.Errorf("loading caddy config: %w", err)
 	}
+
+	a.logger.Info("proxy started",
+		slog.String("schema_version", "v1"),
+		slog.String("event_type", "proxy.started"),
+		slog.String("ai_summary", fmt.Sprintf("Reverse proxy listening on %s, forwarding to %s", a.config.ListenAddr, a.config.UpstreamAddr)),
+		slog.Group("payload",
+			slog.String("listen", a.config.ListenAddr),
+			slog.String("upstream", a.config.UpstreamAddr),
+			slog.Bool("tls_enabled", a.config.TLS.Enabled),
+			slog.String("tls_provider", string(a.config.TLS.Provider)),
+			slog.Bool("security_headers_enabled", a.config.SecurityHeaders.Enabled),
+			slog.String("version", a.config.Version),
+		),
+	)
 
 	// Block until context is cancelled.
 	<-ctx.Done()


### PR DESCRIPTION
Closes the last acceptance criterion for #2.

## Summary

- Emit AI-readable structured log event (`proxy.started`) after Caddy loads successfully
- Follows VibeWarden schema: `schema_version`, `event_type`, `ai_summary`, `payload`
- Payload includes: listen addr, upstream addr, TLS enabled/provider, security headers enabled, version
- Moved log emission to after `caddy.Load` succeeds (was before, which logged even on failure)

## Test plan

- [x] `go build ./...` — no errors
- [x] `go vet ./...` — no issues
- [x] `go test -race ./internal/adapters/caddy/...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)