### PR TITLE
feat(#157): plugin registry and lifecycle

### DIFF
--- a/internal/domain/plugin/names.go
+++ b/internal/domain/plugin/names.go
@@ -1,0 +1,32 @@
+// Package plugin contains domain types for the VibeWarden plugin system.
+package plugin
+
+import "errors"
+
+// Name is a value object representing a unique plugin identifier.
+// It is immutable and equality is determined by value.
+type Name struct {
+	value string
+}
+
+// NewName creates a validated Name value object.
+// Returns an error if the name is empty.
+func NewName(name string) (Name, error) {
+	if name == "" {
+		return Name{}, errors.New("plugin name cannot be empty")
+	}
+	return Name{value: name}, nil
+}
+
+// String returns the string representation of the plugin name.
+func (n Name) String() string { return n.value }
+
+// Well-known plugin name constants. These are the canonical identifiers
+// used in vibewarden.yaml under the plugins: key.
+const (
+	NameTLS            = "tls"
+	NameUserManagement = "user-management"
+	NameRateLimiting   = "rate-limiting"
+	NameGrafana        = "grafana"
+	NameFleet          = "fleet"
+)

--- a/internal/domain/plugin/names_test.go
+++ b/internal/domain/plugin/names_test.go
@@ -1,0 +1,75 @@
+package plugin_test
+
+import (
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/domain/plugin"
+)
+
+func TestNewName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "valid name",
+			input:   "tls",
+			want:    "tls",
+			wantErr: false,
+		},
+		{
+			name:    "valid hyphenated name",
+			input:   "rate-limiting",
+			want:    "rate-limiting",
+			wantErr: false,
+		},
+		{
+			name:    "empty name returns error",
+			input:   "",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := plugin.NewName(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewName(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got.String() != tt.want {
+				t.Errorf("NewName(%q).String() = %q, want %q", tt.input, got.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestName_String(t *testing.T) {
+	n, err := plugin.NewName("fleet")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n.String() != "fleet" {
+		t.Errorf("String() = %q, want %q", n.String(), "fleet")
+	}
+}
+
+func TestNameConstants(t *testing.T) {
+	// Ensure the predefined constants are non-empty strings — they are used
+	// as map keys and must never be blank.
+	constants := []string{
+		plugin.NameTLS,
+		plugin.NameUserManagement,
+		plugin.NameRateLimiting,
+		plugin.NameGrafana,
+		plugin.NameFleet,
+	}
+	for _, c := range constants {
+		if c == "" {
+			t.Errorf("plugin name constant must not be empty")
+		}
+	}
+}

--- a/internal/domain/plugin/types.go
+++ b/internal/domain/plugin/types.go
@@ -1,0 +1,14 @@
+package plugin
+
+// PluginConfig holds the configuration block for a single plugin as loaded
+// from vibewarden.yaml under plugins.<name>. It is intentionally generic so
+// that each plugin can define its own settings structure and unmarshal into it.
+type PluginConfig struct {
+	// Enabled controls whether the plugin is active. Disabled plugins are
+	// never initialised or started.
+	Enabled bool `mapstructure:"enabled"`
+
+	// Settings holds the plugin-specific configuration keys as a free-form
+	// map. Each plugin is responsible for interpreting these values.
+	Settings map[string]any `mapstructure:",remain"`
+}

--- a/internal/plugins/registry.go
+++ b/internal/plugins/registry.go
@@ -1,0 +1,118 @@
+// Package plugins provides the plugin registry and lifecycle management for
+// VibeWarden. It initialises, starts, stops, and health-checks all registered
+// plugins in the correct order.
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// Registry manages the lifecycle of all VibeWarden plugins.
+// Plugins are registered at startup and then driven through Init → Start → Stop.
+// Stop is always called in the reverse of registration order so that
+// dependent plugins shut down before their dependencies.
+type Registry struct {
+	plugins []ports.Plugin
+	logger  *slog.Logger
+}
+
+// NewRegistry creates a Registry that uses logger for lifecycle events.
+func NewRegistry(logger *slog.Logger) *Registry {
+	return &Registry{logger: logger}
+}
+
+// Register adds p to the registry. It must be called before InitAll.
+// Plugins are started and stopped in registration order / reverse order.
+func (r *Registry) Register(p ports.Plugin) {
+	r.plugins = append(r.plugins, p)
+}
+
+// Plugins returns a shallow copy of the registered plugin slice.
+func (r *Registry) Plugins() []ports.Plugin {
+	result := make([]ports.Plugin, len(r.plugins))
+	copy(result, r.plugins)
+	return result
+}
+
+// CaddyContributors returns every registered plugin that implements
+// ports.CaddyContributor.
+func (r *Registry) CaddyContributors() []ports.CaddyContributor {
+	var contributors []ports.CaddyContributor
+	for _, p := range r.plugins {
+		if c, ok := p.(ports.CaddyContributor); ok {
+			contributors = append(contributors, c)
+		}
+	}
+	return contributors
+}
+
+// InitAll calls Init on every registered plugin in registration order.
+// If any plugin's Init returns an error the function returns immediately
+// with that error; subsequent plugins are not initialised.
+func (r *Registry) InitAll(ctx context.Context) error {
+	for _, p := range r.plugins {
+		r.logger.InfoContext(ctx, "initialising plugin", slog.String("plugin", p.Name()))
+		if err := p.Init(ctx); err != nil {
+			return fmt.Errorf("init plugin %q: %w", p.Name(), err)
+		}
+	}
+	return nil
+}
+
+// StartAll calls Start on every registered plugin in registration order.
+// If any plugin's Start returns an error the function returns immediately
+// with that error; subsequent plugins are not started.
+func (r *Registry) StartAll(ctx context.Context) error {
+	for _, p := range r.plugins {
+		r.logger.InfoContext(ctx, "starting plugin", slog.String("plugin", p.Name()))
+		if err := p.Start(ctx); err != nil {
+			return fmt.Errorf("start plugin %q: %w", p.Name(), err)
+		}
+	}
+	return nil
+}
+
+// StopAll calls Stop on every registered plugin in reverse registration order.
+// It collects all errors and returns them combined so that a single failure
+// does not prevent the remaining plugins from being stopped.
+func (r *Registry) StopAll(ctx context.Context) error {
+	var errs []error
+	for i := len(r.plugins) - 1; i >= 0; i-- {
+		p := r.plugins[i]
+		r.logger.InfoContext(ctx, "stopping plugin", slog.String("plugin", p.Name()))
+		if err := p.Stop(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("stop plugin %q: %w", p.Name(), err))
+		}
+	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	if len(errs) > 1 {
+		return fmt.Errorf("multiple stop errors: %w", joinErrors(errs))
+	}
+	return nil
+}
+
+// HealthAll returns a map from plugin name to its current HealthStatus.
+func (r *Registry) HealthAll() map[string]ports.HealthStatus {
+	result := make(map[string]ports.HealthStatus, len(r.plugins))
+	for _, p := range r.plugins {
+		result[p.Name()] = p.Health()
+	}
+	return result
+}
+
+// joinErrors combines multiple errors into a single error whose message is the
+// concatenation of each error's message. Using a simple join keeps the
+// implementation free of non-stdlib dependencies.
+func joinErrors(errs []error) error {
+	msg := errs[0].Error()
+	for _, e := range errs[1:] {
+		msg += "; " + e.Error()
+	}
+	return fmt.Errorf("%s", msg)
+}

--- a/internal/plugins/registry_test.go
+++ b/internal/plugins/registry_test.go
@@ -1,0 +1,334 @@
+package plugins_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/plugins"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ----------------------------------------------------------------------------
+// Fakes
+// ----------------------------------------------------------------------------
+
+// fakePlugin records every lifecycle call so tests can assert on order and
+// error propagation without any real side effects.
+type fakePlugin struct {
+	name      string
+	initErr   error
+	startErr  error
+	stopErr   error
+	health    ports.HealthStatus
+	callOrder *[]string // shared slice so callers can observe cross-plugin order
+}
+
+func (f *fakePlugin) Name() string { return f.name }
+
+func (f *fakePlugin) Init(_ context.Context) error {
+	*f.callOrder = append(*f.callOrder, f.name+":init")
+	return f.initErr
+}
+
+func (f *fakePlugin) Start(_ context.Context) error {
+	*f.callOrder = append(*f.callOrder, f.name+":start")
+	return f.startErr
+}
+
+func (f *fakePlugin) Stop(_ context.Context) error {
+	*f.callOrder = append(*f.callOrder, f.name+":stop")
+	return f.stopErr
+}
+
+func (f *fakePlugin) Health() ports.HealthStatus { return f.health }
+
+// fakeCaddyPlugin additionally implements CaddyContributor.
+type fakeCaddyPlugin struct {
+	fakePlugin
+	routes   []ports.CaddyRoute
+	handlers []ports.CaddyHandler
+}
+
+func (f *fakeCaddyPlugin) ContributeCaddyRoutes() []ports.CaddyRoute     { return f.routes }
+func (f *fakeCaddyPlugin) ContributeCaddyHandlers() []ports.CaddyHandler { return f.handlers }
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(nil_writer{}, nil))
+}
+
+// nil_writer discards all log output so tests stay quiet.
+type nil_writer struct{}
+
+func (nil_writer) Write(p []byte) (int, error) { return len(p), nil }
+
+func newOrder() *[]string { s := []string{}; return &s }
+
+// ----------------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------------
+
+func TestRegistry_Register_And_Plugins(t *testing.T) {
+	order := newOrder()
+	r := plugins.NewRegistry(discardLogger())
+
+	p1 := &fakePlugin{name: "alpha", callOrder: order}
+	p2 := &fakePlugin{name: "beta", callOrder: order}
+
+	r.Register(p1)
+	r.Register(p2)
+
+	got := r.Plugins()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 plugins, got %d", len(got))
+	}
+	if got[0].Name() != "alpha" || got[1].Name() != "beta" {
+		t.Errorf("unexpected plugin order: %v", got)
+	}
+}
+
+func TestRegistry_Plugins_ReturnsCopy(t *testing.T) {
+	order := newOrder()
+	r := plugins.NewRegistry(discardLogger())
+	r.Register(&fakePlugin{name: "alpha", callOrder: order})
+
+	got := r.Plugins()
+	got[0] = &fakePlugin{name: "mutated", callOrder: order}
+
+	// Internal slice must not be mutated.
+	if r.Plugins()[0].Name() != "alpha" {
+		t.Error("Plugins() should return a copy, not a reference to the internal slice")
+	}
+}
+
+func TestRegistry_InitAll_Order(t *testing.T) {
+	order := newOrder()
+	r := plugins.NewRegistry(discardLogger())
+
+	r.Register(&fakePlugin{name: "alpha", callOrder: order})
+	r.Register(&fakePlugin{name: "beta", callOrder: order})
+
+	if err := r.InitAll(context.Background()); err != nil {
+		t.Fatalf("InitAll: unexpected error: %v", err)
+	}
+
+	want := []string{"alpha:init", "beta:init"}
+	assertOrder(t, *order, want)
+}
+
+func TestRegistry_StartAll_Order(t *testing.T) {
+	order := newOrder()
+	r := plugins.NewRegistry(discardLogger())
+
+	r.Register(&fakePlugin{name: "alpha", callOrder: order})
+	r.Register(&fakePlugin{name: "beta", callOrder: order})
+
+	if err := r.StartAll(context.Background()); err != nil {
+		t.Fatalf("StartAll: unexpected error: %v", err)
+	}
+
+	want := []string{"alpha:start", "beta:start"}
+	assertOrder(t, *order, want)
+}
+
+func TestRegistry_StopAll_ReverseOrder(t *testing.T) {
+	order := newOrder()
+	r := plugins.NewRegistry(discardLogger())
+
+	r.Register(&fakePlugin{name: "alpha", callOrder: order})
+	r.Register(&fakePlugin{name: "beta", callOrder: order})
+	r.Register(&fakePlugin{name: "gamma", callOrder: order})
+
+	if err := r.StopAll(context.Background()); err != nil {
+		t.Fatalf("StopAll: unexpected error: %v", err)
+	}
+
+	want := []string{"gamma:stop", "beta:stop", "alpha:stop"}
+	assertOrder(t, *order, want)
+}
+
+func TestRegistry_InitAll_StopsOnFirstError(t *testing.T) {
+	order := newOrder()
+	boom := errors.New("init boom")
+	r := plugins.NewRegistry(discardLogger())
+
+	r.Register(&fakePlugin{name: "alpha", callOrder: order})
+	r.Register(&fakePlugin{name: "beta", initErr: boom, callOrder: order})
+	r.Register(&fakePlugin{name: "gamma", callOrder: order})
+
+	err := r.InitAll(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("expected wrapped boom error, got: %v", err)
+	}
+	// gamma must not have been initialised
+	for _, call := range *order {
+		if call == "gamma:init" {
+			t.Error("gamma should not have been initialised after beta failed")
+		}
+	}
+}
+
+func TestRegistry_StartAll_StopsOnFirstError(t *testing.T) {
+	order := newOrder()
+	boom := errors.New("start boom")
+	r := plugins.NewRegistry(discardLogger())
+
+	r.Register(&fakePlugin{name: "alpha", callOrder: order})
+	r.Register(&fakePlugin{name: "beta", startErr: boom, callOrder: order})
+	r.Register(&fakePlugin{name: "gamma", callOrder: order})
+
+	err := r.StartAll(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("expected wrapped boom error, got: %v", err)
+	}
+	for _, call := range *order {
+		if call == "gamma:start" {
+			t.Error("gamma should not have been started after beta failed")
+		}
+	}
+}
+
+func TestRegistry_StopAll_ContinuesOnError(t *testing.T) {
+	order := newOrder()
+	boom := errors.New("stop boom")
+	r := plugins.NewRegistry(discardLogger())
+
+	r.Register(&fakePlugin{name: "alpha", callOrder: order})
+	r.Register(&fakePlugin{name: "beta", stopErr: boom, callOrder: order})
+	r.Register(&fakePlugin{name: "gamma", callOrder: order})
+
+	err := r.StopAll(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("expected wrapped boom error, got: %v", err)
+	}
+
+	// All three must have been stopped despite beta's error.
+	want := []string{"gamma:stop", "beta:stop", "alpha:stop"}
+	assertOrder(t, *order, want)
+}
+
+func TestRegistry_StopAll_MultipleErrors(t *testing.T) {
+	order := newOrder()
+	boom1 := errors.New("boom1")
+	boom2 := errors.New("boom2")
+	r := plugins.NewRegistry(discardLogger())
+
+	r.Register(&fakePlugin{name: "alpha", stopErr: boom1, callOrder: order})
+	r.Register(&fakePlugin{name: "beta", stopErr: boom2, callOrder: order})
+
+	err := r.StopAll(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// Both original errors should be present somewhere in the chain.
+	// errors.Is won't find them because joinErrors uses fmt.Errorf without %w
+	// for the multi-error case — check the message instead.
+	msg := err.Error()
+	if msg == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func TestRegistry_HealthAll(t *testing.T) {
+	order := newOrder()
+	r := plugins.NewRegistry(discardLogger())
+
+	r.Register(&fakePlugin{name: "alpha", callOrder: order, health: ports.HealthStatus{Healthy: true, Message: "ok"}})
+	r.Register(&fakePlugin{name: "beta", callOrder: order, health: ports.HealthStatus{Healthy: false, Message: "degraded"}})
+
+	got := r.HealthAll()
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 health entries, got %d", len(got))
+	}
+	if !got["alpha"].Healthy {
+		t.Error("alpha should be healthy")
+	}
+	if got["beta"].Healthy {
+		t.Error("beta should be unhealthy")
+	}
+	if got["beta"].Message != "degraded" {
+		t.Errorf("beta message: want %q, got %q", "degraded", got["beta"].Message)
+	}
+}
+
+func TestRegistry_CaddyContributors(t *testing.T) {
+	order := newOrder()
+	r := plugins.NewRegistry(discardLogger())
+
+	plain := &fakePlugin{name: "plain", callOrder: order}
+	caddy := &fakeCaddyPlugin{
+		fakePlugin: fakePlugin{name: "caddy-plugin", callOrder: order},
+		routes:     []ports.CaddyRoute{{MatchPath: "/api", Priority: 10}},
+	}
+
+	r.Register(plain)
+	r.Register(caddy)
+
+	contributors := r.CaddyContributors()
+	if len(contributors) != 1 {
+		t.Fatalf("expected 1 contributor, got %d", len(contributors))
+	}
+	if contributors[0] != caddy {
+		t.Error("expected the caddy plugin to be the contributor")
+	}
+}
+
+func TestRegistry_CaddyContributors_EmptyWhenNone(t *testing.T) {
+	order := newOrder()
+	r := plugins.NewRegistry(discardLogger())
+	r.Register(&fakePlugin{name: "plain", callOrder: order})
+
+	contributors := r.CaddyContributors()
+	if len(contributors) != 0 {
+		t.Errorf("expected 0 contributors, got %d", len(contributors))
+	}
+}
+
+func TestRegistry_EmptyRegistry(t *testing.T) {
+	r := plugins.NewRegistry(discardLogger())
+	ctx := context.Background()
+
+	if err := r.InitAll(ctx); err != nil {
+		t.Errorf("InitAll on empty registry: %v", err)
+	}
+	if err := r.StartAll(ctx); err != nil {
+		t.Errorf("StartAll on empty registry: %v", err)
+	}
+	if err := r.StopAll(ctx); err != nil {
+		t.Errorf("StopAll on empty registry: %v", err)
+	}
+	if h := r.HealthAll(); len(h) != 0 {
+		t.Errorf("HealthAll on empty registry should return empty map, got %v", h)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+func assertOrder(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("call order length: want %d, got %d\n  want: %v\n  got:  %v", len(want), len(got), want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("call order[%d]: want %q, got %q", i, want[i], got[i])
+		}
+	}
+}

--- a/internal/ports/plugin.go
+++ b/internal/ports/plugin.go
@@ -1,0 +1,87 @@
+package ports
+
+import "context"
+
+// HealthStatus reports the current health of a plugin.
+type HealthStatus struct {
+	// Healthy is true when the plugin is operating normally.
+	Healthy bool
+
+	// Message provides a human-readable explanation of the current status.
+	// It should describe the problem when Healthy is false.
+	Message string
+}
+
+// Plugin is the core interface that all VibeWarden plugins must implement.
+// The lifecycle is: Init → Start → (running) → Stop.
+// A plugin is only started when its config has Enabled: true.
+type Plugin interface {
+	// Name returns the canonical plugin identifier (e.g. "tls", "rate-limiting").
+	// Must match the key used in vibewarden.yaml under plugins:.
+	Name() string
+
+	// Init prepares the plugin using its configuration. It is called once
+	// before Start and must not block. Validate config and allocate resources here.
+	Init(ctx context.Context) error
+
+	// Start begins the plugin's background work. It must return promptly;
+	// long-running work must be launched in a goroutine. The provided context
+	// is for the startup phase only — use a stored context or channel for
+	// ongoing work.
+	Start(ctx context.Context) error
+
+	// Stop gracefully shuts down the plugin. It must honour the context
+	// deadline and return promptly when the context is cancelled.
+	Stop(ctx context.Context) error
+
+	// Health returns the current health status of the plugin. It must be
+	// safe to call concurrently and must not block.
+	Health() HealthStatus
+}
+
+// CaddyRoute represents a single route entry to inject into the Caddy config.
+// Lower Priority values are placed earlier in the route chain.
+type CaddyRoute struct {
+	// MatchPath is the URL path prefix or pattern for this route.
+	MatchPath string
+
+	// Handler is the raw Caddy handler JSON object for this route.
+	Handler map[string]any
+
+	// Priority controls ordering. Lower numbers appear first. Use multiples
+	// of 10 (10, 20, 30…) so other plugins can insert between existing entries.
+	Priority int
+}
+
+// CaddyHandler represents an additional handler to append to the catch-all
+// route's handler chain (e.g. middleware applied to every request).
+type CaddyHandler struct {
+	// Handler is the raw Caddy handler JSON object.
+	Handler map[string]any
+
+	// Priority controls ordering within the catch-all handler chain.
+	// Lower numbers run first.
+	Priority int
+}
+
+// CaddyContributor is an optional interface implemented by plugins that need
+// to inject routes or handlers into the Caddy configuration. The registry
+// collects contributions from all enabled plugins before applying the config.
+type CaddyContributor interface {
+	// ContributeCaddyRoutes returns the list of routes this plugin adds to
+	// the Caddy server block. Called after Init and before Start.
+	ContributeCaddyRoutes() []CaddyRoute
+
+	// ContributeCaddyHandlers returns the list of handlers this plugin adds
+	// to the catch-all route. Called after Init and before Start.
+	ContributeCaddyHandlers() []CaddyHandler
+}
+
+// InternalServerPlugin is an optional interface implemented by plugins that
+// expose an internal HTTP server (e.g. an admin API or metrics endpoint).
+// Caddy reverse-proxies external requests to InternalAddr.
+type InternalServerPlugin interface {
+	// InternalAddr returns the host:port of the plugin's internal HTTP server
+	// (e.g. "127.0.0.1:9092"). The address must be stable after Init returns.
+	InternalAddr() string
+}


### PR DESCRIPTION
Closes #157

## Summary

- `internal/ports/plugin.go` — `Plugin` interface (Init/Start/Stop/Health lifecycle), `HealthStatus` value type, `CaddyContributor` optional interface (ContributeCaddyRoutes / ContributeCaddyHandlers), `InternalServerPlugin` optional interface, `CaddyRoute` and `CaddyHandler` types
- `internal/domain/plugin/names.go` — `Name` value object with constructor validation, well-known plugin name constants (tls, user-management, rate-limiting, grafana, fleet)
- `internal/domain/plugin/types.go` — `PluginConfig` domain type (Enabled + free-form Settings map)
- `internal/plugins/registry.go` — `Registry` with Register, InitAll, StartAll, StopAll (reverse order, error accumulation), HealthAll, Plugins (copy), CaddyContributors
- `internal/plugins/registry_test.go` — 13 table-driven / behaviour tests covering lifecycle ordering, error propagation, reverse stop, CaddyContributor filtering, empty registry

No existing code was modified. No new dependencies were added.

## Test plan

- `go test ./internal/domain/plugin/... ./internal/plugins/...` — all 16 tests pass
- `go test -race ./...` — full suite green
- `make check` — formatting, vet, build, tests, demo-app all pass