### PR TITLE
fix(#92,#88): wire admin API in serve.go and add TLS external validation

### DIFF
--- a/cmd/vibewarden/serve.go
+++ b/cmd/vibewarden/serve.go
@@ -12,8 +12,12 @@ import (
 	"github.com/spf13/cobra"
 
 	caddyadapter "github.com/vibewarden/vibewarden/internal/adapters/caddy"
+	httpadapter "github.com/vibewarden/vibewarden/internal/adapters/http"
+	kratosadapter "github.com/vibewarden/vibewarden/internal/adapters/kratos"
 	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
 	metricsadapter "github.com/vibewarden/vibewarden/internal/adapters/metrics"
+	postgresadapter "github.com/vibewarden/vibewarden/internal/adapters/postgres"
+	adminapp "github.com/vibewarden/vibewarden/internal/app/admin"
 	"github.com/vibewarden/vibewarden/internal/app/proxy"
 	"github.com/vibewarden/vibewarden/internal/config"
 	"github.com/vibewarden/vibewarden/internal/ports"
@@ -84,6 +88,46 @@ func runServe(configPath string) error {
 		logger.Info("metrics enabled", slog.String("internal_addr", metricsSrv.Addr()))
 	}
 
+	// Initialize admin API when enabled in config.
+	var adminCfg ports.AdminProxyConfig
+	if cfg.Admin.Enabled {
+		kratosAdmin := kratosadapter.NewAdminAdapter(cfg.Kratos.AdminURL, 0, logger)
+
+		// AuditLogger is optional — only wired when a database URL is configured.
+		var auditLogger ports.AuditLogger
+		if cfg.Database.URL != "" {
+			auditAdapter, err := postgresadapter.NewAuditAdapter(cfg.Database.URL)
+			if err != nil {
+				return fmt.Errorf("connecting to audit database: %w", err)
+			}
+			defer func() {
+				if closeErr := auditAdapter.Close(); closeErr != nil {
+					logger.Error("closing audit database", slog.String("error", closeErr.Error()))
+				}
+			}()
+			auditLogger = auditAdapter
+		}
+
+		adminSvc := adminapp.NewService(kratosAdmin, eventLogger, auditLogger)
+		adminHandlers := httpadapter.NewAdminHandlers(adminSvc, logger)
+		adminSrv := httpadapter.NewAdminServer(adminHandlers, logger)
+		if err := adminSrv.Start(); err != nil {
+			return fmt.Errorf("starting admin server: %w", err)
+		}
+		defer func() {
+			stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer stopCancel()
+			if stopErr := adminSrv.Stop(stopCtx); stopErr != nil {
+				logger.Error("stopping admin server", slog.String("error", stopErr.Error()))
+			}
+		}()
+		adminCfg = ports.AdminProxyConfig{
+			Enabled:      true,
+			InternalAddr: adminSrv.Addr(),
+		}
+		logger.Info("admin API enabled", slog.String("internal_addr", adminSrv.Addr()))
+	}
+
 	// Build ProxyConfig from application config.
 	proxyCfg := &ports.ProxyConfig{
 		ListenAddr:   fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port),
@@ -136,6 +180,7 @@ func runServe(configPath string) error {
 			Enabled: cfg.Admin.Enabled,
 			Token:   cfg.Admin.Token,
 		},
+		Admin: adminCfg,
 	}
 
 	// Create Caddy adapter and proxy service.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -200,6 +200,28 @@ type MetricsConfig struct {
 	PathPatterns []string `mapstructure:"path_patterns"`
 }
 
