### PR TITLE
feat(#36): implement domain event types and constructors

### DIFF
--- a/internal/domain/events/auth.go
+++ b/internal/domain/events/auth.go
@@ -1,0 +1,84 @@
+package events
+
+import (
+	"fmt"
+	"time"
+)
+
+// AuthSuccessParams contains the parameters needed to construct an
+// auth.success event.
+type AuthSuccessParams struct {
+	// Method is the HTTP method of the authenticated request (e.g. "GET").
+	Method string
+
+	// Path is the URL path of the authenticated request.
+	Path string
+
+	// SessionID is the Kratos session identifier.
+	SessionID string
+
+	// IdentityID is the Kratos identity (user) identifier.
+	IdentityID string
+
+	// Email is the email address associated with the authenticated identity.
+	Email string
+}
+
+// NewAuthSuccess creates an auth.success event indicating that a request
+// carried a valid session and was allowed to proceed to the upstream application.
+func NewAuthSuccess(params AuthSuccessParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeAuthSuccess,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"Authenticated request allowed: %s %s (identity %s)",
+			params.Method, params.Path, params.IdentityID,
+		),
+		Payload: map[string]any{
+			"method":      params.Method,
+			"path":        params.Path,
+			"session_id":  params.SessionID,
+			"identity_id": params.IdentityID,
+			"email":       params.Email,
+		},
+	}
+}
+
+// AuthFailedParams contains the parameters needed to construct an
+// auth.failed event.
+type AuthFailedParams struct {
+	// Method is the HTTP method of the rejected request (e.g. "GET").
+	Method string
+
+	// Path is the URL path of the rejected request.
+	Path string
+
+	// Reason is a short description of why the request was rejected (e.g.
+	// "missing session cookie", "invalid or missing session").
+	Reason string
+
+	// Detail is an optional additional detail string (e.g. an error message).
+	// May be empty.
+	Detail string
+}
+
+// NewAuthFailed creates an auth.failed event indicating that a request was
+// rejected due to a missing, invalid, or expired session.
+func NewAuthFailed(params AuthFailedParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeAuthFailed,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"Unauthenticated request rejected: %s",
+			params.Reason,
+		),
+		Payload: map[string]any{
+			"method": params.Method,
+			"path":   params.Path,
+			"reason": params.Reason,
+			"detail": params.Detail,
+		},
+	}
+}

--- a/internal/domain/events/events.go
+++ b/internal/domain/events/events.go
@@ -1,0 +1,82 @@
+// Package events defines domain events for the VibeWarden structured log schema.
+// This package has zero external dependencies — only Go stdlib (time, fmt).
+//
+// Every security-relevant action in VibeWarden emits one of these typed events.
+// Consumers write events via the ports.EventLogger interface; the domain layer
+// never performs I/O directly.
+package events
+
+import "time"
+
+// SchemaVersion is the current version of the event schema.
+// Changing this is a breaking change and must be documented in the schema
+// changelog before being deployed.
+const SchemaVersion = "v1"
+
+// Event type constants identify the kind of event being emitted.
+// These values are stable and form part of the public schema contract.
+const (
+	// EventTypeProxyStarted is emitted once when the reverse proxy starts
+	// successfully and is ready to accept connections.
+	EventTypeProxyStarted = "proxy.started"
+
+	// EventTypeProxyKratosFlow is emitted for every request routed to the
+	// Ory Kratos self-service flow API.
+	EventTypeProxyKratosFlow = "proxy.kratos_flow"
+
+	// EventTypeAuthSuccess is emitted when a request carries a valid session
+	// and is allowed to proceed to the upstream application.
+	EventTypeAuthSuccess = "auth.success"
+
+	// EventTypeAuthFailed is emitted when a request is rejected due to a
+	// missing, invalid, or expired session.
+	EventTypeAuthFailed = "auth.failed"
+
+	// EventTypeRateLimitHit is emitted when a request is rejected because the
+	// caller has exceeded their per-IP or per-user rate limit.
+	EventTypeRateLimitHit = "rate_limit.hit"
+
+	// EventTypeRateLimitUnidentified is emitted when a request is rejected
+	// because the client IP address could not be determined.
+	EventTypeRateLimitUnidentified = "rate_limit.unidentified_client"
+
+	// EventTypeRequestBlocked is emitted when a request is blocked by a
+	// middleware layer for a reason other than auth or rate limiting (e.g. a
+	// security policy violation).
+	EventTypeRequestBlocked = "request.blocked"
+
+	// EventTypeTLSCertificateIssued is emitted when a new TLS certificate is
+	// successfully obtained or renewed.
+	EventTypeTLSCertificateIssued = "tls.certificate_issued"
+
+	// EventTypeUserCreated is emitted when a new user identity is created in
+	// the identity provider.
+	EventTypeUserCreated = "user.created"
+
+	// EventTypeUserDeleted is emitted when a user identity is deleted from the
+	// identity provider.
+	EventTypeUserDeleted = "user.deleted"
+)
+
+// Event is the base structured log event.
+// All VibeWarden log events follow this schema for AI-readability.
+// The schema is published at vibewarden.dev/schema/v1/event.json.
+type Event struct {
+	// SchemaVersion identifies the schema version (always "v1" for now).
+	SchemaVersion string
+
+	// EventType identifies the event kind (e.g., "auth.success", "rate_limit.hit").
+	EventType string
+
+	// Timestamp is when the event occurred, always in UTC.
+	Timestamp time.Time
+
+	// AISummary is a human- and AI-readable sentence describing what happened.
+	// It should be concise (under 200 characters) and include the most relevant
+	// identifiers so an LLM can understand the event without reading the payload.
+	AISummary string
+
+	// Payload contains event-specific structured data.
+	// Keys and value types are defined per event type in the JSON schema.
+	Payload map[string]any
+}

