### PR TITLE
feat(#164): update CLI for plugins

### DIFF
--- a/cmd/vibewarden/serve.go
+++ b/cmd/vibewarden/serve.go
@@ -12,19 +12,21 @@ import (
 	"github.com/spf13/cobra"
 
 	caddyadapter "github.com/vibewarden/vibewarden/internal/adapters/caddy"
-	httpadapter "github.com/vibewarden/vibewarden/internal/adapters/http"
-	kratosadapter "github.com/vibewarden/vibewarden/internal/adapters/kratos"
 	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
-	metricsadapter "github.com/vibewarden/vibewarden/internal/adapters/metrics"
-	postgresadapter "github.com/vibewarden/vibewarden/internal/adapters/postgres"
-	adminapp "github.com/vibewarden/vibewarden/internal/app/admin"
+	ratelimitadapter "github.com/vibewarden/vibewarden/internal/adapters/ratelimit"
 	"github.com/vibewarden/vibewarden/internal/app/proxy"
 	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/plugins"
+	authplugin "github.com/vibewarden/vibewarden/internal/plugins/auth"
+	metricsplugin "github.com/vibewarden/vibewarden/internal/plugins/metrics"
+	ratelimitplugin "github.com/vibewarden/vibewarden/internal/plugins/ratelimit"
+	sechdrs "github.com/vibewarden/vibewarden/internal/plugins/securityheaders"
+	tlsplugin "github.com/vibewarden/vibewarden/internal/plugins/tls"
+	usermgmtplugin "github.com/vibewarden/vibewarden/internal/plugins/usermgmt"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
 // newServeCmd creates the serve subcommand.
-// This is a minimal implementation; the full CLI is handled in Epic #6.
 func newServeCmd() *cobra.Command {
 	var configPath string
 
@@ -45,14 +47,14 @@ Listens for SIGINT/SIGTERM and performs a graceful shutdown.`,
 	return cmd
 }
 
-// runServe loads config, wires up the proxy, and runs until shutdown signal.
+// runServe loads config, builds the plugin registry, wires Caddy via plugin
+// contributors, and runs until a shutdown signal is received.
 func runServe(configPath string) error {
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
-	// Initialize structured logger.
 	logger := buildLogger(cfg.Log)
 
 	logger.Info("VibeWarden starting",
@@ -64,72 +66,163 @@ func runServe(configPath string) error {
 	// Initialize the EventLogger — writes structured JSON events to stdout.
 	eventLogger := logadapter.NewSlogEventLogger(os.Stdout)
 
-	// Initialize Prometheus metrics adapter and start the internal metrics server.
-	// The internal server binds a random localhost port; Caddy reverse-proxies
-	// /_vibewarden/metrics to it when metrics are enabled.
+	// Build the plugin registry and register all compiled-in plugins.
+	registry := plugins.NewRegistry(logger)
+	registerPlugins(registry, cfg, eventLogger, logger)
+
+	// Set up OS signal handling before Init/Start so that a slow Init can
+	// still be interrupted.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		sig := <-sigCh
+		logger.Info("received shutdown signal", slog.String("signal", sig.String()))
+		cancel()
+	}()
+
+	// Initialise all plugins.
+	if err := registry.InitAll(ctx); err != nil {
+		return fmt.Errorf("initialising plugins: %w", err)
+	}
+
+	// Start all plugins (background servers, etc.).
+	if err := registry.StartAll(ctx); err != nil {
+		return fmt.Errorf("starting plugins: %w", err)
+	}
+
+	// Ensure StopAll runs on return (normal or error path).
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		if stopErr := registry.StopAll(stopCtx); stopErr != nil {
+			logger.Error("stopping plugins", slog.String("error", stopErr.Error()))
+		}
+	}()
+
+	// Build ProxyConfig — base fields that the Caddy adapter uses directly.
+	// Plugin-specific wiring (security headers, rate limiting, auth, admin,
+	// metrics) is now driven by each plugin's CaddyContributor implementation.
+	// The legacy top-level fields are still populated for the existing
+	// BuildCaddyConfig path; a follow-up issue will migrate that fully to
+	// the contributor model.
+	proxyCfg := buildProxyConfig(cfg, registry)
+
+	// Create Caddy adapter and proxy service.
+	adapter := caddyadapter.NewAdapter(proxyCfg, logger, eventLogger)
+	svc := proxy.NewService(adapter, logger)
+
+	if err := svc.Run(ctx); err != nil {
+		return fmt.Errorf("proxy service: %w", err)
+	}
+
+	return nil
+}
+
+// registerPlugins creates each compiled-in plugin from cfg and registers it
+// with the registry. Registration order matches plugin priority (low → high).
+func registerPlugins(
+	registry *plugins.Registry,
+	cfg *config.Config,
+	eventLogger ports.EventLogger,
+	logger *slog.Logger,
+) {
+	// TLS — priority 10
+	registry.Register(tlsplugin.New(ports.TLSConfig{
+		Enabled:     cfg.TLS.Enabled,
+		Provider:    ports.TLSProvider(cfg.TLS.Provider),
+		Domain:      cfg.TLS.Domain,
+		CertPath:    cfg.TLS.CertPath,
+		KeyPath:     cfg.TLS.KeyPath,
+		StoragePath: cfg.TLS.StoragePath,
+	}, logger))
+
+	// Security headers — priority 20
+	registry.Register(sechdrs.New(sechdrs.Config{
+		Enabled:               cfg.SecurityHeaders.Enabled,
+		HSTSMaxAge:            cfg.SecurityHeaders.HSTSMaxAge,
+		HSTSIncludeSubDomains: cfg.SecurityHeaders.HSTSIncludeSubDomains,
+		HSTSPreload:           cfg.SecurityHeaders.HSTSPreload,
+		ContentTypeNosniff:    cfg.SecurityHeaders.ContentTypeNosniff,
+		FrameOption:           cfg.SecurityHeaders.FrameOption,
+		ContentSecurityPolicy: cfg.SecurityHeaders.ContentSecurityPolicy,
+		ReferrerPolicy:        cfg.SecurityHeaders.ReferrerPolicy,
+		PermissionsPolicy:     cfg.SecurityHeaders.PermissionsPolicy,
+	}, cfg.TLS.Enabled, logger))
+
+	// Metrics — priority 30
+	registry.Register(metricsplugin.New(metricsplugin.Config{
+		Enabled:      cfg.Metrics.Enabled,
+		PathPatterns: cfg.Metrics.PathPatterns,
+	}, logger))
+
+	// Rate limiting — priority 50
+	registry.Register(ratelimitplugin.New(ratelimitplugin.Config{
+		Enabled:           cfg.RateLimit.Enabled,
+		Store:             "memory",
+		TrustProxyHeaders: cfg.RateLimit.TrustProxyHeaders,
+		ExemptPaths:       cfg.RateLimit.ExemptPaths,
+		PerIP: ratelimitplugin.RuleConfig{
+			RequestsPerSecond: cfg.RateLimit.PerIP.RequestsPerSecond,
+			Burst:             cfg.RateLimit.PerIP.Burst,
+		},
+		PerUser: ratelimitplugin.RuleConfig{
+			RequestsPerSecond: cfg.RateLimit.PerUser.RequestsPerSecond,
+			Burst:             cfg.RateLimit.PerUser.Burst,
+		},
+	}, ratelimitadapter.NewDefaultMemoryFactory(), logger))
+
+	// Auth — priority 40 (registered after rate-limiting for dependency clarity;
+	// actual order is controlled by priority, but registry order matches intent)
+	registry.Register(authplugin.New(authplugin.Config{
+		Enabled:           cfg.Auth.Enabled,
+		KratosPublicURL:   cfg.Kratos.PublicURL,
+		KratosAdminURL:    cfg.Kratos.AdminURL,
+		SessionCookieName: cfg.Auth.SessionCookieName,
+		LoginURL:          cfg.Auth.LoginURL,
+		PublicPaths:       cfg.Auth.PublicPaths,
+		IdentitySchema:    cfg.Auth.IdentitySchema,
+	}, logger, nil))
+
+	// User management — priority 60
+	registry.Register(usermgmtplugin.New(usermgmtplugin.Config{
+		Enabled:        cfg.Admin.Enabled,
+		AdminToken:     cfg.Admin.Token,
+		KratosAdminURL: cfg.Kratos.AdminURL,
+		DatabaseURL:    cfg.Database.URL,
+	}, eventLogger, logger))
+}
+
+// buildProxyConfig constructs the ports.ProxyConfig that the Caddy adapter
+// uses to build its JSON configuration. Plugin-specific fields are read from
+// the running plugins where possible (e.g. metrics internal address after
+// Start).
+func buildProxyConfig(cfg *config.Config, registry *plugins.Registry) *ports.ProxyConfig {
+	// Collect internal addresses from started InternalServerPlugin instances.
 	var metricsCfg ports.MetricsProxyConfig
-	if cfg.Metrics.Enabled {
-		pa := metricsadapter.NewPrometheusAdapter(cfg.Metrics.PathPatterns)
-		metricsSrv := metricsadapter.NewServer(pa.Handler(), logger)
-		if err := metricsSrv.Start(); err != nil {
-			return fmt.Errorf("starting metrics server: %w", err)
-		}
-		defer func() {
-			stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer stopCancel()
-			if stopErr := metricsSrv.Stop(stopCtx); stopErr != nil {
-				logger.Error("stopping metrics server", slog.String("error", stopErr.Error()))
-			}
-		}()
-		metricsCfg = ports.MetricsProxyConfig{
-			Enabled:      true,
-			InternalAddr: metricsSrv.Addr(),
-		}
-		logger.Info("metrics enabled", slog.String("internal_addr", metricsSrv.Addr()))
-	}
-
-	// Initialize admin API when enabled in config.
 	var adminCfg ports.AdminProxyConfig
-	if cfg.Admin.Enabled {
-		kratosAdmin := kratosadapter.NewAdminAdapter(cfg.Kratos.AdminURL, 0, logger)
 
-		// AuditLogger is optional — only wired when a database URL is configured.
-		var auditLogger ports.AuditLogger
-		if cfg.Database.URL != "" {
-			auditAdapter, err := postgresadapter.NewAuditAdapter(cfg.Database.URL)
-			if err != nil {
-				return fmt.Errorf("connecting to audit database: %w", err)
-			}
-			defer func() {
-				if closeErr := auditAdapter.Close(); closeErr != nil {
-					logger.Error("closing audit database", slog.String("error", closeErr.Error()))
+	for _, p := range registry.Plugins() {
+		if isp, ok := p.(ports.InternalServerPlugin); ok {
+			switch p.Name() {
+			case "metrics":
+				metricsCfg = ports.MetricsProxyConfig{
+					Enabled:      cfg.Metrics.Enabled,
+					InternalAddr: isp.InternalAddr(),
 				}
-			}()
-			auditLogger = auditAdapter
-		}
-
-		adminSvc := adminapp.NewService(kratosAdmin, eventLogger, auditLogger)
-		adminHandlers := httpadapter.NewAdminHandlers(adminSvc, logger)
-		adminSrv := httpadapter.NewAdminServer(adminHandlers, logger)
-		if err := adminSrv.Start(); err != nil {
-			return fmt.Errorf("starting admin server: %w", err)
-		}
-		defer func() {
-			stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer stopCancel()
-			if stopErr := adminSrv.Stop(stopCtx); stopErr != nil {
-				logger.Error("stopping admin server", slog.String("error", stopErr.Error()))
+			case "user-management":
+				adminCfg = ports.AdminProxyConfig{
+					Enabled:      cfg.Admin.Enabled,
+					InternalAddr: isp.InternalAddr(),
+				}
 			}
-		}()
-		adminCfg = ports.AdminProxyConfig{
-			Enabled:      true,
-			InternalAddr: adminSrv.Addr(),
 		}
-		logger.Info("admin API enabled", slog.String("internal_addr", adminSrv.Addr()))
 	}
 
-	// Build ProxyConfig from application config.
-	proxyCfg := &ports.ProxyConfig{
+	return &ports.ProxyConfig{
 		ListenAddr:   fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port),
 		UpstreamAddr: fmt.Sprintf("%s:%d", cfg.Upstream.Host, cfg.Upstream.Port),
 		Version:      version,
@@ -153,9 +246,7 @@ func runServe(configPath string) error {
 			PermissionsPolicy:     cfg.SecurityHeaders.PermissionsPolicy,
 		},
 		Auth: ports.AuthConfig{
-			// Auth is enabled when a Kratos public URL is configured.
-			// The KratosPublicURL drives Kratos flow proxy route insertion.
-			Enabled:           cfg.Kratos.PublicURL != "",
+			Enabled:           cfg.Auth.Enabled,
 			KratosPublicURL:   cfg.Kratos.PublicURL,
 			KratosAdminURL:    cfg.Kratos.AdminURL,
 			PublicPaths:       cfg.Auth.PublicPaths,
@@ -182,30 +273,6 @@ func runServe(configPath string) error {
 		},
 		Admin: adminCfg,
 	}
-
-	// Create Caddy adapter and proxy service.
-	adapter := caddyadapter.NewAdapter(proxyCfg, logger, eventLogger)
-	svc := proxy.NewService(adapter, logger)
-
-	// Handle OS signals for graceful shutdown.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-
-	go func() {
-		sig := <-sigCh
-		logger.Info("received shutdown signal", slog.String("signal", sig.String()))
-		cancel()
-	}()
-
-	if err := svc.Run(ctx); err != nil {
-		// context.Canceled is the normal exit path after a signal.
-		return fmt.Errorf("proxy service: %w", err)
-	}
-
-	return nil
 }
 
 // buildLogger creates an slog.Logger from the log configuration.

--- a/internal/app/ops/status.go
+++ b/internal/app/ops/status.go
@@ -49,7 +49,8 @@ func (s *StatusService) Run(ctx context.Context, cfg *config.Config, out io.Writ
 	defer cancel()
 
 	statuses := s.gatherStatuses(checkCtx, cfg, proxyBase)
-	printStatusTable(statuses, out)
+	pluginStatuses := gatherPluginStatuses(cfg)
+	printStatusTable(statuses, pluginStatuses, out)
 	return nil
 }
 
@@ -107,6 +108,55 @@ func (s *StatusService) gatherStatuses(ctx context.Context, cfg *config.Config, 
 	return statuses
 }
 
+// PluginStatus represents the enabled/disabled state of a single plugin
+// as reported from the current configuration.
+type PluginStatus struct {
+	// Name is the canonical plugin identifier (e.g. "tls").
+	Name string
+	// Enabled is true when the plugin is enabled in the config.
+	Enabled bool
+	// Detail is an optional extra detail line shown in the status output.
+	Detail string
+}
+
+// gatherPluginStatuses builds a slice of PluginStatus from cfg.
+// Status is derived from config only — no live HTTP checks are made.
+func gatherPluginStatuses(cfg *config.Config) []PluginStatus {
+	var ps []PluginStatus
+
+	// TLS
+	tlsDetail := fmt.Sprintf("provider: %s", cfg.TLS.Provider)
+	if cfg.TLS.Enabled && cfg.TLS.Domain != "" {
+		tlsDetail = fmt.Sprintf("provider: %s, domain: %s", cfg.TLS.Provider, cfg.TLS.Domain)
+	}
+	ps = append(ps, PluginStatus{Name: "tls", Enabled: cfg.TLS.Enabled, Detail: tlsDetail})
+
+	// Security headers
+	ps = append(ps, PluginStatus{Name: "security-headers", Enabled: cfg.SecurityHeaders.Enabled})
+
+	// Rate limiting
+	rlDetail := ""
+	if cfg.RateLimit.Enabled {
+		rlDetail = fmt.Sprintf("store: memory, %.0f req/s per IP", cfg.RateLimit.PerIP.RequestsPerSecond)
+	}
+	ps = append(ps, PluginStatus{Name: "rate-limiting", Enabled: cfg.RateLimit.Enabled, Detail: rlDetail})
+
+	// Auth
+	authDetail := ""
+	if cfg.Auth.Enabled {
+		authDetail = fmt.Sprintf("kratos: %s", cfg.Kratos.PublicURL)
+	}
+	ps = append(ps, PluginStatus{Name: "auth", Enabled: cfg.Auth.Enabled, Detail: authDetail})
+
+	// Metrics
+	ps = append(ps, PluginStatus{Name: "metrics", Enabled: cfg.Metrics.Enabled})
+
+	// User management
+	ps = append(ps, PluginStatus{Name: "user-management", Enabled: cfg.Admin.Enabled})
+
+	return ps
+}
+
 // checkHTTP performs a health check against url and returns a ComponentStatus.
 func (s *StatusService) checkHTTP(ctx context.Context, name, url, base string) ComponentStatus {
 	ok, code, err := s.health.CheckHealth(ctx, url)
@@ -131,10 +181,11 @@ func (s *StatusService) checkHTTP(ctx context.Context, name, url, base string) C
 	}
 }
 
-// printStatusTable renders the component statuses as a table.
-func printStatusTable(statuses []ComponentStatus, out io.Writer) {
+// printStatusTable renders the component and plugin statuses as a table.
+func printStatusTable(statuses []ComponentStatus, pluginStatuses []PluginStatus, out io.Writer) {
 	green := color.New(color.FgGreen).SprintFunc()
 	red := color.New(color.FgRed).SprintFunc()
+	cyan := color.New(color.FgCyan).SprintFunc()
 
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "VibeWarden Status")
@@ -151,5 +202,25 @@ func printStatusTable(statuses []ComponentStatus, out io.Writer) {
 			fmt.Fprintf(out, "  %s  %s\n", mark, s.Name)
 		}
 	}
+
+	if len(pluginStatuses) > 0 {
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "Plugins")
+		fmt.Fprintln(out, "─────────────────────────────────────────")
+		for _, p := range pluginStatuses {
+			mark := cyan("-")
+			statusStr := "disabled"
+			if p.Enabled {
+				mark = green("✓")
+				statusStr = "enabled"
+			}
+			line := fmt.Sprintf("  %s  %-20s  %s", mark, p.Name, statusStr)
+			if p.Detail != "" {
+				line += fmt.Sprintf("  (%s)", p.Detail)
+			}
+			fmt.Fprintln(out, line)
+		}
+	}
+
 	fmt.Fprintln(out, "")
 }

--- a/internal/app/ops/status_test.go
+++ b/internal/app/ops/status_test.go
@@ -158,6 +158,37 @@ func TestStatusService_MetricsDisabled(t *testing.T) {
 	}
 }
 
+func TestStatusService_PluginSectionShown(t *testing.T) {
+	cfg := defaultConfig()
+
+	proxyBase := "http://localhost:8080"
+	checker := &fakeHealthChecker{responses: map[string]healthResponse{
+		proxyBase + "/_vibewarden/health":          {ok: true, statusCode: 200},
+		proxyBase + "/_vibewarden/metrics":         {ok: true, statusCode: 200},
+		"http://127.0.0.1:4434/admin/health/ready": {ok: true, statusCode: 200},
+	}}
+
+	svc := ops.NewStatusService(checker)
+	var buf bytes.Buffer
+	if err := svc.Run(context.Background(), cfg, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+
+	// Plugin section header must appear.
+	if !strings.Contains(out, "Plugins") {
+		t.Errorf("expected 'Plugins' section header, got:\n%s", out)
+	}
+
+	// Each canonical plugin name must appear.
+	for _, name := range []string{"tls", "security-headers", "rate-limiting", "auth", "metrics", "user-management"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("expected plugin %q in status output, got:\n%s", name, out)
+		}
+	}
+}
+
 func TestStatusService_TLSEnabled(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.TLS.Enabled = true

--- a/internal/cli/cmd/plugins.go
+++ b/internal/cli/cmd/plugins.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/plugins"
+)
+
+// NewPluginsCmd creates the "vibewarden plugins" subcommand.
+//
+// Without a subcommand it lists all compiled-in plugins with their
+// enabled/disabled status as read from the config file.
+// The "show" subcommand prints detailed configuration options for one plugin.
+func NewPluginsCmd() *cobra.Command {
+	var configPath string
+
+	cmd := &cobra.Command{
+		Use:   "plugins",
+		Short: "List available plugins and their status",
+		Long: `List all plugins compiled into this VibeWarden binary.
+
+The enabled/disabled status is read from vibewarden.yaml (or the path
+supplied with --config). When no config file is found the defaults apply.
+
+Examples:
+  vibewarden plugins
+  vibewarden plugins --config ./my-vibewarden.yaml
+  vibewarden plugins show tls`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := config.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+			printPluginList(cmd.OutOrStdout(), cfg)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&configPath, "config", "", "path to vibewarden.yaml (default: ./vibewarden.yaml)")
+	cmd.AddCommand(newPluginsShowCmd())
+
+	return cmd
+}
+
+// newPluginsShowCmd creates the "vibewarden plugins show <name>" subcommand.
+func newPluginsShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <plugin-name>",
+		Short: "Show detailed configuration options for a plugin",
+		Long: `Show the full configuration schema and an example for a single plugin.
+
+Examples:
+  vibewarden plugins show tls
+  vibewarden plugins show rate-limiting`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			d, ok := plugins.FindDescriptor(name)
+			if !ok {
+				return fmt.Errorf("unknown plugin %q; run 'vibewarden plugins' to list available plugins", name)
+			}
+			printPluginDetail(cmd.OutOrStdout(), d)
+			return nil
+		},
+	}
+}
+
+// enabledPlugins returns a set of plugin names that are enabled in cfg.
+// The set keys are canonical plugin names as they appear in the Catalog.
+func enabledPlugins(cfg *config.Config) map[string]bool {
+	return map[string]bool{
+		"tls":              cfg.TLS.Enabled,
+		"security-headers": cfg.SecurityHeaders.Enabled,
+		"rate-limiting":    cfg.RateLimit.Enabled,
+		"auth":             cfg.Auth.Enabled,
+		"metrics":          cfg.Metrics.Enabled,
+		"user-management":  cfg.Admin.Enabled,
+	}
+}
+
+// printPluginList writes a tabular list of all compiled-in plugins to out.
+func printPluginList(out io.Writer, cfg *config.Config) {
+	enabled := enabledPlugins(cfg)
+
+	tw := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tENABLED\tDESCRIPTION")
+	for _, d := range plugins.Catalog {
+		enabledStr := "false"
+		if enabled[d.Name] {
+			enabledStr = "true"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", d.Name, enabledStr, d.Description)
+	}
+	tw.Flush() //nolint:errcheck
+}
+
+// printPluginDetail writes the full metadata for a single plugin to out.
+func printPluginDetail(out io.Writer, d plugins.PluginDescriptor) {
+	fmt.Fprintf(out, "Plugin: %s\n", d.Name)
+	fmt.Fprintf(out, "Description: %s\n\n", d.Description)
+
+	fmt.Fprintln(out, "Configuration (under plugins:):")
+
+	// Sort fields alphabetically for stable output.
+	fields := make([]string, 0, len(d.ConfigSchema))
+	for k := range d.ConfigSchema {
+		fields = append(fields, k)
+	}
+	sort.Strings(fields)
+
+	tw := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
+	for _, field := range fields {
+		fmt.Fprintf(tw, "  %s\t%s\n", field, d.ConfigSchema[field])
+	}
+	tw.Flush() //nolint:errcheck
+
+	fmt.Fprintf(out, "\nExample:\n  plugins:\n%s\n", d.Example)
+}

--- a/internal/cli/cmd/plugins_test.go
+++ b/internal/cli/cmd/plugins_test.go
@@ -1,0 +1,191 @@
+package cmd_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/cli/cmd"
+)
+
+func TestPluginsCmd_ListsAllPlugins(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"plugins"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v\nstderr: %s", err, errBuf.String())
+	}
+
+	out := outBuf.String()
+
+	// All compiled-in plugin names must appear in the output.
+	wantPlugins := []string{
+		"tls",
+		"security-headers",
+		"rate-limiting",
+		"auth",
+		"metrics",
+		"user-management",
+	}
+	for _, name := range wantPlugins {
+		if !strings.Contains(out, name) {
+			t.Errorf("plugin %q not found in plugins output:\n%s", name, out)
+		}
+	}
+
+	// Header columns must appear.
+	if !strings.Contains(out, "NAME") {
+		t.Errorf("expected NAME header in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ENABLED") {
+		t.Errorf("expected ENABLED header in output, got:\n%s", out)
+	}
+}
+
+func TestPluginsCmd_ShowsEnabledStatus(t *testing.T) {
+	// With default config (no config file), rate-limiting and metrics default
+	// to enabled=true; the rest default to false.
+	root := cmd.NewRootCmd("test")
+	var outBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&outBuf)
+	root.SetArgs([]string{"plugins"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	out := outBuf.String()
+	// At least one "true" and one "false" must appear.
+	if !strings.Contains(out, "true") {
+		t.Errorf("expected at least one enabled=true plugin in output:\n%s", out)
+	}
+	if !strings.Contains(out, "false") {
+		t.Errorf("expected at least one enabled=false plugin in output:\n%s", out)
+	}
+}
+
+func TestPluginsCmd_WithConfigFile(t *testing.T) {
+	path := writeConfig(t, `
+server:
+  port: 8080
+upstream:
+  port: 3000
+tls:
+  enabled: true
+  provider: self-signed
+`)
+
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"plugins", "--config", path})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v\nstderr: %s", err, errBuf.String())
+	}
+
+	out := outBuf.String()
+	if !strings.Contains(out, "tls") {
+		t.Errorf("expected tls in output, got:\n%s", out)
+	}
+}
+
+func TestPluginsShowCmd_KnownPlugin(t *testing.T) {
+	tests := []struct {
+		pluginName  string
+		wantStrings []string
+	}{
+		{
+			pluginName:  "tls",
+			wantStrings: []string{"Plugin: tls", "provider", "enabled"},
+		},
+		{
+			pluginName:  "security-headers",
+			wantStrings: []string{"Plugin: security-headers", "frame_option"},
+		},
+		{
+			pluginName:  "rate-limiting",
+			wantStrings: []string{"Plugin: rate-limiting", "per_ip"},
+		},
+		{
+			pluginName:  "auth",
+			wantStrings: []string{"Plugin: auth", "kratos_public_url"},
+		},
+		{
+			pluginName:  "metrics",
+			wantStrings: []string{"Plugin: metrics", "path_patterns"},
+		},
+		{
+			pluginName:  "user-management",
+			wantStrings: []string{"Plugin: user-management", "admin_token"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pluginName, func(t *testing.T) {
+			root := cmd.NewRootCmd("test")
+			var outBuf, errBuf bytes.Buffer
+			root.SetOut(&outBuf)
+			root.SetErr(&errBuf)
+			root.SetArgs([]string{"plugins", "show", tt.pluginName})
+
+			if err := root.Execute(); err != nil {
+				t.Fatalf("Execute() unexpected error: %v\nstderr: %s", err, errBuf.String())
+			}
+
+			out := outBuf.String()
+			for _, want := range tt.wantStrings {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected %q in output for plugin %q:\n%s", want, tt.pluginName, out)
+				}
+			}
+
+			// Every show output must include an Example section.
+			if !strings.Contains(out, "Example:") {
+				t.Errorf("expected Example: section in output for plugin %q:\n%s", tt.pluginName, out)
+			}
+		})
+	}
+}
+
+func TestPluginsShowCmd_UnknownPlugin(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"plugins", "show", "nonexistent-plugin"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Error("Execute() expected error for unknown plugin, got nil")
+	}
+}
+
+func TestPluginsShowCmd_RequiresExactlyOneArg(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"no args", []string{"plugins", "show"}},
+		{"two args", []string{"plugins", "show", "tls", "metrics"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := cmd.NewRootCmd("test")
+			var outBuf, errBuf bytes.Buffer
+			root.SetOut(&outBuf)
+			root.SetErr(&errBuf)
+			root.SetArgs(tt.args)
+
+			if err := root.Execute(); err == nil {
+				t.Errorf("Execute() expected error for %q, got nil", tt.name)
+			}
+		})
+	}
+}

--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -38,6 +38,7 @@ Zero-to-secure in minutes.`,
 	root.AddCommand(NewSecretCmd())
 	root.AddCommand(NewValidateCmd())
 	root.AddCommand(NewGenerateCmd())
+	root.AddCommand(NewPluginsCmd())
 
 	return root
 }

--- a/internal/cli/cmd/validate.go
+++ b/internal/cli/cmd/validate.go
@@ -62,6 +62,7 @@ Checks performed:
   - security_headers.frame_option is one of: DENY, SAMEORIGIN, or empty
   - rate_limit.per_ip.requests_per_second is greater than zero
   - rate_limit.per_ip.burst is greater than zero
+  - user-management requires auth to be enabled (inter-plugin dependency)
 
 Exits with code 0 when configuration is valid, code 1 when invalid.
 
@@ -179,6 +180,11 @@ func validateConfig(cfg *config.Config) []string {
 		if cfg.RateLimit.PerIP.Burst <= 0 {
 			errs = append(errs, "rate_limit.per_ip.burst must be greater than zero")
 		}
+	}
+
+	// Plugin inter-dependency: user-management requires auth.
+	if cfg.Admin.Enabled && !cfg.Auth.Enabled {
+		errs = append(errs, "user-management plugin requires auth to be enabled (set auth.enabled: true)")
 	}
 
 	return errs

--- a/internal/cli/cmd/validate_test.go
+++ b/internal/cli/cmd/validate_test.go
@@ -359,6 +359,70 @@ log:
 	}
 }
 
