### PR TITLE
feat(#139): add deploy-demo.sh convenience script and make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # VibeWarden Makefile
 
-.PHONY: build test lint run docker-up docker-down observability-up observability-down grafana-open prometheus-open loki-open clean check setup-hooks demo demo-down
+.PHONY: build test lint run docker-up docker-down observability-up observability-down grafana-open prometheus-open loki-open clean check setup-hooks demo demo-down deploy-demo
 
 # Build variables
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -86,6 +86,16 @@ demo: ## Start the full local demo stack (https://localhost:8443, Grafana http:/
 # Stop the full local demo stack
 demo-down: ## Stop the full local demo stack
 	docker compose -f examples/demo-app/docker-compose.local-demo.yml down
+
+# Deploy the public demo to a remote VM via SSH.
+# Usage: make deploy-demo SSH=root@challenge.vibewarden.dev
+# Rollback: make deploy-demo SSH=root@challenge.vibewarden.dev ROLLBACK=--rollback
+deploy-demo: ## Deploy the public demo (SSH=<target> required; optional ROLLBACK=--rollback)
+	@if [ -z "$(SSH)" ]; then \
+		echo "error: SSH target is required. Usage: make deploy-demo SSH=root@challenge.vibewarden.dev"; \
+		exit 1; \
+	fi
+	./scripts/deploy-demo.sh $(SSH) $(ROLLBACK)
 
 # Install git hooks for local development
 setup-hooks: ## Install git hooks for local development

--- a/scripts/deploy-demo.sh
+++ b/scripts/deploy-demo.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# deploy-demo.sh — Deploy or roll back the public demo on a remote VM.
+#
+# Usage:
+#   ./scripts/deploy-demo.sh <ssh-target>            # deploy latest
+#   ./scripts/deploy-demo.sh <ssh-target> --rollback # revert to the previous image tag
+#
+# Examples:
+#   ./scripts/deploy-demo.sh root@challenge.vibewarden.dev
+#   ./scripts/deploy-demo.sh root@challenge.vibewarden.dev --rollback
+#
+# The script assumes:
+#   - The remote VM has Docker + Docker Compose v2 installed.
+#   - The demo repo is checked out at DEMO_DIR (default: ~/vibewarden).
+#   - A .env file already exists in examples/demo-app/ with production secrets.
+
+set -euo pipefail
+
+# --------------------------------------------------------------------------
+# Configuration — override via env vars if needed.
+# --------------------------------------------------------------------------
+DEMO_DIR="${DEMO_DIR:-~/vibewarden}"
+COMPOSE_FILE="examples/demo-app/docker-compose.prod.yml"
+
+# --------------------------------------------------------------------------
+# Argument parsing
+# --------------------------------------------------------------------------
+SSH_TARGET=""
+ROLLBACK=false
+
+usage() {
+    echo "Usage: $0 <ssh-target> [--rollback]"
+    echo ""
+    echo "  ssh-target   SSH destination, e.g. root@challenge.vibewarden.dev"
+    echo "  --rollback   Revert services to their previously pulled image tags"
+    echo ""
+    echo "Environment variables:"
+    echo "  DEMO_DIR     Remote path to the vibewarden checkout (default: ~/vibewarden)"
+    exit 1
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --rollback)
+            ROLLBACK=true
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            if [[ -z "$SSH_TARGET" ]]; then
+                SSH_TARGET="$arg"
+            else
+                echo "error: unexpected argument: $arg" >&2
+                usage
+            fi
+            ;;
+    esac
+done
+
+if [[ -z "$SSH_TARGET" ]]; then
+    echo "error: ssh-target is required" >&2
+    usage
+fi
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+log() {
+    echo "[deploy-demo] $*"
+}
+
+remote() {
+    # Run a command on the remote host via SSH.
+    # Pass -T to suppress the "pseudo-terminal" warning when there's no tty.
+    ssh -T "$SSH_TARGET" "$@"
+}
+
+# --------------------------------------------------------------------------
+# Rollback
+# --------------------------------------------------------------------------
+rollback() {
+    log "Rolling back to previous image tags on $SSH_TARGET ..."
+
+    remote bash -s <<EOF
+set -euo pipefail
+cd ${DEMO_DIR}/${COMPOSE_FILE%/*}
+
+# Compose file lives inside examples/demo-app/; change into that dir so
+# relative paths in the file resolve correctly.
+COMPOSE_DIR="${DEMO_DIR}/examples/demo-app"
+cd "\$COMPOSE_DIR"
+
+# Revert by tagging the previous images back and restarting.
+# We track the previous digest in a local file written during the last deploy.
+PREV_FILE=".previous-images"
+if [[ ! -f "\$PREV_FILE" ]]; then
+    echo "error: no previous-images file found — cannot roll back" >&2
+    exit 1
+fi
+
+echo "==> Stopping current stack..."
+docker compose -f docker-compose.prod.yml down --remove-orphans
+
+echo "==> Restoring previous images..."
+while IFS='=' read -r service image; do
+    [[ -z "\$service" || -z "\$image" ]] && continue
+    echo "  \$service => \$image"
+    docker tag "\$image" "\$(docker compose -f docker-compose.prod.yml config --format json | \
+        python3 -c "import sys,json; d=json.load(sys.stdin); print(d['services']['\$service']['image'])" 2>/dev/null || echo "\$image")"
+done < "\$PREV_FILE"
+
+echo "==> Starting stack with previous images..."
+docker compose -f docker-compose.prod.yml up -d --remove-orphans
+
+echo "==> Stack status after rollback:"
+docker compose -f docker-compose.prod.yml ps
+EOF
+
+    log "Rollback complete."
+}
+
+# --------------------------------------------------------------------------
+# Deploy
+# --------------------------------------------------------------------------
+deploy() {
+    log "Deploying to $SSH_TARGET ..."
+
+    remote bash -s <<EOF
+set -euo pipefail
+
+COMPOSE_DIR="${DEMO_DIR}/examples/demo-app"
+cd "\$COMPOSE_DIR"
+
+echo "==> Pulling latest code..."
+cd "${DEMO_DIR}"
+git fetch --all
+git pull --ff-only
+
+cd "\$COMPOSE_DIR"
+
+echo "==> Saving current image digests for rollback..."
+docker compose -f docker-compose.prod.yml ps --format json 2>/dev/null | \
+    python3 -c "
+import sys, json
+lines = sys.stdin.read().strip()
+if not lines:
+    sys.exit(0)
+try:
+    services = json.loads(lines)
+except json.JSONDecodeError:
+    # older Compose emits one JSON object per line
+    services = [json.loads(l) for l in lines.splitlines() if l.strip()]
+if isinstance(services, dict):
+    services = [services]
+for svc in services:
+    name = svc.get('Service', svc.get('Name', ''))
+    image = svc.get('Image', '')
+    if name and image:
+        print(f'{name}={image}')
+" > .previous-images || true
+
+echo "==> Pulling latest images..."
+docker compose -f docker-compose.prod.yml pull --quiet
+
+echo "==> Starting updated stack..."
+docker compose -f docker-compose.prod.yml up -d --remove-orphans
+
+echo "==> Stack status after deployment:"
+docker compose -f docker-compose.prod.yml ps
+EOF
+
+    log "Deployment to $SSH_TARGET complete."
+}
+
+# --------------------------------------------------------------------------
+# Main
+# --------------------------------------------------------------------------
+if [[ "$ROLLBACK" == "true" ]]; then
+    rollback
+else
+    deploy
+fi


### PR DESCRIPTION
Closes #139

## Summary

- Adds `scripts/deploy-demo.sh` — a bash script that SSHes into a remote VM and deploys the public demo stack.
- The script runs `git pull --ff-only` then `docker compose -f docker-compose.prod.yml pull` + `up -d --remove-orphans`.
- Supports a `--rollback` flag: saves the current image digests to `.previous-images` before pulling, and restores them on rollback.
- Adds a `make deploy-demo SSH=<target>` Makefile target as a thin wrapper around the script. The optional `ROLLBACK=--rollback` variable enables the rollback path.
- No new dependencies. Pure bash — works on any machine with `ssh` and `make`.

## Test plan

- [ ] `make check` passes locally (verified above).
- [ ] Manual smoke test: `./scripts/deploy-demo.sh root@challenge.vibewarden.dev` against the real VM.
- [ ] Run with `--rollback` after a deploy to confirm services revert cleanly.
- [ ] Verify `make deploy-demo SSH=root@challenge.vibewarden.dev` delegates to the script correctly.
- [ ] Confirm `make deploy-demo` without `SSH=` prints a clear error and exits non-zero.
