### PR TITLE
feat(#136): add full local demo stack with observability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # VibeWarden Makefile
 
-.PHONY: build test lint run docker-up docker-down observability-up observability-down grafana-open prometheus-open loki-open clean check setup-hooks
+.PHONY: build test lint run docker-up docker-down observability-up observability-down grafana-open prometheus-open loki-open clean check setup-hooks demo demo-down
 
 # Build variables
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -70,6 +70,22 @@ check: ## Run all quality checks (build, format, vet, tests)
 	@test -z "$$(cd examples/demo-app && gofmt -l .)" || (echo "gofmt: these demo-app files need formatting:" && cd examples/demo-app && gofmt -l . && exit 1)
 	cd examples/demo-app && go vet ./... && go build ./... && go test -race ./...
 	@echo "==> All checks passed!"
+
+# Start the full local demo stack (builds from source, includes observability)
+demo: ## Start the full local demo stack (https://localhost:8443, Grafana http://localhost:3000)
+	docker compose -f examples/demo-app/docker-compose.local-demo.yml up -d --build
+	@echo ""
+	@echo "Demo stack is starting — wait ~30 s for all services to be healthy."
+	@echo ""
+	@echo "  App:      https://localhost:8443   (accept the self-signed cert warning)"
+	@echo "  Grafana:  http://localhost:3000    (admin / admin)"
+	@echo "  Prometheus: http://localhost:9090"
+	@echo ""
+	@echo "Demo credentials: demo@vibewarden.dev / demo1234"
+
+# Stop the full local demo stack
+demo-down: ## Stop the full local demo stack
+	docker compose -f examples/demo-app/docker-compose.local-demo.yml down
 
 # Install git hooks for local development
 setup-hooks: ## Install git hooks for local development

--- a/examples/demo-app/README.md
+++ b/examples/demo-app/README.md
@@ -15,6 +15,51 @@ docker compose up -d
 Wait ~15 seconds for the full stack to be healthy.  Your browser will be
 redirected to the demo UI at `http://localhost:8080/static/index.html`.
 
+## Full Demo Stack
+
+The full demo stack adds Prometheus metrics, Grafana dashboards, and Loki log
+aggregation on top of the basic stack.  It also enables self-signed TLS so you
+can exercise the HTTPS path locally.
+
+```bash
+cd examples/demo-app
+docker compose -f docker-compose.local-demo.yml up -d
+# Visit https://localhost:8443  (accept the self-signed certificate warning)
+```
+
+Wait ~30 seconds for all services to become healthy.
+
+### Access URLs
+
+| Service | URL | Credentials |
+|---|---|---|
+| Demo app (via VibeWarden) | https://localhost:8443 | see Demo credentials below |
+| Grafana | http://localhost:3000 | admin / admin |
+| Prometheus | http://localhost:9090 | — |
+| Loki (ready check) | http://localhost:3100/ready | — |
+| Kratos public API | http://localhost:4433 | — |
+| Mailslurper (email UI) | http://localhost:4437 | — |
+
+### What the full stack demonstrates
+
+- **Self-signed TLS** — VibeWarden terminates HTTPS using a Caddy-generated
+  self-signed certificate.  No domain or ACME account required.
+- **Metrics** — Prometheus scrapes `/_vibewarden/metrics` every 15 s.  Open
+  Grafana and navigate to the VibeWarden dashboard to see request rates, latency
+  histograms, rate-limit hits, and auth decisions in real time.
+- **Log aggregation** — Promtail tails every container's stdout/stderr via the
+  Docker socket and ships structured JSON logs to Loki.  Grafana's Explore view
+  lets you query them with LogQL.
+- **Pre-provisioned dashboards** — Grafana starts with the Prometheus and Loki
+  datasources already configured and the VibeWarden dashboard pre-loaded.
+
+### Teardown
+
+```bash
+docker compose -f docker-compose.local-demo.yml down        # stop containers
+docker compose -f docker-compose.local-demo.yml down -v     # also remove volumes
+```
+
 ## Demo UI
 
 A plain HTML + vanilla JS frontend is embedded directly in the binary (no
@@ -130,9 +175,23 @@ curl http://localhost:8080/health
 
 ## Services
 
+### Basic stack (`docker-compose.yml`)
+
 | Service | URL | Description |
 |---|---|---|
 | VibeWarden | http://localhost:8080 | Security sidecar — the entry point |
+| Kratos public API | http://localhost:4433 | Self-service auth flows |
+| Kratos admin API | http://localhost:4434 | Internal admin (not for browsers) |
+| Mailslurper | http://localhost:4437 | Catches Kratos verification emails |
+
+### Full demo stack (`docker-compose.local-demo.yml`)
+
+| Service | URL | Description |
+|---|---|---|
+| VibeWarden (HTTPS) | https://localhost:8443 | Security sidecar with self-signed TLS |
+| Grafana | http://localhost:3000 | Pre-provisioned dashboards (admin / admin) |
+| Prometheus | http://localhost:9090 | Metrics storage and query UI |
+| Loki | http://localhost:3100 | Log aggregation backend |
 | Kratos public API | http://localhost:4433 | Self-service auth flows |
 | Kratos admin API | http://localhost:4434 | Internal admin (not for browsers) |
 | Mailslurper | http://localhost:4437 | Catches Kratos verification emails |

--- a/examples/demo-app/docker-compose.local-demo.yml
+++ b/examples/demo-app/docker-compose.local-demo.yml
@@ -1,0 +1,318 @@
+# VibeWarden Demo App — Full Local Demo Stack
+#
+# Extends the basic stack with a complete observability suite:
+#   postgres       — Kratos session / identity storage
+#   kratos-migrate — runs Kratos DB migrations once, then exits
+#   kratos         — Ory Kratos identity server (public :4433, admin :4434)
+#   mailslurper    — catches outbound Kratos emails (SMTP :4436, web UI :4437)
+#   seed           — seeds demo identities into Kratos once, then exits
+#   demo-app       — the Go API backend (built from local Dockerfile)
+#   vibewarden     — the security sidecar (built from repo root Dockerfile)
+#                    with self-signed TLS on :8443
+#   prometheus     — scrapes VibeWarden metrics every 15 s (:9090)
+#   grafana        — pre-provisioned dashboards (:3000)
+#   loki           — log aggregation backend (:3100)
+#   promtail       — tails Docker container logs and ships them to Loki
+#
+# Usage:
+#   docker compose -f docker-compose.local-demo.yml up -d
+#   # Visit https://localhost:8443  (accept the self-signed cert warning)
+#   # Grafana:  http://localhost:3000  (admin / admin)
+#
+# Demo credentials (seeded automatically):
+#   demo@vibewarden.dev  / demo1234
+#   alice@vibewarden.dev / alice1234
+#
+# Secrets: all credentials are hard-coded to simple demo values.
+# Never use these outside a local demo environment.
+
+version: "3.8"
+
+services:
+  # --------------------------------------------------------------------------
+  # Postgres — persistent storage for Ory Kratos
+  # --------------------------------------------------------------------------
+  postgres:
+    image: postgres:17-alpine
+    container_name: demo-postgres
+    environment:
+      POSTGRES_USER: demo
+      POSTGRES_PASSWORD: demo
+      POSTGRES_DB: demo
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - demo
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U demo -d demo"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  # --------------------------------------------------------------------------
+  # Kratos migrate — runs DB migrations once, then exits
+  # --------------------------------------------------------------------------
+  kratos-migrate:
+    image: oryd/kratos:v1.3.1
+    container_name: demo-kratos-migrate
+    environment:
+      DSN: postgres://demo:demo@postgres:5432/demo?sslmode=disable
+    volumes:
+      - ./kratos:/etc/config/kratos:ro
+    command: migrate sql -e --yes
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - demo
+
+  # --------------------------------------------------------------------------
+  # Kratos — identity / session management
+  #
+  # Public API  (user-facing flows):  http://localhost:4433
+  # Admin API   (internal use only):  http://localhost:4434
+  # --------------------------------------------------------------------------
+  kratos:
+    image: oryd/kratos:v1.3.1
+    container_name: demo-kratos
+    environment:
+      DSN: postgres://demo:demo@postgres:5432/demo?sslmode=disable
+      # Browser-visible base URL points to the VibeWarden HTTPS address so that
+      # Kratos self-service redirects land back at the sidecar.
+      SERVE_PUBLIC_BASE_URL: https://localhost:8443/
+      SERVE_ADMIN_BASE_URL: http://kratos:4434/
+    ports:
+      - "4433:4433"
+      - "4434:4434"
+    volumes:
+      - ./kratos:/etc/config/kratos:ro
+    command: serve --config /etc/config/kratos/kratos.yml --dev --watch-courier
+    depends_on:
+      kratos-migrate:
+        condition: service_completed_successfully
+    networks:
+      - demo
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://kratos:4434/admin/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+  # --------------------------------------------------------------------------
+  # Mailslurper — local SMTP sink for Kratos verification / recovery emails
+  #
+  # SMTP endpoint (used by Kratos): mailslurper:4436
+  # Web UI to read captured emails:  http://localhost:4437
+  # --------------------------------------------------------------------------
+  mailslurper:
+    image: oryd/mailslurper:latest-smtps
+    container_name: demo-mailslurper
+    ports:
+      - "4436:4436"   # SMTP
+      - "4437:4437"   # Web UI
+    networks:
+      - demo
+
+  # --------------------------------------------------------------------------
+  # Seed — seeds demo identities into Kratos once on first boot, then exits.
+  #
+  # Creates:
+  #   demo@vibewarden.dev  / demo1234
+  #   alice@vibewarden.dev / alice1234
+  #
+  # Idempotent: skips identities that already exist.
+  # --------------------------------------------------------------------------
+  seed:
+    image: curlimages/curl:8.12.1
+    container_name: demo-seed
+    environment:
+      KRATOS_ADMIN_URL: http://kratos:4434
+    volumes:
+      - ./scripts/seed-users.sh:/seed-users.sh:ro
+    command: sh /seed-users.sh
+    depends_on:
+      kratos:
+        condition: service_healthy
+    networks:
+      - demo
+    restart: "no"
+
+  # --------------------------------------------------------------------------
+  # Demo app — the Go API backend
+  #
+  # Built from the local Dockerfile in examples/demo-app/.
+  # Not published to the host — only reachable through VibeWarden on :8443.
+  # --------------------------------------------------------------------------
+  demo-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: demo-app
+    environment:
+      PORT: "3000"
+    networks:
+      - demo
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3000/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
+  # --------------------------------------------------------------------------
+  # VibeWarden — the security sidecar
+  #
+  # Built from the repo root Dockerfile (../../Dockerfile).
+  # Listens on :8443 (HTTPS, self-signed TLS) and proxies to demo-app:3000.
+  # Enforces auth (Kratos), rate limiting, and security headers.
+  # Exposes /_vibewarden/metrics for Prometheus to scrape.
+  # --------------------------------------------------------------------------
+  vibewarden:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    container_name: demo-vibewarden
+    ports:
+      - "8443:8443"
+    volumes:
+      - ./vibewarden.local-demo.yaml:/vibewarden.yaml:ro
+      # Caddy stores self-signed certificate state here between restarts.
+      - caddy_data:/root/.local/share/caddy
+    environment:
+      VIBEWARDEN_KRATOS_PUBLIC_URL: http://kratos:4433
+      VIBEWARDEN_KRATOS_ADMIN_URL:  http://kratos:4434
+      VIBEWARDEN_UPSTREAM_HOST: demo-app
+      VIBEWARDEN_UPSTREAM_PORT: "3000"
+      VIBEWARDEN_SERVER_HOST: "0.0.0.0"
+    depends_on:
+      kratos:
+        condition: service_healthy
+      demo-app:
+        condition: service_healthy
+    networks:
+      - demo
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --no-check-certificate --spider https://localhost:8443/_vibewarden/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
+  # --------------------------------------------------------------------------
+  # Prometheus — scrapes VibeWarden metrics every 15 s
+  #
+  # UI available at: http://localhost:9090
+  # --------------------------------------------------------------------------
+  prometheus:
+    image: prom/prometheus:v3.4.0
+    container_name: demo-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ../../observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+    depends_on:
+      vibewarden:
+        condition: service_healthy
+    networks:
+      - demo
+
+  # --------------------------------------------------------------------------
+  # Grafana — pre-provisioned dashboards
+  #
+  # UI available at: http://localhost:3000  (admin / admin)
+  # Datasources (Prometheus + Loki) and the VibeWarden dashboard are
+  # provisioned automatically from the observability/ directory.
+  # --------------------------------------------------------------------------
+  grafana:
+    image: grafana/grafana:12.0.1
+    container_name: demo-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      # Disable the "change password on first login" prompt for the demo.
+      GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION: "false"
+    volumes:
+      - ../../observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../../observability/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+      - loki
+    networks:
+      - demo
+
+  # --------------------------------------------------------------------------
+  # Loki — log aggregation backend
+  #
+  # Receives log streams from Promtail.
+  # Queried by Grafana for the log panels.
+  # API available at: http://localhost:3100
+  # --------------------------------------------------------------------------
+  loki:
+    image: grafana/loki:3.5.0
+    container_name: demo-loki
+    ports:
+      - "3100:3100"
+    volumes:
+      - ../../observability/loki/loki-config.yml:/etc/loki/local-config.yaml:ro
+      - loki_data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - demo
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3100/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  # --------------------------------------------------------------------------
+  # Promtail — tails Docker container logs and ships them to Loki
+  #
+  # Mounts the Docker socket so it can discover all running containers.
+  # Parses VibeWarden's structured JSON logs and promotes fields to Loki labels.
+  # --------------------------------------------------------------------------
+  promtail:
+    image: grafana/promtail:3.5.0
+    container_name: demo-promtail
+    volumes:
+      - ../../observability/promtail/promtail-config.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      loki:
+        condition: service_healthy
+    networks:
+      - demo
+
+# --------------------------------------------------------------------------
+# Named volumes
+# --------------------------------------------------------------------------
+volumes:
+  postgres_data:
+    driver: local
+  caddy_data:
+    driver: local
+  prometheus_data:
+    driver: local
+  grafana_data:
+    driver: local
+  loki_data:
+    driver: local
+
+# --------------------------------------------------------------------------
+# Networks
+# --------------------------------------------------------------------------
+networks:
+  demo:
+    driver: bridge

--- a/examples/demo-app/vibewarden.local-demo.yaml
+++ b/examples/demo-app/vibewarden.local-demo.yaml
@@ -1,0 +1,80 @@
+# VibeWarden configuration for the full local demo stack.
+#
+# Differences from vibewarden.yaml (basic stack):
+#   - TLS enabled with self-signed provider (Caddy generates a local certificate)
+#   - Metrics enabled with all demo-app path patterns registered
+#   - All other features (auth, rate limiting, security headers) identical
+#
+# Used by docker-compose.local-demo.yml.
+# Do NOT use this configuration outside a local demo environment.
+
+server:
+  host: "0.0.0.0"
+  port: 8443
+
+upstream:
+  host: "demo-app"
+  port: 3000
+
+tls:
+  enabled: true
+  # Caddy generates an internal self-signed certificate — no ACME, no domain needed.
+  # Browsers will show a security warning; accept it to proceed.
+  provider: "self-signed"
+
+kratos:
+  # Resolved via the internal Docker network.
+  public_url: "http://kratos:4433"
+  admin_url:  "http://kratos:4434"
+
+auth:
+  # Paths that do NOT require authentication.
+  public_paths:
+    - "/"
+    - "/public"
+    - "/health"
+    - "/static"
+  session_cookie_name: "ory_kratos_session"
+  login_url: ""
+
+rate_limit:
+  enabled: true
+  # Low limits so you can trigger them easily during the demo.
+  # Try: for i in $(seq 1 20); do curl -sk -o /dev/null -w "%{http_code}\n" -X POST https://localhost:8443/spam; done
+  per_ip:
+    requests_per_second: 5
+    burst: 10
+  per_user:
+    requests_per_second: 10
+    burst: 20
+  trust_proxy_headers: false
+  exempt_paths: []
+
+log:
+  level: "info"
+  format: "json"
+
+admin:
+  enabled: false
+  token: ""
+
+metrics:
+  enabled: true
+  path_patterns:
+    - "/"
+    - "/public"
+    - "/me"
+    - "/headers"
+    - "/spam"
+    - "/health"
+
+security_headers:
+  enabled: true
+  hsts_max_age: 31536000
+  hsts_include_subdomains: true
+  hsts_preload: false
+  content_type_nosniff: true
+  frame_option: "DENY"
+  content_security_policy: "default-src 'self'; style-src 'self'; script-src 'self' 'unsafe-inline'"
+  referrer_policy: "strict-origin-when-cross-origin"
+  permissions_policy: ""


### PR DESCRIPTION
Closes #136

## Summary

- **`examples/demo-app/docker-compose.local-demo.yml`** — full demo stack: all services from the basic compose file plus Prometheus, Grafana, Loki, and Promtail. VibeWarden is built from the repo root Dockerfile and listens on `:8443` with self-signed TLS. Observability configs are mounted directly from `observability/` (no duplication).
- **`examples/demo-app/vibewarden.local-demo.yaml`** — vibewarden config with `tls.provider: self-signed`, server on `:8443`, and all demo-app path patterns registered for metrics.
- **`examples/demo-app/README.md`** — new "Full Demo Stack" section with access URLs table, feature list, and teardown commands; existing Services table split into basic vs. full stack.
- **`Makefile`** — `make demo` and `make demo-down` targets added.

## Test plan

- [ ] `make demo` starts the full stack without errors
- [ ] `https://localhost:8443` loads the demo UI (accept self-signed cert warning)
- [ ] `http://localhost:3000` opens Grafana; VibeWarden dashboard is pre-provisioned
- [ ] Prometheus at `http://localhost:9090` shows `vibewarden` job as UP
- [ ] Loki at `http://localhost:3100/ready` returns `ready`
- [ ] Demo credentials `demo@vibewarden.dev / demo1234` log in successfully
- [ ] `make demo-down` tears down cleanly
- [ ] `go build ./...` and `go test ./...` both pass (no Go changes, verified by pre-push hook)