+func TestValidateCmd_UserManagementRequiresAuth(t *testing.T) {
+	path := writeConfig(t, `
+server:
+  port: 8080
+upstream:
+  port: 3000
+admin:
+  enabled: true
+  token: supersecret
+auth:
+  enabled: false
+`)
+
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"validate", path})
+
+	err := root.Execute()
+	if err == nil {
+		t.Error("Execute() expected error when user-management enabled but auth disabled, got nil")
+	}
+
+	errOut := errBuf.String()
+	if !strings.Contains(errOut, "user-management") {
+		t.Errorf("expected user-management mention in stderr, got: %q", errOut)
+	}
+	if !strings.Contains(errOut, "auth") {
+		t.Errorf("expected auth mention in stderr, got: %q", errOut)
+	}
+}
+
+func TestValidateCmd_UserManagementWithAuthEnabled(t *testing.T) {
+	path := writeConfig(t, `
+server:
+  port: 8080
+upstream:
+  port: 3000
+admin:
+  enabled: true
+  token: supersecret
+auth:
+  enabled: true
+  session_cookie_name: ory_kratos_session
+`)
+
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"validate", path})
+
+	err := root.Execute()
+	if err != nil {
+		// Should be valid — no inter-plugin dependency violation.
+		// (There may be other errors from other fields, but NOT the dependency one.)
+		errOut := errBuf.String()
+		if strings.Contains(errOut, "user-management plugin requires auth") {
+			t.Errorf("unexpected user-management/auth dependency error: %q", errOut)
+		}
+	}
+}
+
 func TestValidateConfig_ValidDefaults(t *testing.T) {
 	// Test the exported validateConfig logic (accessed via CLI) with a
 	// minimal valid YAML that relies on defaults.

--- a/internal/plugins/auth/meta.go
+++ b/internal/plugins/auth/meta.go
@@ -1,0 +1,26 @@
+package auth
+
+// Description returns a short description of the auth plugin.
+func (p *Plugin) Description() string {
+	return "Authentication via Ory Kratos session validation"
+}
+
+// ConfigSchema returns the configuration field descriptions for the auth plugin.
+func (p *Plugin) ConfigSchema() map[string]string {
+	return map[string]string{
+		"enabled":             "Enable authentication middleware (default: false)",
+		"kratos_public_url":   "Base URL of the Kratos public API (required when enabled)",
+		"kratos_admin_url":    "Base URL of the Kratos admin API",
+		"session_cookie_name": "Name of the Kratos session cookie (default: ory_kratos_session)",
+		"login_url":           "Redirect URL for unauthenticated users (default: /self-service/login/browser)",
+		"public_paths":        "List of URL path glob patterns that bypass authentication",
+		"identity_schema":     "Identity schema: email_password, email_only, username_password, or file path",
+	}
+}
+
+// Example returns an example YAML configuration for the auth plugin.
+func (p *Plugin) Example() string {
+	return `  auth:
+    enabled: true
+    kratos_public_url: http://127.0.0.1:4433`
+}

--- a/internal/plugins/catalog.go
+++ b/internal/plugins/catalog.go
@@ -1,0 +1,133 @@
+package plugins
+
+// PluginDescriptor holds static metadata about a compiled-in plugin.
+// It is used by the CLI to list and describe plugins without instantiating them.
+type PluginDescriptor struct {
+	// Name is the canonical plugin identifier that matches the key in
+	// vibewarden.yaml under plugins:.
+	Name string
+
+	// Description is a short, one-line summary of what the plugin does.
+	Description string
+
+	// ConfigSchema maps configuration field names to their descriptions.
+	// Used by "vibewarden plugins show <name>".
+	ConfigSchema map[string]string
+
+	// Example is a minimal YAML snippet illustrating an enabled configuration.
+	// The snippet is indented as it would appear under the top-level plugins: key.
+	Example string
+}
+
+// Catalog is the static list of all plugins compiled into the VibeWarden binary.
+// It is the authoritative source of truth for "vibewarden plugins" output.
+// The order reflects the recommended initialisation priority.
+var Catalog = []PluginDescriptor{
+	{
+		Name:        "tls",
+		Description: "TLS termination with Let's Encrypt, self-signed, or external certificates",
+		ConfigSchema: map[string]string{
+			"enabled":      "Enable TLS (default: false)",
+			"provider":     "Certificate provider: letsencrypt, self-signed, external",
+			"domain":       "Domain for certificate (required for letsencrypt)",
+			"cert_path":    "Path to certificate file (external provider)",
+			"key_path":     "Path to key file (external provider)",
+			"storage_path": "Directory for certificate storage",
+		},
+		Example: `  tls:
+    enabled: true
+    provider: letsencrypt
+    domain: app.example.com`,
+	},
+	{
+		Name:        "security-headers",
+		Description: "Security headers: HSTS, X-Frame-Options, CSP, Referrer-Policy, and more",
+		ConfigSchema: map[string]string{
+			"enabled":                 "Enable security headers middleware (default: true)",
+			"hsts_max_age":            "Strict-Transport-Security max-age in seconds (default: 31536000)",
+			"hsts_include_subdomains": "Append includeSubDomains to HSTS header (default: true)",
+			"hsts_preload":            "Append preload to HSTS header (default: false)",
+			"content_type_nosniff":    "Set X-Content-Type-Options: nosniff (default: true)",
+			"frame_option":            "X-Frame-Options value: DENY, SAMEORIGIN, or empty (default: DENY)",
+			"content_security_policy": "Content-Security-Policy header value (default: default-src 'self')",
+			"referrer_policy":         "Referrer-Policy header value (default: strict-origin-when-cross-origin)",
+			"permissions_policy":      "Permissions-Policy header value (default: empty/disabled)",
+		},
+		Example: `  security-headers:
+    enabled: true
+    frame_option: DENY
+    content_security_policy: "default-src 'self'"`,
+	},
+	{
+		Name:        "rate-limiting",
+		Description: "Per-IP and per-user token-bucket rate limiting on every proxied request",
+		ConfigSchema: map[string]string{
+			"enabled":                      "Enable rate limiting (default: true)",
+			"store":                        "Backing store for limiter state: memory (default)",
+			"per_ip.requests_per_second":   "Sustained per-IP request rate (default: 10)",
+			"per_ip.burst":                 "Per-IP burst size above the sustained rate (default: 20)",
+			"per_user.requests_per_second": "Sustained per-user request rate (default: 100)",
+			"per_user.burst":               "Per-user burst size above the sustained rate (default: 200)",
+			"trust_proxy_headers":          "Read X-Forwarded-For for real client IP (default: false)",
+			"exempt_paths":                 "URL path glob patterns that bypass rate limiting",
+		},
+		Example: `  rate-limiting:
+    enabled: true
+    per_ip:
+      requests_per_second: 10
+      burst: 20`,
+	},
+	{
+		Name:        "auth",
+		Description: "Authentication via Ory Kratos session validation",
+		ConfigSchema: map[string]string{
+			"enabled":             "Enable authentication middleware (default: false)",
+			"kratos_public_url":   "Base URL of the Kratos public API (required when enabled)",
+			"kratos_admin_url":    "Base URL of the Kratos admin API",
+			"session_cookie_name": "Name of the Kratos session cookie (default: ory_kratos_session)",
+			"login_url":           "Redirect URL for unauthenticated users",
+			"public_paths":        "URL path glob patterns that bypass authentication",
+			"identity_schema":     "Identity schema preset or file path",
+		},
+		Example: `  auth:
+    enabled: true
+    kratos_public_url: http://127.0.0.1:4433`,
+	},
+	{
+		Name:        "metrics",
+		Description: "Prometheus metrics endpoint at /_vibewarden/metrics",
+		ConfigSchema: map[string]string{
+			"enabled":       "Enable metrics collection and /_vibewarden/metrics endpoint (default: true)",
+			"path_patterns": "URL path normalisation patterns using :param syntax (e.g. /users/:id)",
+		},
+		Example: `  metrics:
+    enabled: true
+    path_patterns:
+      - /users/:id`,
+	},
+	{
+		Name:        "user-management",
+		Description: "Admin API for user CRUD operations via Ory Kratos",
+		ConfigSchema: map[string]string{
+			"enabled":          "Enable user management admin API (default: false)",
+			"admin_token":      "Bearer token for /_vibewarden/admin/* endpoints (required)",
+			"kratos_admin_url": "Base URL of the Kratos admin API (required)",
+			"database_url":     "PostgreSQL connection string for audit logging (optional)",
+		},
+		Example: `  user-management:
+    enabled: true
+    admin_token: ${VIBEWARDEN_ADMIN_TOKEN}
+    kratos_admin_url: http://127.0.0.1:4434`,
+	},
+}
+
+// FindDescriptor returns the PluginDescriptor for the plugin with the given
+// name, or (PluginDescriptor{}, false) when no match is found.
+func FindDescriptor(name string) (PluginDescriptor, bool) {
+	for _, d := range Catalog {
+		if d.Name == name {
+			return d, true
+		}
+	}
+	return PluginDescriptor{}, false
+}

--- a/internal/plugins/catalog_test.go
+++ b/internal/plugins/catalog_test.go
@@ -1,0 +1,102 @@
+package plugins_test
+
+import (
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/plugins"
+)
+
+func TestCatalog_ContainsAllExpectedPlugins(t *testing.T) {
+	wantNames := []string{
+		"tls",
+		"security-headers",
+		"rate-limiting",
+		"auth",
+		"metrics",
+		"user-management",
+	}
+
+	nameSet := make(map[string]bool, len(plugins.Catalog))
+	for _, d := range plugins.Catalog {
+		nameSet[d.Name] = true
+	}
+
+	for _, name := range wantNames {
+		if !nameSet[name] {
+			t.Errorf("plugin %q not found in Catalog", name)
+		}
+	}
+}
+
+func TestCatalog_EachDescriptorIsComplete(t *testing.T) {
+	for _, d := range plugins.Catalog {
+		t.Run(d.Name, func(t *testing.T) {
+			if d.Name == "" {
+				t.Error("Name must not be empty")
+			}
+			if d.Description == "" {
+				t.Errorf("plugin %q has empty Description", d.Name)
+			}
+			if len(d.ConfigSchema) == 0 {
+				t.Errorf("plugin %q has empty ConfigSchema", d.Name)
+			}
+			if d.Example == "" {
+				t.Errorf("plugin %q has empty Example", d.Name)
+			}
+			// Every ConfigSchema entry must have a non-empty key and value.
+			for k, v := range d.ConfigSchema {
+				if k == "" {
+					t.Errorf("plugin %q has empty ConfigSchema key", d.Name)
+				}
+				if v == "" {
+					t.Errorf("plugin %q has empty description for key %q", d.Name, k)
+				}
+			}
+		})
+	}
+}
+
+func TestFindDescriptor_Found(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{"tls"},
+		{"security-headers"},
+		{"rate-limiting"},
+		{"auth"},
+		{"metrics"},
+		{"user-management"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, ok := plugins.FindDescriptor(tt.name)
+			if !ok {
+				t.Errorf("FindDescriptor(%q) = false, want true", tt.name)
+			}
+			if d.Name != tt.name {
+				t.Errorf("FindDescriptor(%q).Name = %q, want %q", tt.name, d.Name, tt.name)
+			}
+		})
+	}
+}
+
+func TestFindDescriptor_NotFound(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{"nonexistent"},
+		{""},
+		{"TLS"},
+		{"Rate-Limiting"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := plugins.FindDescriptor(tt.name)
+			if ok {
+				t.Errorf("FindDescriptor(%q) = true, want false", tt.name)
+			}
+		})
+	}
+}

