### PR TITLE
feat(#166): add Kratos OIDC config generation for social providers

### DIFF
--- a/internal/app/generate/service.go
+++ b/internal/app/generate/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/vibewarden/vibewarden/internal/config"
 	"github.com/vibewarden/vibewarden/internal/config/presets"
+	"github.com/vibewarden/vibewarden/internal/config/templates"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
@@ -31,6 +32,7 @@ func NewService(renderer ports.TemplateRenderer) *Service {
 //
 //	kratos/kratos.yml
 //	kratos/identity.schema.json
+//	kratos/mappers/<provider>.jsonnet  (one per configured social provider)
 //	docker-compose.yml
 func (s *Service) Generate(ctx context.Context, cfg *config.Config, outputDir string) error {
 	if outputDir == "" {
@@ -71,6 +73,13 @@ func (s *Service) Generate(ctx context.Context, cfg *config.Config, outputDir st
 		}
 	}
 
+	// Generate OIDC mapper files if social providers are configured.
+	if len(cfg.Auth.SocialProviders) > 0 {
+		if err := s.generateMappers(cfg, outputDir); err != nil {
+			return fmt.Errorf("generating OIDC mappers: %w", err)
+		}
+	}
+
 	// Generate docker-compose.yml unless an override path is configured.
 	composePath := filepath.Join(outputDir, "docker-compose.yml")
 	if cfg.Overrides.ComposeFile != "" {
@@ -89,6 +98,57 @@ func (s *Service) Generate(ctx context.Context, cfg *config.Config, outputDir st
 	}
 
 	return nil
+}
+
+// generateMappers writes Kratos OIDC Jsonnet mapper files to
+// <outputDir>/kratos/mappers/ — one file per unique mapper required by the
+// configured social providers.
+//
+// Mapper selection:
+//   - google  → mappers/google.jsonnet
+//   - github  → mappers/github.jsonnet
+//   - all others → mappers/generic.jsonnet
+//
+// Files are written only for mappers that are actually referenced so the
+// output directory stays minimal.
+func (s *Service) generateMappers(cfg *config.Config, outputDir string) error {
+	mappersDir := filepath.Join(outputDir, "kratos", "mappers")
+	if err := os.MkdirAll(mappersDir, 0o755); err != nil {
+		return fmt.Errorf("creating mappers directory: %w", err)
+	}
+
+	// Collect the set of mapper file names required by the configuration.
+	needed := make(map[string]bool)
+	for _, sp := range cfg.Auth.SocialProviders {
+		needed[mapperFileName(sp.Provider)] = true
+	}
+
+	// Write each required mapper file from the embedded FS.
+	for mapperFile := range needed {
+		src := "mappers/" + mapperFile
+		data, err := templates.FS.ReadFile(src)
+		if err != nil {
+			return fmt.Errorf("reading embedded mapper %q: %w", src, err)
+		}
+		dst := filepath.Join(mappersDir, mapperFile)
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			return fmt.Errorf("writing mapper file %q: %w", dst, err)
+		}
+	}
+	return nil
+}
+
+// mapperFileName returns the Jsonnet mapper file name for the given provider name.
+// Google and GitHub have dedicated mappers; all other providers use the generic mapper.
+func mapperFileName(provider string) string {
+	switch provider {
+	case "google":
+		return "google.jsonnet"
+	case "github":
+		return "github.jsonnet"
+	default:
+		return "generic.jsonnet"
+	}
 }
 
 // resolveIdentitySchema returns the JSON bytes for the identity schema.

--- a/internal/app/generate/service_integration_test.go
+++ b/internal/app/generate/service_integration_test.go
@@ -1,0 +1,136 @@
+package generate_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/adapters/template"
+	"github.com/vibewarden/vibewarden/internal/app/generate"
+	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/config/templates"
+)
+
+// TestGenerate_Integration_KratosOIDCRendering verifies that the real template
+// renderer produces a kratos.yml that includes the OIDC method block when
+// social providers are configured and omits it when they are not.
+func TestGenerate_Integration_KratosOIDCRendering(t *testing.T) {
+	renderer := template.NewRenderer(templates.FS)
+	svc := generate.NewService(renderer)
+
+	tests := []struct {
+		name           string
+		providers      []config.SocialProviderConfig
+		wantSubstrings []string
+		wantAbsent     []string
+	}{
+		{
+			name:      "no social providers — no OIDC section",
+			providers: nil,
+			wantAbsent: []string{
+				"oidc:",
+				"providers:",
+			},
+		},
+		{
+			name: "google provider — OIDC section present with google mapper",
+			providers: []config.SocialProviderConfig{
+				{Provider: "google", ClientID: "my-google-client", ClientSecret: "my-google-secret"},
+			},
+			wantSubstrings: []string{
+				"oidc:",
+				"enabled: true",
+				"providers:",
+				"id: google",
+				"provider: google",
+				"client_id: my-google-client",
+				"client_secret: my-google-secret",
+				"mapper_url: file:///etc/kratos/mappers/google.jsonnet",
+				"- email",
+				"- profile",
+			},
+		},
+		{
+			name: "github provider — OIDC section present with github mapper",
+			providers: []config.SocialProviderConfig{
+				{Provider: "github", ClientID: "ghid", ClientSecret: "ghsecret"},
+			},
+			wantSubstrings: []string{
+				"oidc:",
+				"id: github",
+				"provider: github",
+				"mapper_url: file:///etc/kratos/mappers/github.jsonnet",
+				"- user:email",
+			},
+		},
+		{
+			name: "generic OIDC provider — uses generic mapper and issuer_url",
+			providers: []config.SocialProviderConfig{
+				{
+					Provider:     "oidc",
+					ID:           "acme-sso",
+					ClientID:     "oidc-cid",
+					ClientSecret: "oidc-secret",
+					IssuerURL:    "https://sso.acme.example",
+				},
+			},
+			wantSubstrings: []string{
+				"oidc:",
+				"id: acme-sso",
+				"provider: oidc",
+				"mapper_url: file:///etc/kratos/mappers/generic.jsonnet",
+				"issuer_url: https://sso.acme.example",
+			},
+		},
+		{
+			name: "explicit scopes override provider defaults",
+			providers: []config.SocialProviderConfig{
+				{
+					Provider:     "google",
+					ClientID:     "gcid",
+					ClientSecret: "gsec",
+					Scopes:       []string{"openid", "email"},
+				},
+			},
+			wantSubstrings: []string{
+				"- openid",
+				"- email",
+			},
+			wantAbsent: []string{
+				"- profile",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+			cfg := minimalConfig()
+			cfg.Auth.SocialProviders = tt.providers
+
+			if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+				t.Fatalf("Generate() unexpected error: %v", err)
+			}
+
+			kratosYML := filepath.Join(outputDir, "kratos", "kratos.yml")
+			data, err := os.ReadFile(kratosYML)
+			if err != nil {
+				t.Fatalf("reading kratos.yml: %v", err)
+			}
+
+			for _, want := range tt.wantSubstrings {
+				if !bytes.Contains(data, []byte(want)) {
+					t.Errorf("kratos.yml missing expected substring %q\n--- content ---\n%s", want, data)
+				}
+			}
+
+			for _, absent := range tt.wantAbsent {
+				if bytes.Contains(data, []byte(absent)) {
+					t.Errorf("kratos.yml contains unexpected substring %q\n--- content ---\n%s", absent, data)
+				}
+			}
+		})
+	}
+}

