### PR TITLE
fix: minor review cleanups — init() godoc, logs cmd tests, close non-issues

### DIFF
--- a/internal/adapters/caddy/admin_auth_handler.go
+++ b/internal/adapters/caddy/admin_auth_handler.go
@@ -13,6 +13,10 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
+// init registers AdminAuthHandler with the Caddy module system so it can be
+// referenced by name ("http.handlers.vibewarden_admin_auth") in Caddy's JSON
+// configuration. This function is called automatically by the Go runtime before
+// main() runs.
 func init() {
 	gocaddy.RegisterModule(AdminAuthHandler{})
 }

--- a/internal/adapters/caddy/ratelimit_handler.go
+++ b/internal/adapters/caddy/ratelimit_handler.go
@@ -17,6 +17,10 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
+// init registers RateLimitHandler with the Caddy module system so it can be
+// referenced by name ("http.handlers.vibewarden_rate_limit") in Caddy's JSON
+// configuration. This function is called automatically by the Go runtime before
+// main() runs.
 func init() {
 	gocaddy.RegisterModule(RateLimitHandler{})
 }

--- a/internal/cli/cmd/logs_test.go
+++ b/internal/cli/cmd/logs_test.go
@@ -1,0 +1,138 @@
+package cmd_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/cli/cmd"
+)
+
+// TestNewLogsCmd_RegisteredOnRoot verifies that the logs subcommand is
+// reachable from the root command with its expected flags registered.
+func TestNewLogsCmd_RegisteredOnRoot(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+
+	logsCmd, _, err := root.Find([]string{"logs"})
+	if err != nil {
+		t.Fatalf("Find(logs) error: %v", err)
+	}
+	if logsCmd == nil || logsCmd.Use != "logs" {
+		t.Fatal("expected 'logs' subcommand to be registered on root")
+	}
+
+	flags := []struct {
+		name      string
+		shorthand string
+	}{
+		{"follow", "f"},
+		{"filter", ""},
+		{"json", ""},
+		{"verbose", "v"},
+		{"stdin", ""},
+	}
+
+	for _, f := range flags {
+		if logsCmd.Flags().Lookup(f.name) == nil {
+			t.Errorf("expected --%s flag to be registered on 'logs' command", f.name)
+		}
+	}
+}
+
+// TestNewLogsCmd_Short verifies the Short description is non-empty.
+func TestNewLogsCmd_Short(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	logsCmd, _, _ := root.Find([]string{"logs"})
+	if logsCmd == nil {
+		t.Fatal("logs command not found")
+	}
+	if logsCmd.Short == "" {
+		t.Error("expected non-empty Short description on 'logs' command")
+	}
+}
+
+// TestNewLogsCmd_Help verifies that help output for logs contains expected content.
+func TestNewLogsCmd_Help(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var outBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetArgs([]string{"logs", "--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	out := outBuf.String()
+	for _, want := range []string{"logs", "follow", "filter", "stdin"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("help output missing %q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+// TestNewLogsCmd_StdinMode verifies that the logs command runs when reading
+// from stdin using a pipe of empty input.
+func TestNewLogsCmd_StdinMode(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+
+	// Provide empty stdin; the command should complete without error.
+	root.SetIn(strings.NewReader(""))
+	root.SetArgs([]string{"logs", "--stdin"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error with empty stdin: %v\nstderr: %s", err, errBuf.String())
+	}
+}
+
+// TestNewLogsCmd_StdinModeWithLines verifies that plain non-JSON lines from
+// stdin are processed without error.
+func TestNewLogsCmd_StdinModeWithLines(t *testing.T) {
+	lines := "not json at all\nanother plain line\n"
+
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetIn(strings.NewReader(lines))
+	root.SetArgs([]string{"logs", "--stdin"})
+
+	// The command must complete without error when receiving non-JSON lines.
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error processing non-JSON lines: %v\nstderr: %s", err, errBuf.String())
+	}
+}
+
+// TestNewLogsCmd_StdinModeRawJSON verifies that --json flag does not crash
+// when processing structured log lines from stdin.
+func TestNewLogsCmd_StdinModeRawJSON(t *testing.T) {
+	jsonLine := `{"schema_version":"v1","event_type":"proxy.started","timestamp":"2026-03-26T10:00:00Z","ai_summary":"Proxy started on :8080","payload":{}}` + "\n"
+
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetIn(strings.NewReader(jsonLine))
+	root.SetArgs([]string{"logs", "--stdin", "--json"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error with raw JSON flag: %v\nstderr: %s", err, errBuf.String())
+	}
+}
+
+// TestNewLogsCmd_FilterFlag verifies that the --filter flag is accepted
+// and does not cause an error when processing input from stdin.
+func TestNewLogsCmd_FilterFlag(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetIn(strings.NewReader(""))
+	root.SetArgs([]string{"logs", "--stdin", "--filter", "auth"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error with --filter flag: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #91
Closes #93
Closes #96
Closes #100

Issue #98 was closed separately with a comment explaining why it is by design.

## Summary

- **#91 — init() godoc**: Added godoc comments to both `init()` functions in the Caddy adapter package (`ratelimit_handler.go` and `admin_auth_handler.go`). Each comment explains that the function registers the Caddy module with the module system and is invoked automatically by the Go runtime.

- **#93 — event constructor tests**: Reviewed `internal/domain/events/events_test.go`. The tests are already comprehensive: every constructor is covered with table-driven cases, payload keys are verified, AISummary content is checked, and a dedicated `TestTimestampIsRecent` test confirms timestamps are set to a recent UTC value. No gaps found — closing the issue without changes.

- **#96 — logs command tests**: Added `internal/cli/cmd/logs_test.go` covering: command registration on root, all expected flags (`--follow`, `--filter`, `--json`, `--verbose`, `--stdin`), non-empty Short description, help output content, stdin mode with empty input, stdin mode with non-JSON lines, raw JSON flag acceptance, and filter flag acceptance.

- **#98 — ports interfaces tests** (closed via comment): Interfaces in `ports/` define contracts; they contain no executable logic and do not require tests. The test obligation rests with concrete adapter implementations. Closed as "not planned".

- **#100 — missing godoc**: Reviewed all exported types and functions across `internal/`. Coverage is already complete throughout the codebase. No gaps found — closing without changes.

## Test plan

- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./...` — all 26 packages pass