### PR TITLE
docs(#132): add ACKNOWLEDGMENTS.md with hall of fame template

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -1,0 +1,31 @@
+# Acknowledgments
+
+VibeWarden thanks every security researcher who responsibly discloses vulnerabilities
+and helps keep users safe. Researchers listed here have given explicit permission to
+be named.
+
+To report a vulnerability, see [SECURITY.md](SECURITY.md).
+
+## Hall of Fame
+
+| # | Researcher | Date | Description | Reference |
+|---|-----------|------|-------------|-----------|
+| — | *No entries yet — be the first!* | — | — | — |
+
+---
+
+### Entry format (for maintainers)
+
+When adding an entry, use the following columns:
+
+- **#** — sequential number (1, 2, 3, …)
+- **Researcher** — name or handle *with explicit permission from the researcher*
+- **Date** — ISO 8601 date the fix was released (YYYY-MM-DD)
+- **Description** — one-sentence summary of the vulnerability class
+- **Reference** — link to the public advisory, CVE, or GitHub Security Advisory
+
+Example row:
+
+```
+| 1 | Jane Doe (@janed) | 2026-01-15 | Reflected XSS in dashboard query parameter | [GHSA-xxxx-xxxx-xxxx](https://github.com/vibewarden/vibewarden/security/advisories/GHSA-xxxx-xxxx-xxxx) |
+```


### PR DESCRIPTION
Closes #132

## Summary

- Adds `ACKNOWLEDGMENTS.md` at the repo root
- Explains the purpose: crediting security researchers who responsibly disclose vulnerabilities with explicit permission
- Contains an empty Hall of Fame table ready for the first entry
- Includes an entry format guide for maintainers (columns, example row)
- Links to `SECURITY.md` (already present on disk in a parallel branch; the link will resolve once that file is merged)

Note: `SECURITY.md` does not yet exist on `main`. Once the `docs/116-security-md` PR is merged the link in `ACKNOWLEDGMENTS.md` will resolve correctly.

## Test plan

- [ ] `make check` passes (all Go quality checks)
- [ ] `ACKNOWLEDGMENTS.md` is present in repo root
- [ ] Hall of Fame table renders correctly in GitHub markdown preview
- [ ] Entry format example is clear and copy-paste friendly