--- a/internal/plugins/metrics/meta.go
+++ b/internal/plugins/metrics/meta.go
@@ -1,0 +1,23 @@
+package metrics
+
+// Description returns a short description of the metrics plugin.
+func (p *Plugin) Description() string {
+	return "Prometheus metrics endpoint at /_vibewarden/metrics"
+}
+
+// ConfigSchema returns the configuration field descriptions for the metrics plugin.
+func (p *Plugin) ConfigSchema() map[string]string {
+	return map[string]string{
+		"enabled":       "Enable metrics collection and the /_vibewarden/metrics endpoint (default: true)",
+		"path_patterns": "URL path normalisation patterns using :param syntax (e.g. /users/:id)",
+	}
+}
+
+// Example returns an example YAML configuration for the metrics plugin.
+func (p *Plugin) Example() string {
+	return `  metrics:
+    enabled: true
+    path_patterns:
+      - /users/:id
+      - /api/v1/items/:item_id`
+}

--- a/internal/plugins/ratelimit/meta.go
+++ b/internal/plugins/ratelimit/meta.go
@@ -1,0 +1,29 @@
+package ratelimit
+
+// Description returns a short description of the rate-limiting plugin.
+func (p *Plugin) Description() string {
+	return "Per-IP and per-user token-bucket rate limiting on every proxied request"
+}
+
+// ConfigSchema returns the configuration field descriptions for the rate-limiting plugin.
+func (p *Plugin) ConfigSchema() map[string]string {
+	return map[string]string{
+		"enabled":                      "Enable rate limiting (default: true)",
+		"store":                        "Backing store for limiter state: memory (default)",
+		"per_ip.requests_per_second":   "Sustained per-IP request rate (default: 10)",
+		"per_ip.burst":                 "Per-IP burst size above the sustained rate (default: 20)",
+		"per_user.requests_per_second": "Sustained per-user request rate (default: 100)",
+		"per_user.burst":               "Per-user burst size above the sustained rate (default: 200)",
+		"trust_proxy_headers":          "Read X-Forwarded-For to determine real client IP (default: false)",
+		"exempt_paths":                 "URL path glob patterns that bypass rate limiting",
+	}
+}
+
+// Example returns an example YAML configuration for the rate-limiting plugin.
+func (p *Plugin) Example() string {
+	return `  rate-limiting:
+    enabled: true
+    per_ip:
+      requests_per_second: 10
+      burst: 20`
+}

