### PR TITLE
feat(#137): add Loki log aggregation to the observability stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # VibeWarden Makefile
 
-.PHONY: build test lint run docker-up docker-down observability-up observability-down grafana-open prometheus-open clean check setup-hooks
+.PHONY: build test lint run docker-up docker-down observability-up observability-down grafana-open prometheus-open loki-open clean check setup-hooks
 
 # Build variables
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -47,6 +47,10 @@ grafana-open:
 # Open Prometheus UI in the default browser (macOS/Linux)
 prometheus-open:
 	open http://localhost:9090 2>/dev/null || xdg-open http://localhost:9090
+
+# Open Loki UI in the default browser (macOS/Linux)
+loki-open:
+	open http://localhost:3100/ready 2>/dev/null || xdg-open http://localhost:3100/ready
 
 # Clean build artifacts
 clean:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@
 # Observability profile (optional):
 #   prometheus     — metrics collection and storage (UI: http://localhost:9090)
 #   grafana        — metrics visualization and dashboards (UI: http://localhost:3000)
+#   loki           — log aggregation backend (API: http://localhost:3100)
+#   promtail       — log shipper (scrapes Docker container logs → Loki)
 #
 # Usage:
 #   docker compose up -d                           # start baseline stack
@@ -229,12 +231,68 @@ services:
     depends_on:
       prometheus:
         condition: service_healthy
+      loki:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 10s
+
+  # --------------------------------------------------------------------------
+  # Loki — log aggregation backend
+  #
+  # API: http://localhost:3100
+  # Single-node, filesystem storage, 7-day retention.
+  #
+  # Only starts when the "observability" profile is active:
+  #   docker compose --profile observability up -d
+  # --------------------------------------------------------------------------
+  loki:
+    image: grafana/loki:latest
+    container_name: vibewarden-loki
+    profiles:
+      - observability
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./observability/loki/loki-config.yml:/etc/loki/local-config.yaml:ro
+      - loki_data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - vibewarden
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3100/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
+  # --------------------------------------------------------------------------
+  # Promtail — log shipper
+  #
+  # Discovers all running Docker containers via the Docker socket, tails their
+  # log files, and ships structured JSON log entries to Loki.
+  #
+  # Only starts when the "observability" profile is active:
+  #   docker compose --profile observability up -d
+  # --------------------------------------------------------------------------
+  promtail:
+    image: grafana/promtail:latest
+    container_name: vibewarden-promtail
+    profiles:
+      - observability
+    volumes:
+      - ./observability/promtail/promtail-config.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    command: -config.file=/etc/promtail/config.yml
+    networks:
+      - vibewarden
+    depends_on:
+      loki:
+        condition: service_healthy
 
 # --------------------------------------------------------------------------
 # Named volumes
@@ -245,6 +303,8 @@ volumes:
   prometheus_data:
     driver: local
   grafana_data:
+    driver: local
+  loki_data:
     driver: local
 
 # --------------------------------------------------------------------------

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,8 +1,9 @@
 # Observability Stack
 
 VibeWarden includes an optional local observability stack for development and testing.
-It consists of **Prometheus** (metrics collection) and **Grafana** (dashboards), both
-started via Docker Compose profiles so they do not run unless explicitly requested.
+It consists of **Prometheus** (metrics collection), **Loki** (log aggregation),
+**Promtail** (log shipper), and **Grafana** (dashboards and log explorer), all started
+via Docker Compose profiles so they do not run unless explicitly requested.
 
 ## Quick Start
 
@@ -27,14 +28,16 @@ Open the dashboards in your browser:
 ```bash
 make grafana-open      # opens http://localhost:3000
 make prometheus-open   # opens http://localhost:9090
+make loki-open         # opens http://localhost:3100/ready
 ```
 
 ## Accessing the UIs
 
-| Service    | URL                    | Notes                                  |
-|------------|------------------------|----------------------------------------|
-| Grafana    | http://localhost:3000  | Anonymous access, Admin role, no login |
-| Prometheus | http://localhost:9090  | No authentication required             |
+| Service    | URL                          | Notes                                  |
+|------------|------------------------------|----------------------------------------|
+| Grafana    | http://localhost:3000        | Anonymous access, Admin role, no login |
+| Prometheus | http://localhost:9090        | No authentication required             |
+| Loki       | http://localhost:3100/ready  | API only; query logs via Grafana       |
 
 Grafana is configured with anonymous authentication so there is no login screen in
 the local dev environment. This is intentional — do not use this configuration in
@@ -97,12 +100,67 @@ Prometheus collectors:
                           |                                     |
                           +---> /_vibewarden/metrics            v
                                                          [Grafana :3000]
+                                                               ^
+[Docker container logs]  -->  [Promtail]  -->  [Loki :3100] --+
 ```
 
 Prometheus scrapes VibeWarden every 15 seconds (configured in
-`observability/prometheus/prometheus.yml`). Grafana queries Prometheus as its
-data source (provisioned automatically in
+`observability/prometheus/prometheus.yml`). Promtail discovers all running Docker
+containers via the Docker socket, tails their log files, and ships log entries to Loki.
+Grafana queries both Prometheus and Loki as data sources (provisioned automatically in
 `observability/grafana/provisioning/datasources/prometheus.yml`).
+
+## Loki Log Aggregation
+
+Loki aggregates logs from all Docker containers in the stack. Logs are available in
+Grafana's **Explore** view (select the **Loki** data source).
+
+### Querying VibeWarden Logs
+
+VibeWarden emits structured JSON logs with the following top-level fields:
+
+| Field            | Description                                      | Indexed as label |
+|------------------|--------------------------------------------------|------------------|
+| `schema_version` | Log schema version (e.g., `v1`)                  | Yes              |
+| `event_type`     | Event kind (e.g., `request.completed`)           | Yes              |
+| `level`          | Log level (`DEBUG`, `INFO`, `WARN`, `ERROR`)     | Yes              |
+| `ai_summary`     | Human/AI-readable one-line description           | Structured metadata |
+| `time`           | RFC 3339 timestamp of the event                  | Used as log timestamp |
+| `payload`        | Event-specific data (arbitrary JSON object)      | Full-text search |
+
+Example LogQL queries in Grafana Explore:
+
+```logql
+# All VibeWarden logs
+{container="vibewarden-sidecar"}
+
+# Only error-level events
+{container="vibewarden-sidecar", level="ERROR"}
+
+# Request completed events
+{container="vibewarden-sidecar", event_type="request.completed"}
+
+# Full-text search within payloads
+{container="vibewarden-sidecar"} |= "rate_limit"
+
+# Parse and filter on a payload field (e.g. status_code)
+{container="vibewarden-sidecar", event_type="request.completed"}
+  | json
+  | payload_status_code >= 500
+```
+
+### Promtail Pipeline
+
+Promtail parses each VibeWarden log line as JSON and:
+
+1. Extracts `schema_version`, `event_type`, and `level` as Loki labels (low-cardinality,
+   indexed for fast filtering).
+2. Maps the `time` field to the Loki log timestamp so events are stored at the time
+   VibeWarden recorded them, not the scrape time.
+3. Promotes `ai_summary` as Loki structured metadata so it appears in the Grafana log
+   details panel without bloating the label index.
+
+Configuration lives in `observability/promtail/promtail-config.yml`.
 
 ## Adding Custom Dashboards
 
@@ -155,6 +213,26 @@ malformed, Grafana will start without it. Check the Grafana container logs:
 ```bash
 docker compose logs grafana
 ```
+
+### Loki shows no logs in Grafana
+
+1. Verify Loki is ready:
+   ```bash
+   curl http://localhost:3100/ready
+   # expected: ready
+   ```
+2. Check Promtail is running and has no errors:
+   ```bash
+   docker compose --profile observability logs promtail
+   ```
+3. Confirm Promtail has write access to the Docker socket:
+   ```bash
+   docker compose --profile observability ps promtail
+   ```
+4. In Grafana Explore, select the **Loki** datasource and run:
+   ```logql
+   {service="vibewarden"}
+   ```
 
 ### Prometheus cannot reach VibeWarden
 

--- a/observability/grafana/provisioning/datasources/prometheus.yml
+++ b/observability/grafana/provisioning/datasources/prometheus.yml
@@ -8,3 +8,15 @@ datasources:
     url: http://prometheus:9090
     isDefault: true
     editable: false
+
+  - name: Loki
+    type: loki
+    uid: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: false
+    jsonData:
+      # Derive fields turn the ai_summary structured metadata field into a
+      # clickable link in Grafana's log detail view (optional enhancement).
+      maxLines: 1000

--- a/observability/loki/loki-config.yml
+++ b/observability/loki/loki-config.yml
@@ -1,0 +1,45 @@
+# Loki — minimal single-node configuration for local development
+#
+# Storage: local filesystem (no S3, no clustering).
+# Retention: 7 days of log data.
+# This configuration is intended for local dev only — do not use in production.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: "2020-10-24"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 168h   # 7 days
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+
+ruler:
+  alertmanager_url: http://localhost:9093

--- a/observability/promtail/promtail-config.yml
+++ b/observability/promtail/promtail-config.yml
@@ -1,0 +1,90 @@
+# Promtail — scrapes Docker container logs and ships them to Loki
+#
+# Mounts:
+#   /var/run/docker.sock  — Docker socket for container discovery
+#   /var/lib/docker/containers  — raw container log files
+#
+# VibeWarden's structured JSON logs are parsed via the json pipeline stage so
+# that each field (event_type, ai_summary, schema_version, etc.) becomes a Loki
+# label or structured metadata that can be queried in Grafana.
+#
+# This configuration is intended for local dev only — do not use in production.
+
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+  log_level: warn
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  # --------------------------------------------------------------------------
+  # Docker — discover all containers via the Docker socket and tail their logs
+  # --------------------------------------------------------------------------
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 10s
+        filters:
+          - name: status
+            values: ["running"]
+
+    relabel_configs:
+      # Use the container name as the "container" label
+      - source_labels: [__meta_docker_container_name]
+        regex: "/(.*)"
+        target_label: container
+      # Propagate the compose service name as a label
+      - source_labels: [__meta_docker_container_label_com_docker_compose_service]
+        target_label: service
+      # Keep the compose project name as a label
+      - source_labels: [__meta_docker_container_label_com_docker_compose_project]
+        target_label: compose_project
+
+    pipeline_stages:
+      # ------------------------------------------------------------------
+      # VibeWarden structured JSON log parsing
+      #
+      # VibeWarden emits log lines as JSON objects with the schema:
+      #   {
+      #     "schema_version": "v1",
+      #     "event_type": "request.completed",
+      #     "ai_summary": "GET /api/users returned 200 in 12ms",
+      #     "payload": { ... }
+      #   }
+      #
+      # The json stage extracts the top-level fields into pipeline data so
+      # they can be promoted to Loki labels (for indexing) or structured
+      # metadata (for ad-hoc querying without label cardinality explosion).
+      # ------------------------------------------------------------------
+      - json:
+          expressions:
+            schema_version: schema_version
+            event_type: event_type
+            ai_summary: ai_summary
+            level: level
+            time: time
+
+      # Promote low-cardinality fields to Loki labels for efficient querying
+      - labels:
+          schema_version:
+          event_type:
+          level:
+
+      # Map the parsed "time" field to the log entry timestamp so Loki stores
+      # the event at the time VibeWarden recorded it, not the scrape time.
+      - timestamp:
+          source: time
+          format: RFC3339Nano
+          fallback_formats:
+            - RFC3339
+            - UnixMs
+
+      # Surface the ai_summary as a structured metadata field so Grafana can
+      # display it in the log details panel without adding it as a label.
+      - structured_metadata:
+          ai_summary:


### PR DESCRIPTION
Closes #137

## Summary

- **`observability/loki/loki-config.yml`** — minimal single-node Loki config: filesystem storage, 7-day retention, no S3, no clustering. Suitable for local dev only.
- **`observability/promtail/promtail-config.yml`** — Promtail scrapes all running Docker containers via `docker_sd_configs`. For each log line it runs a JSON pipeline stage that:
  - promotes `schema_version`, `event_type`, and `level` as Loki labels (low-cardinality, indexed)
  - maps the `time` field to the Loki log timestamp (events stored at VibeWarden record time, not scrape time)
  - surfaces `ai_summary` as structured metadata (visible in Grafana log details, not added to the label index)
- **`docker-compose.yml`** — adds `loki` (grafana/loki:latest) and `promtail` (grafana/promtail:latest) services under the `observability` profile; adds `loki_data` named volume; Grafana now depends on `loki` being healthy so the datasource works on first start.
- **`observability/grafana/provisioning/datasources/prometheus.yml`** — adds Loki as a second datasource alongside Prometheus. No dashboard changes needed; queries happen in Grafana Explore.
- **`Makefile`** — adds `loki-open` target.
- **`docs/observability.md`** — new Loki section covering architecture diagram, LogQL example queries, Promtail pipeline explanation, and troubleshooting steps.

## License note

Loki is AGPL-3.0, used only as a dev tool container (same pattern as Grafana). Promtail is Apache 2.0. No Go dependencies added.

## Test plan

- [ ] `make check` passes (no Go changes — confirmed clean)
- [ ] `docker compose --profile observability up -d` starts all six observability services without errors
- [ ] `curl http://localhost:3100/ready` returns `ready`
- [ ] Grafana Explore (http://localhost:3000) shows Loki as a selectable datasource
- [ ] `{container="vibewarden-sidecar"}` LogQL query returns VibeWarden log lines
- [ ] `{container="vibewarden-sidecar", event_type="request.completed"}` filters correctly by label
- [ ] `ai_summary` field appears in the Grafana log line detail panel
