### PR TITLE
docs(#129): add CHALLENGE.md with challenge scope and rules

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -1,0 +1,32 @@
+# Acknowledgments
+
+VibeWarden thanks every security researcher who responsibly discloses vulnerabilities
+and helps keep users safe. Researchers listed here have given explicit permission to
+be named.
+
+To report a vulnerability see [SECURITY.md](SECURITY.md) (coming soon — in the
+meantime, open a GitHub Security Advisory via the **Security** tab).
+
+## Hall of Fame
+
+| # | Researcher | Date | Description | Reference |
+|---|-----------|------|-------------|-----------|
+| — | *No entries yet — be the first!* | — | — | — |
+
+---
+
+### Entry format (for maintainers)
+
+When adding an entry, use the following columns:
+
+- **#** — sequential number (1, 2, 3, …)
+- **Researcher** — name or handle *with explicit permission from the researcher*
+- **Date** — ISO 8601 date the fix was released (YYYY-MM-DD)
+- **Description** — one-sentence summary of the vulnerability class
+- **Reference** — link to the public advisory, CVE, or GitHub Security Advisory
+
+Example row:
+
+```
+| 1 | Jane Doe (@janed) | 2026-01-15 | Reflected XSS in dashboard query parameter | [GHSA-xxxx-xxxx-xxxx](https://github.com/vibewarden/vibewarden/security/advisories/GHSA-xxxx-xxxx-xxxx) |
+```

--- a/README.md
+++ b/README.md
@@ -269,3 +269,8 @@ Apache 2.0 — see [LICENSE](LICENSE).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding standards,
 and how to submit changes.
+
+## Security
+
+To report a vulnerability, see [SECURITY.md](SECURITY.md) for our responsible
+disclosure policy and contact details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy
+
+Thank you for helping keep VibeWarden and its users safe. We take security
+seriously and appreciate responsible disclosure.
+
+## Reporting a Vulnerability
+
+### Critical vulnerabilities
+
+For issues that could lead to remote code execution, privilege escalation,
+authentication bypass, or exposure of sensitive data, please report **privately**
+by email:
+
+**security@vibewarden.dev**
+
+Include as much detail as possible:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept
+- Any affected versions you have identified
+- Suggested remediation if you have one
+
+Do not open a public GitHub issue for critical vulnerabilities until a fix has
+been released.
+
+### Non-critical vulnerabilities
+
+For lower-severity issues (hardening improvements, minor information leaks,
+dependency advisories), you may open a public GitHub issue or use
+[GitHub's private vulnerability reporting](https://github.com/vibewarden/vibewarden/security/advisories/new).
+
+If you are unsure whether an issue is critical, default to the private email.
+
+## Response Time
+
+We aim to:
+
+- **Acknowledge** your report within **48 hours**
+- Provide an initial assessment within 5 business days
+- Release a fix and publish a security advisory as quickly as the severity warrants
+
+We will keep you informed throughout the process.
+
+## Credit
+
+We believe researchers who responsibly disclose vulnerabilities deserve public
+recognition. With your permission, we will credit you by name (or handle) in
+`ACKNOWLEDGMENTS.md` and in the release notes for the fix.
+
+If you prefer to remain anonymous, just let us know and we will honour that
+preference.
+
+## Bug Bounty
+
+VibeWarden does not currently operate a paid bug bounty programme. We offer
+public credit and our sincere gratitude.
+
+## Scope
+
+This policy covers the VibeWarden open-source sidecar binary and the code in
+this repository. It does not cover third-party dependencies (Caddy, Ory Kratos,
+etc.) — please report those vulnerabilities to their respective projects.
+
+## Disclosure Policy
+
+We follow a **coordinated disclosure** model:
+
+1. Reporter notifies us privately.
+2. We confirm the issue and develop a fix.
+3. Fix is released and a security advisory is published.
+4. Reporter is credited (with permission).
+
+We ask that you give us a reasonable amount of time to address the issue before
+any public disclosure.

--- a/examples/demo-app/CHALLENGE.md
+++ b/examples/demo-app/CHALLENGE.md
@@ -1,0 +1,76 @@
+# VibeWarden Security Challenge
+
+Want to put VibeWarden through its paces? We encourage security-minded people to
+probe the demo app and try to find gaps in the sidecar's defences. This is the
+best way to harden the project — and we genuinely enjoy hearing about what you
+find.
+
+## What to attack
+
+The demo app is an intentionally minimal Go server that trusts VibeWarden
+completely. The interesting surface is the **sidecar**, not the app behind it.
+
+Things we want you to try:
+
+| Attack class | What to look for |
+|---|---|
+| **Auth bypass** | Can you reach a protected endpoint without a valid Kratos session? Can you forge or replay session cookies? |
+| **Rate limiting** | Can you exceed the configured request budget without triggering a 429? Any per-IP bypass (header spoofing, IP rotation via local proxy, chunked requests)? |
+| **Header forging** | Can a client inject `X-User-Id`, `X-User-Email`, or `X-User-Verified` so that the app trusts a fake identity? |
+| **Security header gaps** | Are any of the expected response headers (`Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`, `Content-Security-Policy`, `Referrer-Policy`) missing on any endpoint or response code? |
+| **Misconfiguration** | Does any combination of `vibewarden.yaml` settings leave a door open that should be closed? |
+
+## What is out of scope
+
+Please do not:
+
+- **DDoS the demo VM or infrastructure** — bandwidth costs money and
+  disrupts other users. Rate-limit bypass testing should stay local (`docker compose up`).
+- **Attack the VM operating system, SSH daemon, or host networking** — we care
+  about the sidecar, not the underlying server.
+- **Attack Grafana, Prometheus, or Loki** — those are not part of VibeWarden's
+  security surface. Report those to their respective projects instead.
+- **DNS hijacking or BGP manipulation** — out of scope for a localhost sidecar.
+- **Social engineering** — phishing, pretexting, or impersonating team members.
+
+If you are unsure whether something is in scope, run it locally and open a
+discussion issue before touching shared infrastructure.
+
+## This is not a bug bounty
+
+VibeWarden does not currently offer financial rewards for security findings. We
+are an open-source project run by a solo founder. What we do offer:
+
+- Public credit in [`ACKNOWLEDGMENTS.md`](../../ACKNOWLEDGMENTS.md) and in the
+  release notes for any fix (with your permission).
+- Our sincere gratitude and a mention on the challenge page at
+  [vibewarden.dev](https://vibewarden.dev) once it launches.
+
+## Found something?
+
+Please follow the responsible disclosure process in
+[`SECURITY.md`](../../SECURITY.md):
+
+- **Critical findings** (auth bypass, RCE, privilege escalation, data exposure)
+  — email **security@vibewarden.dev** privately. Do not open a public issue
+  until a fix is released.
+- **Lower-severity findings** (hardening improvements, missing headers, minor
+  information leaks) — open a public GitHub issue or use
+  [GitHub private vulnerability reporting](https://github.com/vibewarden/vibewarden/security/advisories/new).
+
+We aim to acknowledge every report within 48 hours.
+
+## Running the demo locally
+
+The safest way to probe VibeWarden is against your own local instance:
+
+```bash
+cd examples/demo-app
+docker compose up -d
+# VibeWarden is now listening on http://localhost:8080
+```
+
+See [`README.md`](README.md) for the full list of endpoints and what each one
+demonstrates.
+
+Happy hacking — and thank you for helping make VibeWarden more secure.


### PR DESCRIPTION
Closes #129

## Summary

- Creates `examples/demo-app/CHALLENGE.md` defining what is in scope for security testing against the demo app and the VibeWarden sidecar
- In scope: auth bypass, rate limit bypass (local only), header forging (`X-User-Id` / `X-User-Email` / `X-User-Verified`), missing security headers, misconfigurations in `vibewarden.yaml`
- Out of scope: DDoS / bandwidth attacks against shared infrastructure, VM/SSH attacks, Grafana / Prometheus / Loki, DNS hijacking, social engineering
- Includes explicit not-a-bug-bounty disclaimer (public credit offered instead)
- Links to `SECURITY.md` for responsible disclosure with the 48-hour acknowledgement commitment
- Friendly, inviting tone — encourages local testing via `docker compose up`

## Test plan

- [ ] `make check` passes (verified locally — all checks passed)
- [ ] Render `examples/demo-app/CHALLENGE.md` in GitHub preview and confirm all links resolve correctly (`../../SECURITY.md`, `../../ACKNOWLEDGMENTS.md`, `README.md`)
- [ ] Confirm in-scope table covers the four attack classes specified in the issue
- [ ] Confirm out-of-scope list matches the issue requirements exactly