--- a/internal/plugins/securityheaders/meta.go
+++ b/internal/plugins/securityheaders/meta.go
@@ -1,0 +1,29 @@
+package securityheaders
+
+// Description returns a short description of the security-headers plugin.
+func (p *Plugin) Description() string {
+	return "Security headers: HSTS, X-Frame-Options, CSP, Referrer-Policy, and more"
+}
+
+// ConfigSchema returns the configuration field descriptions for the security-headers plugin.
+func (p *Plugin) ConfigSchema() map[string]string {
+	return map[string]string{
+		"enabled":                 "Enable security headers middleware (default: true)",
+		"hsts_max_age":            "Strict-Transport-Security max-age in seconds (default: 31536000)",
+		"hsts_include_subdomains": "Append includeSubDomains to HSTS header (default: true)",
+		"hsts_preload":            "Append preload to HSTS header (default: false)",
+		"content_type_nosniff":    "Set X-Content-Type-Options: nosniff (default: true)",
+		"frame_option":            "X-Frame-Options value: DENY, SAMEORIGIN, or empty to disable (default: DENY)",
+		"content_security_policy": "Content-Security-Policy header value (default: default-src 'self')",
+		"referrer_policy":         "Referrer-Policy header value (default: strict-origin-when-cross-origin)",
+		"permissions_policy":      "Permissions-Policy header value (default: empty/disabled)",
+	}
+}
+
+// Example returns an example YAML configuration for the security-headers plugin.
+func (p *Plugin) Example() string {
+	return `  security-headers:
+    enabled: true
+    frame_option: DENY
+    content_security_policy: "default-src 'self'"`
+}

