### PR TITLE
feat(#161): implement security-headers plugin

### DIFF
--- a/internal/plugins/securityheaders/config.go
+++ b/internal/plugins/securityheaders/config.go
@@ -1,0 +1,55 @@
+// Package securityheaders implements the VibeWarden security-headers plugin.
+//
+// It injects security-related HTTP response headers (HSTS, X-Frame-Options,
+// Content-Security-Policy, etc.) into every response via the Caddy headers
+// handler. HSTS is only included when the TLS plugin is also enabled so that
+// the header is never sent over plain HTTP connections.
+package securityheaders
+
+// Config holds all settings for the security-headers plugin.
+// It maps to the plugins.security-headers section of vibewarden.yaml.
+type Config struct {
+	// Enabled toggles the security-headers plugin.
+	Enabled bool
+
+	// HSTSMaxAge is the Strict-Transport-Security max-age directive value in
+	// seconds. A value of 0 disables HSTS even when TLS is enabled.
+	// Default: 31536000 (1 year).
+	HSTSMaxAge int
+
+	// HSTSIncludeSubDomains appends the includeSubDomains directive to the
+	// Strict-Transport-Security header.
+	// Default: true.
+	HSTSIncludeSubDomains bool
+
+	// HSTSPreload appends the preload directive to the
+	// Strict-Transport-Security header. Requires manual submission to the HSTS
+	// preload list and should only be set after careful consideration.
+	// Default: false.
+	HSTSPreload bool
+
+	// ContentTypeNosniff, when true, sets the X-Content-Type-Options response
+	// header to "nosniff".
+	// Default: true.
+	ContentTypeNosniff bool
+
+	// FrameOption sets the X-Frame-Options response header value.
+	// Valid values: "DENY", "SAMEORIGIN", or "" (disabled).
+	// Default: "DENY".
+	FrameOption string
+
+	// ContentSecurityPolicy sets the Content-Security-Policy response header
+	// value. An empty string disables the header.
+	// Default: "default-src 'self'".
+	ContentSecurityPolicy string
+
+	// ReferrerPolicy sets the Referrer-Policy response header value.
+	// An empty string disables the header.
+	// Default: "strict-origin-when-cross-origin".
+	ReferrerPolicy string
+
+	// PermissionsPolicy sets the Permissions-Policy response header value.
+	// An empty string disables the header.
+	// Default: "".
+	PermissionsPolicy string
+}

--- a/internal/plugins/securityheaders/plugin.go
+++ b/internal/plugins/securityheaders/plugin.go
@@ -1,0 +1,173 @@
+package securityheaders
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// Plugin is the security-headers plugin for VibeWarden.
+// It implements ports.Plugin and ports.CaddyContributor.
+//
+// On every HTTP response the plugin injects the following headers (all
+// individually toggleable via Config):
+//   - Strict-Transport-Security (only when tlsEnabled is true)
+//   - X-Content-Type-Options
+//   - X-Frame-Options
+//   - Content-Security-Policy
+//   - Referrer-Policy
+//   - Permissions-Policy
+//
+// Start and Stop are no-ops; the plugin is fully stateless. Health reports
+// whether the plugin is enabled.
+type Plugin struct {
+	cfg        Config
+	tlsEnabled bool
+	logger     *slog.Logger
+}
+
+// New creates a new security-headers Plugin.
+// tlsEnabled must be true for the HSTS header to be included in contributions;
+// HSTS must not be sent over plain HTTP.
+func New(cfg Config, tlsEnabled bool, logger *slog.Logger) *Plugin {
+	return &Plugin{cfg: cfg, tlsEnabled: tlsEnabled, logger: logger}
+}
+
+// Name returns the canonical plugin identifier "security-headers".
+// This must match the key used under plugins: in vibewarden.yaml.
+func (p *Plugin) Name() string { return "security-headers" }
+
+// Priority returns the plugin's initialisation priority.
+// Security headers are assigned priority 20 so they run after TLS (10) but
+// before other middleware.
+func (p *Plugin) Priority() int { return 20 }
+
+// Init validates the plugin configuration. It returns an error if
+// FrameOption contains an unsupported value.
+// Init must be called before ContributeCaddyHandlers.
+func (p *Plugin) Init(_ context.Context) error {
+	if !p.cfg.Enabled {
+		return nil
+	}
+	if err := validateConfig(p.cfg); err != nil {
+		return fmt.Errorf("security-headers plugin init: %w", err)
+	}
+	p.logger.Info("security-headers plugin initialised",
+		slog.Bool("hsts", p.cfg.HSTSMaxAge > 0),
+		slog.Bool("tls_enabled", p.tlsEnabled),
+	)
+	return nil
+}
+
+// Start is a no-op for the security-headers plugin.
+// Headers are injected at request time by the Caddy handler contributed via
+// ContributeCaddyHandlers; no background goroutine is required.
+func (p *Plugin) Start(_ context.Context) error { return nil }
+
+// Stop is a no-op for the security-headers plugin.
+func (p *Plugin) Stop(_ context.Context) error { return nil }
+
+// Health returns the current health status of the security-headers plugin.
+// The plugin is always healthy; it reports whether it is enabled or disabled.
+func (p *Plugin) Health() ports.HealthStatus {
+	if !p.cfg.Enabled {
+		return ports.HealthStatus{
+			Healthy: true,
+			Message: "security-headers disabled",
+		}
+	}
+	return ports.HealthStatus{
+		Healthy: true,
+		Message: "security-headers configured",
+	}
+}
+
+// ContributeCaddyRoutes returns nil.
+// The security-headers plugin does not add named routes; it contributes a
+// catch-all handler via ContributeCaddyHandlers.
+func (p *Plugin) ContributeCaddyRoutes() []ports.CaddyRoute { return nil }
+
+// ContributeCaddyHandlers returns the Caddy headers handler that injects all
+// configured security headers into every response. Returns an empty slice when
+// the plugin is disabled.
+//
+// The returned handler has Priority 20 so it is placed early in the catch-all
+// handler chain — after TLS connection policies but before rate-limiting.
+func (p *Plugin) ContributeCaddyHandlers() []ports.CaddyHandler {
+	if !p.cfg.Enabled {
+		return nil
+	}
+	return []ports.CaddyHandler{
+		{
+			Handler:  buildHeadersHandler(p.cfg, p.tlsEnabled),
+			Priority: 20,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Internal builders — pure functions, no side effects.
+// ---------------------------------------------------------------------------
+
+// validateConfig checks that the security-headers configuration is valid.
+func validateConfig(cfg Config) error {
+	switch cfg.FrameOption {
+	case "DENY", "SAMEORIGIN", "":
+		// Valid values.
+	default:
+		return fmt.Errorf("invalid frame_option %q; valid values: DENY, SAMEORIGIN, \"\" (disabled)", cfg.FrameOption)
+	}
+	return nil
+}
+
+// buildHeadersHandler creates the Caddy headers handler map for security
+// headers. tlsEnabled must be true for the HSTS header to be included.
+func buildHeadersHandler(cfg Config, tlsEnabled bool) map[string]any {
+	headers := map[string][]string{}
+
+	// Strict-Transport-Security — only over HTTPS.
+	if cfg.HSTSMaxAge > 0 && tlsEnabled {
+		hsts := fmt.Sprintf("max-age=%d", cfg.HSTSMaxAge)
+		if cfg.HSTSIncludeSubDomains {
+			hsts += "; includeSubDomains"
+		}
+		if cfg.HSTSPreload {
+			hsts += "; preload"
+		}
+		headers["Strict-Transport-Security"] = []string{hsts}
+	}
+
+	// X-Content-Type-Options.
+	if cfg.ContentTypeNosniff {
+		headers["X-Content-Type-Options"] = []string{"nosniff"}
+	}
+
+	// X-Frame-Options.
+	if cfg.FrameOption != "" {
+		headers["X-Frame-Options"] = []string{cfg.FrameOption}
+	}
+
+	// Content-Security-Policy.
+	if cfg.ContentSecurityPolicy != "" {
+		headers["Content-Security-Policy"] = []string{cfg.ContentSecurityPolicy}
+	}
+
+	// Referrer-Policy.
+	if cfg.ReferrerPolicy != "" {
+		headers["Referrer-Policy"] = []string{cfg.ReferrerPolicy}
+	}
+
+	// Permissions-Policy.
+	if cfg.PermissionsPolicy != "" {
+		headers["Permissions-Policy"] = []string{cfg.PermissionsPolicy}
+	}
+
+	return map[string]any{
+		"handler": "headers",
+		"response": map[string]any{
+			"set": headers,
+		},
+	}
+}

--- a/internal/plugins/securityheaders/plugin_test.go
+++ b/internal/plugins/securityheaders/plugin_test.go
@@ -1,0 +1,500 @@
+package securityheaders_test
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/plugins/securityheaders"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// discardLogger returns an slog.Logger that discards all output.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(noopWriter{}, nil))
+}
+
+type noopWriter struct{}
+
+func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func defaultConfig() securityheaders.Config {
+	return securityheaders.Config{
+		Enabled:               true,
+		HSTSMaxAge:            31536000,
+		HSTSIncludeSubDomains: true,
+		HSTSPreload:           false,
+		ContentTypeNosniff:    true,
+		FrameOption:           "DENY",
+		ContentSecurityPolicy: "default-src 'self'",
+		ReferrerPolicy:        "strict-origin-when-cross-origin",
+		PermissionsPolicy:     "",
+	}
+}
+
+func newPlugin(cfg securityheaders.Config, tlsEnabled bool) *securityheaders.Plugin {
+	return securityheaders.New(cfg, tlsEnabled, discardLogger())
+}
+
+// responseHeaders extracts the set headers map from a Caddy headers handler.
+func responseHeaders(t *testing.T, handler map[string]any) map[string][]string {
+	t.Helper()
+	resp, ok := handler["response"].(map[string]any)
+	if !ok {
+		t.Fatal("expected response key in handler")
+	}
+	set, ok := resp["set"].(map[string][]string)
+	if !ok {
+		t.Fatal("expected set key in response")
+	}
+	return set
+}
+
+// ---------------------------------------------------------------------------
+// Name / Priority
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Name(t *testing.T) {
+	p := newPlugin(defaultConfig(), false)
+	if got := p.Name(); got != "security-headers" {
+		t.Errorf("Name() = %q, want %q", got, "security-headers")
+	}
+}
+
+func TestPlugin_Priority(t *testing.T) {
+	p := newPlugin(defaultConfig(), false)
+	if got := p.Priority(); got != 20 {
+		t.Errorf("Priority() = %d, want 20", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Init(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     securityheaders.Config
+		wantErr bool
+	}{
+		{
+			name:    "disabled — no validation",
+			cfg:     securityheaders.Config{Enabled: false},
+			wantErr: false,
+		},
+		{
+			name:    "enabled with valid DENY frame option",
+			cfg:     securityheaders.Config{Enabled: true, FrameOption: "DENY"},
+			wantErr: false,
+		},
+		{
+			name:    "enabled with valid SAMEORIGIN frame option",
+			cfg:     securityheaders.Config{Enabled: true, FrameOption: "SAMEORIGIN"},
+			wantErr: false,
+		},
+		{
+			name:    "enabled with empty frame option",
+			cfg:     securityheaders.Config{Enabled: true, FrameOption: ""},
+			wantErr: false,
+		},
+		{
+			name:    "enabled with invalid frame option",
+			cfg:     securityheaders.Config{Enabled: true, FrameOption: "ALLOWALL"},
+			wantErr: true,
+		},
+		{
+			name:    "enabled with full valid config",
+			cfg:     defaultConfig(),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg, false)
+			err := p.Init(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Start / Stop — no-ops
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Start_IsNoop(t *testing.T) {
+	p := newPlugin(defaultConfig(), false)
+	if err := p.Start(context.Background()); err != nil {
+		t.Errorf("Start() unexpected error: %v", err)
+	}
+}
+
+func TestPlugin_Stop_IsNoop(t *testing.T) {
+	p := newPlugin(defaultConfig(), false)
+	if err := p.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Health(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            securityheaders.Config
+		wantHealthy    bool
+		wantMsgContain string
+	}{
+		{
+			name:           "disabled",
+			cfg:            securityheaders.Config{Enabled: false},
+			wantHealthy:    true,
+			wantMsgContain: "disabled",
+		},
+		{
+			name:           "enabled",
+			cfg:            securityheaders.Config{Enabled: true},
+			wantHealthy:    true,
+			wantMsgContain: "configured",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg, false)
+			h := p.Health()
+			if h.Healthy != tt.wantHealthy {
+				t.Errorf("Health().Healthy = %v, want %v", h.Healthy, tt.wantHealthy)
+			}
+			if !strings.Contains(h.Message, tt.wantMsgContain) {
+				t.Errorf("Health().Message = %q, want it to contain %q", h.Message, tt.wantMsgContain)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyRoutes
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyRoutes_AlwaysEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  securityheaders.Config
+	}{
+		{"disabled", securityheaders.Config{Enabled: false}},
+		{"enabled", defaultConfig()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg, false)
+			if routes := p.ContributeCaddyRoutes(); len(routes) != 0 {
+				t.Errorf("ContributeCaddyRoutes() = %v, want empty", routes)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyHandlers
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyHandlers_DisabledReturnsNil(t *testing.T) {
+	p := newPlugin(securityheaders.Config{Enabled: false}, false)
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 0 {
+		t.Errorf("ContributeCaddyHandlers() = %v, want empty when disabled", handlers)
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_EnabledReturnsOne(t *testing.T) {
+	p := newPlugin(defaultConfig(), false)
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 1 {
+		t.Fatalf("ContributeCaddyHandlers() len = %d, want 1", len(handlers))
+	}
+	if handlers[0].Priority != 20 {
+		t.Errorf("handler Priority = %d, want 20", handlers[0].Priority)
+	}
+	if handlers[0].Handler["handler"] != "headers" {
+		t.Errorf("handler[\"handler\"] = %v, want \"headers\"", handlers[0].Handler["handler"])
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_HSTS(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         securityheaders.Config
+		tlsEnabled  bool
+		wantHSTS    bool
+		wantContain string
+	}{
+		{
+			name: "hsts included when tls enabled",
+			cfg: securityheaders.Config{
+				Enabled:    true,
+				HSTSMaxAge: 31536000,
+			},
+			tlsEnabled:  true,
+			wantHSTS:    true,
+			wantContain: "max-age=31536000",
+		},
+		{
+			name: "hsts excluded when tls disabled",
+			cfg: securityheaders.Config{
+				Enabled:    true,
+				HSTSMaxAge: 31536000,
+			},
+			tlsEnabled: false,
+			wantHSTS:   false,
+		},
+		{
+			name: "hsts excluded when max age is zero",
+			cfg: securityheaders.Config{
+				Enabled:    true,
+				HSTSMaxAge: 0,
+			},
+			tlsEnabled: true,
+			wantHSTS:   false,
+		},
+		{
+			name: "hsts with includeSubDomains",
+			cfg: securityheaders.Config{
+				Enabled:               true,
+				HSTSMaxAge:            31536000,
+				HSTSIncludeSubDomains: true,
+			},
+			tlsEnabled:  true,
+			wantHSTS:    true,
+			wantContain: "includeSubDomains",
+		},
+		{
+			name: "hsts with preload",
+			cfg: securityheaders.Config{
+				Enabled:     true,
+				HSTSMaxAge:  31536000,
+				HSTSPreload: true,
+			},
+			tlsEnabled:  true,
+			wantHSTS:    true,
+			wantContain: "preload",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg, tt.tlsEnabled)
+			handlers := p.ContributeCaddyHandlers()
+			if len(handlers) == 0 {
+				t.Fatal("expected at least one handler")
+			}
+			hdrs := responseHeaders(t, handlers[0].Handler)
+			sts, hasHSTS := hdrs["Strict-Transport-Security"]
+			if tt.wantHSTS && !hasHSTS {
+				t.Error("expected Strict-Transport-Security header to be set")
+			}
+			if !tt.wantHSTS && hasHSTS {
+				t.Errorf("unexpected Strict-Transport-Security header: %v", sts)
+			}
+			if tt.wantHSTS && tt.wantContain != "" {
+				if len(sts) == 0 || !strings.Contains(sts[0], tt.wantContain) {
+					t.Errorf("HSTS value = %q, want it to contain %q", sts, tt.wantContain)
+				}
+			}
+		})
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_XContentTypeOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		nosniff bool
+		want    bool
+	}{
+		{"nosniff enabled", true, true},
+		{"nosniff disabled", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := securityheaders.Config{Enabled: true, ContentTypeNosniff: tt.nosniff}
+			p := newPlugin(cfg, false)
+			handlers := p.ContributeCaddyHandlers()
+			hdrs := responseHeaders(t, handlers[0].Handler)
+			_, has := hdrs["X-Content-Type-Options"]
+			if tt.want && !has {
+				t.Error("expected X-Content-Type-Options header")
+			}
+			if !tt.want && has {
+				t.Error("unexpected X-Content-Type-Options header")
+			}
+			if tt.want {
+				if v := hdrs["X-Content-Type-Options"]; len(v) == 0 || v[0] != "nosniff" {
+					t.Errorf("X-Content-Type-Options = %v, want [\"nosniff\"]", v)
+				}
+			}
+		})
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_XFrameOptions(t *testing.T) {
+	tests := []struct {
+		name        string
+		frameOption string
+		wantSet     bool
+	}{
+		{"DENY", "DENY", true},
+		{"SAMEORIGIN", "SAMEORIGIN", true},
+		{"empty disables header", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := securityheaders.Config{Enabled: true, FrameOption: tt.frameOption}
+			p := newPlugin(cfg, false)
+			handlers := p.ContributeCaddyHandlers()
+			hdrs := responseHeaders(t, handlers[0].Handler)
+			val, has := hdrs["X-Frame-Options"]
+			if tt.wantSet && !has {
+				t.Error("expected X-Frame-Options header")
+			}
+			if !tt.wantSet && has {
+				t.Errorf("unexpected X-Frame-Options header: %v", val)
+			}
+			if tt.wantSet && (len(val) == 0 || val[0] != tt.frameOption) {
+				t.Errorf("X-Frame-Options = %v, want [%q]", val, tt.frameOption)
+			}
+		})
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_CSP(t *testing.T) {
+	tests := []struct {
+		name    string
+		csp     string
+		wantSet bool
+	}{
+		{"CSP set", "default-src 'self'", true},
+		{"CSP empty disables header", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := securityheaders.Config{Enabled: true, ContentSecurityPolicy: tt.csp}
+			p := newPlugin(cfg, false)
+			handlers := p.ContributeCaddyHandlers()
+			hdrs := responseHeaders(t, handlers[0].Handler)
+			val, has := hdrs["Content-Security-Policy"]
+			if tt.wantSet && !has {
+				t.Error("expected Content-Security-Policy header")
+			}
+			if !tt.wantSet && has {
+				t.Errorf("unexpected Content-Security-Policy header: %v", val)
+			}
+			if tt.wantSet && (len(val) == 0 || val[0] != tt.csp) {
+				t.Errorf("Content-Security-Policy = %v, want [%q]", val, tt.csp)
+			}
+		})
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_ReferrerPolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  string
+		wantSet bool
+	}{
+		{"policy set", "strict-origin-when-cross-origin", true},
+		{"policy empty disables header", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := securityheaders.Config{Enabled: true, ReferrerPolicy: tt.policy}
+			p := newPlugin(cfg, false)
+			handlers := p.ContributeCaddyHandlers()
+			hdrs := responseHeaders(t, handlers[0].Handler)
+			val, has := hdrs["Referrer-Policy"]
+			if tt.wantSet && !has {
+				t.Error("expected Referrer-Policy header")
+			}
+			if !tt.wantSet && has {
+				t.Errorf("unexpected Referrer-Policy header: %v", val)
+			}
+			if tt.wantSet && (len(val) == 0 || val[0] != tt.policy) {
+				t.Errorf("Referrer-Policy = %v, want [%q]", val, tt.policy)
+			}
+		})
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_PermissionsPolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  string
+		wantSet bool
+	}{
+		{"policy set", "camera=(), microphone=()", true},
+		{"policy empty disables header", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := securityheaders.Config{Enabled: true, PermissionsPolicy: tt.policy}
+			p := newPlugin(cfg, false)
+			handlers := p.ContributeCaddyHandlers()
+			hdrs := responseHeaders(t, handlers[0].Handler)
+			val, has := hdrs["Permissions-Policy"]
+			if tt.wantSet && !has {
+				t.Error("expected Permissions-Policy header")
+			}
+			if !tt.wantSet && has {
+				t.Errorf("unexpected Permissions-Policy header: %v", val)
+			}
+			if tt.wantSet && (len(val) == 0 || val[0] != tt.policy) {
+				t.Errorf("Permissions-Policy = %v, want [%q]", val, tt.policy)
+			}
+		})
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_HandlerStructure(t *testing.T) {
+	p := newPlugin(defaultConfig(), true)
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 1 {
+		t.Fatalf("expected 1 handler, got %d", len(handlers))
+	}
+	h := handlers[0].Handler
+
+	// Must have handler type "headers".
+	if h["handler"] != "headers" {
+		t.Errorf("handler[\"handler\"] = %v, want \"headers\"", h["handler"])
+	}
+
+	// Must have a "response" key containing "set".
+	resp, ok := h["response"].(map[string]any)
+	if !ok {
+		t.Fatal("expected response key to be map[string]any")
+	}
+	if _, ok := resp["set"]; !ok {
+		t.Error("expected set key in response map")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Interface compliance
+// ---------------------------------------------------------------------------
+
+// TestPlugin_ImplementsPortsPlugin asserts at compile time that *Plugin
+// satisfies the ports.Plugin interface.
+func TestPlugin_ImplementsPortsPlugin(t *testing.T) {
+	var _ ports.Plugin = (*securityheaders.Plugin)(nil)
+}
+
+// TestPlugin_ImplementsCaddyContributor asserts at compile time that *Plugin
+// satisfies the ports.CaddyContributor interface.
+func TestPlugin_ImplementsCaddyContributor(t *testing.T) {
+	var _ ports.CaddyContributor = (*securityheaders.Plugin)(nil)
+}


### PR DESCRIPTION
Closes #161

## Summary

- Add `internal/plugins/securityheaders/config.go` — `Config` struct holding all security-headers settings (HSTS, X-Frame-Options, CSP, X-Content-Type-Options, Referrer-Policy, Permissions-Policy).
- Add `internal/plugins/securityheaders/plugin.go` — `Plugin` implementing `ports.Plugin` and `ports.CaddyContributor`. `Name()` returns `"security-headers"`, `Priority()` returns `20`. `Init` validates `FrameOption`. `ContributeCaddyHandlers` returns the Caddy `headers` handler extracted from the existing `buildSecurityHeadersHandler` logic in `adapters/caddy/config.go`. HSTS is gated on `tlsEnabled` so the header is never sent over plain HTTP.
- Add `internal/plugins/securityheaders/plugin_test.go` — 28 table-driven unit tests covering Name, Priority, Init validation, Start/Stop no-ops, Health, ContributeCaddyRoutes (always empty), ContributeCaddyHandlers (disabled, each individual header, HSTS TLS gating, handler structure), and compile-time interface assertions.

## Test plan

- `make check` passes (all 28 new tests plus the full existing suite green).
- `go test -race ./internal/plugins/securityheaders/...` — all pass.
- Compile-time assertions `var _ ports.Plugin = (*securityheaders.Plugin)(nil)` and `var _ ports.CaddyContributor = (*securityheaders.Plugin)(nil)` confirm interface compliance.
