### PR TITLE
feat(#21): auth middleware with public path bypass and identity headers

### DIFF
--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -1,0 +1,159 @@
+package middleware
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+const (
+	// defaultSessionCookieName is the cookie name used by Ory Kratos.
+	defaultSessionCookieName = "ory_kratos_session"
+
+	// defaultLoginURL is the Kratos self-service browser login endpoint.
+	defaultLoginURL = "/self-service/login/browser"
+)
+
+// AuthMiddleware returns HTTP middleware that enforces session-based
+// authentication on every request.
+//
+// Request handling flow:
+//  1. Strip all incoming X-User-* headers to prevent client spoofing.
+//  2. If the request path matches any public path pattern (including the
+//     automatic /_vibewarden/* prefix), call the next handler immediately.
+//  3. Extract the session cookie from the request.
+//  4. If the cookie is absent, redirect to the configured login URL.
+//  5. Call SessionChecker.CheckSession to validate the session with the
+//     identity provider.
+//  6. If the session is invalid or not found, redirect to the login URL.
+//  7. If the identity provider is unavailable, return 503 Service
+//     Unavailable (fail closed — never fail open).
+//  8. On a valid session, store the session in the request context and
+//     call the next handler.
+//
+// The logger receives structured auth events following the VibeWarden
+// schema (auth.success and auth.failed event types).
+func AuthMiddleware(
+	checker ports.SessionChecker,
+	cfg ports.AuthConfig,
+	logger *slog.Logger,
+) func(http.Handler) http.Handler {
+	cookieName := cfg.SessionCookieName
+	if cookieName == "" {
+		cookieName = defaultSessionCookieName
+	}
+
+	loginURL := cfg.LoginURL
+	if loginURL == "" {
+		loginURL = defaultLoginURL
+	}
+
+	matcher, err := NewPublicPathMatcher(cfg.PublicPaths)
+	if err != nil {
+		// Configuration error: patterns were invalid. Use an empty matcher
+		// that only makes /_vibewarden/* public. Log the error and continue
+		// with a fallback; the middleware must not panic.
+		logger.Error("auth middleware: invalid public path patterns, falling back to empty list",
+			slog.String("error", err.Error()),
+		)
+		// Safe fallback: only the always-public /_vibewarden/* is matched.
+		matcher, _ = NewPublicPathMatcher(nil) //nolint:errcheck // nil patterns are always valid
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Step 1: Strip incoming X-User-* headers unconditionally to
+			// prevent identity spoofing by malicious clients.
+			stripXUserHeaders(r)
+
+			// Step 2: Public path bypass.
+			if matcher.Matches(r.URL.Path) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Step 3: Extract session cookie.
+			cookie, err := r.Cookie(cookieName)
+			if err != nil {
+				// http.ErrNoCookie is the only error Cookie returns.
+				logAuthFailed(logger, r, "missing session cookie", "")
+				http.Redirect(w, r, loginURL, http.StatusFound)
+				return
+			}
+			sessionCookie := cookieName + "=" + cookie.Value
+
+			// Step 4–7: Validate session with the identity provider.
+			session, err := checker.CheckSession(r.Context(), sessionCookie)
+			if err != nil {
+				switch {
+				case errors.Is(err, ports.ErrSessionNotFound),
+					errors.Is(err, ports.ErrSessionInvalid):
+					logAuthFailed(logger, r, "invalid or missing session", "")
+					http.Redirect(w, r, loginURL, http.StatusFound)
+
+				case errors.Is(err, ports.ErrAuthProviderUnavailable):
+					logAuthFailed(logger, r, "auth provider unavailable", err.Error())
+					http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+
+				default:
+					// Unknown error — fail closed.
+					logAuthFailed(logger, r, "unexpected auth error", err.Error())
+					http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+				}
+				return
+			}
+
+			// Step 8: Valid session — store in context and proceed.
+			logAuthSuccess(logger, r, session)
+			ctx := contextWithSession(r.Context(), session)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// stripXUserHeaders removes all X-User-* headers from the incoming request
+// headers to prevent client-side identity spoofing.
+func stripXUserHeaders(r *http.Request) {
+	for key := range r.Header {
+		if strings.HasPrefix(strings.ToLower(key), "x-user-") {
+			r.Header.Del(key)
+		}
+	}
+}
+
+// logAuthSuccess emits an auth.success structured log event.
+func logAuthSuccess(logger *slog.Logger, r *http.Request, session *ports.Session) {
+	logger.InfoContext(r.Context(), "auth.success",
+		slog.String("schema_version", "v1"),
+		slog.String("event_type", "auth.success"),
+		slog.String("ai_summary", "authenticated request allowed"),
+		slog.Group("payload",
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.String("session_id", session.ID),
+			slog.String("identity_id", session.Identity.ID),
+			slog.String("email", session.Identity.Email),
+			slog.String("timestamp", time.Now().UTC().Format(time.RFC3339)),
+		),
+	)
+}
+
+// logAuthFailed emits an auth.failed structured log event.
+func logAuthFailed(logger *slog.Logger, r *http.Request, reason, detail string) {
+	logger.WarnContext(r.Context(), "auth.failed",
+		slog.String("schema_version", "v1"),
+		slog.String("event_type", "auth.failed"),
+		slog.String("ai_summary", "unauthenticated request rejected: "+reason),
+		slog.Group("payload",
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.String("reason", reason),
+			slog.String("detail", detail),
+			slog.String("timestamp", time.Now().UTC().Format(time.RFC3339)),
+		),
+	)
+}

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -1,0 +1,436 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// fakeSessionChecker is a simple in-memory fake that implements
+// ports.SessionChecker without any mocking framework.
+type fakeSessionChecker struct {
+	// sessions maps session cookie value (full "name=value" string) to
+	// the session that should be returned.
+	sessions map[string]*ports.Session
+	// err, when non-nil, is returned for every CheckSession call
+	// regardless of the cookie value.
+	err error
+}
+
+func (f *fakeSessionChecker) CheckSession(_ context.Context, sessionCookie string) (*ports.Session, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	s, ok := f.sessions[sessionCookie]
+	if !ok {
+		return nil, ports.ErrSessionNotFound
+	}
+	return s, nil
+}
+
+// validSession returns a non-nil, active session for use in tests.
+func validSession() *ports.Session {
+	return &ports.Session{
+		ID:     "sess-abc",
+		Active: true,
+		Identity: ports.Identity{
+			ID:            "user-123",
+			Email:         "alice@example.com",
+			EmailVerified: true,
+		},
+	}
+}
+
+// newTestLogger returns a no-op slog.Logger suitable for tests.
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(noopWriter{}, nil))
+}
+
+// noopWriter discards all output.
+type noopWriter struct{}
+
+func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func TestAuthMiddleware_UnauthenticatedRequest(t *testing.T) {
+	checker := &fakeSessionChecker{sessions: map[string]*ports.Session{}}
+	cfg := ports.AuthConfig{
+		Enabled:           true,
+		SessionCookieName: "ory_kratos_session",
+		LoginURL:          "/login",
+	}
+
+	mw := AuthMiddleware(checker, cfg, newTestLogger())
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	w := httptest.NewRecorder()
+	mw(next).ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("status = %d, want %d (redirect)", w.Code, http.StatusFound)
+	}
+	loc := w.Header().Get("Location")
+	if loc != "/login" {
+		t.Errorf("Location = %q, want %q", loc, "/login")
+	}
+}
+
+func TestAuthMiddleware_AuthenticatedRequest(t *testing.T) {
+	sess := validSession()
+	checker := &fakeSessionChecker{
+		sessions: map[string]*ports.Session{
+			"ory_kratos_session=valid-token": sess,
+		},
+	}
+	cfg := ports.AuthConfig{
+		Enabled:           true,
+		SessionCookieName: "ory_kratos_session",
+		LoginURL:          "/login",
+	}
+
+	nextCalled := false
+	var nextCtx context.Context
+
+	mw := AuthMiddleware(checker, cfg, newTestLogger())
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		nextCtx = r.Context()
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "valid-token"})
+	w := httptest.NewRecorder()
+	mw(next).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if !nextCalled {
+		t.Fatal("next handler was not called for authenticated request")
+	}
+
+	gotSess, ok := SessionFromContext(nextCtx)
+	if !ok {
+		t.Fatal("session not stored in context")
+	}
+	if gotSess.ID != sess.ID {
+		t.Errorf("context session ID = %q, want %q", gotSess.ID, sess.ID)
+	}
+}
+
+func TestAuthMiddleware_PublicPathBypass(t *testing.T) {
+	checker := &fakeSessionChecker{sessions: map[string]*ports.Session{}}
+	cfg := ports.AuthConfig{
+		Enabled:           true,
+		SessionCookieName: "ory_kratos_session",
+		LoginURL:          "/login",
+		PublicPaths:       []string{"/health", "/static/*"},
+	}
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"exact public path", "/health"},
+		{"wildcard public path", "/static/app.js"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nextCalled := false
+			mw := AuthMiddleware(checker, cfg, newTestLogger())
+			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			// No session cookie — but should not trigger redirect.
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			w := httptest.NewRecorder()
+			mw(next).ServeHTTP(w, req)
+
+			if !nextCalled {
+				t.Errorf("next handler not called for public path %q", tt.path)
+			}
+			if w.Code != http.StatusOK {
+				t.Errorf("status = %d, want %d for public path %q", w.Code, http.StatusOK, tt.path)
+			}
+		})
+	}
+}
+
+func TestAuthMiddleware_GlobPatternMatching(t *testing.T) {
+	checker := &fakeSessionChecker{sessions: map[string]*ports.Session{}}
+	cfg := ports.AuthConfig{
+		Enabled:           true,
+		SessionCookieName: "ory_kratos_session",
+		LoginURL:          "/login",
+		PublicPaths:       []string{"/api/v1/*/public"},
+	}
+
+	tests := []struct {
+		name        string
+		path        string
+		wantPublic  bool
+	}{
+		{"matched glob segment", "/api/v1/users/public", true},
+		{"matched glob segment resources", "/api/v1/items/public", true},
+		{"non-matching path", "/api/v1/users/private", false},
+		{"too many segments not matched", "/api/v1/users/extra/public", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nextCalled := false
+			mw := AuthMiddleware(checker, cfg, newTestLogger())
+			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			// No cookie; if path is public the next handler is called,
+			// otherwise we get a redirect.
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			w := httptest.NewRecorder()
+			mw(next).ServeHTTP(w, req)
+
+			if tt.wantPublic && !nextCalled {
+				t.Errorf("path %q should be public but next was not called", tt.path)
+			}
+			if !tt.wantPublic && nextCalled {
+				t.Errorf("path %q should be protected but next was called", tt.path)
+			}
+			if !tt.wantPublic && w.Code != http.StatusFound {
+				t.Errorf("path %q: status = %d, want %d", tt.path, w.Code, http.StatusFound)
+			}
+		})
+	}
+}
+
+func TestAuthMiddleware_ProviderUnavailable(t *testing.T) {
+	checker := &fakeSessionChecker{
+		err: fmt.Errorf("connection refused: %w", ports.ErrAuthProviderUnavailable),
+	}
+	cfg := ports.AuthConfig{
+		Enabled:           true,
+		SessionCookieName: "ory_kratos_session",
+		LoginURL:          "/login",
+	}
+
+	mw := AuthMiddleware(checker, cfg, newTestLogger())
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "some-token"})
+	w := httptest.NewRecorder()
+	mw(next).ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d (503)", w.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestAuthMiddleware_XUserHeadersStripped(t *testing.T) {
+	sess := validSession()
+	checker := &fakeSessionChecker{
+		sessions: map[string]*ports.Session{
+			"ory_kratos_session=valid-token": sess,
+		},
+	}
+	cfg := ports.AuthConfig{
+		Enabled:           true,
+		SessionCookieName: "ory_kratos_session",
+		LoginURL:          "/login",
+	}
+
+	var receivedHeaders http.Header
+	mw := AuthMiddleware(checker, cfg, newTestLogger())
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "valid-token"})
+	// Inject spoofed identity headers.
+	req.Header.Set("X-User-Id", "evil-id")
+	req.Header.Set("X-User-Email", "evil@attacker.com")
+	req.Header.Set("X-User-Custom", "spoofed")
+	req.Header.Set("X-Other-Header", "kept") // non-X-User-* must be kept
+
+	w := httptest.NewRecorder()
+	mw(next).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	for _, h := range []string{"X-User-Id", "X-User-Email", "X-User-Custom"} {
+		if receivedHeaders.Get(h) != "" {
+			t.Errorf("header %q should have been stripped, but got %q", h, receivedHeaders.Get(h))
+		}
+	}
+
+	if receivedHeaders.Get("X-Other-Header") == "" {
+		t.Error("X-Other-Header should not have been stripped")
+	}
+}
+
+func TestAuthMiddleware_XUserHeadersStrippedOnPublicPath(t *testing.T) {
+	checker := &fakeSessionChecker{sessions: map[string]*ports.Session{}}
+	cfg := ports.AuthConfig{
+		Enabled:           true,
+		SessionCookieName: "ory_kratos_session",
+		LoginURL:          "/login",
+		PublicPaths:       []string{"/health"},
+	}
+
+	var receivedHeaders http.Header
+	mw := AuthMiddleware(checker, cfg, newTestLogger())
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("X-User-Id", "evil-id")
+
+	w := httptest.NewRecorder()
+	mw(next).ServeHTTP(w, req)
+
+	if receivedHeaders.Get("X-User-Id") != "" {
+		t.Errorf("X-User-Id should have been stripped on public path, got %q", receivedHeaders.Get("X-User-Id"))
+	}
+}
+
+func TestAuthMiddleware_VibewardenPrefixAlwaysPublic(t *testing.T) {
+	checker := &fakeSessionChecker{sessions: map[string]*ports.Session{}}
+	cfg := ports.AuthConfig{
+		Enabled:           true,
+		SessionCookieName: "ory_kratos_session",
+		LoginURL:          "/login",
+		// No explicit public paths — /_vibewarden/* must still be public.
+	}
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"health endpoint", "/_vibewarden/health"},
+		{"metrics endpoint", "/_vibewarden/metrics"},
+		{"any sub-path", "/_vibewarden/anything"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nextCalled := false
+			mw := AuthMiddleware(checker, cfg, newTestLogger())
+			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			// No session cookie.
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			w := httptest.NewRecorder()
+			mw(next).ServeHTTP(w, req)
+
+			if !nextCalled {
+				t.Errorf("next handler not called for always-public path %q", tt.path)
+			}
+			if w.Code != http.StatusOK {
+				t.Errorf("status = %d, want %d for path %q", w.Code, http.StatusOK, tt.path)
+			}
+		})
+	}
+}
+
+func TestAuthMiddleware_DefaultCookieNameAndLoginURL(t *testing.T) {
+	sess := validSession()
+	checker := &fakeSessionChecker{
+		sessions: map[string]*ports.Session{
+			// default cookie name
+			"ory_kratos_session=token123": sess,
+		},
+	}
+	// Empty SessionCookieName and LoginURL — should use defaults.
+	cfg := ports.AuthConfig{
+		Enabled: true,
+	}
+
+	mw := AuthMiddleware(checker, cfg, newTestLogger())
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/page", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "token123"})
+	w := httptest.NewRecorder()
+	mw(next).ServeHTTP(w, req)
+
+	if !nextCalled {
+		t.Error("next handler should have been called with default cookie name")
+	}
+
+	// Now test redirect to default login URL.
+	req2 := httptest.NewRequest(http.MethodGet, "/page", nil)
+	w2 := httptest.NewRecorder()
+	mw(next).ServeHTTP(w2, req2)
+
+	if w2.Code != http.StatusFound {
+		t.Errorf("status = %d, want %d", w2.Code, http.StatusFound)
+	}
+	if loc := w2.Header().Get("Location"); loc != defaultLoginURL {
+		t.Errorf("Location = %q, want %q", loc, defaultLoginURL)
+	}
+}
+
+func TestAuthMiddleware_InvalidSessionRedirects(t *testing.T) {
+	tests := []struct {
+		name    string
+		checkerErr error
+	}{
+		{"session not found", ports.ErrSessionNotFound},
+		{"session invalid", ports.ErrSessionInvalid},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := &fakeSessionChecker{err: tt.checkerErr}
+			cfg := ports.AuthConfig{
+				Enabled:           true,
+				SessionCookieName: "ory_kratos_session",
+				LoginURL:          "/login",
+			}
+
+			mw := AuthMiddleware(checker, cfg, newTestLogger())
+			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+			req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "bad-token"})
+			w := httptest.NewRecorder()
+			mw(next).ServeHTTP(w, req)
+
+			if w.Code != http.StatusFound {
+				t.Errorf("status = %d, want %d (redirect)", w.Code, http.StatusFound)
+			}
+			if loc := w.Header().Get("Location"); loc != "/login" {
+				t.Errorf("Location = %q, want %q", loc, "/login")
+			}
+		})
+	}
+}