--- a/internal/plugins/tls/meta.go
+++ b/internal/plugins/tls/meta.go
@@ -1,0 +1,27 @@
+package tls
+
+// Description returns a short description of the TLS plugin.
+func (p *Plugin) Description() string {
+	return "TLS termination with Let's Encrypt, self-signed, or external certificates"
+}
+
+// ConfigSchema returns the configuration field descriptions for the TLS plugin.
+func (p *Plugin) ConfigSchema() map[string]string {
+	return map[string]string{
+		"enabled":      "Enable TLS (default: false)",
+		"provider":     "Certificate provider: letsencrypt, self-signed, external",
+		"domain":       "Domain for certificate (required for letsencrypt)",
+		"email":        "Email for Let's Encrypt notifications",
+		"cert_path":    "Path to certificate file (external provider)",
+		"key_path":     "Path to key file (external provider)",
+		"storage_path": "Directory for certificate storage",
+	}
+}
+
+// Example returns an example YAML configuration for the TLS plugin.
+func (p *Plugin) Example() string {
+	return `  tls:
+    enabled: true
+    provider: letsencrypt
+    domain: app.example.com`
+}

--- a/internal/plugins/usermgmt/meta.go
+++ b/internal/plugins/usermgmt/meta.go
@@ -1,0 +1,24 @@
+package usermgmt
+
+// Description returns a short description of the user-management plugin.
+func (p *Plugin) Description() string {
+	return "Admin API for user CRUD operations via Ory Kratos"
+}
+
+// ConfigSchema returns the configuration field descriptions for the user-management plugin.
+func (p *Plugin) ConfigSchema() map[string]string {
+	return map[string]string{
+		"enabled":          "Enable user management admin API (default: false)",
+		"admin_token":      "Bearer token for /_vibewarden/admin/* endpoints (required when enabled)",
+		"kratos_admin_url": "Base URL of the Kratos admin API (required when enabled)",
+		"database_url":     "PostgreSQL connection string for audit logging (optional)",
+	}
+}
+
+// Example returns an example YAML configuration for the user-management plugin.
+func (p *Plugin) Example() string {
+	return `  user-management:
+    enabled: true
+    admin_token: ${VIBEWARDEN_ADMIN_TOKEN}
+    kratos_admin_url: http://127.0.0.1:4434`
+}

