### PR TITLE
feat(#160): migrate rate limiting to plugin

### DIFF
--- a/internal/plugins/ratelimit/config.go
+++ b/internal/plugins/ratelimit/config.go
@@ -1,0 +1,48 @@
+// Package ratelimit implements the VibeWarden rate-limiting plugin.
+//
+// It enforces per-IP and per-user token-bucket rate limits on every proxied
+// request via the vibewarden_rate_limit Caddy handler module. Limiters are
+// created from an in-memory factory on Init and closed on Stop to release the
+// background GC goroutines.
+package ratelimit
+
+// Config holds all settings for the rate-limiting plugin.
+// It maps to the plugins.rate-limiting section of vibewarden.yaml.
+type Config struct {
+	// Enabled toggles the rate-limiting plugin.
+	Enabled bool
+
+	// Store names the backing store for limiter state.
+	// The only supported value in v1 is "memory" (the default).
+	// "redis" is reserved for future work.
+	Store string
+
+	// PerIP configures the per-IP rate limit applied to every request.
+	PerIP RuleConfig
+
+	// PerUser configures the per-user rate limit applied to authenticated
+	// requests only. Unauthenticated requests are not subject to this limit.
+	PerUser RuleConfig
+
+	// TrustProxyHeaders enables reading the X-Forwarded-For header to
+	// determine the real client IP address. Only enable this when
+	// VibeWarden is behind a trusted reverse proxy.
+	TrustProxyHeaders bool
+
+	// ExemptPaths is a list of URL path glob patterns that bypass rate
+	// limiting entirely. The /_vibewarden/* prefix is always exempt and
+	// is added automatically by the middleware.
+	ExemptPaths []string
+}
+
+// RuleConfig defines the sustained request rate and burst size for one rate
+// limit dimension (per-IP or per-user).
+type RuleConfig struct {
+	// RequestsPerSecond is the sustained request rate allowed per key.
+	// A value of 0 disables this limit dimension.
+	RequestsPerSecond float64
+
+	// Burst is the maximum number of requests allowed in a burst above the
+	// sustained rate.
+	Burst int
+}

--- a/internal/plugins/ratelimit/plugin.go
+++ b/internal/plugins/ratelimit/plugin.go
@@ -1,0 +1,203 @@
+package ratelimit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// Plugin is the rate-limiting plugin for VibeWarden.
+// It implements ports.Plugin and ports.CaddyContributor.
+//
+// On Init the plugin creates per-IP and per-user MemoryStore rate limiters.
+// On Stop it closes both limiters to release the background GC goroutines.
+// ContributeCaddyHandlers returns the vibewarden_rate_limit Caddy handler
+// fragment so the middleware is injected into the catch-all handler chain.
+// Health reports whether the plugin is enabled.
+type Plugin struct {
+	cfg         Config
+	factory     ports.RateLimiterFactory
+	ipLimiter   ports.RateLimiter
+	userLimiter ports.RateLimiter
+	logger      *slog.Logger
+}
+
+// New creates a new rate-limiting Plugin.
+// factory is the RateLimiterFactory used to create the per-IP and per-user
+// limiters during Init. Pass ratelimitadapter.NewDefaultMemoryFactory() for
+// production use.
+func New(cfg Config, factory ports.RateLimiterFactory, logger *slog.Logger) *Plugin {
+	return &Plugin{
+		cfg:     cfg,
+		factory: factory,
+		logger:  logger,
+	}
+}
+
+// Name returns the canonical plugin identifier "rate-limiting".
+// This must match the key used under plugins: in vibewarden.yaml.
+func (p *Plugin) Name() string { return "rate-limiting" }
+
+// Priority returns the plugin's initialisation priority.
+// Rate limiting is assigned priority 50 so it runs after TLS (10) and
+// security-headers (20) but before application-layer middleware.
+func (p *Plugin) Priority() int { return 50 }
+
+// Init creates the per-IP and per-user rate limiters from the configured
+// factory. It is a no-op when the plugin is disabled.
+// Init must be called before ContributeCaddyHandlers.
+func (p *Plugin) Init(_ context.Context) error {
+	if !p.cfg.Enabled {
+		return nil
+	}
+
+	p.ipLimiter = p.factory.NewLimiter(ports.RateLimitRule{
+		RequestsPerSecond: p.cfg.PerIP.RequestsPerSecond,
+		Burst:             p.cfg.PerIP.Burst,
+	})
+
+	p.userLimiter = p.factory.NewLimiter(ports.RateLimitRule{
+		RequestsPerSecond: p.cfg.PerUser.RequestsPerSecond,
+		Burst:             p.cfg.PerUser.Burst,
+	})
+
+	p.logger.Info("rate-limiting plugin initialised",
+		slog.Float64("per_ip_rps", p.cfg.PerIP.RequestsPerSecond),
+		slog.Int("per_ip_burst", p.cfg.PerIP.Burst),
+		slog.Float64("per_user_rps", p.cfg.PerUser.RequestsPerSecond),
+		slog.Int("per_user_burst", p.cfg.PerUser.Burst),
+	)
+	return nil
+}
+
+// Start is a no-op for the rate-limiting plugin.
+// Limiters are created during Init; no additional background work is started
+// here. The MemoryStore's own cleanup goroutine is managed internally.
+func (p *Plugin) Start(_ context.Context) error { return nil }
+
+// Stop closes the per-IP and per-user limiters to release the background GC
+// goroutines. It is safe to call Stop when the plugin is disabled.
+func (p *Plugin) Stop(_ context.Context) error {
+	if p.ipLimiter != nil {
+		if err := p.ipLimiter.Close(); err != nil {
+			return fmt.Errorf("closing IP rate limiter: %w", err)
+		}
+	}
+	if p.userLimiter != nil {
+		if err := p.userLimiter.Close(); err != nil {
+			return fmt.Errorf("closing user rate limiter: %w", err)
+		}
+	}
+	return nil
+}
+
+// Health returns the current health status of the rate-limiting plugin.
+// The plugin is always healthy; it reports whether it is enabled or disabled.
+func (p *Plugin) Health() ports.HealthStatus {
+	if !p.cfg.Enabled {
+		return ports.HealthStatus{
+			Healthy: true,
+			Message: "rate-limiting disabled",
+		}
+	}
+	return ports.HealthStatus{
+		Healthy: true,
+		Message: fmt.Sprintf(
+			"rate-limiting active (per-IP: %.1f rps burst %d, per-user: %.1f rps burst %d)",
+			p.cfg.PerIP.RequestsPerSecond, p.cfg.PerIP.Burst,
+			p.cfg.PerUser.RequestsPerSecond, p.cfg.PerUser.Burst,
+		),
+	}
+}
+
+// ContributeCaddyRoutes returns nil.
+// The rate-limiting plugin does not add named routes; it contributes a
+// catch-all handler via ContributeCaddyHandlers.
+func (p *Plugin) ContributeCaddyRoutes() []ports.CaddyRoute { return nil }
+
+// ContributeCaddyHandlers returns the Caddy vibewarden_rate_limit handler
+// fragment that enforces rate limiting on every request. Returns an empty
+// slice when the plugin is disabled.
+//
+// The returned handler has Priority 50 so it is placed after security-headers
+// (20) but before the reverse proxy in the catch-all handler chain.
+func (p *Plugin) ContributeCaddyHandlers() []ports.CaddyHandler {
+	if !p.cfg.Enabled {
+		return nil
+	}
+	handler, err := buildRateLimitHandlerJSON(p.cfg)
+	if err != nil {
+		// buildRateLimitHandlerJSON only fails on JSON marshal of a known
+		// struct — this cannot happen in practice. Log and return nothing so
+		// we do not panic in library code.
+		p.logger.Error("rate-limiting plugin: building handler JSON", slog.String("err", err.Error()))
+		return nil
+	}
+	return []ports.CaddyHandler{
+		{
+			Handler:  handler,
+			Priority: 50,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Internal builders — pure functions, no side effects.
+// ---------------------------------------------------------------------------
+
+// rateLimitHandlerConfig is the JSON-serialisable configuration sent to the
+// vibewarden_rate_limit Caddy module. It mirrors the fields on
+// caddy.RateLimitHandlerConfig so the module can unmarshal them correctly.
+type rateLimitHandlerConfig struct {
+	Enabled           bool              `json:"enabled"`
+	PerIP             rateLimitRuleJSON `json:"per_ip"`
+	PerUser           rateLimitRuleJSON `json:"per_user"`
+	TrustProxyHeaders bool              `json:"trust_proxy_headers"`
+	ExemptPaths       []string          `json:"exempt_paths,omitempty"`
+}
+
+// rateLimitRuleJSON is the JSON shape of one rate-limit rule dimension.
+type rateLimitRuleJSON struct {
+	RequestsPerSecond float64 `json:"requests_per_second"`
+	Burst             int     `json:"burst"`
+}
+
+// buildRateLimitHandlerJSON serialises cfg into the Caddy handler JSON map
+// expected by the vibewarden_rate_limit module.
+func buildRateLimitHandlerJSON(cfg Config) (map[string]any, error) {
+	hcfg := rateLimitHandlerConfig{
+		Enabled:           cfg.Enabled,
+		TrustProxyHeaders: cfg.TrustProxyHeaders,
+		ExemptPaths:       cfg.ExemptPaths,
+		PerIP: rateLimitRuleJSON{
+			RequestsPerSecond: cfg.PerIP.RequestsPerSecond,
+			Burst:             cfg.PerIP.Burst,
+		},
+		PerUser: rateLimitRuleJSON{
+			RequestsPerSecond: cfg.PerUser.RequestsPerSecond,
+			Burst:             cfg.PerUser.Burst,
+		},
+	}
+
+	cfgBytes, err := json.Marshal(hcfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling rate limit handler config: %w", err)
+	}
+
+	return map[string]any{
+		"handler": "vibewarden_rate_limit",
+		"config":  json.RawMessage(cfgBytes),
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Interface guards.
+// ---------------------------------------------------------------------------
+
+var (
+	_ ports.Plugin           = (*Plugin)(nil)
+	_ ports.CaddyContributor = (*Plugin)(nil)
+)

--- a/internal/plugins/ratelimit/plugin_test.go
+++ b/internal/plugins/ratelimit/plugin_test.go
@@ -1,0 +1,345 @@
+package ratelimit_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	ratelimitadapter "github.com/vibewarden/vibewarden/internal/adapters/ratelimit"
+	"github.com/vibewarden/vibewarden/internal/plugins/ratelimit"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// discardLogger returns an slog.Logger that discards all output.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(noopWriter{}, nil))
+}
+
+type noopWriter struct{}
+
+func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// defaultConfig returns a fully-enabled Config for tests.
+func defaultConfig() ratelimit.Config {
+	return ratelimit.Config{
+		Enabled: true,
+		Store:   "memory",
+		PerIP: ratelimit.RuleConfig{
+			RequestsPerSecond: 10,
+			Burst:             20,
+		},
+		PerUser: ratelimit.RuleConfig{
+			RequestsPerSecond: 100,
+			Burst:             200,
+		},
+		TrustProxyHeaders: false,
+		ExemptPaths:       []string{"/health"},
+	}
+}
+
+// newPlugin creates a Plugin using the real MemoryFactory.
+func newPlugin(cfg ratelimit.Config) *ratelimit.Plugin {
+	return ratelimit.New(cfg, ratelimitadapter.NewDefaultMemoryFactory(), discardLogger())
+}
+
+// ---------------------------------------------------------------------------
+// Name / Priority
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Name(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if got := p.Name(); got != "rate-limiting" {
+		t.Errorf("Name() = %q, want %q", got, "rate-limiting")
+	}
+}
+
+func TestPlugin_Priority(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if got := p.Priority(); got != 50 {
+		t.Errorf("Priority() = %d, want 50", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Init(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     ratelimit.Config
+		wantErr bool
+	}{
+		{
+			name:    "disabled — no-op",
+			cfg:     ratelimit.Config{Enabled: false},
+			wantErr: false,
+		},
+		{
+			name:    "enabled with valid config",
+			cfg:     defaultConfig(),
+			wantErr: false,
+		},
+		{
+			name: "enabled with zero rates",
+			cfg: ratelimit.Config{
+				Enabled: true,
+				PerIP:   ratelimit.RuleConfig{RequestsPerSecond: 0, Burst: 0},
+				PerUser: ratelimit.RuleConfig{RequestsPerSecond: 0, Burst: 0},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			err := p.Init(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			// Always stop to release GC goroutines started during Init.
+			_ = p.Stop(context.Background())
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Start — no-op
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Start_IsNoop(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() unexpected error: %v", err)
+	}
+	defer p.Stop(context.Background()) //nolint:errcheck
+	if err := p.Start(context.Background()); err != nil {
+		t.Errorf("Start() unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Stop
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Stop_WhenDisabled(t *testing.T) {
+	p := newPlugin(ratelimit.Config{Enabled: false})
+	if err := p.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() on disabled plugin unexpected error: %v", err)
+	}
+}
+
+func TestPlugin_Stop_ClosesLimiters(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() unexpected error: %v", err)
+	}
+	if err := p.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() unexpected error: %v", err)
+	}
+	// Calling Stop a second time must not panic or error (idempotent).
+	if err := p.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() second call unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Health(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            ratelimit.Config
+		wantHealthy    bool
+		wantMsgContain string
+	}{
+		{
+			name:           "disabled",
+			cfg:            ratelimit.Config{Enabled: false},
+			wantHealthy:    true,
+			wantMsgContain: "disabled",
+		},
+		{
+			name:           "enabled",
+			cfg:            defaultConfig(),
+			wantHealthy:    true,
+			wantMsgContain: "active",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			h := p.Health()
+			if h.Healthy != tt.wantHealthy {
+				t.Errorf("Health().Healthy = %v, want %v", h.Healthy, tt.wantHealthy)
+			}
+			if !strings.Contains(h.Message, tt.wantMsgContain) {
+				t.Errorf("Health().Message = %q, want it to contain %q", h.Message, tt.wantMsgContain)
+			}
+		})
+	}
+}
+
+func TestPlugin_Health_ContainsRates(t *testing.T) {
+	cfg := ratelimit.Config{
+		Enabled: true,
+		PerIP:   ratelimit.RuleConfig{RequestsPerSecond: 10, Burst: 20},
+		PerUser: ratelimit.RuleConfig{RequestsPerSecond: 100, Burst: 200},
+	}
+	p := newPlugin(cfg)
+	h := p.Health()
+	for _, want := range []string{"10.0", "20", "100.0", "200"} {
+		if !strings.Contains(h.Message, want) {
+			t.Errorf("Health().Message = %q, want it to contain %q", h.Message, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyRoutes
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyRoutes_AlwaysEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  ratelimit.Config
+	}{
+		{"disabled", ratelimit.Config{Enabled: false}},
+		{"enabled", defaultConfig()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			if routes := p.ContributeCaddyRoutes(); len(routes) != 0 {
+				t.Errorf("ContributeCaddyRoutes() = %v, want empty", routes)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyHandlers
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyHandlers_DisabledReturnsNil(t *testing.T) {
+	p := newPlugin(ratelimit.Config{Enabled: false})
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 0 {
+		t.Errorf("ContributeCaddyHandlers() = %v, want empty when disabled", handlers)
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_EnabledReturnsOne(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 1 {
+		t.Fatalf("ContributeCaddyHandlers() len = %d, want 1", len(handlers))
+	}
+	if handlers[0].Priority != 50 {
+		t.Errorf("handler Priority = %d, want 50", handlers[0].Priority)
+	}
+	if handlers[0].Handler["handler"] != "vibewarden_rate_limit" {
+		t.Errorf("handler[\"handler\"] = %v, want %q", handlers[0].Handler["handler"], "vibewarden_rate_limit")
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_HandlerHasConfig(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) == 0 {
+		t.Fatal("expected at least one handler")
+	}
+	h := handlers[0].Handler
+	if _, ok := h["config"]; !ok {
+		t.Error("expected \"config\" key in handler map")
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_ConfigDeserialises(t *testing.T) {
+	cfg := ratelimit.Config{
+		Enabled:           true,
+		PerIP:             ratelimit.RuleConfig{RequestsPerSecond: 5, Burst: 10},
+		PerUser:           ratelimit.RuleConfig{RequestsPerSecond: 50, Burst: 100},
+		TrustProxyHeaders: true,
+		ExemptPaths:       []string{"/health", "/_vibewarden/*"},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) == 0 {
+		t.Fatal("expected at least one handler")
+	}
+
+	rawConfig := handlers[0].Handler["config"]
+
+	// The config value must be JSON-marshalable back to a map.
+	b, err := json.Marshal(rawConfig)
+	if err != nil {
+		t.Fatalf("json.Marshal(config) error: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(config) error: %v", err)
+	}
+
+	// Verify enabled flag round-trips.
+	if enabled, ok := decoded["enabled"].(bool); !ok || !enabled {
+		t.Errorf("decoded config enabled = %v, want true", decoded["enabled"])
+	}
+
+	// Verify trust_proxy_headers round-trips.
+	if tph, ok := decoded["trust_proxy_headers"].(bool); !ok || !tph {
+		t.Errorf("decoded config trust_proxy_headers = %v, want true", decoded["trust_proxy_headers"])
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_ExemptPaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		exemptPaths []string
+	}{
+		{"no exempt paths", nil},
+		{"with exempt paths", []string{"/health", "/_vibewarden/*"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := ratelimit.Config{
+				Enabled:     true,
+				PerIP:       ratelimit.RuleConfig{RequestsPerSecond: 10, Burst: 20},
+				ExemptPaths: tt.exemptPaths,
+			}
+			p := newPlugin(cfg)
+			handlers := p.ContributeCaddyHandlers()
+			if len(handlers) == 0 {
+				t.Fatal("expected at least one handler")
+			}
+			// Just assert the handler is present with correct type.
+			if handlers[0].Handler["handler"] != "vibewarden_rate_limit" {
+				t.Errorf("unexpected handler type: %v", handlers[0].Handler["handler"])
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Interface compliance
+// ---------------------------------------------------------------------------
+
+// TestPlugin_ImplementsPortsPlugin asserts at compile time that *Plugin
+// satisfies the ports.Plugin interface.
+func TestPlugin_ImplementsPortsPlugin(t *testing.T) {
+	var _ ports.Plugin = (*ratelimit.Plugin)(nil)
+}
+
+// TestPlugin_ImplementsCaddyContributor asserts at compile time that *Plugin
+// satisfies the ports.CaddyContributor interface.
+func TestPlugin_ImplementsCaddyContributor(t *testing.T) {
+	var _ ports.CaddyContributor = (*ratelimit.Plugin)(nil)
+}


### PR DESCRIPTION
Closes #160

## Summary

- Adds `internal/plugins/ratelimit/config.go` — `Config` and `RuleConfig` value types that map to the `plugins.rate-limiting` section of `vibewarden.yaml`. Fields: `enabled`, `store`, `per_ip`, `per_user`, `trust_proxy_headers`, `exempt_paths`.
- Adds `internal/plugins/ratelimit/plugin.go` — `Plugin` implementing `ports.Plugin` and `ports.CaddyContributor` at priority 50 (after TLS=10, security-headers=20). `Init` creates per-IP and per-user `MemoryStore` limiters from the injected `ports.RateLimiterFactory`. `Stop` closes both limiters to release the background GC goroutines. `ContributeCaddyHandlers` emits the `vibewarden_rate_limit` Caddy handler JSON fragment.
- Adds `internal/plugins/ratelimit/plugin_test.go` — table-driven unit tests for all methods; interface-compliance compile-time guards for `ports.Plugin` and `ports.CaddyContributor`.

No existing files modified — this is a pure addition that can be wired in by the serve command in a follow-up.

## Test plan

- [ ] `make check` passes (formatting, vet, build, all tests including race detector)
- [ ] `go test -race ./internal/plugins/ratelimit/...` passes
- [ ] `Init` on disabled config is a no-op (no limiters created)
- [ ] `Stop` on disabled config (nil limiters) returns nil without panic
- [ ] `Stop` twice on an enabled plugin is idempotent
- [ ] `ContributeCaddyHandlers` returns nil when disabled, one handler at priority 50 when enabled
- [ ] Handler JSON deserialises correctly with all fields round-tripping