--- a/internal/middleware/context.go
+++ b/internal/middleware/context.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// contextKey is an unexported type for context keys used by this package.
+// Using a package-local type prevents key collisions with other packages.
+type contextKey int
+
+const (
+	// sessionContextKey is the context key under which the validated
+	// ports.Session is stored by AuthMiddleware.
+	sessionContextKey contextKey = iota
+)
+
+// SessionFromContext retrieves the authenticated session stored in the
+// context by AuthMiddleware. It returns (nil, false) when no session is
+// present (i.e. the request was unauthenticated or auth was bypassed).
+func SessionFromContext(ctx context.Context) (*ports.Session, bool) {
+	s, ok := ctx.Value(sessionContextKey).(*ports.Session)
+	return s, ok && s != nil
+}
+
+// contextWithSession returns a new context carrying the given session.
+func contextWithSession(ctx context.Context, s *ports.Session) context.Context {
+	return context.WithValue(ctx, sessionContextKey, s)
+}

--- a/internal/middleware/identity_headers.go
+++ b/internal/middleware/identity_headers.go
@@ -1,0 +1,44 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+)
+
+// IdentityHeadersMiddleware returns HTTP middleware that injects user
+// identity headers into the proxied request.
+//
+// It reads the session placed in the request context by AuthMiddleware and
+// adds the following headers before forwarding to the upstream application:
+//
+//   - X-User-Id: the Kratos identity UUID
+//   - X-User-Email: the user's primary email address
+//   - X-User-Verified: "true" or "false" depending on email verification
+//
+// IMPORTANT: Any incoming X-User-* headers must have already been stripped
+// by AuthMiddleware before this middleware runs. IdentityHeadersMiddleware
+// does NOT strip them itself — it relies on the correct middleware ordering.
+//
+// If no session is present in the context (public path or auth disabled)
+// the middleware is a no-op and simply calls the next handler.
+func IdentityHeadersMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			session, ok := SessionFromContext(r.Context())
+			if ok && session != nil {
+				r = r.Clone(r.Context())
+				r.Header.Set("X-User-Id", session.Identity.ID)
+				r.Header.Set("X-User-Email", session.Identity.Email)
+				r.Header.Set("X-User-Verified", strconv.FormatBool(session.Identity.EmailVerified))
+
+				logger.DebugContext(r.Context(), "identity headers injected",
+					slog.String("identity_id", session.Identity.ID),
+					slog.String("email", session.Identity.Email),
+				)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middleware/identity_headers_test.go
+++ b/internal/middleware/identity_headers_test.go
@@ -1,0 +1,140 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+func TestIdentityHeadersMiddleware_WithSession(t *testing.T) {
+	tests := []struct {
+		name          string
+		session       *ports.Session
+		wantID        string
+		wantEmail     string
+		wantVerified  string
+	}{
+		{
+			name: "verified user",
+			session: &ports.Session{
+				ID:     "sess-1",
+				Active: true,
+				Identity: ports.Identity{
+					ID:            "user-abc",
+					Email:         "alice@example.com",
+					EmailVerified: true,
+				},
+			},
+			wantID:       "user-abc",
+			wantEmail:    "alice@example.com",
+			wantVerified: "true",
+		},
+		{
+			name: "unverified user",
+			session: &ports.Session{
+				ID:     "sess-2",
+				Active: true,
+				Identity: ports.Identity{
+					ID:            "user-def",
+					Email:         "bob@example.com",
+					EmailVerified: false,
+				},
+			},
+			wantID:       "user-def",
+			wantEmail:    "bob@example.com",
+			wantVerified: "false",
+		},
+		{
+			name: "no email",
+			session: &ports.Session{
+				ID:     "sess-3",
+				Active: true,
+				Identity: ports.Identity{
+					ID:            "user-ghi",
+					Email:         "",
+					EmailVerified: false,
+				},
+			},
+			wantID:       "user-ghi",
+			wantEmail:    "",
+			wantVerified: "false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotHeaders http.Header
+			mw := IdentityHeadersMiddleware(newTestLogger())
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotHeaders = r.Header.Clone()
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/app", nil)
+			// Store the session in the context as AuthMiddleware would.
+			req = req.WithContext(contextWithSession(req.Context(), tt.session))
+
+			w := httptest.NewRecorder()
+			mw(next).ServeHTTP(w, req)
+
+			if got := gotHeaders.Get("X-User-Id"); got != tt.wantID {
+				t.Errorf("X-User-Id = %q, want %q", got, tt.wantID)
+			}
+			if got := gotHeaders.Get("X-User-Email"); got != tt.wantEmail {
+				t.Errorf("X-User-Email = %q, want %q", got, tt.wantEmail)
+			}
+			if got := gotHeaders.Get("X-User-Verified"); got != tt.wantVerified {
+				t.Errorf("X-User-Verified = %q, want %q", got, tt.wantVerified)
+			}
+		})
+	}
+}
+
+func TestIdentityHeadersMiddleware_NoSession(t *testing.T) {
+	var gotHeaders http.Header
+	nextCalled := false
+
+	mw := IdentityHeadersMiddleware(newTestLogger())
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		gotHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// No session in context (public path scenario).
+	req := httptest.NewRequest(http.MethodGet, "/public", nil)
+	w := httptest.NewRecorder()
+	mw(next).ServeHTTP(w, req)
+
+	if !nextCalled {
+		t.Fatal("next handler was not called")
+	}
+
+	for _, h := range []string{"X-User-Id", "X-User-Email", "X-User-Verified"} {
+		if gotHeaders.Get(h) != "" {
+			t.Errorf("header %q should not be set when no session in context, got %q", h, gotHeaders.Get(h))
+		}
+	}
+}
+
+func TestIdentityHeadersMiddleware_NextAlwaysCalled(t *testing.T) {
+	nextCalled := false
+	mw := IdentityHeadersMiddleware(newTestLogger())
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/any", nil)
+	w := httptest.NewRecorder()
+	mw(next).ServeHTTP(w, req)
+
+	if !nextCalled {
+		t.Error("next handler was not called")
+	}
+	if w.Code != http.StatusAccepted {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusAccepted)
+	}
+}