--- a/internal/ports/plugin.go
+++ b/internal/ports/plugin.go
@@ -85,3 +85,20 @@ type InternalServerPlugin interface {
 	// (e.g. "127.0.0.1:9092"). The address must be stable after Init returns.
 	InternalAddr() string
 }
+
+// PluginMeta is an optional interface implemented by plugins that expose
+// metadata for CLI display (vibewarden plugins, vibewarden plugins show).
+// All compiled-in plugins implement this interface.
+type PluginMeta interface {
+	// Description returns a short, one-line description of the plugin.
+	Description() string
+
+	// ConfigSchema returns a map of field name to field description for use
+	// in "vibewarden plugins show <name>" output. Fields should be listed in
+	// logical order; the caller is responsible for display ordering.
+	ConfigSchema() map[string]string
+
+	// Example returns an example YAML snippet (indented under "plugins:")
+	// illustrating a minimal enabled configuration.
+	Example() string
+}


### PR DESCRIPTION
Closes #164

## Summary

- Added `vibewarden plugins` command that lists all compiled-in plugins with enabled/disabled status read from `vibewarden.yaml`
- Added `vibewarden plugins show <name>` subcommand that prints the full configuration schema and an example YAML snippet for any plugin
- Added `PluginMeta` interface to `internal/ports/plugin.go` with `Description()`, `ConfigSchema()`, and `Example()` methods; each of the six plugin packages now implements it via a `meta.go` file
- Added `internal/plugins/catalog.go` with a static `PluginDescriptor` slice (`Catalog`) and `FindDescriptor` helper
- Updated `vibewarden status` to display a "Plugins" section showing enabled/disabled state and relevant detail for each compiled-in plugin
- Updated `vibewarden validate` to check the user-management to auth inter-plugin dependency
- Rewrote `cmd/vibewarden/serve.go` to build a `plugins.Registry`, register all six plugins from config, call `registry.InitAll`/`StartAll`, and call `registry.StopAll` on shutdown

## Test plan

- `internal/cli/cmd/plugins_test.go`: table-driven tests for `plugins` list output, `plugins show`, unknown plugin error, and arg count validation
- `internal/plugins/catalog_test.go`: catalog completeness and `FindDescriptor` tests
- Extended `internal/app/ops/status_test.go`: verifies the Plugins section header and all six plugin names appear
- Extended `internal/cli/cmd/validate_test.go`: user-management/auth dependency tests
- All existing tests pass; `make check` passes cleanly

Generated with Claude Code