--- a/internal/app/generate/service_test.go
+++ b/internal/app/generate/service_test.go
@@ -266,3 +266,167 @@ func TestGenerate_UnknownPreset_ReturnsError(t *testing.T) {
 		t.Error("Generate() expected error for unknown preset, got nil")
 	}
 }
+
+func TestGenerate_WithSocialProviders_GeneratesMapperFiles(t *testing.T) {
+	tests := []struct {
+		name          string
+		providers     []config.SocialProviderConfig
+		wantMappers   []string
+		wantNoMappers []string
+	}{
+		{
+			name: "google provider uses google mapper",
+			providers: []config.SocialProviderConfig{
+				{Provider: "google", ClientID: "gid", ClientSecret: "gsecret"},
+			},
+			wantMappers:   []string{"google.jsonnet"},
+			wantNoMappers: []string{"github.jsonnet"},
+		},
+		{
+			name: "github provider uses github mapper",
+			providers: []config.SocialProviderConfig{
+				{Provider: "github", ClientID: "ghid", ClientSecret: "ghsecret"},
+			},
+			wantMappers:   []string{"github.jsonnet"},
+			wantNoMappers: []string{"google.jsonnet"},
+		},
+		{
+			name: "generic oidc provider uses generic mapper",
+			providers: []config.SocialProviderConfig{
+				{Provider: "oidc", ID: "acme", ClientID: "oid", ClientSecret: "osecret", IssuerURL: "https://accounts.acme.example"},
+			},
+			wantMappers:   []string{"generic.jsonnet"},
+			wantNoMappers: []string{"google.jsonnet", "github.jsonnet"},
+		},
+		{
+			name: "multiple providers with overlapping mapper type",
+			providers: []config.SocialProviderConfig{
+				{Provider: "google", ClientID: "gid", ClientSecret: "gsecret"},
+				{Provider: "github", ClientID: "ghid", ClientSecret: "ghsecret"},
+				{Provider: "gitlab", ClientID: "glid", ClientSecret: "glsecret"},
+			},
+			wantMappers:   []string{"google.jsonnet", "github.jsonnet", "generic.jsonnet"},
+			wantNoMappers: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+			svc := generate.NewService(&fakeRenderer{})
+			cfg := minimalConfig()
+			cfg.Auth.SocialProviders = tt.providers
+
+			if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+				t.Fatalf("Generate() unexpected error: %v", err)
+			}
+
+			mappersDir := filepath.Join(outputDir, "kratos", "mappers")
+
+			for _, m := range tt.wantMappers {
+				path := filepath.Join(mappersDir, m)
+				if _, err := os.Stat(path); err != nil {
+					t.Errorf("expected mapper file %q to exist: %v", path, err)
+				}
+			}
+
+			for _, m := range tt.wantNoMappers {
+				path := filepath.Join(mappersDir, m)
+				if _, err := os.Stat(path); err == nil {
+					t.Errorf("unexpected mapper file %q exists", path)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerate_MapperFilesContainValidJsonnet(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "generated")
+
+	svc := generate.NewService(&fakeRenderer{})
+	cfg := minimalConfig()
+	cfg.Auth.SocialProviders = []config.SocialProviderConfig{
+		{Provider: "google", ClientID: "gid", ClientSecret: "gsecret"},
+		{Provider: "github", ClientID: "ghid", ClientSecret: "ghsecret"},
+		{Provider: "oidc", ID: "custom", ClientID: "oid", ClientSecret: "osecret", IssuerURL: "https://issuer.example"},
+	}
+
+	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+		t.Fatalf("Generate() unexpected error: %v", err)
+	}
+
+	mappers := []string{"google.jsonnet", "github.jsonnet", "generic.jsonnet"}
+	for _, m := range mappers {
+		path := filepath.Join(outputDir, "kratos", "mappers", m)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading mapper %q: %v", m, err)
+		}
+		if !bytes.Contains(data, []byte("identity")) {
+			t.Errorf("mapper %q does not contain 'identity' key, content: %s", m, data)
+		}
+		if !bytes.Contains(data, []byte("traits")) {
+			t.Errorf("mapper %q does not contain 'traits' key, content: %s", m, data)
+		}
+	}
+}
+
+func TestGenerate_WithoutSocialProviders_NoMappersDir(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "generated")
+
+	svc := generate.NewService(&fakeRenderer{})
+	cfg := minimalConfig()
+	// No social providers configured.
+
+	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+		t.Fatalf("Generate() unexpected error: %v", err)
+	}
+
+	mappersDir := filepath.Join(outputDir, "kratos", "mappers")
+	if _, err := os.Stat(mappersDir); err == nil {
+		t.Errorf("expected mappers directory NOT to exist when no social providers configured, but it does: %q", mappersDir)
+	}
+}
+
+func TestGenerate_WithSocialProviders_KratosTemplatePassesConfig(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "generated")
+
+	var capturedData any
+	renderer := &fakeRenderer{
+		renderFn: func(templateName string, data any) ([]byte, error) {
+			if templateName == "kratos.yml.tmpl" {
+				capturedData = data
+			}
+			return []byte("# rendered: " + templateName), nil
+		},
+	}
+
+	svc := generate.NewService(renderer)
+	cfg := minimalConfig()
+	cfg.Auth.SocialProviders = []config.SocialProviderConfig{
+		{Provider: "google", ClientID: "my-client-id", ClientSecret: "my-secret"},
+	}
+
+	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+		t.Fatalf("Generate() unexpected error: %v", err)
+	}
+
+	if capturedData == nil {
+		t.Fatal("kratos.yml.tmpl was not rendered")
+	}
+
+	renderedCfg, ok := capturedData.(*config.Config)
+	if !ok {
+		t.Fatalf("expected *config.Config passed to renderer, got %T", capturedData)
+	}
+
+	if len(renderedCfg.Auth.SocialProviders) != 1 {
+		t.Errorf("expected 1 social provider in rendered config, got %d", len(renderedCfg.Auth.SocialProviders))
+	}
+	if renderedCfg.Auth.SocialProviders[0].ClientID != "my-client-id" {
+		t.Errorf("expected ClientID %q, got %q", "my-client-id", renderedCfg.Auth.SocialProviders[0].ClientID)
+	}
+}