--- a/internal/domain/events/events_test.go
+++ b/internal/domain/events/events_test.go
@@ -1,0 +1,596 @@
+package events_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+)
+
+// maxAISummaryLen is the maximum allowed length of an AISummary, as defined
+// in the JSON schema.
+const maxAISummaryLen = 200
+
+// assertEvent verifies the invariants that every Event must satisfy regardless
+// of its type.
+func assertEvent(t *testing.T, e events.Event, wantType string) {
+	t.Helper()
+
+	if e.SchemaVersion != "v1" {
+		t.Errorf("SchemaVersion = %q, want %q", e.SchemaVersion, "v1")
+	}
+	if e.EventType != wantType {
+		t.Errorf("EventType = %q, want %q", e.EventType, wantType)
+	}
+	if e.Timestamp.IsZero() {
+		t.Error("Timestamp is zero")
+	}
+	if e.Timestamp.Location() != time.UTC {
+		t.Errorf("Timestamp location = %v, want UTC", e.Timestamp.Location())
+	}
+	if e.AISummary == "" {
+		t.Error("AISummary is empty")
+	}
+	if len(e.AISummary) > maxAISummaryLen {
+		t.Errorf("AISummary length = %d, want <= %d; value: %q", len(e.AISummary), maxAISummaryLen, e.AISummary)
+	}
+	if e.Payload == nil {
+		t.Error("Payload is nil")
+	}
+}
+
+// requirePayloadKey asserts that the payload map contains the given key.
+func requirePayloadKey(t *testing.T, payload map[string]any, key string) {
+	t.Helper()
+	if _, ok := payload[key]; !ok {
+		t.Errorf("Payload missing key %q", key)
+	}
+}
+
+// requirePayloadString asserts that the payload map contains key with the
+// expected string value.
+func requirePayloadString(t *testing.T, payload map[string]any, key, want string) {
+	t.Helper()
+	v, ok := payload[key]
+	if !ok {
+		t.Errorf("Payload missing key %q", key)
+		return
+	}
+	got, ok := v.(string)
+	if !ok {
+		t.Errorf("Payload[%q] type = %T, want string", key, v)
+		return
+	}
+	if got != want {
+		t.Errorf("Payload[%q] = %q, want %q", key, got, want)
+	}
+}
+
+// requirePayloadBool asserts that the payload map contains key with the
+// expected bool value.
+func requirePayloadBool(t *testing.T, payload map[string]any, key string, want bool) {
+	t.Helper()
+	v, ok := payload[key]
+	if !ok {
+		t.Errorf("Payload missing key %q", key)
+		return
+	}
+	got, ok := v.(bool)
+	if !ok {
+		t.Errorf("Payload[%q] type = %T, want bool", key, v)
+		return
+	}
+	if got != want {
+		t.Errorf("Payload[%q] = %v, want %v", key, got, want)
+	}
+}
+
+// requireSummaryContains asserts that the AISummary contains the given substring.
+func requireSummaryContains(t *testing.T, summary, substr string) {
+	t.Helper()
+	if !strings.Contains(summary, substr) {
+		t.Errorf("AISummary %q does not contain %q", summary, substr)
+	}
+}
+
+// --- proxy.started ---
+
+func TestNewProxyStarted(t *testing.T) {
+	tests := []struct {
+		name           string
+		params         events.ProxyStartedParams
+		wantListen     string
+		wantUpstream   string
+		wantTLSEnabled bool
+		wantTLSProv    string
+		wantSecHeaders bool
+		wantVersion    string
+		wantSummary    string
+	}{
+		{
+			name: "tls enabled with security headers",
+			params: events.ProxyStartedParams{
+				ListenAddr:             ":8443",
+				UpstreamAddr:           "localhost:3000",
+				TLSEnabled:             true,
+				TLSProvider:            "letsencrypt",
+				SecurityHeadersEnabled: true,
+				Version:                "1.0.0",
+			},
+			wantListen:     ":8443",
+			wantUpstream:   "localhost:3000",
+			wantTLSEnabled: true,
+			wantTLSProv:    "letsencrypt",
+			wantSecHeaders: true,
+			wantVersion:    "1.0.0",
+			wantSummary:    ":8443",
+		},
+		{
+			name: "tls disabled no security headers",
+			params: events.ProxyStartedParams{
+				ListenAddr:             ":8080",
+				UpstreamAddr:           "localhost:4000",
+				TLSEnabled:             false,
+				TLSProvider:            "",
+				SecurityHeadersEnabled: false,
+				Version:                "0.1.0",
+			},
+			wantListen:     ":8080",
+			wantUpstream:   "localhost:4000",
+			wantTLSEnabled: false,
+			wantTLSProv:    "",
+			wantSecHeaders: false,
+			wantVersion:    "0.1.0",
+			wantSummary:    "localhost:4000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := events.NewProxyStarted(tt.params)
+
+			assertEvent(t, e, events.EventTypeProxyStarted)
+			requireSummaryContains(t, e.AISummary, tt.wantSummary)
+			requirePayloadString(t, e.Payload, "listen", tt.wantListen)
+			requirePayloadString(t, e.Payload, "upstream", tt.wantUpstream)
+			requirePayloadBool(t, e.Payload, "tls_enabled", tt.wantTLSEnabled)
+			requirePayloadString(t, e.Payload, "tls_provider", tt.wantTLSProv)
+			requirePayloadBool(t, e.Payload, "security_headers_enabled", tt.wantSecHeaders)
+			requirePayloadString(t, e.Payload, "version", tt.wantVersion)
+		})
+	}
+}
+
+// --- proxy.kratos_flow ---
+
+func TestNewProxyKratosFlow(t *testing.T) {
+	tests := []struct {
+		name   string
+		params events.ProxyKratosFlowParams
+	}{
+		{
+			name: "login browser flow",
+			params: events.ProxyKratosFlowParams{
+				Method: "GET",
+				Path:   "/self-service/login/browser",
+			},
+		},
+		{
+			name: "registration API",
+			params: events.ProxyKratosFlowParams{
+				Method: "POST",
+				Path:   "/.ory/kratos/public/self-service/registration",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := events.NewProxyKratosFlow(tt.params)
+
+			assertEvent(t, e, events.EventTypeProxyKratosFlow)
+			requireSummaryContains(t, e.AISummary, "Kratos")
+			requirePayloadString(t, e.Payload, "method", tt.params.Method)
+			requirePayloadString(t, e.Payload, "path", tt.params.Path)
+		})
+	}
+}
+
+// --- auth.success ---
+
+func TestNewAuthSuccess(t *testing.T) {
+	tests := []struct {
+		name   string
+		params events.AuthSuccessParams
+	}{
+		{
+			name: "standard authenticated GET",
+			params: events.AuthSuccessParams{
+				Method:     "GET",
+				Path:       "/api/data",
+				SessionID:  "sess-abc123",
+				IdentityID: "id-xyz456",
+				Email:      "alice@example.com",
+			},
+		},
+		{
+			name: "authenticated POST to admin",
+			params: events.AuthSuccessParams{
+				Method:     "POST",
+				Path:       "/admin/users",
+				SessionID:  "sess-def789",
+				IdentityID: "id-admin001",
+				Email:      "admin@example.com",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := events.NewAuthSuccess(tt.params)
+
+			assertEvent(t, e, events.EventTypeAuthSuccess)
+			requireSummaryContains(t, e.AISummary, tt.params.IdentityID)
+			requirePayloadString(t, e.Payload, "method", tt.params.Method)
+			requirePayloadString(t, e.Payload, "path", tt.params.Path)
+			requirePayloadString(t, e.Payload, "session_id", tt.params.SessionID)
+			requirePayloadString(t, e.Payload, "identity_id", tt.params.IdentityID)
+			requirePayloadString(t, e.Payload, "email", tt.params.Email)
+		})
+	}
+}
+
+// --- auth.failed ---
+
+func TestNewAuthFailed(t *testing.T) {
+	tests := []struct {
+		name   string
+		params events.AuthFailedParams
+	}{
+		{
+			name: "missing cookie",
+			params: events.AuthFailedParams{
+				Method: "GET",
+				Path:   "/dashboard",
+				Reason: "missing session cookie",
+				Detail: "",
+			},
+		},
+		{
+			name: "provider unavailable",
+			params: events.AuthFailedParams{
+				Method: "POST",
+				Path:   "/api/submit",
+				Reason: "auth provider unavailable",
+				Detail: "connection refused",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := events.NewAuthFailed(tt.params)
+
+			assertEvent(t, e, events.EventTypeAuthFailed)
+			requireSummaryContains(t, e.AISummary, tt.params.Reason)
+			requirePayloadString(t, e.Payload, "method", tt.params.Method)
+			requirePayloadString(t, e.Payload, "path", tt.params.Path)
+			requirePayloadString(t, e.Payload, "reason", tt.params.Reason)
+			requirePayloadString(t, e.Payload, "detail", tt.params.Detail)
+		})
+	}
+}
+
+// --- rate_limit.hit ---
+
+func TestNewRateLimitHit(t *testing.T) {
+	tests := []struct {
+		name            string
+		params          events.RateLimitHitParams
+		wantClientIPKey bool
+	}{
+		{
+			name: "IP limit exceeded",
+			params: events.RateLimitHitParams{
+				LimitType:         "ip",
+				Identifier:        "192.168.1.1",
+				RequestsPerSecond: 10,
+				Burst:             20,
+				RetryAfterSeconds: 3,
+				Path:              "/api/data",
+				Method:            "GET",
+				ClientIP:          "",
+			},
+			wantClientIPKey: false,
+		},
+		{
+			name: "user limit exceeded",
+			params: events.RateLimitHitParams{
+				LimitType:         "user",
+				Identifier:        "user-123",
+				RequestsPerSecond: 100,
+				Burst:             200,
+				RetryAfterSeconds: 1,
+				Path:              "/api/data",
+				Method:            "GET",
+				ClientIP:          "10.0.0.5",
+			},
+			wantClientIPKey: true,
+		},
+		{
+			name: "user limit no client ip",
+			params: events.RateLimitHitParams{
+				LimitType:         "user",
+				Identifier:        "user-456",
+				RequestsPerSecond: 50,
+				Burst:             100,
+				RetryAfterSeconds: 2,
+				Path:              "/upload",
+				Method:            "POST",
+				ClientIP:          "",
+			},
+			wantClientIPKey: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := events.NewRateLimitHit(tt.params)
+
+			assertEvent(t, e, events.EventTypeRateLimitHit)
+			requireSummaryContains(t, e.AISummary, tt.params.LimitType)
+			requireSummaryContains(t, e.AISummary, tt.params.Identifier)
+			requirePayloadString(t, e.Payload, "limit_type", tt.params.LimitType)
+			requirePayloadString(t, e.Payload, "identifier", tt.params.Identifier)
+			requirePayloadKey(t, e.Payload, "requests_per_second")
+			requirePayloadKey(t, e.Payload, "burst")
+			requirePayloadKey(t, e.Payload, "retry_after_seconds")
+			requirePayloadString(t, e.Payload, "path", tt.params.Path)
+			requirePayloadString(t, e.Payload, "method", tt.params.Method)
+
+			_, hasClientIP := e.Payload["client_ip"]
+			if hasClientIP != tt.wantClientIPKey {
+				t.Errorf("Payload has client_ip = %v, want %v", hasClientIP, tt.wantClientIPKey)
+			}
+		})
+	}
+}
+
+// --- rate_limit.unidentified_client ---
+
+func TestNewRateLimitUnidentified(t *testing.T) {
+	tests := []struct {
+		name   string
+		params events.RateLimitUnidentifiedParams
+	}{
+		{
+			name: "GET request",
+			params: events.RateLimitUnidentifiedParams{
+				Path:   "/api/resource",
+				Method: "GET",
+			},
+		},
+		{
+			name: "POST request",
+			params: events.RateLimitUnidentifiedParams{
+				Path:   "/submit",
+				Method: "POST",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := events.NewRateLimitUnidentified(tt.params)
+
+			assertEvent(t, e, events.EventTypeRateLimitUnidentified)
+			requireSummaryContains(t, e.AISummary, "IP")
+			requirePayloadString(t, e.Payload, "path", tt.params.Path)
+			requirePayloadString(t, e.Payload, "method", tt.params.Method)
+		})
+	}
+}
+
+// --- request.blocked ---
+
+func TestNewRequestBlocked(t *testing.T) {
+	tests := []struct {
+		name   string
+		params events.RequestBlockedParams
+	}{
+		{
+			name: "blocked with client IP",
+			params: events.RequestBlockedParams{
+				Method:    "GET",
+				Path:      "/admin",
+				Reason:    "IP blocklist match",
+				BlockedBy: "ip_blocklist",
+				ClientIP:  "1.2.3.4",
+			},
+		},
+		{
+			name: "blocked without client IP",
+			params: events.RequestBlockedParams{
+				Method:    "POST",
+				Path:      "/api/dangerous",
+				Reason:    "security policy violation",
+				BlockedBy: "security_headers",
+				ClientIP:  "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := events.NewRequestBlocked(tt.params)
+
+			assertEvent(t, e, events.EventTypeRequestBlocked)
+			requireSummaryContains(t, e.AISummary, tt.params.BlockedBy)
+			requireSummaryContains(t, e.AISummary, tt.params.Reason)
+			requirePayloadString(t, e.Payload, "method", tt.params.Method)
+			requirePayloadString(t, e.Payload, "path", tt.params.Path)
+			requirePayloadString(t, e.Payload, "reason", tt.params.Reason)
+			requirePayloadString(t, e.Payload, "blocked_by", tt.params.BlockedBy)
+			requirePayloadString(t, e.Payload, "client_ip", tt.params.ClientIP)
+		})
+	}
+}
+
+// --- tls.certificate_issued ---
+
+func TestNewTLSCertificateIssued(t *testing.T) {
+	tests := []struct {
+		name   string
+		params events.TLSCertificateIssuedParams
+	}{
+		{
+			name: "letsencrypt certificate",
+			params: events.TLSCertificateIssuedParams{
+				Domain:    "example.com",
+				Provider:  "letsencrypt",
+				ExpiresAt: "2026-06-26T00:00:00Z",
+			},
+		},
+		{
+			name: "self-signed certificate",
+			params: events.TLSCertificateIssuedParams{
+				Domain:    "localhost",
+				Provider:  "self-signed",
+				ExpiresAt: "2027-03-26T00:00:00Z",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := events.NewTLSCertificateIssued(tt.params)
+
+			assertEvent(t, e, events.EventTypeTLSCertificateIssued)
+			requireSummaryContains(t, e.AISummary, tt.params.Domain)
+			requireSummaryContains(t, e.AISummary, tt.params.Provider)
+			requirePayloadString(t, e.Payload, "domain", tt.params.Domain)
+			requirePayloadString(t, e.Payload, "provider", tt.params.Provider)
+			requirePayloadString(t, e.Payload, "expires_at", tt.params.ExpiresAt)
+		})
+	}
+}
+
+// --- user.created ---
+
+func TestNewUserCreated(t *testing.T) {
+	tests := []struct {
+		name   string
+		params events.UserCreatedParams
+	}{
+		{
+			name: "standard user creation",
+			params: events.UserCreatedParams{
+				IdentityID: "id-newuser001",
+				Email:      "newuser@example.com",
+			},
+		},
+		{
+			name: "admin user creation",
+			params: events.UserCreatedParams{
+				IdentityID: "id-admin002",
+				Email:      "admin2@example.com",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := events.NewUserCreated(tt.params)
+
+			assertEvent(t, e, events.EventTypeUserCreated)
+			requireSummaryContains(t, e.AISummary, tt.params.Email)
+			requireSummaryContains(t, e.AISummary, tt.params.IdentityID)
+			requirePayloadString(t, e.Payload, "identity_id", tt.params.IdentityID)
+			requirePayloadString(t, e.Payload, "email", tt.params.Email)
+		})
+	}
+}
+
+// --- user.deleted ---
+
+func TestNewUserDeleted(t *testing.T) {
+	tests := []struct {
+		name   string
+		params events.UserDeletedParams
+	}{
+		{
+			name: "standard user deletion",
+			params: events.UserDeletedParams{
+				IdentityID: "id-olduser007",
+				Email:      "leavinguser@example.com",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := events.NewUserDeleted(tt.params)
+
+			assertEvent(t, e, events.EventTypeUserDeleted)
+			requireSummaryContains(t, e.AISummary, tt.params.Email)
+			requireSummaryContains(t, e.AISummary, tt.params.IdentityID)
+			requirePayloadString(t, e.Payload, "identity_id", tt.params.IdentityID)
+			requirePayloadString(t, e.Payload, "email", tt.params.Email)
+		})
+	}
+}
+
+// TestTimestampIsRecent verifies that all constructors set the Timestamp to a
+// time close to now (within 5 seconds), confirming it is not a zero value
+// and not some fixed/hardcoded time.
+func TestTimestampIsRecent(t *testing.T) {
+	before := time.Now().UTC()
+
+	constructors := []struct {
+		name string
+		fn   func() events.Event
+	}{
+		{"NewProxyStarted", func() events.Event {
+			return events.NewProxyStarted(events.ProxyStartedParams{ListenAddr: ":8080", UpstreamAddr: "localhost:3000"})
+		}},
+		{"NewProxyKratosFlow", func() events.Event {
+			return events.NewProxyKratosFlow(events.ProxyKratosFlowParams{Method: "GET", Path: "/self-service/login/browser"})
+		}},
+		{"NewAuthSuccess", func() events.Event {
+			return events.NewAuthSuccess(events.AuthSuccessParams{Method: "GET", Path: "/", IdentityID: "id-1"})
+		}},
+		{"NewAuthFailed", func() events.Event {
+			return events.NewAuthFailed(events.AuthFailedParams{Method: "GET", Path: "/", Reason: "test"})
+		}},
+		{"NewRateLimitHit", func() events.Event {
+			return events.NewRateLimitHit(events.RateLimitHitParams{LimitType: "ip", Identifier: "1.1.1.1"})
+		}},
+		{"NewRateLimitUnidentified", func() events.Event {
+			return events.NewRateLimitUnidentified(events.RateLimitUnidentifiedParams{Method: "GET", Path: "/"})
+		}},
+		{"NewRequestBlocked", func() events.Event {
+			return events.NewRequestBlocked(events.RequestBlockedParams{Method: "GET", Path: "/", Reason: "test", BlockedBy: "test"})
+		}},
+		{"NewTLSCertificateIssued", func() events.Event {
+			return events.NewTLSCertificateIssued(events.TLSCertificateIssuedParams{Domain: "example.com", Provider: "letsencrypt"})
+		}},
+		{"NewUserCreated", func() events.Event {
+			return events.NewUserCreated(events.UserCreatedParams{IdentityID: "id-1", Email: "a@example.com"})
+		}},
+		{"NewUserDeleted", func() events.Event {
+			return events.NewUserDeleted(events.UserDeletedParams{IdentityID: "id-1", Email: "a@example.com"})
+		}},
+	}
+
+	after := time.Now().UTC().Add(5 * time.Second)
+
+	for _, tc := range constructors {
+		t.Run(tc.name, func(t *testing.T) {
+			e := tc.fn()
+			if e.Timestamp.Before(before) || e.Timestamp.After(after) {
+				t.Errorf("%s: Timestamp %v is not within [%v, %v]", tc.name, e.Timestamp, before, after)
+			}
+		})
+	}
+}

