### PR TITLE
fix(#153): remove deprecated version field from docker-compose files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,6 @@
 #   Postgres password and DSN are hard-coded to simple dev values — never use
 #   these credentials outside of a local dev environment.
 
-version: "3.8"
-
 services:
   # --------------------------------------------------------------------------
   # Postgres — persistent storage for Ory Kratos

--- a/examples/demo-app/docker-compose.local-demo.yml
+++ b/examples/demo-app/docker-compose.local-demo.yml
@@ -26,8 +26,6 @@
 # Secrets: all credentials are hard-coded to simple demo values.
 # Never use these outside a local demo environment.
 
-version: "3.8"
-
 services:
   # --------------------------------------------------------------------------
   # Postgres — persistent storage for Ory Kratos

--- a/examples/demo-app/docker-compose.prod.yml
+++ b/examples/demo-app/docker-compose.prod.yml
@@ -27,8 +27,6 @@
 #   # Full wipe including volumes:
 #   docker compose -f docker-compose.prod.yml down -v
 
-version: "3.8"
-
 services:
   # --------------------------------------------------------------------------
   # Postgres — persistent storage for Ory Kratos

--- a/examples/demo-app/docker-compose.yml
+++ b/examples/demo-app/docker-compose.yml
@@ -20,8 +20,6 @@
 # Secrets: all credentials are hard-coded to simple demo values.
 # Never use these outside a local demo environment.
 
-version: "3.8"
-
 services:
   # --------------------------------------------------------------------------
   # Postgres — persistent storage for Ory Kratos


### PR DESCRIPTION
Closes #153

## Summary

- Removed the top-level `version: "3.8"` field from all four Docker Compose files:
  - `docker-compose.yml`
  - `examples/demo-app/docker-compose.yml`
  - `examples/demo-app/docker-compose.local-demo.yml`
  - `examples/demo-app/docker-compose.prod.yml`

Modern Docker Compose (v2+) does not require this field and emits a deprecation warning when it is present. Removing it silences the warning and aligns with current best practices.

## Test plan

- `make check` passes (all formatting, vet, build, and test targets green)
- The field no longer appears in any compose file (`grep -r "^version:" **/*.yml` returns nothing)