### PR TITLE
chore: add make check target, pre-push hook, and fix gofmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # VibeWarden Makefile
 
-.PHONY: build test lint run docker-up docker-down observability-up observability-down grafana-open prometheus-open clean
+.PHONY: build test lint run docker-up docker-down observability-up observability-down grafana-open prometheus-open clean check setup-hooks
 
 # Build variables
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -51,3 +51,23 @@ prometheus-open:
 # Clean build artifacts
 clean:
 	rm -rf bin/
+
+# Run all quality checks (build, format, vet, tests)
+check: ## Run all quality checks (build, format, vet, tests)
+	@echo "==> Checking formatting (main module)..."
+	@test -z "$$(gofmt -l .)" || (echo "gofmt: these files need formatting:" && gofmt -l . && exit 1)
+	@echo "==> Running go vet (main module)..."
+	go vet ./...
+	@echo "==> Building (main module)..."
+	go build ./...
+	@echo "==> Running tests (main module)..."
+	go test -race ./...
+	@echo "==> Checking demo-app..."
+	@test -z "$$(cd examples/demo-app && gofmt -l .)" || (echo "gofmt: these demo-app files need formatting:" && cd examples/demo-app && gofmt -l . && exit 1)
+	cd examples/demo-app && go vet ./... && go build ./... && go test -race ./...
+	@echo "==> All checks passed!"
+
+# Install git hooks for local development
+setup-hooks: ## Install git hooks for local development
+	ln -sf ../../scripts/hooks/pre-push .git/hooks/pre-push
+	@echo "Git pre-push hook installed"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # vibewarden
 Open source security sidecar for vibe-coded apps. Zero-to-secure in minutes.
+
+## Contributing
+
+### Quality checks
+
+Before submitting a pull request, run all quality checks locally:
+
+```sh
+make check
+```
+
+This runs `gofmt`, `go vet`, `go build`, and `go test -race` across both the
+main module and `examples/demo-app`.
+
+### Git pre-push hook (opt-in)
+
+To have `make check` run automatically before every `git push`, install the
+provided hook after cloning:
+
+```sh
+make setup-hooks
+```
+
+The hook is opt-in and can always be bypassed with `git push --no-verify`.

--- a/examples/demo-app/main_test.go
+++ b/examples/demo-app/main_test.go
@@ -96,14 +96,14 @@ func TestHandlePublic(t *testing.T) {
 
 func TestHandleMe(t *testing.T) {
 	tests := []struct {
-		name           string
-		userID         string
-		userEmail      string
-		userVerified   string
-		wantStatus     int
-		wantUserID     string
-		wantEmail      string
-		wantVerified   string
+		name         string
+		userID       string
+		userEmail    string
+		userVerified string
+		wantStatus   int
+		wantUserID   string
+		wantEmail    string
+		wantVerified string
 	}{
 		{
 			name:       "no X-User-Id returns 401",

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# pre-push — runs make check before every push.
+#
+# Install this hook with:
+#   make setup-hooks
+#
+# Skip with:
+#   git push --no-verify
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+echo "==> Running make check before push (skip with --no-verify)..."
+cd "$REPO_ROOT" && make check


### PR DESCRIPTION
## Summary

- Adds `make check` to the Makefile: runs `gofmt`, `go vet`, `go build`, and `go test -race` across the main module and `examples/demo-app`; fails fast on first error
- Adds `make setup-hooks` for opt-in installation of the pre-push git hook
- Adds `scripts/hooks/pre-push`: calls `make check` before every push; skippable with `--no-verify`
- Adds a Contributing section to `README.md` documenting both targets
- Fixes gofmt alignment in `examples/demo-app/main_test.go` (struct field alignment in `TestHandleMe` was off by extra spaces)

## Test plan

- [ ] `make check` runs clean from the repo root
- [ ] `make setup-hooks` creates `.git/hooks/pre-push -> ../../scripts/hooks/pre-push`
- [ ] `git push` triggers the hook and runs `make check` automatically
- [ ] `git push --no-verify` bypasses the hook
- [ ] `gofmt -l .` and `gofmt -l examples/demo-app` both produce no output

make check passed before this commit was created.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>