### PR TITLE
fix(#83): apply gofmt to 6 test files with formatting violations

### DIFF
--- a/cmd/vibewarden/serve_test.go
+++ b/cmd/vibewarden/serve_test.go
@@ -67,8 +67,8 @@ func TestBuildLogger_Level(t *testing.T) {
 
 func TestBuildLogger_Format(t *testing.T) {
 	tests := []struct {
-		name   string
-		cfg    config.LogConfig
+		name    string
+		cfg     config.LogConfig
 		wantNil bool
 	}{
 		{

--- a/internal/adapters/caddy/config_test.go
+++ b/internal/adapters/caddy/config_test.go
@@ -904,13 +904,13 @@ func TestBuildCaddyConfig_KratosFlowRoutes_Present(t *testing.T) {
 
 	// Verify all expected self-service paths are present.
 	wantPaths := map[string]bool{
-		"/self-service/login/*":         true,
-		"/self-service/registration/*":  true,
-		"/self-service/logout/*":        true,
-		"/self-service/settings/*":      true,
-		"/self-service/recovery/*":      true,
-		"/self-service/verification/*":  true,
-		"/.ory/kratos/public/*":         true,
+		"/self-service/login/*":        true,
+		"/self-service/registration/*": true,
+		"/self-service/logout/*":       true,
+		"/self-service/settings/*":     true,
+		"/self-service/recovery/*":     true,
+		"/self-service/verification/*": true,
+		"/.ory/kratos/public/*":        true,
 	}
 	for _, p := range paths {
 		delete(wantPaths, p)

--- a/internal/adapters/caddy/ratelimit_handler_test.go
+++ b/internal/adapters/caddy/ratelimit_handler_test.go
@@ -158,7 +158,7 @@ func TestRateLimitHandler_Cleanup(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name: "both limiters present — both closed",
+			name:        "both limiters present — both closed",
 			ipLimiter:   &fakeRateLimiter{},
 			userLimiter: &fakeRateLimiter{},
 			wantErr:     false,

--- a/internal/domain/events/events_test.go
+++ b/internal/domain/events/events_test.go
@@ -545,8 +545,8 @@ func TestNewUserDeleted(t *testing.T) {
 
 func TestNewUserDeactivated(t *testing.T) {
 	tests := []struct {
-		name    string
-		params  events.UserDeactivatedParams
+		name       string
+		params     events.UserDeactivatedParams
 		wantReason string
 	}{
 		{

--- a/internal/middleware/identity_headers_test.go
+++ b/internal/middleware/identity_headers_test.go
@@ -10,11 +10,11 @@ import (
 
 func TestIdentityHeadersMiddleware_WithSession(t *testing.T) {
 	tests := []struct {
-		name          string
-		session       *ports.Session
-		wantID        string
-		wantEmail     string
-		wantVerified  string
+		name         string
+		session      *ports.Session
+		wantID       string
+		wantEmail    string
+		wantVerified string
 	}{
 		{
 			name: "verified user",

--- a/internal/middleware/public_paths_test.go
+++ b/internal/middleware/public_paths_test.go
@@ -30,10 +30,10 @@ func TestNewPublicPathMatcher_InvalidPattern(t *testing.T) {
 
 func TestPublicPathMatcher_Matches(t *testing.T) {
 	tests := []struct {
-		name         string
-		patterns     []string
-		requestPath  string
-		wantMatch    bool
+		name        string
+		patterns    []string
+		requestPath string
+		wantMatch   bool
 	}{
 		// /_vibewarden/* is always added automatically.
 		{


### PR DESCRIPTION
Closes #83

## Summary

- Ran `gofmt -l` to identify 6 test files with formatting violations
- Ran `gofmt -w` to fix all violations in place
- Verified `gofmt -l` produces no output after the fix
- All 6 files are test files only — no production logic changed

Files fixed:
- `cmd/vibewarden/serve_test.go`
- `internal/adapters/caddy/config_test.go`
- `internal/adapters/caddy/ratelimit_handler_test.go`
- `internal/domain/events/events_test.go`
- `internal/middleware/identity_headers_test.go`
- `internal/middleware/public_paths_test.go`

## Test plan

- `gofmt -l` produces no output (verified locally)
- `go build ./...` passes
- `go vet ./...` passes
- `go test ./...` all pass (26 packages, no failures)