### PR TITLE
feat(#130): add automated backup script and recovery documentation

### DIFF
--- a/examples/demo-app/RECOVERY.md
+++ b/examples/demo-app/RECOVERY.md
@@ -1,0 +1,170 @@
+# Demo VM — Backup and Recovery
+
+This document covers how to set up daily automated backups of the Kratos
+Postgres database on the demo VM and how to restore from a backup.
+
+The backup script lives at `scripts/backup-demo.sh` in this repository.
+
+---
+
+## How backups work
+
+The script:
+
+1. Runs `pg_dump` inside the running `demo-postgres` Docker container.
+2. Compresses the dump with `gzip -9` directly into a timestamped file:
+   `kratos-backup-YYYY-MM-DD.sql.gz`.
+3. Stores the file in a configurable directory (default: `/backups`).
+4. Deletes backup files older than 7 days (configurable).
+5. Optionally rsyncs the backup directory to a Hetzner Storage Box or any
+   rsync-compatible remote, when `RSYNC_TARGET` is set.
+
+---
+
+## Setting up the daily cron job
+
+### 1. Copy the repository to the VM (already done if you used `make deploy-demo`)
+
+The repository is checked out at `~/vibewarden` on the demo VM.
+
+### 2. Create the backup directory
+
+```bash
+mkdir -p /backups
+```
+
+### 3. Test the script manually
+
+```bash
+POSTGRES_USER=kratos \
+POSTGRES_DB=kratos \
+~/vibewarden/scripts/backup-demo.sh
+```
+
+You should see output like:
+
+```
+[backup-demo] 2025-06-01T03:00:01Z Starting pg_dump of database 'kratos' from container 'demo-postgres'...
+[backup-demo] 2025-06-01T03:00:03Z Backup written: /backups/kratos-backup-2025-06-01.sql.gz (48K)
+[backup-demo] 2025-06-01T03:00:03Z Pruning backups older than 7 days...
+[backup-demo] 2025-06-01T03:00:03Z RSYNC_TARGET not set — skipping remote copy.
+[backup-demo] 2025-06-01T03:00:03Z Backup finished successfully.
+```
+
+### 4. Add the cron job
+
+Run `crontab -e` on the VM and add the line below to run backups every day at
+03:00 UTC:
+
+```crontab
+0 3 * * * POSTGRES_USER=kratos POSTGRES_DB=kratos /root/vibewarden/scripts/backup-demo.sh >> /var/log/backup-demo.log 2>&1
+```
+
+To verify the cron job is installed:
+
+```bash
+crontab -l
+```
+
+### 5. (Optional) Remote copy to Hetzner Storage Box
+
+Set `RSYNC_TARGET` to your Storage Box rsync endpoint and the cron job will
+mirror the `/backups` directory after every successful dump:
+
+```crontab
+0 3 * * * POSTGRES_USER=kratos POSTGRES_DB=kratos RSYNC_TARGET=u123456@u123456.your-storagebox.de::backups/vibewarden RSYNC_SSH_KEY=/root/.ssh/storagebox_ed25519 /root/vibewarden/scripts/backup-demo.sh >> /var/log/backup-demo.log 2>&1
+```
+
+Make sure the SSH key is pre-authorized in the Storage Box settings and that
+`ssh -i /root/.ssh/storagebox_ed25519 u123456@u123456.your-storagebox.de` works
+without a passphrase before relying on this in cron.
+
+---
+
+## Configuration reference
+
+| Environment variable   | Default                    | Description                                         |
+|------------------------|----------------------------|-----------------------------------------------------|
+| `BACKUP_DIR`           | `/backups`                 | Directory where `.sql.gz` files are written         |
+| `RETAIN_DAYS`          | `7`                        | Days to keep; older files are deleted automatically |
+| `POSTGRES_CONTAINER`   | `demo-postgres`            | Name of the running Postgres Docker container       |
+| `POSTGRES_USER`        | `kratos`                   | Postgres user passed to `pg_dump`                   |
+| `POSTGRES_DB`          | `kratos`                   | Database name to dump                               |
+| `RSYNC_TARGET`         | *(empty — skip rsync)*     | rsync destination for remote offsite copy           |
+| `RSYNC_SSH_KEY`        | `~/.ssh/id_ed25519`        | SSH key used by rsync (only when target is set)     |
+
+---
+
+## Restoring from a backup
+
+### 1. Identify the backup to restore
+
+```bash
+ls -lh /backups/
+# kratos-backup-2025-06-01.sql.gz
+# kratos-backup-2025-05-31.sql.gz
+# ...
+```
+
+### 2. Stop services that write to the database
+
+Stop Kratos (and the seed service if it ever restarts) so no writes occur
+during the restore:
+
+```bash
+cd ~/vibewarden/examples/demo-app
+docker compose -f docker-compose.prod.yml stop kratos kratos-migrate seed
+```
+
+### 3. Drop and recreate the database
+
+Connect to the running Postgres container and reset the database:
+
+```bash
+docker exec -it demo-postgres psql -U kratos -c "DROP DATABASE IF EXISTS kratos;"
+docker exec -it demo-postgres psql -U kratos -c "CREATE DATABASE kratos;"
+```
+
+### 4. Restore the dump
+
+Decompress and pipe into `psql` inside the container:
+
+```bash
+gunzip -c /backups/kratos-backup-2025-06-01.sql.gz \
+  | docker exec -i demo-postgres psql -U kratos kratos
+```
+
+### 5. Restart the stack
+
+```bash
+cd ~/vibewarden/examples/demo-app
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Wait for the `demo-kratos` container to become healthy, then verify the
+application is responding normally.
+
+### 6. Verify
+
+```bash
+docker compose -f docker-compose.prod.yml ps
+curl -s https://challenge.vibewarden.dev/_vibewarden/health | python3 -m json.tool
+```
+
+---
+
+## Log file rotation (optional)
+
+If you redirect cron output to `/var/log/backup-demo.log`, set up logrotate to
+keep the log manageable:
+
+```
+# /etc/logrotate.d/backup-demo
+/var/log/backup-demo.log {
+    weekly
+    rotate 4
+    compress
+    missingok
+    notifempty
+}
+```

--- a/scripts/backup-demo.sh
+++ b/scripts/backup-demo.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# backup-demo.sh — Daily backup of the Kratos Postgres database on the demo VM.
+#
+# Usage:
+#   ./scripts/backup-demo.sh
+#
+# Configuration (environment variables):
+#   BACKUP_DIR          Directory where backup files are stored.
+#                       Default: /backups
+#   RETAIN_DAYS         Number of daily backups to keep before pruning.
+#                       Default: 7
+#   POSTGRES_CONTAINER  Name of the running Postgres Docker container.
+#                       Default: demo-postgres
+#   POSTGRES_USER       Postgres superuser for pg_dump.
+#                       Default: kratos
+#   POSTGRES_DB         Database name to dump.
+#                       Default: kratos
+#   RSYNC_TARGET        Optional rsync destination for remote copy, e.g.
+#                       u123456@u123456.your-storagebox.de::backups/vibewarden
+#                       When empty, the rsync step is skipped.
+#   RSYNC_SSH_KEY       Path to the SSH private key used by rsync.
+#                       Only consulted when RSYNC_TARGET is set.
+#                       Default: ~/.ssh/id_ed25519
+#
+# The script is designed to be run as a daily cron job. See
+# examples/demo-app/RECOVERY.md for full setup instructions.
+
+set -euo pipefail
+
+# --------------------------------------------------------------------------
+# Configuration
+# --------------------------------------------------------------------------
+BACKUP_DIR="${BACKUP_DIR:-/backups}"
+RETAIN_DAYS="${RETAIN_DAYS:-7}"
+POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-demo-postgres}"
+POSTGRES_USER="${POSTGRES_USER:-kratos}"
+POSTGRES_DB="${POSTGRES_DB:-kratos}"
+RSYNC_TARGET="${RSYNC_TARGET:-}"
+RSYNC_SSH_KEY="${RSYNC_SSH_KEY:-${HOME}/.ssh/id_ed25519}"
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+log() {
+    echo "[backup-demo] $(date -u '+%Y-%m-%dT%H:%M:%SZ') $*"
+}
+
+die() {
+    log "ERROR: $*" >&2
+    exit 1
+}
+
+# --------------------------------------------------------------------------
+# Validate environment
+# --------------------------------------------------------------------------
+command -v docker >/dev/null 2>&1 || die "docker not found in PATH"
+
+if ! docker inspect --type container "$POSTGRES_CONTAINER" >/dev/null 2>&1; then
+    die "container '$POSTGRES_CONTAINER' is not running"
+fi
+
+# --------------------------------------------------------------------------
+# Prepare backup directory
+# --------------------------------------------------------------------------
+mkdir -p "$BACKUP_DIR"
+
+TIMESTAMP="$(date -u '+%Y-%m-%d')"
+BACKUP_FILE="${BACKUP_DIR}/kratos-backup-${TIMESTAMP}.sql.gz"
+
+# --------------------------------------------------------------------------
+# Run pg_dump inside the Postgres container, compress on the fly
+# --------------------------------------------------------------------------
+log "Starting pg_dump of database '$POSTGRES_DB' from container '$POSTGRES_CONTAINER'..."
+
+docker exec "$POSTGRES_CONTAINER" \
+    pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" \
+    | gzip -9 > "$BACKUP_FILE"
+
+BACKUP_SIZE="$(du -sh "$BACKUP_FILE" | cut -f1)"
+log "Backup written: $BACKUP_FILE ($BACKUP_SIZE)"
+
+# --------------------------------------------------------------------------
+# Prune old backups (keep last RETAIN_DAYS daily files)
+# --------------------------------------------------------------------------
+log "Pruning backups older than ${RETAIN_DAYS} days..."
+find "$BACKUP_DIR" -maxdepth 1 -name 'kratos-backup-*.sql.gz' \
+    -mtime "+${RETAIN_DAYS}" -delete -print \
+    | while read -r pruned; do
+        log "Deleted old backup: $pruned"
+    done
+
+# --------------------------------------------------------------------------
+# Optional: rsync to remote storage (Hetzner Storage Box or any rsync target)
+# --------------------------------------------------------------------------
+if [[ -n "$RSYNC_TARGET" ]]; then
+    log "Rsyncing $BACKUP_DIR to $RSYNC_TARGET ..."
+
+    SSH_OPTS="-o StrictHostKeyChecking=no -o BatchMode=yes"
+    if [[ -f "$RSYNC_SSH_KEY" ]]; then
+        SSH_OPTS="$SSH_OPTS -i $RSYNC_SSH_KEY"
+    fi
+
+    rsync -az --delete \
+        -e "ssh $SSH_OPTS" \
+        "${BACKUP_DIR}/" \
+        "$RSYNC_TARGET"
+
+    log "Rsync complete."
+else
+    log "RSYNC_TARGET not set — skipping remote copy."
+fi
+
+log "Backup finished successfully."


### PR DESCRIPTION
Closes #130

## Summary

- Adds `scripts/backup-demo.sh` — a shell script that runs `pg_dump` inside the `demo-postgres` container, compresses the output with `gzip -9` to a timestamped file (`kratos-backup-YYYY-MM-DD.sql.gz`), auto-prunes to the last 7 daily backups, and optionally rsyncs the backup directory to a Hetzner Storage Box (or any rsync target) when `RSYNC_TARGET` is set.
- Adds `examples/demo-app/RECOVERY.md` — documents how to install the daily cron job, all configuration environment variables, and the full step-by-step restore procedure.

## Test plan

- [ ] SSH into the demo VM, run `POSTGRES_USER=kratos POSTGRES_DB=kratos ~/vibewarden/scripts/backup-demo.sh` and confirm a `.sql.gz` file is written to `/backups`.
- [ ] Run the script a second time on the same day; verify the previous file is overwritten (same timestamp).
- [ ] Set `RETAIN_DAYS=0` and re-run; verify older files are pruned.
- [ ] Add the crontab entry from `RECOVERY.md`; confirm the next 03:00 UTC run produces a new log entry in `/var/log/backup-demo.log`.
- [ ] Follow the restore steps in `RECOVERY.md` against a test database to verify the procedure works end-to-end.

Generated with Claude Code
