### PR TITLE
docs: rewrite README and add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,151 @@
+# Contributing to VibeWarden
+
+## Prerequisites
+
+- Go 1.26+ ([download](https://go.dev/dl/))
+- Docker and Docker Compose
+- Git
+
+## Getting Started
+
+```bash
+git clone https://github.com/vibewarden/vibewarden.git
+cd vibewarden
+make setup-hooks   # install pre-push quality gate (opt-in)
+```
+
+## Building
+
+```bash
+go build ./...
+```
+
+The demo app has its own module:
+
+```bash
+cd examples/demo-app && go build ./...
+```
+
+## Running Tests
+
+```bash
+# Unit tests (fast)
+go test -race ./...
+
+# Integration tests (requires Docker)
+go test -race -tags integration ./...
+```
+
+## Quality Checks
+
+Run all checks before submitting a PR:
+
+```bash
+make check
+```
+
+This runs across both the main module and `examples/demo-app`:
+
+1. **gofmt** — formatting (fails if any file needs formatting)
+2. **go vet** — static analysis
+3. **go build** — compilation
+4. **go test -race** — tests with race detector
+
+If you installed the pre-push hook (`make setup-hooks`), this runs
+automatically before every `git push`. Skip with `git push --no-verify`
+if needed.
+
+## Code Style
+
+- **Formatting**: `gofmt` (enforced by `make check`)
+- **Error handling**: always wrap with context — `fmt.Errorf("doing X: %w", err)`
+- **No panics** in library code — only in `main()` for unrecoverable startup failures
+- **No swallowed errors** — every error must be returned, logged, or explicitly handled
+- **Godoc**: every exported type and function must have a comment
+- **Tests**: table-driven, tests live next to the code (`foo_test.go`)
+
+## Architecture
+
+VibeWarden follows **hexagonal architecture** (ports and adapters) with **DDD**:
+
+```
+internal/
+  domain/       Zero external dependencies. Entities, value objects, events.
+  ports/        Interfaces only. No implementations.
+  adapters/     Implements port interfaces. All I/O lives here.
+  app/          Application services. Orchestrates domain + ports.
+  middleware/   HTTP middleware. Depends on ports, not adapters.
+  config/       Configuration loading and validation.
+```
+
+**Dependency rule**: inner layers never import outer layers.
+
+```
+domain ← ports ← app ← adapters
+                      ← middleware
+                      ← cli
+```
+
+## Adding a Dependency
+
+Before adding any dependency:
+
+1. **Check the license** — approved: Apache 2.0, MIT, BSD-2, BSD-3
+2. **Rejected**: GPL, AGPL, LGPL, CC-BY-SA, proprietary
+3. **Prefer stdlib** — only add external deps when stdlib is insufficient
+4. If unsure, open an issue to discuss
+
+## Branch and Commit Conventions
+
+- **Branches**: `feat/<issue>-<slug>`, `fix/<issue>-<slug>`
+- **Commits**: [conventional commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`, `chore:`, `docs:`, `test:`
+- **PRs**: target `main`, title follows conventional commit style
+
+## Development Workflow
+
+```bash
+# Create a feature branch
+git checkout -b feat/123-my-feature
+
+# Make changes, then check
+make check
+
+# Commit and push
+git add <files>
+git commit -m "feat(#123): short description"
+git push -u origin feat/123-my-feature
+
+# Open a PR targeting main
+gh pr create --base main
+```
+
+## Running the Demo App
+
+```bash
+cd examples/demo-app
+docker compose up -d
+# Visit http://localhost:8080
+```
+
+See [`examples/demo-app/README.md`](examples/demo-app/README.md) for details.
+
+## Running the Observability Stack
+
+```bash
+make observability-up     # Prometheus + Grafana
+make grafana-open         # Open dashboard
+make observability-down   # Tear down
+```
+
+See [`docs/observability.md`](docs/observability.md) for details.
+
+## Makefile Targets
+
+| Target | Description |
+|--------|-------------|
+| `make check` | Run all quality checks |
+| `make setup-hooks` | Install git pre-push hook |
+| `make observability-up` | Start Prometheus + Grafana |
+| `make observability-down` | Stop Prometheus + Grafana |
+| `make grafana-open` | Open Grafana in browser |
+| `make prometheus-open` | Open Prometheus in browser |

--- a/README.md
+++ b/README.md
@@ -1,26 +1,271 @@
-# vibewarden
-Open source security sidecar for vibe-coded apps. Zero-to-secure in minutes.
+# VibeWarden
+
+Open-source security sidecar for vibe-coded apps. Zero-to-secure in minutes.
+
+VibeWarden sits between the internet and your app as a reverse proxy, handling
+TLS, authentication, rate limiting, security headers, and structured logging —
+so you don't have to build any of it yourself.
+
+## Why VibeWarden?
+
+If you're building with AI coding tools (Claude Code, Cursor, Copilot), you
+ship fast — but security often gets skipped. VibeWarden adds production-grade
+security to any app without changing a single line of your code.
+
+- **Automatic TLS** via Let's Encrypt (or self-signed for dev)
+- **Authentication** via Ory Kratos — login, registration, session management
+- **Rate limiting** — per-IP and per-user, token bucket algorithm
+- **Security headers** — HSTS, CSP, X-Frame-Options, and more
+- **AI-readable structured logs** — every security event follows a versioned JSON schema
+- **Prometheus metrics** with a pre-built Grafana dashboard
+- **Admin API** for user management with audit logging
+
+## Quick Start
+
+```bash
+# Download the wrapper script
+curl -fsSL https://vibewarden.dev/vibew > vibew && chmod +x vibew
+
+# Scaffold VibeWarden into your project
+./vibew init --upstream 3000 --auth --rate-limit
+
+# Start everything
+./vibew dev
+```
+
+That's it. Your app on port 3000 is now behind VibeWarden with TLS, auth,
+rate limiting, and security headers.
+
+### What `init` generates
+
+```
+vibewarden.yaml          # VibeWarden configuration
+docker-compose.yml       # Full stack: VibeWarden + Kratos + Postgres
+vibew                    # Wrapper script (macOS/Linux)
+vibew.ps1                # Wrapper script (Windows)
+vibew.cmd                # Wrapper script (Windows)
+.vibewarden-version      # Pinned version
+.claude/CLAUDE.md        # AI agent context (Claude Code)
+.cursor/rules            # AI agent context (Cursor)
+AGENTS.md                # AI agent context (generic)
+```
+
+### Windows
+
+```powershell
+Invoke-WebRequest -Uri https://vibewarden.dev/vibew.ps1 -OutFile vibew.ps1
+.\vibew.ps1 init --upstream 3000 --auth --rate-limit
+.\vibew.ps1 dev
+```
+
+## How It Works
+
+```
+Internet → VibeWarden (port 8080) → Your App (port 3000)
+              │
+              ├── TLS termination
+              ├── Security headers
+              ├── Authentication (Ory Kratos)
+              ├── Rate limiting
+              ├── Structured logging
+              └── Metrics collection
+```
+
+VibeWarden runs as a local sidecar next to your app. It is never hosted
+remotely — it always runs on the same machine as the app it protects.
+
+## Features
+
+### Authentication
+
+VibeWarden uses [Ory Kratos](https://www.ory.sh/kratos/) for identity
+management. Your app receives authenticated user info via headers:
+
+| Header | Description |
+|--------|-------------|
+| `X-User-Id` | Kratos identity UUID |
+| `X-User-Email` | Primary email address |
+| `X-User-Verified` | Email verification status (`true`/`false`) |
+
+Configure public paths that skip authentication:
+
+```yaml
+auth:
+  public_paths:
+    - /static/*
+    - /api/public/*
+    - /health
+```
+
+### Rate Limiting
+
+Dual rate limiting with token bucket algorithm:
+
+```yaml
+rate_limit:
+  per_ip:
+    requests_per_second: 10
+    burst: 20
+  per_user:
+    requests_per_second: 100
+    burst: 200
+```
+
+Blocked requests get a `429 Too Many Requests` response with a `Retry-After` header.
+
+### TLS
+
+Three provider modes:
+
+| Provider | Use case |
+|----------|----------|
+| `letsencrypt` | Production — automatic ACME certificates |
+| `self-signed` | Development — Caddy generates internal certs |
+| `external` | You provide cert/key files (Cloudflare, ACM, etc.) |
+
+### Security Headers
+
+All responses include security headers by default:
+
+- `Strict-Transport-Security` (HTTPS only)
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Content-Security-Policy: default-src 'self'`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+
+Every header is individually configurable or disableable in `vibewarden.yaml`.
+
+### AI-Readable Structured Logs
+
+Every security event follows a versioned JSON schema:
+
+```json
+{
+  "schema_version": "v1",
+  "event_type": "auth.failed",
+  "timestamp": "2026-03-26T10:30:00Z",
+  "ai_summary": "Authentication failed for IP 192.168.1.1: invalid session",
+  "payload": {
+    "ip": "192.168.1.1",
+    "reason": "invalid_session"
+  }
+}
+```
+
+Pretty-print logs in your terminal:
+
+```bash
+./vibew logs --follow
+```
+
+### Observability
+
+Prometheus metrics at `/_vibewarden/metrics` with a pre-built Grafana dashboard.
+
+```bash
+# Start with observability stack
+./vibew dev --observability
+
+# Open Grafana
+make grafana-open    # http://localhost:3000
+```
+
+See [docs/observability.md](docs/observability.md) for details.
+
+### Admin API
+
+User management at `/_vibewarden/admin/*` (protected by bearer token):
+
+```bash
+# List users
+curl -H "X-Admin-Key: $TOKEN" http://localhost:8080/_vibewarden/admin/users
+
+# Create user
+curl -X POST -H "X-Admin-Key: $TOKEN" \
+  -d '{"email":"user@example.com","password":"..."}' \
+  http://localhost:8080/_vibewarden/admin/users
+```
+
+## CLI Reference
+
+| Command | Description |
+|---------|-------------|
+| `vibew init` | Scaffold VibeWarden into a project |
+| `vibew add auth` | Enable authentication |
+| `vibew add rate-limit` | Enable rate limiting |
+| `vibew add tls --domain example.com` | Enable TLS |
+| `vibew add observability` | Add Prometheus + Grafana |
+| `vibew dev` | Start local dev environment |
+| `vibew status` | Show health of all components |
+| `vibew doctor` | Diagnose common issues |
+| `vibew logs` | Pretty-print structured logs |
+| `vibew secret generate` | Generate secure tokens |
+| `vibew validate` | Validate configuration |
+| `vibew context refresh` | Regenerate AI agent context |
+
+## AI Agent Context
+
+When you run `vibew init`, VibeWarden generates context files for your AI
+coding agent. This tells the AI how to work with VibeWarden — so when you say
+"add a login page," it knows to use Kratos flows instead of building auth
+from scratch.
+
+Supported agents:
+- **Claude Code** — `.claude/CLAUDE.md`
+- **Cursor** — `.cursor/rules`
+- **Generic** — `AGENTS.md`
+
+Regenerate after config changes:
+
+```bash
+./vibew context refresh
+```
+
+## Configuration
+
+Copy the example config and customize:
+
+```bash
+cp vibewarden.example.yaml vibewarden.yaml
+```
+
+See [`vibewarden.example.yaml`](vibewarden.example.yaml) for all options with
+detailed comments.
+
+## Demo
+
+A complete demo app is included at [`examples/demo-app/`](examples/demo-app/):
+
+```bash
+cd examples/demo-app
+docker compose up -d
+# Open http://localhost:8080
+```
+
+The demo shows authentication, rate limiting, security headers, and identity
+header injection in action.
+
+## Architecture
+
+VibeWarden is built with hexagonal architecture (ports and adapters):
+
+```
+cmd/vibewarden/          # CLI entrypoint
+internal/
+  domain/                # Pure domain logic (zero external deps)
+  ports/                 # Interface definitions
+  adapters/              # Implementations (Caddy, Kratos, Postgres, ...)
+  app/                   # Application services
+  middleware/            # HTTP middleware
+  config/                # Configuration loading
+migrations/              # Database migrations
+```
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).
 
 ## Contributing
 
-### Quality checks
-
-Before submitting a pull request, run all quality checks locally:
-
-```sh
-make check
-```
-
-This runs `gofmt`, `go vet`, `go build`, and `go test -race` across both the
-main module and `examples/demo-app`.
-
-### Git pre-push hook (opt-in)
-
-To have `make check` run automatically before every `git push`, install the
-provided hook after cloning:
-
-```sh
-make setup-hooks
-```
-
-The hook is opt-in and can always be bypassed with `git push --no-verify`.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding standards,
+and how to submit changes.


### PR DESCRIPTION
## Summary

- **README.md**: Complete rewrite — covers why VibeWarden, quick start, features (auth, rate limiting, TLS, security headers, structured logs, observability, admin API), CLI reference, AI agent context, configuration, demo app, architecture overview
- **CONTRIBUTING.md**: New file — prerequisites, building, testing, quality checks (`make check`), code style, architecture rules, dependency policy, branch/commit conventions, development workflow, Makefile targets

Separates "what VibeWarden does" (README) from "how to develop it" (CONTRIBUTING).

## Test plan

- [x] `make check` passes
- [ ] README renders correctly on GitHub
- [ ] CONTRIBUTING renders correctly on GitHub
