### PR TITLE
feat(#138): seed demo users into Kratos on first boot

### DIFF
--- a/examples/demo-app/README.md
+++ b/examples/demo-app/README.md
@@ -137,6 +137,19 @@ curl http://localhost:8080/health
 | Kratos admin API | http://localhost:4434 | Internal admin (not for browsers) |
 | Mailslurper | http://localhost:4437 | Catches Kratos verification emails |
 
+## Demo credentials
+
+Two users are seeded automatically when the stack starts.  No registration
+step required — just use these at the login page:
+
+| Email | Password |
+|---|---|
+| `demo@vibewarden.dev` | `demo1234` |
+| `alice@vibewarden.dev` | `alice1234` |
+
+Both accounts have their email address pre-verified so you can immediately
+access protected endpoints without completing a verification flow.
+
 ## Registration and login
 
 VibeWarden proxies Kratos self-service flows, so you can register and log in

--- a/examples/demo-app/docker-compose.yml
+++ b/examples/demo-app/docker-compose.yml
@@ -5,12 +5,17 @@
 #   kratos-migrate — runs Kratos DB migrations once, then exits
 #   kratos         — Ory Kratos identity server (public :4433, admin :4434)
 #   mailslurper    — catches outbound Kratos emails (SMTP :4436, web UI :4437)
+#   seed           — seeds demo identities into Kratos once, then exits
 #   demo-app       — the Go API backend (internal only — not published to host)
 #   vibewarden     — the security sidecar exposed on :8080
 #
 # Usage:
 #   docker compose up -d
 #   # Visit http://localhost:8080
+#
+# Demo credentials (seeded automatically):
+#   demo@vibewarden.dev  / demo1234
+#   alice@vibewarden.dev / alice1234
 #
 # Secrets: all credentials are hard-coded to simple demo values.
 # Never use these outside a local demo environment.
@@ -101,6 +106,30 @@ services:
       - "4437:4437"   # Web UI
     networks:
       - demo
+
+  # --------------------------------------------------------------------------
+  # Seed — seeds demo identities into Kratos once on first boot, then exits.
+  #
+  # Creates:
+  #   demo@vibewarden.dev  / demo1234
+  #   alice@vibewarden.dev / alice1234
+  #
+  # Idempotent: skips identities that already exist.
+  # --------------------------------------------------------------------------
+  seed:
+    image: curlimages/curl:8.12.1
+    container_name: demo-seed
+    environment:
+      KRATOS_ADMIN_URL: http://kratos:4434
+    volumes:
+      - ./scripts/seed-users.sh:/seed-users.sh:ro
+    command: sh /seed-users.sh
+    depends_on:
+      kratos:
+        condition: service_healthy
+    networks:
+      - demo
+    restart: "no"
 
   # --------------------------------------------------------------------------
   # Demo app — the Go API backend

--- a/examples/demo-app/scripts/seed-users.sh
+++ b/examples/demo-app/scripts/seed-users.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env sh
+# seed-users.sh — seeds demo identities into Ory Kratos on first boot.
+#
+# Usage:
+#   KRATOS_ADMIN_URL=http://kratos:4434 ./seed-users.sh
+#
+# Environment variables:
+#   KRATOS_ADMIN_URL   Base URL of the Kratos admin API (default: http://kratos:4434)
+#
+# The script is idempotent: it checks whether each identity already exists
+# (by email lookup) before attempting to create it.  Exits 0 on success.
+
+set -eu
+
+KRATOS_ADMIN_URL="${KRATOS_ADMIN_URL:-http://kratos:4434}"
+
+# ---------------------------------------------------------------------------
+# wait_for_kratos — poll the admin health endpoint until Kratos is ready.
+# ---------------------------------------------------------------------------
+wait_for_kratos() {
+  echo "[seed] Waiting for Kratos admin API at ${KRATOS_ADMIN_URL} ..."
+  retries=30
+  while [ "$retries" -gt 0 ]; do
+    status=$(curl -s -o /dev/null -w "%{http_code}" "${KRATOS_ADMIN_URL}/admin/health/ready" 2>/dev/null || true)
+    if [ "$status" = "200" ]; then
+      echo "[seed] Kratos is ready."
+      return 0
+    fi
+    retries=$((retries - 1))
+    echo "[seed] Not ready yet (HTTP ${status}), retrying in 3s ... (${retries} retries left)"
+    sleep 3
+  done
+  echo "[seed] ERROR: Kratos did not become ready in time." >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# identity_exists — returns 0 if an identity with the given email exists.
+# ---------------------------------------------------------------------------
+identity_exists() {
+  email="$1"
+  result=$(curl -s \
+    "${KRATOS_ADMIN_URL}/admin/identities?credentials_identifier=${email}" \
+    -H "Accept: application/json")
+  # The endpoint returns a JSON array; a non-empty array means the user exists.
+  count=$(printf '%s' "$result" | grep -c '"id"' || true)
+  [ "$count" -gt 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# create_identity — creates an identity and sets its password.
+# ---------------------------------------------------------------------------
+create_identity() {
+  email="$1"
+  password="$2"
+
+  if identity_exists "$email"; then
+    echo "[seed] Identity ${email} already exists, skipping."
+    return 0
+  fi
+
+  echo "[seed] Creating identity: ${email} ..."
+  response=$(curl -s -w "\n%{http_code}" -X POST \
+    "${KRATOS_ADMIN_URL}/admin/identities" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"schema_id\": \"default\",
+      \"traits\": {
+        \"email\": \"${email}\"
+      },
+      \"credentials\": {
+        \"password\": {
+          \"config\": {
+            \"password\": \"${password}\"
+          }
+        }
+      },
+      \"verifiable_addresses\": [
+        {
+          \"value\": \"${email}\",
+          \"verified\": true,
+          \"via\": \"email\",
+          \"status\": \"completed\"
+        }
+      ]
+    }")
+
+  http_code=$(printf '%s' "$response" | tail -n1)
+  body=$(printf '%s' "$response" | head -n -1)
+
+  if [ "$http_code" = "201" ]; then
+    echo "[seed] Created identity: ${email}"
+  else
+    echo "[seed] ERROR: Failed to create ${email} (HTTP ${http_code}): ${body}" >&2
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+wait_for_kratos
+
+create_identity "demo@vibewarden.dev"  "demo1234"
+create_identity "alice@vibewarden.dev" "alice1234"
+
+echo "[seed] Seed complete."


