### PR TITLE
feat(#59): add Prometheus service to Docker Compose with observability profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # VibeWarden Makefile
 
-.PHONY: build test lint run docker-up docker-down clean
+.PHONY: build test lint run docker-up docker-down observability-up observability-down clean
 
 # Build variables
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -31,6 +31,14 @@ docker-up:
 # Stop dev environment
 docker-down:
 	docker compose down
+
+# Start observability stack (Prometheus)
+observability-up:
+	docker compose --profile observability up -d
+
+# Stop observability stack
+observability-down:
+	docker compose --profile observability down
 
 # Clean build artifacts
 clean:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,21 @@
 # VibeWarden — Docker Compose dev environment
 #
 # Brings up the full local stack:
-#   postgres      — Kratos session/identity storage
+#   postgres       — Kratos session/identity storage
 #   kratos-migrate — runs Kratos DB migrations once, then exits
 #   kratos         — Ory Kratos identity server (public :4433, admin :4434)
 #   mailslurper    — catches outbound Kratos emails (SMTP :4436, web UI :4437)
 #   vibewarden     — the security sidecar (proxies your upstream app on :8080)
 #
+# Observability profile (optional):
+#   prometheus     — metrics collection and storage (UI: http://localhost:9090)
+#
 # Usage:
-#   docker compose up -d          # start everything
-#   docker compose logs -f        # tail logs
-#   docker compose down           # stop and remove containers
-#   docker compose down -v        # also remove the postgres volume
+#   docker compose up -d                           # start baseline stack
+#   docker compose --profile observability up -d   # start with observability stack
+#   docker compose logs -f                         # tail logs
+#   docker compose down                            # stop and remove containers
+#   docker compose down -v                         # also remove named volumes
 #
 # Secrets:
 #   Postgres password and DSN are hard-coded to simple dev values — never use
@@ -156,11 +160,48 @@ services:
       retries: 5
       start_period: 5s
 
+  # --------------------------------------------------------------------------
+  # Prometheus — metrics collection and storage
+  #
+  # Web UI: http://localhost:9090
+  # Scrapes VibeWarden metrics at vibewarden:8080/_vibewarden/metrics
+  #
+  # Only starts when the "observability" profile is active:
+  #   docker compose --profile observability up -d
+  # --------------------------------------------------------------------------
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: vibewarden-prometheus
+    profiles:
+      - observability
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.enable-lifecycle'
+    networks:
+      - vibewarden
+    depends_on:
+      vibewarden:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
 # --------------------------------------------------------------------------
 # Named volumes
 # --------------------------------------------------------------------------
 volumes:
   postgres_data:
+    driver: local
+  prometheus_data:
     driver: local
 
 # --------------------------------------------------------------------------

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -1,0 +1,21 @@
+# Prometheus configuration for VibeWarden local development
+#
+# Scrapes VibeWarden metrics at vibewarden:8080/_vibewarden/metrics every 15s.
+# Start with: docker compose --profile observability up -d
+# UI available at: http://localhost:9090
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'vibewarden'
+    metrics_path: '/_vibewarden/metrics'
+    static_configs:
+      - targets: ['vibewarden:8080']
+        labels:
+          instance: 'vibewarden-sidecar'
+
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
Closes #59

## Summary

- Adds a `prometheus` service to `docker-compose.yml` under the `observability` Docker Compose profile. The baseline `docker compose up -d` is completely unaffected — Prometheus only starts when explicitly activated.
- Creates `observability/prometheus/prometheus.yml` with scrape config targeting `vibewarden:8080/_vibewarden/metrics` (the existing metrics endpoint) and self-scrape of Prometheus itself.
- Adds `prometheus_data` named volume for TSDB persistence across restarts.
- Adds `observability-up` and `observability-down` Makefile targets as specified in ADR-005.

## Acceptance criteria

- [x] Prometheus service added with `profiles: [observability]`
- [x] Service does NOT start with plain `docker compose up -d`
- [x] Service DOES start with `docker compose --profile observability up -d` (or `make observability-up`)
- [x] Prometheus scrapes `vibewarden:8080/_vibewarden/metrics`
- [x] Prometheus UI accessible at `http://localhost:9090`
- [x] Health check configured (`wget -q --spider http://localhost:9090/-/healthy`)
- [x] Volume for data persistence configured (`prometheus_data`)
- [x] `depends_on: vibewarden: condition: service_healthy` ensures ordering

## Test plan

```bash
# Verify baseline does not start Prometheus
docker compose up -d
docker ps | grep prometheus  # should show nothing

# Verify observability profile starts Prometheus
make observability-up
docker ps | grep prometheus  # should show vibewarden-prometheus

# Verify Prometheus UI
open http://localhost:9090

# Verify scrape targets
curl http://localhost:9090/api/v1/targets | jq '.data.activeTargets[].health'

# Teardown
make observability-down
```

## Files changed

- `docker-compose.yml` — adds prometheus service and prometheus_data volume
- `observability/prometheus/prometheus.yml` — Prometheus scrape configuration
- `Makefile` — adds observability-up / observability-down targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)