--- a/internal/domain/events/placeholders.go
+++ b/internal/domain/events/placeholders.go
@@ -1,0 +1,138 @@
+package events
+
+import (
+	"fmt"
+	"time"
+)
+
+// RequestBlockedParams contains the parameters needed to construct a
+// request.blocked event.
+type RequestBlockedParams struct {
+	// Method is the HTTP method of the blocked request (e.g. "GET").
+	Method string
+
+	// Path is the URL path of the blocked request.
+	Path string
+
+	// Reason is a short description of why the request was blocked.
+	Reason string
+
+	// BlockedBy identifies the middleware or policy that blocked the request
+	// (e.g. "security_headers", "ip_blocklist").
+	BlockedBy string
+
+	// ClientIP is the client IP address. May be empty if it could not be
+	// determined.
+	ClientIP string
+}
+
+// NewRequestBlocked creates a request.blocked event indicating that a request
+// was blocked by a middleware layer for a reason other than auth or rate
+// limiting (e.g. a security policy violation).
+func NewRequestBlocked(params RequestBlockedParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeRequestBlocked,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"Request blocked by %s: %s %s — %s",
+			params.BlockedBy, params.Method, params.Path, params.Reason,
+		),
+		Payload: map[string]any{
+			"method":     params.Method,
+			"path":       params.Path,
+			"reason":     params.Reason,
+			"blocked_by": params.BlockedBy,
+			"client_ip":  params.ClientIP,
+		},
+	}
+}
+
+// TLSCertificateIssuedParams contains the parameters needed to construct a
+// tls.certificate_issued event.
+type TLSCertificateIssuedParams struct {
+	// Domain is the domain name for which the certificate was issued.
+	Domain string
+
+	// Provider is the certificate authority or provider (e.g. "letsencrypt",
+	// "self-signed").
+	Provider string
+
+	// ExpiresAt is the certificate expiry time in RFC3339 format.
+	ExpiresAt string
+}
+
+// NewTLSCertificateIssued creates a tls.certificate_issued event indicating
+// that a new TLS certificate was successfully obtained or renewed.
+func NewTLSCertificateIssued(params TLSCertificateIssuedParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeTLSCertificateIssued,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"TLS certificate issued for %s via %s",
+			params.Domain, params.Provider,
+		),
+		Payload: map[string]any{
+			"domain":     params.Domain,
+			"provider":   params.Provider,
+			"expires_at": params.ExpiresAt,
+		},
+	}
+}
+
+// UserCreatedParams contains the parameters needed to construct a
+// user.created event.
+type UserCreatedParams struct {
+	// IdentityID is the identity provider identifier for the new user.
+	IdentityID string
+
+	// Email is the email address of the new user.
+	Email string
+}
+
+// NewUserCreated creates a user.created event indicating that a new user
+// identity was created in the identity provider.
+func NewUserCreated(params UserCreatedParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeUserCreated,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"New user created: %s (identity %s)",
+			params.Email, params.IdentityID,
+		),
+		Payload: map[string]any{
+			"identity_id": params.IdentityID,
+			"email":       params.Email,
+		},
+	}
+}
+
+// UserDeletedParams contains the parameters needed to construct a
+// user.deleted event.
+type UserDeletedParams struct {
+	// IdentityID is the identity provider identifier of the deleted user.
+	IdentityID string
+
+	// Email is the email address of the deleted user.
+	Email string
+}
+
+// NewUserDeleted creates a user.deleted event indicating that a user identity
+// was deleted from the identity provider.
+func NewUserDeleted(params UserDeletedParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeUserDeleted,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"User deleted: %s (identity %s)",
+			params.Email, params.IdentityID,
+		),
+		Payload: map[string]any{
+			"identity_id": params.IdentityID,
+			"email":       params.Email,
+		},
+	}
+}