### PR DESCRIPTION
Closes #138

## Summary

- Added `examples/demo-app/scripts/seed-users.sh` — a POSIX shell script (uses `curlimages/curl`) that polls the Kratos admin health endpoint until ready, then idempotently creates two demo identities via `POST /admin/identities`: `demo@vibewarden.dev`/`demo1234` and `alice@vibewarden.dev`/`alice1234`. Both are pre-verified so users skip the email verification flow.
- Added a `seed` service to `examples/demo-app/docker-compose.yml` that depends on `kratos: service_healthy`, mounts the script read-only, and runs once with `restart: "no"`.
- Updated `examples/demo-app/README.md` with a "Demo credentials" section listing both accounts.

## Test plan

- [ ] `docker compose up -d` in `examples/demo-app/` -- stack comes up cleanly
- [ ] `docker compose logs seed` shows `[seed] Seed complete.`
- [ ] Browse to `http://localhost:8080/self-service/login/browser`, log in as `demo@vibewarden.dev` / `demo1234` -- succeeds
- [ ] Log in as `alice@vibewarden.dev` / `alice1234` -- succeeds
- [ ] Run `docker compose down -v && docker compose up -d` -- seed runs again, skips existing users with `already exists, skipping`
- [ ] `make check` passes

Generated with Claude Code