--- a/internal/config/templates/embed.go
+++ b/internal/config/templates/embed.go
@@ -5,6 +5,8 @@ package templates
 import "embed"
 
 // FS holds all runtime configuration template files embedded at compile time.
+// It includes both *.tmpl files and the mappers/ subdirectory containing
+// Kratos OIDC Jsonnet mapper files.
 //
-//go:embed *.tmpl
+//go:embed *.tmpl mappers/*.jsonnet
 var FS embed.FS

--- a/internal/config/templates/kratos.yml.tmpl
+++ b/internal/config/templates/kratos.yml.tmpl
@@ -59,6 +59,41 @@ selfservice:
     password:
       enabled: true
 {{- end }}
+{{- if .Auth.SocialProviders }}
+    oidc:
+      enabled: true
+      config:
+        providers:
+{{- range .Auth.SocialProviders }}
+          - id: {{ if eq .Provider "oidc" }}{{ .ID }}{{ else }}{{ .Provider }}{{ end }}
+            provider: {{ .Provider }}
+            client_id: {{ .ClientID }}
+            client_secret: {{ .ClientSecret }}
+            mapper_url: file:///etc/kratos/mappers/{{ if eq .Provider "google" }}google{{ else if eq .Provider "github" }}github{{ else }}generic{{ end }}.jsonnet
+{{- if .IssuerURL }}
+            issuer_url: {{ .IssuerURL }}
+{{- end }}
+{{- if .Scopes }}
+            scope:
+{{- range .Scopes }}
+              - {{ . }}
+{{- end }}
+{{- else if eq .Provider "google" }}
+            scope:
+              - email
+              - profile
+{{- else if eq .Provider "github" }}
+            scope:
+              - user:email
+{{- end }}
+{{- if and (eq .Provider "apple") .TeamID }}
+            apple_team_id: {{ .TeamID }}
+{{- end }}
+{{- if and (eq .Provider "apple") .KeyID }}
+            apple_private_key_id: {{ .KeyID }}
+{{- end }}
+{{- end }}
+{{- end }}
 
   flows:
     error:

