### PR TITLE
feat(#163): migrate user management to plugin

### DIFF
--- a/internal/plugins/usermgmt/config.go
+++ b/internal/plugins/usermgmt/config.go
@@ -1,0 +1,31 @@
+// Package usermgmt implements the VibeWarden user-management plugin.
+//
+// The user-management plugin migrates the standalone admin API wiring from
+// serve.go into the plugin system. It creates a Kratos admin adapter, an
+// admin application service, and an internal HTTP server that serves the
+// admin user management API. Caddy reverse-proxies /_vibewarden/admin/* to
+// the internal server after the admin auth handler validates the bearer token.
+package usermgmt
+
+// Config holds all settings for the user-management plugin.
+// It maps to the plugins.user-management section of vibewarden.yaml.
+type Config struct {
+	// Enabled toggles the user-management plugin. When false all methods are no-ops.
+	Enabled bool
+
+	// AdminToken is the static bearer token clients must supply in the
+	// X-Admin-Key request header to access /_vibewarden/admin/* endpoints.
+	// Required when Enabled is true.
+	// Can be set via VIBEWARDEN_ADMIN_TOKEN env var.
+	AdminToken string
+
+	// KratosAdminURL is the base URL of the Ory Kratos admin API
+	// (e.g. "http://127.0.0.1:4434"). Used to manage user identities.
+	// Required when Enabled is true.
+	KratosAdminURL string
+
+	// DatabaseURL is a libpq-compatible connection string for the audit log
+	// database (e.g. "postgres://user:pass@localhost:5432/vibewarden?sslmode=disable").
+	// When empty, audit logging is skipped.
+	DatabaseURL string
+}

--- a/internal/plugins/usermgmt/plugin.go
+++ b/internal/plugins/usermgmt/plugin.go
@@ -1,0 +1,348 @@
+package usermgmt
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+
+	httpadapter "github.com/vibewarden/vibewarden/internal/adapters/http"
+	kratosadapter "github.com/vibewarden/vibewarden/internal/adapters/kratos"
+	postgresadapter "github.com/vibewarden/vibewarden/internal/adapters/postgres"
+	adminapp "github.com/vibewarden/vibewarden/internal/app/admin"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// adminPath is the URL path wildcard that the plugin exposes through Caddy.
+const adminPath = "/_vibewarden/admin/*"
+
+// adminPathPrefix is the route prefix used when matching admin requests.
+const adminPathPrefix = "/_vibewarden/admin/"
+
+// healthCheckTimeout is the deadline used for Kratos admin API connectivity
+// probes performed during HealthCheck.
+const healthCheckTimeout = 3 * time.Second
+
+// kratosAdminHealthPath is the Kratos admin health endpoint used as a
+// liveness probe.
+const kratosAdminHealthPath = "/health/ready"
+
+// AdminServerIface is the minimal interface the plugin needs from its internal
+// HTTP server. Exported so that test packages can provide fakes without
+// importing the concrete httpadapter package.
+type AdminServerIface interface {
+	// Start binds the listener and begins serving.
+	Start() error
+	// Addr returns the host:port the server is listening on, after Start.
+	Addr() string
+	// Stop gracefully shuts down the server.
+	Stop(ctx context.Context) error
+}
+
+// ExportedServiceFactory is a replaceable factory that creates a
+// ports.AdminService from the plugin config. The second return value is an
+// optional cleanup func (e.g. to close a database connection) that is called
+// by Stop. Tests may replace this variable to inject fakes without dialling
+// Kratos or PostgreSQL.
+//
+// Exported for testing only — production code must not reassign this.
+var ExportedServiceFactory func(Config, ports.EventLogger, *slog.Logger) (ports.AdminService, func(), error) = defaultServiceFactory
+
+// ExportedServerFactory is a replaceable factory that creates an
+// AdminServerIface backed by the supplied handlers. Tests may replace this
+// variable to inject a fake server that does not bind a real port.
+//
+// Exported for testing only — production code must not reassign this.
+var ExportedServerFactory func(*httpadapter.AdminHandlers, *slog.Logger) AdminServerIface = defaultServerFactory
+
+// defaultServiceFactory builds the real admin application service, wiring the
+// Kratos admin adapter and the optional PostgreSQL audit logger.
+func defaultServiceFactory(cfg Config, eventLogger ports.EventLogger, logger *slog.Logger) (ports.AdminService, func(), error) {
+	kratosAdmin := kratosadapter.NewAdminAdapter(cfg.KratosAdminURL, 0, logger)
+
+	var auditLogger ports.AuditLogger
+	var cleanup func()
+
+	if cfg.DatabaseURL != "" {
+		adapter, err := postgresadapter.NewAuditAdapter(cfg.DatabaseURL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("connecting to audit database: %w", err)
+		}
+		auditLogger = adapter
+		cleanup = func() {
+			if closeErr := adapter.Close(); closeErr != nil {
+				logger.Error("closing audit database", slog.String("error", closeErr.Error()))
+			}
+		}
+	}
+
+	svc := adminapp.NewService(kratosAdmin, eventLogger, auditLogger)
+	return svc, cleanup, nil
+}
+
+// defaultServerFactory builds the real internal AdminServer.
+func defaultServerFactory(handlers *httpadapter.AdminHandlers, logger *slog.Logger) AdminServerIface {
+	return httpadapter.NewAdminServer(handlers, logger)
+}
+
+// Plugin is the VibeWarden user-management plugin.
+//
+// It implements ports.Plugin, ports.CaddyContributor, and
+// ports.InternalServerPlugin. Priority is 60, placing it after TLS (10),
+// security-headers (20), rate-limiting (30), and auth (40).
+//
+// Responsibilities:
+//   - Validate configuration on Init.
+//   - Create a Kratos admin adapter, admin application service, and HTTP
+//     handlers on Init.
+//   - Start an internal HTTP server on a random localhost port on Start.
+//   - Contribute a Caddy route that reverse-proxies /_vibewarden/admin/* to
+//     the internal server (ContributeCaddyRoutes).
+//   - Contribute the admin-auth handler that validates the X-Admin-Key bearer
+//     token (ContributeCaddyHandlers).
+//   - Report the internal server address (InternalAddr).
+//   - Report the health of the admin server (Health).
+type Plugin struct {
+	cfg          Config
+	logger       *slog.Logger
+	eventLogger  ports.EventLogger
+	handlers     *httpadapter.AdminHandlers
+	server       AdminServerIface
+	dbCleanup    func()
+	internalAddr string
+	healthy      bool
+	healthMsg    string
+}
+
+// New creates a new user-management Plugin with the given configuration,
+// event logger, and structured logger.
+// eventLogger must be non-nil; it is forwarded to the admin application service.
+func New(cfg Config, eventLogger ports.EventLogger, logger *slog.Logger) *Plugin {
+	return &Plugin{
+		cfg:         cfg,
+		logger:      logger,
+		eventLogger: eventLogger,
+	}
+}
+
+// Name returns the canonical plugin identifier "user-management".
+// This must match the key used under plugins: in vibewarden.yaml.
+func (p *Plugin) Name() string { return "user-management" }
+
+// Priority returns the plugin's initialisation priority.
+// User management is assigned priority 60 so it is initialised after TLS (10),
+// security-headers (20), rate-limiting (30), and auth (40).
+func (p *Plugin) Priority() int { return 60 }
+
+// Init validates the plugin configuration and creates the admin service and
+// HTTP handlers. It must be called before Start. Long-running work (server
+// binding) is deferred to Start.
+//
+// Returns an error when:
+//   - Enabled is true but AdminToken is empty.
+//   - Enabled is true but KratosAdminURL is empty or not a valid URL.
+//   - The audit database cannot be reached (when DatabaseURL is non-empty).
+func (p *Plugin) Init(_ context.Context) error {
+	if !p.cfg.Enabled {
+		p.healthy = true
+		p.healthMsg = "user-management disabled"
+		return nil
+	}
+
+	if err := validateConfig(p.cfg); err != nil {
+		return fmt.Errorf("user-management plugin init: %w", err)
+	}
+
+	svc, cleanup, err := ExportedServiceFactory(p.cfg, p.eventLogger, p.logger)
+	if err != nil {
+		return fmt.Errorf("user-management plugin init: %w", err)
+	}
+	p.dbCleanup = cleanup
+	p.handlers = httpadapter.NewAdminHandlers(svc, p.logger)
+
+	p.healthy = true
+	p.healthMsg = fmt.Sprintf("user-management configured, kratos admin: %s", p.cfg.KratosAdminURL)
+
+	p.logger.Info("user-management plugin initialised",
+		slog.String("kratos_admin_url", p.cfg.KratosAdminURL),
+		slog.Bool("audit_log", p.cfg.DatabaseURL != ""),
+	)
+
+	return nil
+}
+
+// Start creates the internal HTTP server, binds it to a random localhost
+// port, and begins accepting connections. It returns promptly; the server
+// runs in a background goroutine managed by the AdminServer implementation.
+//
+// Start must be called after Init. Calling Start on a disabled plugin is a
+// no-op.
+func (p *Plugin) Start(_ context.Context) error {
+	if !p.cfg.Enabled {
+		return nil
+	}
+
+	srv := ExportedServerFactory(p.handlers, p.logger)
+	if err := srv.Start(); err != nil {
+		p.healthy = false
+		p.healthMsg = fmt.Sprintf("user-management: admin server failed to start: %s", err)
+		return fmt.Errorf("starting user-management admin server: %w", err)
+	}
+
+	p.server = srv
+	p.internalAddr = srv.Addr()
+
+	p.logger.Info("user-management admin server started",
+		slog.String("internal_addr", p.internalAddr),
+	)
+
+	return nil
+}
+
+// Stop gracefully shuts down the internal admin HTTP server and closes any
+// database connections opened during Init. Calling Stop on a disabled or
+// not-yet-started plugin is a no-op.
+func (p *Plugin) Stop(ctx context.Context) error {
+	if p.dbCleanup != nil {
+		p.dbCleanup()
+	}
+	if !p.cfg.Enabled || p.server == nil {
+		return nil
+	}
+	if err := p.server.Stop(ctx); err != nil {
+		return fmt.Errorf("stopping user-management admin server: %w", err)
+	}
+	return nil
+}
+
+// Health returns the current health status of the user-management plugin.
+// Returns healthy=true with a "user-management disabled" message when the
+// plugin is disabled. When enabled, reflects the state set during Init/Start.
+// Health is safe to call concurrently and does not block.
+func (p *Plugin) Health() ports.HealthStatus {
+	return ports.HealthStatus{
+		Healthy: p.healthy,
+		Message: p.healthMsg,
+	}
+}
+
+// HealthCheck performs a live connectivity probe against the Kratos admin API
+// and updates the internal health state. Unlike Health, this method makes a
+// real HTTP request and is safe to call from a background goroutine.
+func (p *Plugin) HealthCheck(ctx context.Context) ports.HealthStatus {
+	if !p.cfg.Enabled {
+		return ports.HealthStatus{Healthy: true, Message: "user-management disabled"}
+	}
+
+	probeURL := p.cfg.KratosAdminURL + kratosAdminHealthPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, nil)
+	if err != nil {
+		p.healthy = false
+		p.healthMsg = fmt.Sprintf("user-management: cannot build health probe: %s", err)
+		return ports.HealthStatus{Healthy: false, Message: p.healthMsg}
+	}
+
+	client := &http.Client{Timeout: healthCheckTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		p.healthy = false
+		p.healthMsg = fmt.Sprintf("user-management: kratos admin unreachable: %s", err)
+		return ports.HealthStatus{Healthy: false, Message: p.healthMsg}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 500 {
+		p.healthy = false
+		p.healthMsg = fmt.Sprintf("user-management: kratos admin health probe returned %d", resp.StatusCode)
+		return ports.HealthStatus{Healthy: false, Message: p.healthMsg}
+	}
+
+	p.healthy = true
+	p.healthMsg = fmt.Sprintf("user-management configured, kratos admin: %s", p.cfg.KratosAdminURL)
+	return ports.HealthStatus{Healthy: true, Message: p.healthMsg}
+}
+
+// InternalAddr returns the host:port the internal admin HTTP server is
+// listening on. It must only be called after a successful Start.
+// Implements ports.InternalServerPlugin.
+func (p *Plugin) InternalAddr() string {
+	return p.internalAddr
+}
+
+// ContributeCaddyRoutes returns the Caddy route that reverse-proxies all
+// /_vibewarden/admin/* requests to the internal admin HTTP server.
+//
+// The route has Priority 60 and is placed before the catch-all reverse proxy
+// route so that admin requests are never forwarded to the upstream application.
+//
+// Returns nil when the plugin is disabled.
+func (p *Plugin) ContributeCaddyRoutes() []ports.CaddyRoute {
+	if !p.cfg.Enabled {
+		return nil
+	}
+
+	return []ports.CaddyRoute{
+		{
+			MatchPath: adminPath,
+			Priority:  60,
+			Handler: map[string]any{
+				"match": []map[string]any{
+					{"path": []string{adminPath}},
+				},
+				"handle": []map[string]any{
+					{
+						"handler": "reverse_proxy",
+						"upstreams": []map[string]any{
+							{"dial": p.internalAddr},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// ContributeCaddyHandlers returns the Caddy handler that validates the
+// X-Admin-Key bearer token for all /_vibewarden/admin/* requests.
+//
+// The handler has Priority 60 and is placed in the catch-all handler chain.
+// Requests to other paths pass through unchanged.
+//
+// Returns nil when the plugin is disabled.
+func (p *Plugin) ContributeCaddyHandlers() []ports.CaddyHandler {
+	if !p.cfg.Enabled {
+		return nil
+	}
+
+	return []ports.CaddyHandler{
+		{
+			Handler: map[string]any{
+				"handler":     "admin_auth",
+				"admin_token": p.cfg.AdminToken,
+				"admin_path":  adminPathPrefix,
+			},
+			Priority: 60,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers — pure functions, no side effects.
+// ---------------------------------------------------------------------------
+
+// validateConfig checks that the user-management configuration is
+// self-consistent and returns an error describing the first violation found.
+func validateConfig(cfg Config) error {
+	if cfg.AdminToken == "" {
+		return fmt.Errorf("admin_token is required when user-management is enabled")
+	}
+	if cfg.KratosAdminURL == "" {
+		return fmt.Errorf("kratos_admin_url is required when user-management is enabled")
+	}
+	if _, err := url.ParseRequestURI(cfg.KratosAdminURL); err != nil {
+		return fmt.Errorf("kratos_admin_url %q is not a valid URL: %w", cfg.KratosAdminURL, err)
+	}
+	return nil
+}

--- a/internal/plugins/usermgmt/plugin_test.go
+++ b/internal/plugins/usermgmt/plugin_test.go
@@ -1,0 +1,823 @@
+package usermgmt_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	httpadapter "github.com/vibewarden/vibewarden/internal/adapters/http"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/domain/user"
+	"github.com/vibewarden/vibewarden/internal/plugins/usermgmt"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+// fakeAdminService implements ports.AdminService for testing.
+type fakeAdminService struct {
+	listErr       error
+	getUserErr    error
+	inviteErr     error
+	deactivateErr error
+}
+
+func (f *fakeAdminService) ListUsers(_ context.Context, _ ports.Pagination) (*ports.PaginatedUsers, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return &ports.PaginatedUsers{Users: []user.User{}, Total: 0}, nil
+}
+
+func (f *fakeAdminService) GetUser(_ context.Context, _ string) (*user.User, error) {
+	if f.getUserErr != nil {
+		return nil, f.getUserErr
+	}
+	u := user.User{ID: "test-id", Email: "test@example.com"}
+	return &u, nil
+}
+
+func (f *fakeAdminService) InviteUser(_ context.Context, _ string, _ string) (*ports.InviteResult, error) {
+	if f.inviteErr != nil {
+		return nil, f.inviteErr
+	}
+	return &ports.InviteResult{User: user.User{ID: "new-id", Email: "new@example.com"}}, nil
+}
+
+func (f *fakeAdminService) DeactivateUser(_ context.Context, _ string, _ string, _ string) error {
+	return f.deactivateErr
+}
+
+// fakeAdminServer implements adminServer interface for testing without binding
+// a real port.
+type fakeAdminServer struct {
+	started  bool
+	stopped  bool
+	addr     string
+	startErr error
+	stopErr  error
+}
+
+func (s *fakeAdminServer) Start() error {
+	if s.startErr != nil {
+		return s.startErr
+	}
+	s.started = true
+	if s.addr == "" {
+		s.addr = "127.0.0.1:19999"
+	}
+	return nil
+}
+
+func (s *fakeAdminServer) Addr() string { return s.addr }
+
+func (s *fakeAdminServer) Stop(_ context.Context) error {
+	s.stopped = true
+	return s.stopErr
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// noopWriter discards all writes.
+type noopWriter struct{}
+
+func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// discardLogger returns an slog.Logger that discards all output.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(noopWriter{}, nil))
+}
+
+// fakeNopEventLogger is a ports.EventLogger that always succeeds.
+type fakeNopEventLogger struct{}
+
+func (f *fakeNopEventLogger) Log(_ context.Context, _ events.Event) error { return nil }
+
+// defaultConfig returns a valid enabled Config for testing.
+func defaultConfig() usermgmt.Config {
+	return usermgmt.Config{
+		Enabled:        true,
+		AdminToken:     "super-secret-token",
+		KratosAdminURL: "http://127.0.0.1:4434",
+		DatabaseURL:    "",
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Name / Priority
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Name(t *testing.T) {
+	p := usermgmt.New(defaultConfig(), &fakeNopEventLogger{}, discardLogger())
+	if got := p.Name(); got != "user-management" {
+		t.Errorf("Name() = %q, want %q", got, "user-management")
+	}
+}
+
+func TestPlugin_Priority(t *testing.T) {
+	p := usermgmt.New(defaultConfig(), &fakeNopEventLogger{}, discardLogger())
+	if got := p.Priority(); got != 60 {
+		t.Errorf("Priority() = %d, want 60", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Init(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     usermgmt.Config
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "disabled — no validation performed",
+			cfg:     usermgmt.Config{Enabled: false},
+			wantErr: false,
+		},
+		{
+			name:    "enabled without admin token",
+			cfg:     usermgmt.Config{Enabled: true, KratosAdminURL: "http://127.0.0.1:4434"},
+			wantErr: true,
+			errMsg:  "admin_token is required",
+		},
+		{
+			name:    "enabled without kratos admin url",
+			cfg:     usermgmt.Config{Enabled: true, AdminToken: "token"},
+			wantErr: true,
+			errMsg:  "kratos_admin_url is required",
+		},
+		{
+			name:    "enabled with invalid kratos admin url",
+			cfg:     usermgmt.Config{Enabled: true, AdminToken: "token", KratosAdminURL: "not-a-url"},
+			wantErr: true,
+			errMsg:  "not a valid URL",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Install a fake service factory so Init does not dial Kratos or Postgres.
+			old := usermgmt.ExportedServiceFactory
+			usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+				return &fakeAdminService{}, nil, nil
+			}
+			defer func() { usermgmt.ExportedServiceFactory = old }()
+
+			p := usermgmt.New(tt.cfg, &fakeNopEventLogger{}, discardLogger())
+			err := p.Init(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.errMsg != "" {
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("Init() error = %q, want to contain %q", err.Error(), tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestPlugin_Init_ServiceFactoryError(t *testing.T) {
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return nil, nil, errors.New("db connection failed")
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	p := usermgmt.New(defaultConfig(), &fakeNopEventLogger{}, discardLogger())
+	err := p.Init(context.Background())
+	if err == nil {
+		t.Fatal("Init() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "db connection failed") {
+		t.Errorf("Init() error = %q, want to contain %q", err.Error(), "db connection failed")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Start / Stop
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Start_BindsServer(t *testing.T) {
+	fake := &fakeAdminServer{addr: "127.0.0.1:19999"}
+
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	oldSrv := usermgmt.ExportedServerFactory
+	usermgmt.ExportedServerFactory = func(_ *httpadapter.AdminHandlers, _ *slog.Logger) usermgmt.AdminServerIface {
+		return fake
+	}
+	defer func() { usermgmt.ExportedServerFactory = oldSrv }()
+
+	p := usermgmt.New(defaultConfig(), &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+
+	if !fake.started {
+		t.Error("Start() did not call server.Start()")
+	}
+	if p.InternalAddr() != "127.0.0.1:19999" {
+		t.Errorf("InternalAddr() = %q, want %q", p.InternalAddr(), "127.0.0.1:19999")
+	}
+}
+
+func TestPlugin_Start_Disabled_IsNoop(t *testing.T) {
+	p := usermgmt.New(usermgmt.Config{Enabled: false}, &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Errorf("Start() on disabled plugin returned error: %v", err)
+	}
+}
+
+func TestPlugin_Start_ServerStartError(t *testing.T) {
+	fake := &fakeAdminServer{startErr: errors.New("port in use")}
+
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	oldSrv := usermgmt.ExportedServerFactory
+	usermgmt.ExportedServerFactory = func(_ *httpadapter.AdminHandlers, _ *slog.Logger) usermgmt.AdminServerIface {
+		return fake
+	}
+	defer func() { usermgmt.ExportedServerFactory = oldSrv }()
+
+	p := usermgmt.New(defaultConfig(), &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	err := p.Start(context.Background())
+	if err == nil {
+		t.Fatal("Start() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "port in use") {
+		t.Errorf("Start() error = %q, want to contain %q", err.Error(), "port in use")
+	}
+}
+
+func TestPlugin_Stop_CallsServerStop(t *testing.T) {
+	fake := &fakeAdminServer{addr: "127.0.0.1:19999"}
+
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	oldSrv := usermgmt.ExportedServerFactory
+	usermgmt.ExportedServerFactory = func(_ *httpadapter.AdminHandlers, _ *slog.Logger) usermgmt.AdminServerIface {
+		return fake
+	}
+	defer func() { usermgmt.ExportedServerFactory = oldSrv }()
+
+	p := usermgmt.New(defaultConfig(), &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	if err := p.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() error: %v", err)
+	}
+	if !fake.stopped {
+		t.Error("Stop() did not call server.Stop()")
+	}
+}
+
+func TestPlugin_Stop_Disabled_IsNoop(t *testing.T) {
+	p := usermgmt.New(usermgmt.Config{Enabled: false}, &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	if err := p.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() on disabled plugin returned error: %v", err)
+	}
+}
+
+func TestPlugin_Stop_ServerStopError(t *testing.T) {
+	fake := &fakeAdminServer{addr: "127.0.0.1:19999", stopErr: errors.New("shutdown timeout")}
+
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	oldSrv := usermgmt.ExportedServerFactory
+	usermgmt.ExportedServerFactory = func(_ *httpadapter.AdminHandlers, _ *slog.Logger) usermgmt.AdminServerIface {
+		return fake
+	}
+	defer func() { usermgmt.ExportedServerFactory = oldSrv }()
+
+	p := usermgmt.New(defaultConfig(), &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	err := p.Stop(context.Background())
+	if err == nil {
+		t.Fatal("Stop() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "shutdown timeout") {
+		t.Errorf("Stop() error = %q, want to contain %q", err.Error(), "shutdown timeout")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Health_Disabled(t *testing.T) {
+	p := usermgmt.New(usermgmt.Config{Enabled: false}, &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	h := p.Health()
+	if !h.Healthy {
+		t.Errorf("Health().Healthy = false for disabled plugin, want true")
+	}
+	if !strings.Contains(h.Message, "disabled") {
+		t.Errorf("Health().Message = %q, want to contain %q", h.Message, "disabled")
+	}
+}
+
+func TestPlugin_Health_EnabledAfterInit(t *testing.T) {
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	p := usermgmt.New(defaultConfig(), &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	h := p.Health()
+	if !h.Healthy {
+		t.Errorf("Health().Healthy = false after Init, want true")
+	}
+	if !strings.Contains(h.Message, "configured") {
+		t.Errorf("Health().Message = %q, want to contain %q", h.Message, "configured")
+	}
+}
+
+func TestPlugin_Health_Table(t *testing.T) {
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	tests := []struct {
+		name           string
+		cfg            usermgmt.Config
+		wantHealthy    bool
+		wantMsgContain string
+	}{
+		{
+			name:           "disabled",
+			cfg:            usermgmt.Config{Enabled: false},
+			wantHealthy:    true,
+			wantMsgContain: "disabled",
+		},
+		{
+			name:           "enabled with valid config",
+			cfg:            defaultConfig(),
+			wantHealthy:    true,
+			wantMsgContain: "configured",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := usermgmt.New(tt.cfg, &fakeNopEventLogger{}, discardLogger())
+			if err := p.Init(context.Background()); err != nil {
+				t.Fatalf("Init() error: %v", err)
+			}
+			h := p.Health()
+			if h.Healthy != tt.wantHealthy {
+				t.Errorf("Health().Healthy = %v, want %v", h.Healthy, tt.wantHealthy)
+			}
+			if !strings.Contains(h.Message, tt.wantMsgContain) {
+				t.Errorf("Health().Message = %q, want to contain %q", h.Message, tt.wantMsgContain)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HealthCheck — live probe
+// ---------------------------------------------------------------------------
+
+func TestPlugin_HealthCheck_KratosAdminReachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health/ready" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	cfg := usermgmt.Config{
+		Enabled:        true,
+		AdminToken:     "token",
+		KratosAdminURL: srv.URL,
+	}
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	p := usermgmt.New(cfg, &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	h := p.HealthCheck(context.Background())
+	if !h.Healthy {
+		t.Errorf("HealthCheck() healthy = false, want true; message: %s", h.Message)
+	}
+}
+
+func TestPlugin_HealthCheck_KratosAdminUnreachable(t *testing.T) {
+	cfg := usermgmt.Config{
+		Enabled:        true,
+		AdminToken:     "token",
+		KratosAdminURL: "http://127.0.0.1:19998", // nothing listening
+	}
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	p := usermgmt.New(cfg, &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	h := p.HealthCheck(context.Background())
+	if h.Healthy {
+		t.Error("HealthCheck() healthy = true for unreachable Kratos admin, want false")
+	}
+}
+
+func TestPlugin_HealthCheck_Disabled(t *testing.T) {
+	p := usermgmt.New(usermgmt.Config{Enabled: false}, &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	h := p.HealthCheck(context.Background())
+	if !h.Healthy {
+		t.Error("HealthCheck() healthy = false for disabled plugin, want true")
+	}
+}
+
+func TestPlugin_HealthCheck_KratosAdminServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := usermgmt.Config{
+		Enabled:        true,
+		AdminToken:     "token",
+		KratosAdminURL: srv.URL,
+	}
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	p := usermgmt.New(cfg, &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	h := p.HealthCheck(context.Background())
+	if h.Healthy {
+		t.Error("HealthCheck() healthy = true for 500 response, want false")
+	}
+	if !strings.Contains(h.Message, "500") {
+		t.Errorf("HealthCheck().Message = %q, want to contain status code", h.Message)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyRoutes
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyRoutes_Disabled(t *testing.T) {
+	p := usermgmt.New(usermgmt.Config{Enabled: false}, &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	routes := p.ContributeCaddyRoutes()
+	if len(routes) != 0 {
+		t.Errorf("ContributeCaddyRoutes() = %d routes for disabled plugin, want 0", len(routes))
+	}
+}
+
+func TestPlugin_ContributeCaddyRoutes_Enabled(t *testing.T) {
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	oldSrv := usermgmt.ExportedServerFactory
+	usermgmt.ExportedServerFactory = func(_ *httpadapter.AdminHandlers, _ *slog.Logger) usermgmt.AdminServerIface {
+		return &fakeAdminServer{addr: "127.0.0.1:19999"}
+	}
+	defer func() { usermgmt.ExportedServerFactory = oldSrv }()
+
+	p := usermgmt.New(defaultConfig(), &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+
+	routes := p.ContributeCaddyRoutes()
+	if len(routes) == 0 {
+		t.Fatal("ContributeCaddyRoutes() returned empty slice for enabled plugin")
+	}
+}
+
+func TestPlugin_ContributeCaddyRoutes_HandlerIsReverseProxy(t *testing.T) {
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	oldSrv := usermgmt.ExportedServerFactory
+	usermgmt.ExportedServerFactory = func(_ *httpadapter.AdminHandlers, _ *slog.Logger) usermgmt.AdminServerIface {
+		return &fakeAdminServer{addr: "127.0.0.1:19999"}
+	}
+	defer func() { usermgmt.ExportedServerFactory = oldSrv }()
+
+	p := usermgmt.New(defaultConfig(), &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+
+	routes := p.ContributeCaddyRoutes()
+	if len(routes) == 0 {
+		t.Fatal("no routes contributed")
+	}
+
+	handleSlice, ok := routes[0].Handler["handle"].([]map[string]any)
+	if !ok {
+		t.Fatalf("handle is not []map[string]any: %T", routes[0].Handler["handle"])
+	}
+	if len(handleSlice) == 0 {
+		t.Fatal("handle slice is empty")
+	}
+	if got := handleSlice[0]["handler"]; got != "reverse_proxy" {
+		t.Errorf("handler = %q, want %q", got, "reverse_proxy")
+	}
+}
+
+func TestPlugin_ContributeCaddyRoutes_DialAddrMatchesInternalAddr(t *testing.T) {
+	const wantAddr = "127.0.0.1:19999"
+
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	oldSrv := usermgmt.ExportedServerFactory
+	usermgmt.ExportedServerFactory = func(_ *httpadapter.AdminHandlers, _ *slog.Logger) usermgmt.AdminServerIface {
+		return &fakeAdminServer{addr: wantAddr}
+	}
+	defer func() { usermgmt.ExportedServerFactory = oldSrv }()
+
+	p := usermgmt.New(defaultConfig(), &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+
+	routes := p.ContributeCaddyRoutes()
+	if len(routes) == 0 {
+		t.Fatal("no routes contributed")
+	}
+
+	handleSlice, ok := routes[0].Handler["handle"].([]map[string]any)
+	if !ok || len(handleSlice) == 0 {
+		t.Fatal("handle slice invalid")
+	}
+	upstreams, ok := handleSlice[0]["upstreams"].([]map[string]any)
+	if !ok || len(upstreams) == 0 {
+		t.Fatal("upstreams slice invalid")
+	}
+	dialAddr, ok := upstreams[0]["dial"].(string)
+	if !ok {
+		t.Fatal("dial is not a string")
+	}
+	if dialAddr != wantAddr {
+		t.Errorf("dial = %q, want %q", dialAddr, wantAddr)
+	}
+}
+
+func TestPlugin_ContributeCaddyRoutes_Priority(t *testing.T) {
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	oldSrv := usermgmt.ExportedServerFactory
+	usermgmt.ExportedServerFactory = func(_ *httpadapter.AdminHandlers, _ *slog.Logger) usermgmt.AdminServerIface {
+		return &fakeAdminServer{addr: "127.0.0.1:19999"}
+	}
+	defer func() { usermgmt.ExportedServerFactory = oldSrv }()
+
+	p := usermgmt.New(defaultConfig(), &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+
+	routes := p.ContributeCaddyRoutes()
+	if len(routes) == 0 {
+		t.Fatal("no routes")
+	}
+	if routes[0].Priority != 60 {
+		t.Errorf("route Priority = %d, want 60", routes[0].Priority)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyHandlers
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyHandlers_Disabled(t *testing.T) {
+	p := usermgmt.New(usermgmt.Config{Enabled: false}, &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 0 {
+		t.Errorf("ContributeCaddyHandlers() = %d handlers for disabled plugin, want 0", len(handlers))
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_Enabled(t *testing.T) {
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	p := usermgmt.New(defaultConfig(), &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 1 {
+		t.Fatalf("ContributeCaddyHandlers() = %d handlers, want 1", len(handlers))
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_AdminAuthHandler(t *testing.T) {
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	p := usermgmt.New(defaultConfig(), &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) < 1 {
+		t.Fatal("no handlers contributed")
+	}
+
+	h := handlers[0]
+	if h.Priority != 60 {
+		t.Errorf("admin_auth handler Priority = %d, want 60", h.Priority)
+	}
+	if h.Handler["handler"] != "admin_auth" {
+		t.Errorf("handler type = %q, want %q", h.Handler["handler"], "admin_auth")
+	}
+	if _, ok := h.Handler["admin_token"]; !ok {
+		t.Error("admin_auth handler missing admin_token field")
+	}
+	if _, ok := h.Handler["admin_path"]; !ok {
+		t.Error("admin_auth handler missing admin_path field")
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_AdminTokenSet(t *testing.T) {
+	const wantToken = "my-secret-token"
+
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	cfg := defaultConfig()
+	cfg.AdminToken = wantToken
+	p := usermgmt.New(cfg, &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) < 1 {
+		t.Fatal("no handlers")
+	}
+	token, ok := handlers[0].Handler["admin_token"].(string)
+	if !ok {
+		t.Fatalf("admin_token is not string: %T", handlers[0].Handler["admin_token"])
+	}
+	if token != wantToken {
+		t.Errorf("admin_token = %q, want %q", token, wantToken)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// InternalAddr
+// ---------------------------------------------------------------------------
+
+func TestPlugin_InternalAddr_Empty_BeforeStart(t *testing.T) {
+	old := usermgmt.ExportedServiceFactory
+	usermgmt.ExportedServiceFactory = func(_ usermgmt.Config, _ ports.EventLogger, _ *slog.Logger) (ports.AdminService, func(), error) {
+		return &fakeAdminService{}, nil, nil
+	}
+	defer func() { usermgmt.ExportedServiceFactory = old }()
+
+	p := usermgmt.New(defaultConfig(), &fakeNopEventLogger{}, discardLogger())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	if got := p.InternalAddr(); got != "" {
+		t.Errorf("InternalAddr() before Start = %q, want empty string", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Interface compliance
+// ---------------------------------------------------------------------------
+
+// TestPlugin_ImplementsPortsPlugin asserts at compile time that *Plugin
+// satisfies ports.Plugin.
+func TestPlugin_ImplementsPortsPlugin(t *testing.T) {
+	var _ ports.Plugin = (*usermgmt.Plugin)(nil)
+}
+
+// TestPlugin_ImplementsCaddyContributor asserts at compile time that *Plugin
+// satisfies ports.CaddyContributor.
+func TestPlugin_ImplementsCaddyContributor(t *testing.T) {
+	var _ ports.CaddyContributor = (*usermgmt.Plugin)(nil)
+}
+
+// TestPlugin_ImplementsInternalServerPlugin asserts at compile time that
+// *Plugin satisfies ports.InternalServerPlugin.
+func TestPlugin_ImplementsInternalServerPlugin(t *testing.T) {
+	var _ ports.InternalServerPlugin = (*usermgmt.Plugin)(nil)
+}


### PR DESCRIPTION
Closes #163

## Summary

- Adds `internal/plugins/usermgmt/config.go` — `Config` struct with `Enabled`, `AdminToken`, `KratosAdminURL`, and `DatabaseURL` fields
- Adds `internal/plugins/usermgmt/plugin.go` — `Plugin` implementing `ports.Plugin`, `ports.CaddyContributor`, and `ports.InternalServerPlugin`
- Adds `internal/plugins/usermgmt/plugin_test.go` — unit tests with fakes covering all plugin methods

The plugin wraps the existing admin API wiring (Kratos admin adapter, `app/admin.Service`, `adapters/http.AdminServer`) behind the plugin lifecycle:

- `Init` validates config, builds the admin service via the replaceable `ExportedServiceFactory`, and creates HTTP handlers
- `Start` creates the internal HTTP server via `ExportedServerFactory` and binds a random localhost port
- `Stop` gracefully shuts down the server and closes the optional audit DB connection
- `ContributeCaddyRoutes` returns a Priority 60 route that reverse-proxies `/_vibewarden/admin/*` to the internal server
- `ContributeCaddyHandlers` returns a Priority 60 admin-auth handler
- `InternalAddr` returns the bound `host:port` after `Start`
- `HealthCheck` performs a live probe against the Kratos admin `/health/ready` endpoint

Both factories are exported (`ExportedServiceFactory`, `ExportedServerFactory`) so tests can inject fakes without dialling real services.

## Test plan

- `go test ./internal/plugins/usermgmt/...` — all tests pass
- `make check` — all checks pass including demo-app