### PR TITLE
feat(#124): add production Docker Compose and env example for public demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .env
 .env.*
 !.env.example
+!.env.*.example
 
 # IDE
 .idea/

--- a/examples/demo-app/.env.prod.example
+++ b/examples/demo-app/.env.prod.example
@@ -1,0 +1,39 @@
+# VibeWarden Production Demo — Required Environment Variables
+#
+# Copy this file to .env and fill in all values before starting the stack:
+#
+#   cp .env.prod.example .env
+#   # edit .env — set every value marked CHANGE_ME
+#   docker compose -f docker-compose.prod.yml up -d
+#
+# SECURITY NOTES:
+#   - Never commit .env to version control (it is in .gitignore).
+#   - Use long, randomly-generated passwords for all credentials.
+#     You can generate one with: openssl rand -hex 32
+#   - Rotate credentials if this server is ever compromised.
+
+# --------------------------------------------------------------------------
+# Public domain
+# --------------------------------------------------------------------------
+
+# The fully-qualified domain name that resolves to this server.
+# DNS must point here BEFORE you start the stack so that Let's Encrypt can
+# issue a certificate.
+# Example: challenge.vibewarden.dev
+DOMAIN=CHANGE_ME
+
+# --------------------------------------------------------------------------
+# PostgreSQL
+# --------------------------------------------------------------------------
+
+POSTGRES_USER=vibewarden
+POSTGRES_PASSWORD=CHANGE_ME
+POSTGRES_DB=vibewarden
+
+# --------------------------------------------------------------------------
+# Grafana
+# --------------------------------------------------------------------------
+
+# Password for the Grafana admin account (username: admin).
+# Anonymous visitors get read-only Viewer access regardless of this value.
+GRAFANA_ADMIN_PASSWORD=CHANGE_ME

--- a/examples/demo-app/docker-compose.prod.yml
+++ b/examples/demo-app/docker-compose.prod.yml
@@ -1,0 +1,316 @@
+# VibeWarden Demo App — Production Stack (challenge.vibewarden.dev)
+#
+# Adapts the local demo stack for public deployment on a Hetzner VPS.
+# Key differences from docker-compose.local-demo.yml:
+#
+#   - VibeWarden listens on 80 + 443 (not 8443); Let's Encrypt TLS
+#   - All credentials come from a .env file (see .env.prod.example)
+#   - Mailslurper is kept for Kratos email delivery but NOT exposed publicly
+#   - Only VibeWarden (80/443) and Grafana (3000) are published to the host
+#   - Grafana runs in anonymous read-only (Viewer) mode; admin password via env
+#   - All services restart unless explicitly stopped
+#   - Kratos SERVE_PUBLIC_BASE_URL points to the real public domain
+#
+# Pre-requisites:
+#   1. Copy .env.prod.example to .env and fill in all values.
+#   2. Ensure DNS for DOMAIN points to this server before starting.
+#   3. Ports 80, 443, and 3000 must be open in the firewall.
+#
+# Usage:
+#   cp .env.prod.example .env
+#   # edit .env
+#   docker compose -f docker-compose.prod.yml up -d
+#
+#   # Tear down (keeps volumes):
+#   docker compose -f docker-compose.prod.yml down
+#
+#   # Full wipe including volumes:
+#   docker compose -f docker-compose.prod.yml down -v
+
+version: "3.8"
+
+services:
+  # --------------------------------------------------------------------------
+  # Postgres — persistent storage for Ory Kratos
+  # --------------------------------------------------------------------------
+  postgres:
+    image: postgres:17-alpine
+    container_name: demo-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - demo
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  # --------------------------------------------------------------------------
+  # Kratos migrate — runs DB migrations once, then exits
+  # --------------------------------------------------------------------------
+  kratos-migrate:
+    image: oryd/kratos:v1.3.1
+    container_name: demo-kratos-migrate
+    environment:
+      DSN: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+    volumes:
+      - ./kratos:/etc/config/kratos:ro
+    command: migrate sql -e --yes
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - demo
+    restart: "no"
+
+  # --------------------------------------------------------------------------
+  # Kratos — identity / session management
+  #
+  # Public API (user-facing flows):  NOT exposed to host — proxied via VibeWarden
+  # Admin API  (internal use only):  NOT exposed to host
+  # --------------------------------------------------------------------------
+  kratos:
+    image: oryd/kratos:v1.3.1
+    container_name: demo-kratos
+    restart: unless-stopped
+    environment:
+      DSN: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+      # Browser-visible base URL must be the public HTTPS domain so that
+      # Kratos self-service redirects land back at the sidecar.
+      SERVE_PUBLIC_BASE_URL: https://${DOMAIN}/
+      SERVE_ADMIN_BASE_URL: http://kratos:4434/
+    volumes:
+      - ./kratos:/etc/config/kratos:ro
+    command: serve --config /etc/config/kratos/kratos.yml --watch-courier
+    depends_on:
+      kratos-migrate:
+        condition: service_completed_successfully
+    networks:
+      - demo
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://kratos:4434/admin/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+  # --------------------------------------------------------------------------
+  # Mailslurper — SMTP sink for Kratos verification / recovery emails
+  #
+  # In production the SMTP port (4436) is intentionally NOT published to the
+  # host — traffic stays on the internal Docker network.
+  # If you want real email delivery, replace this with an external SMTP relay
+  # and update the Kratos courier config accordingly.
+  # --------------------------------------------------------------------------
+  mailslurper:
+    image: oryd/mailslurper:latest-smtps
+    container_name: demo-mailslurper
+    restart: unless-stopped
+    networks:
+      - demo
+
+  # --------------------------------------------------------------------------
+  # Seed — seeds demo identities into Kratos once on first boot, then exits.
+  #
+  # Creates:
+  #   demo@vibewarden.dev  / demo1234
+  #   alice@vibewarden.dev / alice1234
+  #
+  # Idempotent: skips identities that already exist.
+  # --------------------------------------------------------------------------
+  seed:
+    image: curlimages/curl:8.12.1
+    container_name: demo-seed
+    environment:
+      KRATOS_ADMIN_URL: http://kratos:4434
+    volumes:
+      - ./scripts/seed-users.sh:/seed-users.sh:ro
+    command: sh /seed-users.sh
+    depends_on:
+      kratos:
+        condition: service_healthy
+    networks:
+      - demo
+    restart: "no"
+
+  # --------------------------------------------------------------------------
+  # Demo app — the Go API backend
+  #
+  # NOT exposed to the host — only reachable through VibeWarden on 80/443.
+  # --------------------------------------------------------------------------
+  demo-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: demo-app
+    restart: unless-stopped
+    environment:
+      PORT: "3000"
+    networks:
+      - demo
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3000/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
+  # --------------------------------------------------------------------------
+  # VibeWarden — the security sidecar
+  #
+  # Listens on :80 (HTTP → redirects to HTTPS) and :443 (HTTPS, Let's Encrypt).
+  # Proxies to demo-app:3000, enforces auth (Kratos), rate limiting, and
+  # security headers. Exposes /_vibewarden/metrics for Prometheus to scrape.
+  # --------------------------------------------------------------------------
+  vibewarden:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    container_name: demo-vibewarden
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./vibewarden.prod.yaml:/vibewarden.yaml:ro
+      # Caddy stores the Let's Encrypt certificate state between restarts.
+      - caddy_data:/root/.local/share/caddy
+    environment:
+      VIBEWARDEN_KRATOS_PUBLIC_URL: http://kratos:4433
+      VIBEWARDEN_KRATOS_ADMIN_URL: http://kratos:4434
+      VIBEWARDEN_UPSTREAM_HOST: demo-app
+      VIBEWARDEN_UPSTREAM_PORT: "3000"
+      VIBEWARDEN_SERVER_HOST: "0.0.0.0"
+    depends_on:
+      kratos:
+        condition: service_healthy
+      demo-app:
+        condition: service_healthy
+    networks:
+      - demo
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:80/_vibewarden/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # --------------------------------------------------------------------------
+  # Prometheus — scrapes VibeWarden metrics every 15 s
+  #
+  # NOT exposed to the host — queried by Grafana via the internal network.
+  # --------------------------------------------------------------------------
+  prometheus:
+    image: prom/prometheus:v3.4.0
+    container_name: demo-prometheus
+    restart: unless-stopped
+    volumes:
+      - ../../observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+    depends_on:
+      vibewarden:
+        condition: service_healthy
+    networks:
+      - demo
+
+  # --------------------------------------------------------------------------
+  # Grafana — pre-provisioned dashboards (public read-only)
+  #
+  # Exposed at :3000 so operators can monitor the demo.
+  # Anonymous access is enabled with Viewer role (read-only).
+  # Admin password is taken from GRAFANA_ADMIN_PASSWORD in .env.
+  # --------------------------------------------------------------------------
+  grafana:
+    image: grafana/grafana:12.0.1
+    container_name: demo-grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      # Anonymous access — visitors see dashboards as read-only Viewers.
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Viewer"
+    volumes:
+      - ../../observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../../observability/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+      - loki
+    networks:
+      - demo
+
+  # --------------------------------------------------------------------------
+  # Loki — log aggregation backend
+  #
+  # NOT exposed to the host — queried by Grafana via the internal network.
+  # --------------------------------------------------------------------------
+  loki:
+    image: grafana/loki:3.5.0
+    container_name: demo-loki
+    restart: unless-stopped
+    volumes:
+      - ../../observability/loki/loki-config.yml:/etc/loki/local-config.yaml:ro
+      - loki_data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - demo
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3100/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  # --------------------------------------------------------------------------
+  # Promtail — tails Docker container logs and ships them to Loki
+  # --------------------------------------------------------------------------
+  promtail:
+    image: grafana/promtail:3.5.0
+    container_name: demo-promtail
+    restart: unless-stopped
+    volumes:
+      - ../../observability/promtail/promtail-config.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      loki:
+        condition: service_healthy
+    networks:
+      - demo
+
+# --------------------------------------------------------------------------
+# Named volumes
+# --------------------------------------------------------------------------
+volumes:
+  postgres_data:
+    driver: local
+  caddy_data:
+    driver: local
+  prometheus_data:
+    driver: local
+  grafana_data:
+    driver: local
+  loki_data:
+    driver: local
+
+# --------------------------------------------------------------------------
+# Networks
+# --------------------------------------------------------------------------
+networks:
+  demo:
+    driver: bridge


### PR DESCRIPTION
Closes #124

## Summary

- Adds `examples/demo-app/docker-compose.prod.yml` — a production variant of the local demo stack for `challenge.vibewarden.dev`:
  - VibeWarden publishes ports 80 and 443 (not 8443); mounts `vibewarden.prod.yaml` which uses Let's Encrypt TLS
  - All credentials (`POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `GRAFANA_ADMIN_PASSWORD`, `DOMAIN`) come from a `.env` file — nothing is hardcoded
  - Kratos `SERVE_PUBLIC_BASE_URL` is `https://${DOMAIN}/` so self-service redirects land at the real domain
  - Mailslurper is kept for Kratos email delivery but its ports are NOT published to the host
  - Kratos (4433/4434), Prometheus (9090), and Loki (3100) are also not published — only VibeWarden (80/443) and Grafana (3000) are exposed
  - Grafana runs with `GF_AUTH_ANONYMOUS_ENABLED=true` and `GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer` (read-only public access); admin password from env
  - `restart: unless-stopped` on every long-running service; one-shot services (`kratos-migrate`, `seed`) keep `restart: "no"`
- Adds `examples/demo-app/.env.prod.example` documenting all required variables with inline instructions on how to generate secure values
- Extends `.gitignore` with `!.env.*.example` so example env files are tracked alongside the existing `!.env.example` rule

## Test plan

- [ ] Verify `make check` passes (all Go build/test/vet/fmt checks)
- [ ] Copy `.env.prod.example` to `.env`, set `DOMAIN` to a test subdomain pointing at a VPS, fill passwords
- [ ] Run `docker compose -f docker-compose.prod.yml up -d --build` and confirm all services reach healthy state
- [ ] Confirm Let's Encrypt certificate is issued and HTTPS works on the domain
- [ ] Confirm Grafana is accessible without login at `http://<host>:3000` with Viewer (read-only) access
- [ ] Confirm Kratos ports 4433/4434 are NOT reachable from outside the server
- [ ] Confirm `docker compose -f docker-compose.prod.yml down` stops all services cleanly