--- a/internal/config/templates/mappers/generic.jsonnet
+++ b/internal/config/templates/mappers/generic.jsonnet
@@ -1,0 +1,14 @@
+// generic.jsonnet — Kratos OIDC claims mapper for generic OIDC providers.
+// Used for providers not covered by a dedicated mapper (e.g. custom OIDC).
+// Attempts standard OIDC claims: email, name, picture.
+local claims = std.extVar('claims');
+
+{
+  identity: {
+    traits: {
+      [if 'email' in claims then 'email']: claims.email,
+      [if 'name' in claims then 'name']: claims.name,
+      [if 'picture' in claims then 'picture']: claims.picture,
+    },
+  },
+}

--- a/internal/config/templates/mappers/github.jsonnet
+++ b/internal/config/templates/mappers/github.jsonnet
@@ -1,0 +1,16 @@
+// github.jsonnet — Kratos OIDC claims mapper for GitHub.
+// Maps GitHub's userinfo claims to VibeWarden identity traits.
+// GitHub returns the primary email in the `email` claim when the user
+// has granted the `user:email` scope, and the display name in `name`.
+local claims = std.extVar('claims');
+
+{
+  identity: {
+    traits: {
+      // GitHub may return null for email when the user has set it private.
+      [if 'email' in claims && claims.email != null then 'email']: claims.email,
+      [if 'name' in claims && claims.name != null then 'name']: claims.name,
+      [if 'avatar_url' in claims then 'picture']: claims.avatar_url,
+    },
+  },
+}

