### PR TITLE
feat(#162): add metrics plugin (Plugin + CaddyContributor + InternalServerPlugin)

### DIFF
--- a/internal/plugins/metrics/config.go
+++ b/internal/plugins/metrics/config.go
@@ -1,0 +1,21 @@
+// Package metrics implements the VibeWarden metrics plugin.
+//
+// It creates a Prometheus adapter and an internal HTTP server, then contributes
+// a Caddy route that reverse-proxies /_vibewarden/metrics to that server.
+// The plugin implements ports.Plugin, ports.CaddyContributor, and
+// ports.InternalServerPlugin.
+package metrics
+
+// Config holds all settings for the metrics plugin.
+// It maps to the plugins.metrics section of vibewarden.yaml and falls back
+// to the legacy top-level metrics.* configuration keys.
+type Config struct {
+	// Enabled toggles the metrics plugin and the /_vibewarden/metrics endpoint.
+	// Default: true.
+	Enabled bool
+
+	// PathPatterns is a list of URL path normalization patterns using :param
+	// syntax (e.g. "/users/:id"). Paths that match no pattern are recorded
+	// as "other". An empty slice disables path normalization.
+	PathPatterns []string
+}

--- a/internal/plugins/metrics/plugin.go
+++ b/internal/plugins/metrics/plugin.go
@@ -1,0 +1,164 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	metricsadapter "github.com/vibewarden/vibewarden/internal/adapters/metrics"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// Plugin is the metrics plugin for VibeWarden.
+// It implements ports.Plugin, ports.CaddyContributor, and ports.InternalServerPlugin.
+//
+// On Init the plugin creates a PrometheusAdapter.
+// On Start the plugin starts an internal HTTP server that serves the Prometheus
+// handler at /metrics on a random localhost port.
+// On Stop the internal server is shut down gracefully.
+// ContributeCaddyRoutes returns a route that reverse-proxies the public path
+// /_vibewarden/metrics to the internal server, rewriting the path to /metrics.
+// InternalAddr returns the internal server address after a successful Start.
+// Health reports whether the internal server is running.
+type Plugin struct {
+	cfg          Config
+	logger       *slog.Logger
+	prometheus   *metricsadapter.PrometheusAdapter
+	server       *metricsadapter.Server
+	internalAddr string
+	running      bool
+}
+
+// New creates a new metrics Plugin with the given configuration and logger.
+func New(cfg Config, logger *slog.Logger) *Plugin {
+	return &Plugin{cfg: cfg, logger: logger}
+}
+
+// Name returns the canonical plugin identifier "metrics".
+// This must match the key used under plugins: in vibewarden.yaml.
+func (p *Plugin) Name() string { return "metrics" }
+
+// Priority returns the plugin's initialization priority.
+// Metrics is assigned priority 30 — after TLS (10) and security-headers (20).
+func (p *Plugin) Priority() int { return 30 }
+
+// Init creates the PrometheusAdapter.
+// It must be called once before Start.
+func (p *Plugin) Init(_ context.Context) error {
+	if !p.cfg.Enabled {
+		return nil
+	}
+	p.prometheus = metricsadapter.NewPrometheusAdapter(p.cfg.PathPatterns)
+	p.logger.Info("metrics plugin initialised",
+		slog.Int("path_patterns", len(p.cfg.PathPatterns)),
+	)
+	return nil
+}
+
+// Start creates and starts the internal metrics HTTP server.
+// The server binds a random localhost port; Caddy reverse-proxies
+// /_vibewarden/metrics to it.
+// Start must only be called after a successful Init.
+func (p *Plugin) Start(_ context.Context) error {
+	if !p.cfg.Enabled {
+		return nil
+	}
+	p.server = metricsadapter.NewServer(p.prometheus.Handler(), p.logger)
+	if err := p.server.Start(); err != nil {
+		return fmt.Errorf("metrics plugin: starting internal server: %w", err)
+	}
+	p.internalAddr = p.server.Addr()
+	p.running = true
+	p.logger.Info("metrics plugin started",
+		slog.String("internal_addr", p.internalAddr),
+	)
+	return nil
+}
+
+// Stop gracefully shuts down the internal metrics server.
+func (p *Plugin) Stop(ctx context.Context) error {
+	if p.server == nil {
+		return nil
+	}
+	p.running = false
+	if err := p.server.Stop(ctx); err != nil {
+		return fmt.Errorf("metrics plugin: stopping internal server: %w", err)
+	}
+	return nil
+}
+
+// Health returns the current health status of the metrics plugin.
+// When disabled, Health reports healthy with a "metrics disabled" message.
+// When enabled and running, Health reports healthy with the internal address.
+// When enabled but not yet started, Health reports healthy with a "not started" message.
+func (p *Plugin) Health() ports.HealthStatus {
+	if !p.cfg.Enabled {
+		return ports.HealthStatus{
+			Healthy: true,
+			Message: "metrics disabled",
+		}
+	}
+	if !p.running {
+		return ports.HealthStatus{
+			Healthy: true,
+			Message: "metrics not started",
+		}
+	}
+	return ports.HealthStatus{
+		Healthy: true,
+		Message: fmt.Sprintf("metrics running at %s", p.internalAddr),
+	}
+}
+
+// ContributeCaddyRoutes returns a single route that reverse-proxies
+// /_vibewarden/metrics to the internal Prometheus server at InternalAddr.
+// A rewrite handler translates /_vibewarden/metrics to /metrics before
+// the reverse_proxy handler forwards the request.
+// Returns nil when the plugin is disabled or has not been started yet.
+func (p *Plugin) ContributeCaddyRoutes() []ports.CaddyRoute {
+	if !p.cfg.Enabled || p.internalAddr == "" {
+		return nil
+	}
+	return []ports.CaddyRoute{
+		{
+			MatchPath: "/_vibewarden/metrics",
+			Handler:   buildMetricsRoute(p.internalAddr),
+			Priority:  30,
+		},
+	}
+}
+
+// ContributeCaddyHandlers returns nil.
+// The metrics plugin does not add catch-all handlers; it uses a named route.
+func (p *Plugin) ContributeCaddyHandlers() []ports.CaddyHandler { return nil }
+
+// InternalAddr returns the host:port of the internal metrics HTTP server.
+// The address is only valid after a successful Start.
+func (p *Plugin) InternalAddr() string { return p.internalAddr }
+
+// ---------------------------------------------------------------------------
+// Internal builders — pure functions, no side effects.
+// ---------------------------------------------------------------------------
+
+// buildMetricsRoute constructs the Caddy route map that reverse-proxies
+// /_vibewarden/metrics to the internal server at internalAddr.
+// The rewrite handler translates the public path to /metrics before proxying.
+func buildMetricsRoute(internalAddr string) map[string]any {
+	return map[string]any{
+		"match": []map[string]any{
+			{"path": []string{"/_vibewarden/metrics"}},
+		},
+		"handle": []map[string]any{
+			{
+				"handler": "rewrite",
+				"uri":     "/metrics",
+			},
+			{
+				"handler": "reverse_proxy",
+				"upstreams": []map[string]any{
+					{"dial": internalAddr},
+				},
+			},
+		},
+	}
+}

--- a/internal/plugins/metrics/plugin_test.go
+++ b/internal/plugins/metrics/plugin_test.go
@@ -1,0 +1,339 @@
+package metrics_test
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/plugins/metrics"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type noopWriter struct{}
+
+func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(noopWriter{}, nil))
+}
+
+func enabledConfig() metrics.Config {
+	return metrics.Config{
+		Enabled:      true,
+		PathPatterns: []string{"/users/:id", "/api/v1/*"},
+	}
+}
+
+func disabledConfig() metrics.Config {
+	return metrics.Config{Enabled: false}
+}
+
+func newPlugin(cfg metrics.Config) *metrics.Plugin {
+	return metrics.New(cfg, discardLogger())
+}
+
+// ---------------------------------------------------------------------------
+// Name / Priority
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Name(t *testing.T) {
+	p := newPlugin(enabledConfig())
+	if got := p.Name(); got != "metrics" {
+		t.Errorf("Name() = %q, want %q", got, "metrics")
+	}
+}
+
+func TestPlugin_Priority(t *testing.T) {
+	p := newPlugin(enabledConfig())
+	if got := p.Priority(); got != 30 {
+		t.Errorf("Priority() = %d, want 30", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Init(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     metrics.Config
+		wantErr bool
+	}{
+		{"enabled", enabledConfig(), false},
+		{"disabled", disabledConfig(), false},
+		{"enabled no patterns", metrics.Config{Enabled: true}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			err := p.Init(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Start / Stop lifecycle
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Start_Disabled_IsNoop(t *testing.T) {
+	p := newPlugin(disabledConfig())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Errorf("Start() unexpected error for disabled plugin: %v", err)
+	}
+	if p.InternalAddr() != "" {
+		t.Errorf("InternalAddr() = %q, want empty for disabled plugin", p.InternalAddr())
+	}
+}
+
+func TestPlugin_Stop_BeforeStart_IsNoop(t *testing.T) {
+	p := newPlugin(enabledConfig())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	// Stop without Start — must not panic or return error.
+	if err := p.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() before Start returned unexpected error: %v", err)
+	}
+}
+
+func TestPlugin_StartStop_Enabled(t *testing.T) {
+	p := newPlugin(enabledConfig())
+
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = p.Stop(context.Background())
+	})
+
+	addr := p.InternalAddr()
+	if addr == "" {
+		t.Error("InternalAddr() returned empty string after Start")
+	}
+	if !strings.HasPrefix(addr, "127.0.0.1:") {
+		t.Errorf("InternalAddr() = %q, want 127.0.0.1:<port>", addr)
+	}
+
+	if err := p.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Health(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            metrics.Config
+		initAndStart   bool
+		wantHealthy    bool
+		wantMsgContain string
+	}{
+		{
+			name:           "disabled",
+			cfg:            disabledConfig(),
+			wantHealthy:    true,
+			wantMsgContain: "disabled",
+		},
+		{
+			name:           "enabled not started",
+			cfg:            enabledConfig(),
+			wantHealthy:    true,
+			wantMsgContain: "not started",
+		},
+		{
+			name:           "enabled and running",
+			cfg:            enabledConfig(),
+			initAndStart:   true,
+			wantHealthy:    true,
+			wantMsgContain: "running",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			if tt.initAndStart {
+				if err := p.Init(context.Background()); err != nil {
+					t.Fatalf("Init() error: %v", err)
+				}
+				if err := p.Start(context.Background()); err != nil {
+					t.Fatalf("Start() error: %v", err)
+				}
+				t.Cleanup(func() { _ = p.Stop(context.Background()) })
+			}
+			h := p.Health()
+			if h.Healthy != tt.wantHealthy {
+				t.Errorf("Health().Healthy = %v, want %v", h.Healthy, tt.wantHealthy)
+			}
+			if !strings.Contains(h.Message, tt.wantMsgContain) {
+				t.Errorf("Health().Message = %q, want to contain %q", h.Message, tt.wantMsgContain)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyRoutes
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyRoutes_Disabled(t *testing.T) {
+	p := newPlugin(disabledConfig())
+	if routes := p.ContributeCaddyRoutes(); len(routes) != 0 {
+		t.Errorf("ContributeCaddyRoutes() disabled = %v, want empty", routes)
+	}
+}
+
+func TestPlugin_ContributeCaddyRoutes_EnabledNotStarted(t *testing.T) {
+	p := newPlugin(enabledConfig())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	// Not started yet — InternalAddr is empty, should return nil.
+	if routes := p.ContributeCaddyRoutes(); len(routes) != 0 {
+		t.Errorf("ContributeCaddyRoutes() before Start = %v, want empty", routes)
+	}
+}
+
+func TestPlugin_ContributeCaddyRoutes_AfterStart(t *testing.T) {
+	p := newPlugin(enabledConfig())
+
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Stop(context.Background()) })
+
+	routes := p.ContributeCaddyRoutes()
+	if len(routes) != 1 {
+		t.Fatalf("ContributeCaddyRoutes() len = %d, want 1", len(routes))
+	}
+
+	route := routes[0]
+	if route.MatchPath != "/_vibewarden/metrics" {
+		t.Errorf("route.MatchPath = %q, want %q", route.MatchPath, "/_vibewarden/metrics")
+	}
+	if route.Priority != 30 {
+		t.Errorf("route.Priority = %d, want 30", route.Priority)
+	}
+}
+
+func TestPlugin_ContributeCaddyRoutes_RouteStructure(t *testing.T) {
+	p := newPlugin(enabledConfig())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Stop(context.Background()) })
+
+	routes := p.ContributeCaddyRoutes()
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
+
+	h := routes[0].Handler
+
+	// Must have a "match" with path /_vibewarden/metrics.
+	match, ok := h["match"].([]map[string]any)
+	if !ok || len(match) == 0 {
+		t.Fatal("route handler missing 'match' key")
+	}
+	paths, ok := match[0]["path"].([]string)
+	if !ok || len(paths) == 0 {
+		t.Fatal("match missing 'path' key")
+	}
+	if paths[0] != "/_vibewarden/metrics" {
+		t.Errorf("match path = %q, want %q", paths[0], "/_vibewarden/metrics")
+	}
+
+	// Must have a "handle" slice with at least rewrite + reverse_proxy.
+	handle, ok := h["handle"].([]map[string]any)
+	if !ok || len(handle) < 2 {
+		t.Fatalf("expected at least 2 handlers (rewrite + reverse_proxy) in route, got %v", h["handle"])
+	}
+
+	// First handler must be a rewrite to /metrics.
+	if handle[0]["handler"] != "rewrite" {
+		t.Errorf("handle[0].handler = %v, want %q", handle[0]["handler"], "rewrite")
+	}
+	if handle[0]["uri"] != "/metrics" {
+		t.Errorf("handle[0].uri = %v, want %q", handle[0]["uri"], "/metrics")
+	}
+
+	// Second handler must be a reverse_proxy with the correct upstream dial.
+	if handle[1]["handler"] != "reverse_proxy" {
+		t.Errorf("handle[1].handler = %v, want %q", handle[1]["handler"], "reverse_proxy")
+	}
+	upstreams, ok := handle[1]["upstreams"].([]map[string]any)
+	if !ok || len(upstreams) == 0 {
+		t.Fatal("reverse_proxy handler missing 'upstreams'")
+	}
+	dial, _ := upstreams[0]["dial"].(string)
+	if dial != p.InternalAddr() {
+		t.Errorf("upstream dial = %q, want %q", dial, p.InternalAddr())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyHandlers
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyHandlers_AlwaysNil(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  metrics.Config
+	}{
+		{"disabled", disabledConfig()},
+		{"enabled", enabledConfig()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			if h := p.ContributeCaddyHandlers(); len(h) != 0 {
+				t.Errorf("ContributeCaddyHandlers() = %v, want empty", h)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Interface compliance
+// ---------------------------------------------------------------------------
+
+// TestPlugin_ImplementsPortsPlugin asserts at compile time that *Plugin
+// satisfies the ports.Plugin interface.
+func TestPlugin_ImplementsPortsPlugin(t *testing.T) {
+	var _ ports.Plugin = (*metrics.Plugin)(nil)
+}
+
+// TestPlugin_ImplementsCaddyContributor asserts at compile time that *Plugin
+// satisfies the ports.CaddyContributor interface.
+func TestPlugin_ImplementsCaddyContributor(t *testing.T) {
+	var _ ports.CaddyContributor = (*metrics.Plugin)(nil)
+}
+
+// TestPlugin_ImplementsInternalServerPlugin asserts at compile time that *Plugin
+// satisfies the ports.InternalServerPlugin interface.
+func TestPlugin_ImplementsInternalServerPlugin(t *testing.T) {
+	var _ ports.InternalServerPlugin = (*metrics.Plugin)(nil)
+}


### PR DESCRIPTION
Closes #162

## Summary

- Adds `internal/plugins/metrics/config.go` — `Config` struct (`Enabled`, `PathPatterns`) mapping to the `plugins.metrics` section of `vibewarden.yaml`
- Adds `internal/plugins/metrics/plugin.go` — `Plugin` type that implements `ports.Plugin`, `ports.CaddyContributor`, and `ports.InternalServerPlugin`:
  - `Name()` → `"metrics"`, `Priority()` → `30`
  - `Init` creates a `PrometheusAdapter` (wraps existing `adapters/metrics`)
  - `Start` creates and starts an internal `metrics.Server` on a random `127.0.0.1` port
  - `Stop` gracefully shuts down the internal server
  - `ContributeCaddyRoutes` returns the `/_vibewarden/metrics` route (rewrite + reverse_proxy to internal addr) after `Start`
  - `ContributeCaddyHandlers` returns nil (plugin uses a named route, not catch-all middleware)
  - `InternalAddr` returns the bound address after `Start`
  - `Health` reports disabled / not-started / running with internal addr
- Adds `internal/plugins/metrics/plugin_test.go` — 20 table-driven unit tests covering all public methods and interface compliance assertions

## Test plan

- `make check` passes (all 38 test packages, race detector enabled, demo-app included)
- `go test -race ./internal/plugins/metrics/...` → 20 tests, all pass
- Interface compliance tests assert at compile time that `*Plugin` satisfies `ports.Plugin`, `ports.CaddyContributor`, and `ports.InternalServerPlugin`