--- a/internal/domain/events/proxy.go
+++ b/internal/domain/events/proxy.go
@@ -1,0 +1,76 @@
+package events
+
+import (
+	"fmt"
+	"time"
+)
+
+// ProxyStartedParams contains the parameters needed to construct a
+// proxy.started event.
+type ProxyStartedParams struct {
+	// ListenAddr is the address the reverse proxy is listening on (e.g. ":8080").
+	ListenAddr string
+
+	// UpstreamAddr is the address requests are forwarded to (e.g. "localhost:3000").
+	UpstreamAddr string
+
+	// TLSEnabled reports whether TLS termination is active.
+	TLSEnabled bool
+
+	// TLSProvider is the TLS certificate provider (e.g. "letsencrypt", "self-signed").
+	// Empty when TLSEnabled is false.
+	TLSProvider string
+
+	// SecurityHeadersEnabled reports whether the security headers middleware is active.
+	SecurityHeadersEnabled bool
+
+	// Version is the VibeWarden binary version string.
+	Version string
+}
+
+// NewProxyStarted creates a proxy.started event indicating the reverse proxy
+// started successfully and is ready to accept connections.
+func NewProxyStarted(params ProxyStartedParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeProxyStarted,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"Reverse proxy listening on %s, forwarding to %s",
+			params.ListenAddr, params.UpstreamAddr,
+		),
+		Payload: map[string]any{
+			"listen":                   params.ListenAddr,
+			"upstream":                 params.UpstreamAddr,
+			"tls_enabled":              params.TLSEnabled,
+			"tls_provider":             params.TLSProvider,
+			"security_headers_enabled": params.SecurityHeadersEnabled,
+			"version":                  params.Version,
+		},
+	}
+}
+
+// ProxyKratosFlowParams contains the parameters needed to construct a
+// proxy.kratos_flow event.
+type ProxyKratosFlowParams struct {
+	// Method is the HTTP method of the request (e.g. "GET", "POST").
+	Method string
+
+	// Path is the URL path of the request.
+	Path string
+}
+
+// NewProxyKratosFlow creates a proxy.kratos_flow event indicating that a
+// request was routed to the Ory Kratos self-service flow API.
+func NewProxyKratosFlow(params ProxyKratosFlowParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeProxyKratosFlow,
+		Timestamp:     time.Now().UTC(),
+		AISummary:     "Request proxied to Kratos self-service API",
+		Payload: map[string]any{
+			"method": params.Method,
+			"path":   params.Path,
+		},
+	}
+}