--- a/internal/config/templates/mappers/google.jsonnet
+++ b/internal/config/templates/mappers/google.jsonnet
@@ -1,0 +1,13 @@
+// google.jsonnet — Kratos OIDC claims mapper for Google.
+// Maps Google's userinfo claims to VibeWarden identity traits.
+local claims = std.extVar('claims');
+
+{
+  identity: {
+    traits: {
+      email: claims.email,
+      [if 'name' in claims then 'name']: claims.name,
+      [if 'picture' in claims then 'picture']: claims.picture,
+    },
+  },
+}


### PR DESCRIPTION
Closes #166

## Summary

- **`kratos.yml.tmpl`**: adds an `oidc` selfservice method block rendered only when `auth.social_providers` is non-empty. Includes provider-specific default scopes (Google: email+profile, GitHub: user:email), explicit scope overrides, `issuer_url` for generic OIDC providers, and Apple `team_id`/`key_id` fields.
- **`mappers/google.jsonnet`**, **`mappers/github.jsonnet`**, **`mappers/generic.jsonnet`**: embedded Jsonnet claim mapper files. Google maps `email`, `name`, `picture`. GitHub maps `email`, `name`, `avatar_url` (handles nullable email). Generic maps standard OIDC claims.
- **`embed.go`**: extended `//go:embed` directive to include `mappers/*.jsonnet` alongside `*.tmpl`.
- **`generate/service.go`**: `Generate()` calls `generateMappers()` when social providers are configured. `generateMappers()` reads mapper files from the embedded FS and writes only those referenced by the configuration to `<outputDir>/kratos/mappers/`. `mapperFileName()` routes google to google.jsonnet, github to github.jsonnet, everything else to generic.jsonnet.

## Test plan

- `TestGenerate_WithSocialProviders_GeneratesMapperFiles` — table-driven: google/github/generic-oidc/multi-provider cases; asserts correct mapper files are created and unexpected ones absent.
- `TestGenerate_MapperFilesContainValidJsonnet` — asserts each mapper contains `identity` and `traits` keys.
- `TestGenerate_WithoutSocialProviders_NoMappersDir` — asserts mappers directory is not created when no social providers are configured.
- `TestGenerate_WithSocialProviders_KratosTemplatePassesConfig` — asserts the full config (including social providers) is passed to the template renderer.
- `TestGenerate_Integration_KratosOIDCRendering` — integration tests using the real template renderer; verifies rendered YAML contains/omits OIDC section, correct mapper paths, issuer_url, default and explicit scopes.

All 17 tests in `internal/app/generate` pass. `make check` passes (format, vet, build, all tests including demo-app).