+// Validate checks the loaded configuration for logical consistency.
+// It returns a combined error listing all violations found.
+// Call Validate after Load to catch misconfiguration early.
+func (c *Config) Validate() error {
+	var errs []string
+
+	// TLS external provider requires cert_path and key_path.
+	if c.TLS.Enabled && c.TLS.Provider == "external" {
+		if c.TLS.CertPath == "" {
+			errs = append(errs, "tls.cert_path is required when tls.provider is \"external\"")
+		}
+		if c.TLS.KeyPath == "" {
+			errs = append(errs, "tls.key_path is required when tls.provider is \"external\"")
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
 // Load reads configuration from file and environment variables.
 // Config file path can be specified; defaults to "./vibewarden.yaml".
 // Environment variables override file values using VIBEWARDEN_ prefix.
@@ -268,6 +290,10 @@ func Load(configPath string) (*Config, error) {
 	var cfg Config
 	if err := v.Unmarshal(&cfg); err != nil {
 		return nil, fmt.Errorf("unmarshaling config: %w", err)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
 	return &cfg, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,156 @@ import (
 	"github.com/vibewarden/vibewarden/internal/config"
 )
 
+// TestValidate_TLSExternal verifies that provider=external requires cert_path and key_path.
+func TestValidate_TLSExternal(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config.Config
+		wantErr bool
+	}{
+		{
+			name: "external with both paths",
+			cfg: config.Config{
+				TLS: config.TLSConfig{
+					Enabled:  true,
+					Provider: "external",
+					CertPath: "/etc/tls/cert.pem",
+					KeyPath:  "/etc/tls/key.pem",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "external missing cert_path",
+			cfg: config.Config{
+				TLS: config.TLSConfig{
+					Enabled:  true,
+					Provider: "external",
+					KeyPath:  "/etc/tls/key.pem",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "external missing key_path",
+			cfg: config.Config{
+				TLS: config.TLSConfig{
+					Enabled:  true,
+					Provider: "external",
+					CertPath: "/etc/tls/cert.pem",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "external missing both paths",
+			cfg: config.Config{
+				TLS: config.TLSConfig{
+					Enabled:  true,
+					Provider: "external",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "letsencrypt does not require cert_path or key_path",
+			cfg: config.Config{
+				TLS: config.TLSConfig{
+					Enabled:  true,
+					Provider: "letsencrypt",
+					Domain:   "example.com",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "self-signed does not require cert_path or key_path",
+			cfg: config.Config{
+				TLS: config.TLSConfig{
+					Enabled:  true,
+					Provider: "self-signed",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "TLS disabled external without paths is valid",
+			cfg: config.Config{
+				TLS: config.TLSConfig{
+					Enabled:  false,
+					Provider: "external",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestLoad_TLSExternalValidation verifies that Load returns an error when
+// provider=external is configured without cert_path and/or key_path.
+func TestLoad_TLSExternalValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{
+			name: "external with both paths passes",
+			yaml: `
+tls:
+  enabled: true
+  provider: external
+  cert_path: /etc/tls/cert.pem
+  key_path: /etc/tls/key.pem
+`,
+			wantErr: false,
+		},
+		{
+			name: "external missing cert_path fails",
+			yaml: `
+tls:
+  enabled: true
+  provider: external
+  key_path: /etc/tls/key.pem
+`,
+			wantErr: true,
+		},
+		{
+			name: "external missing key_path fails",
+			yaml: `
+tls:
+  enabled: true
+  provider: external
+  cert_path: /etc/tls/cert.pem
+`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgFile := filepath.Join(dir, "vibewarden.yaml")
+			if err := os.WriteFile(cfgFile, []byte(tt.yaml), 0600); err != nil {
+				t.Fatalf("writing temp config file: %v", err)
+			}
+			_, err := config.Load(cfgFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Load() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestLoad_Defaults(t *testing.T) {
 	cfg, err := config.Load("")
 	if err != nil {


### PR DESCRIPTION
Closes #92
Closes #88

## Summary

- **serve.go admin wiring (#92)**: When `admin.enabled=true`, `runServe` now creates the full admin API stack: `KratosAdminAdapter` (using `kratos.admin_url`), `SlogEventLogger`, an optional `PostgresAuditAdapter` (wired only when `database.url` is set), `AdminService`, `AdminHandlers`, and an `AdminServer` bound to a random localhost port. The resolved address is passed as `AdminProxyConfig{Enabled:true, InternalAddr}` to `ProxyConfig.Admin` so Caddy routes `/_vibewarden/admin/*` to it. The admin server is stopped on shutdown via a deferred `Stop` call.
- **Config validation (#88)**: Added `Config.Validate()` to `internal/config/config.go`. It collects all validation violations and returns them in one combined error. The first rule enforced: when `tls.enabled=true` and `tls.provider=external`, both `tls.cert_path` and `tls.key_path` are required. `Load()` calls `Validate()` after unmarshaling and wraps any error.
- **Tests**: Table-driven tests added to `internal/config/config_test.go` covering all cases for the external TLS validation.

## Test plan

- [ ] `go build ./...` no compile errors
- [ ] `go test ./...` all tests pass
- [ ] `go vet ./...` no issues
- [ ] Manual smoke: admin.enabled=true with Kratos running serves /_vibewarden/admin/users
- [ ] Manual smoke: tls.provider=external without paths exits with clear error

Generated with Claude Code