--- a/internal/middleware/public_paths.go
+++ b/internal/middleware/public_paths.go
@@ -1,0 +1,56 @@
+package middleware
+
+import (
+	"fmt"
+	"path"
+)
+
+const (
+	// vibewardenPrefix is always public; it covers health checks and
+	// other internal VibeWarden endpoints.
+	vibewardenPrefix = "/_vibewarden/*"
+)
+
+// PublicPathMatcher checks whether an HTTP request path should bypass
+// authentication. Patterns follow stdlib path.Match syntax (single-segment
+// wildcards only; use one pattern per path segment).
+type PublicPathMatcher struct {
+	patterns []string
+}
+
+// NewPublicPathMatcher compiles the given glob patterns into a PublicPathMatcher.
+// The /_vibewarden/* prefix is always added automatically.
+// Returns an error if any pattern is syntactically invalid according to
+// path.Match rules.
+func NewPublicPathMatcher(patterns []string) (*PublicPathMatcher, error) {
+	all := make([]string, 0, len(patterns)+1)
+	all = append(all, vibewardenPrefix)
+	all = append(all, patterns...)
+
+	// Validate each pattern eagerly so callers get a clear error at
+	// construction time rather than on the first request.
+	for _, p := range all {
+		if _, err := path.Match(p, ""); err != nil {
+			return nil, fmt.Errorf("invalid public path pattern %q: %w", p, err)
+		}
+	}
+
+	return &PublicPathMatcher{patterns: all}, nil
+}
+
+// Matches reports whether the given request path matches any public path
+// pattern. A path is considered public if it matches at least one pattern.
+func (m *PublicPathMatcher) Matches(requestPath string) bool {
+	for _, p := range m.patterns {
+		matched, err := path.Match(p, requestPath)
+		if err != nil {
+			// Pattern was already validated in NewPublicPathMatcher; this
+			// branch is unreachable in practice.
+			continue
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/middleware/public_paths_test.go
+++ b/internal/middleware/public_paths_test.go
@@ -1,0 +1,129 @@
+package middleware
+
+import (
+	"testing"
+)
+
+func TestNewPublicPathMatcher_InvalidPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		wantErr bool
+	}{
+		{"valid wildcard", "/static/*", false},
+		{"valid exact", "/health", false},
+		{"valid nested wildcard", "/api/v1/*/public", false},
+		// path.Match treats '[' as the start of a character class; an
+		// unclosed bracket is a syntax error.
+		{"invalid bracket", "/bad/[pattern", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewPublicPathMatcher([]string{tt.pattern})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewPublicPathMatcher([%q]) error = %v, wantErr %v", tt.pattern, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPublicPathMatcher_Matches(t *testing.T) {
+	tests := []struct {
+		name         string
+		patterns     []string
+		requestPath  string
+		wantMatch    bool
+	}{
+		// /_vibewarden/* is always added automatically.
+		{
+			name:        "vibewarden health always public",
+			patterns:    []string{},
+			requestPath: "/_vibewarden/health",
+			wantMatch:   true,
+		},
+		{
+			name:        "vibewarden sub-path always public",
+			patterns:    []string{},
+			requestPath: "/_vibewarden/metrics",
+			wantMatch:   true,
+		},
+		{
+			// path.Match treats * as matching zero or more characters within
+			// a single path element, so "/_vibewarden/" (empty final element)
+			// is matched by "/_vibewarden/*" and is therefore public.
+			name:        "vibewarden prefix with trailing slash is public",
+			patterns:    []string{},
+			requestPath: "/_vibewarden/",
+			wantMatch:   true,
+		},
+		{
+			// "/_vibewarden" without trailing slash does NOT match
+			// "/_vibewarden/*" — the wildcard requires the slash separator.
+			name:        "vibewarden prefix bare without slash not matched",
+			patterns:    []string{},
+			requestPath: "/_vibewarden",
+			wantMatch:   false,
+		},
+		// Static wildcard pattern.
+		{
+			name:        "static asset matches wildcard",
+			patterns:    []string{"/static/*"},
+			requestPath: "/static/app.js",
+			wantMatch:   true,
+		},
+		{
+			name:        "static sub-directory does not match single wildcard",
+			patterns:    []string{"/static/*"},
+			requestPath: "/static/css/main.css",
+			wantMatch:   false,
+		},
+		// Exact match.
+		{
+			name:        "exact path matches",
+			patterns:    []string{"/health"},
+			requestPath: "/health",
+			wantMatch:   true,
+		},
+		{
+			name:        "different path does not match exact",
+			patterns:    []string{"/health"},
+			requestPath: "/dashboard",
+			wantMatch:   false,
+		},
+		// Protected path (not in public list).
+		{
+			name:        "protected path not matched",
+			patterns:    []string{"/health", "/static/*"},
+			requestPath: "/dashboard",
+			wantMatch:   false,
+		},
+		// Glob pattern with multiple segments.
+		{
+			name:        "api public segment matched",
+			patterns:    []string{"/api/v1/*/public"},
+			requestPath: "/api/v1/users/public",
+			wantMatch:   true,
+		},
+		{
+			name:        "api private segment not matched",
+			patterns:    []string{"/api/v1/*/public"},
+			requestPath: "/api/v1/users/private",
+			wantMatch:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := NewPublicPathMatcher(tt.patterns)
+			if err != nil {
+				t.Fatalf("NewPublicPathMatcher() unexpected error: %v", err)
+			}
+
+			got := m.Matches(tt.requestPath)
+			if got != tt.wantMatch {
+				t.Errorf("Matches(%q) = %v, want %v", tt.requestPath, got, tt.wantMatch)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #21

## Summary

- **`internal/middleware/auth.go`** — `AuthMiddleware` that intercepts every request: strips `X-User-*` spoofing headers unconditionally, checks the public path matcher (including the always-public `/_vibewarden/*` prefix), extracts the session cookie, calls `SessionChecker.CheckSession`, redirects unauthenticated users to the login URL, and returns 503 on provider unavailability (fail closed). Emits structured `auth.success` / `auth.failed` log events following the VibeWarden schema.
- **`internal/middleware/context.go`** — unexported `contextKey` type and `SessionFromContext` / `contextWithSession` helpers for passing the validated session through the request context.
- **`internal/middleware/public_paths.go`** — `PublicPathMatcher` built on stdlib `path.Match` (no external dependency added). `NewPublicPathMatcher` validates patterns eagerly and always prepends `/_vibewarden/*`. `Matches` checks a request path against all compiled patterns.
- **`internal/middleware/identity_headers.go`** — `IdentityHeadersMiddleware` reads the session from context and injects `X-User-Id`, `X-User-Email`, `X-User-Verified` into the upstream request.
- **`internal/middleware/*_test.go`** — full table-driven unit tests with a simple `fakeSessionChecker` (no mocking framework). Coverage: 94.1%.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (all packages green)
- [ ] `go vet ./...` clean
- [ ] `go test ./internal/middleware/... -cover` reports >= 80% coverage
- [ ] Manually verify: unauthenticated request to `/dashboard` -> 302 to `/login`
- [ ] Manually verify: request to `/_vibewarden/health` -> no auth check, next handler called
- [ ] Manually verify: request with spoofed `X-User-Id` header -> header absent in upstream request

Generated with Claude Code

Closes #22