--- a/internal/domain/events/ratelimit.go
+++ b/internal/domain/events/ratelimit.go
@@ -1,0 +1,91 @@
+package events
+
+import (
+	"fmt"
+	"time"
+)
+
+// RateLimitHitParams contains the parameters needed to construct a
+// rate_limit.hit event.
+type RateLimitHitParams struct {
+	// LimitType is the kind of limit that was exceeded: "ip" or "user".
+	LimitType string
+
+	// Identifier is the value that was rate-limited: the client IP for
+	// LimitType "ip", or the user ID for LimitType "user".
+	Identifier string
+
+	// RequestsPerSecond is the configured rate limit (tokens per second).
+	RequestsPerSecond float64
+
+	// Burst is the configured burst capacity.
+	Burst int
+
+	// RetryAfterSeconds is how long the caller must wait before retrying.
+	RetryAfterSeconds int
+
+	// Path is the URL path of the rate-limited request.
+	Path string
+
+	// Method is the HTTP method of the rate-limited request.
+	Method string
+
+	// ClientIP is the client IP address. Only relevant when LimitType is
+	// "user" to record which IP the user was connecting from.
+	// May be empty when LimitType is "ip" (identifier already is the IP).
+	ClientIP string
+}
+
+// NewRateLimitHit creates a rate_limit.hit event indicating that a request
+// was rejected because the caller exceeded their rate limit.
+func NewRateLimitHit(params RateLimitHitParams) Event {
+	payload := map[string]any{
+		"limit_type":          params.LimitType,
+		"identifier":          params.Identifier,
+		"requests_per_second": params.RequestsPerSecond,
+		"burst":               params.Burst,
+		"retry_after_seconds": params.RetryAfterSeconds,
+		"path":                params.Path,
+		"method":              params.Method,
+	}
+	if params.LimitType == "user" && params.ClientIP != "" {
+		payload["client_ip"] = params.ClientIP
+	}
+
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeRateLimitHit,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"Rate limit exceeded for %s %s: %.0f requests/second limit reached",
+			params.LimitType, params.Identifier, params.RequestsPerSecond,
+		),
+		Payload: payload,
+	}
+}
+
+// RateLimitUnidentifiedParams contains the parameters needed to construct a
+// rate_limit.unidentified_client event.
+type RateLimitUnidentifiedParams struct {
+	// Path is the URL path of the rejected request.
+	Path string
+
+	// Method is the HTTP method of the rejected request.
+	Method string
+}
+
+// NewRateLimitUnidentified creates a rate_limit.unidentified_client event
+// indicating that a request was rejected because the client IP address could
+// not be determined.
+func NewRateLimitUnidentified(params RateLimitUnidentifiedParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeRateLimitUnidentified,
+		Timestamp:     time.Now().UTC(),
+		AISummary:     "Request rejected because the client IP could not be determined",
+		Payload: map[string]any{
+			"path":   params.Path,
+			"method": params.Method,
+		},
+	}
+}


### PR DESCRIPTION
Closes #36

## Summary

- Creates `internal/domain/events/` package implementing ADR-007 sub-issue #5.1
- `events.go` — `Event` base struct, `SchemaVersion` constant, and all ten `EventType*` constants
- `proxy.go` — `NewProxyStarted` and `NewProxyKratosFlow` constructors with typed params structs
- `auth.go` — `NewAuthSuccess` and `NewAuthFailed` constructors
- `ratelimit.go` — `NewRateLimitHit` and `NewRateLimitUnidentified` constructors
- `placeholders.go` — `NewRequestBlocked`, `NewTLSCertificateIssued`, `NewUserCreated`, `NewUserDeleted` constructors
- `events_test.go` — table-driven tests for all constructors; 100% statement coverage

Zero external dependencies — only Go stdlib (`time`, `fmt`). No ports, no adapters, no slog.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/domain/events/... -v` — all 31 tests pass
- [ ] `go test ./internal/domain/events/... -cover` — 100% coverage
- [ ] `go vet ./internal/domain/events/...` — no issues
- [ ] `go test ./...` — all existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)