### PR TITLE
feat(#167): add social identity schema preset with auto-selection

### DIFF
--- a/internal/app/generate/service.go
+++ b/internal/app/generate/service.go
@@ -152,7 +152,16 @@ func mapperFileName(provider string) string {
 }
 
 // resolveIdentitySchema returns the JSON bytes for the identity schema.
-// Precedence: overrides.identity_schema path > auth.identity_schema preset/path.
+//
+// Precedence (highest to lowest):
+//  1. overrides.identity_schema — explicit filesystem path, used verbatim.
+//  2. auth.identity_schema — explicit preset name or filesystem path chosen
+//     by the operator.
+//  3. Auto-selection: when social providers are configured and
+//     auth.identity_schema is "email_password" (the default), the service
+//     upgrades to the "social" preset so that name and picture traits are
+//     available for OIDC mappers to populate.
+//  4. Fallback: "email_password" preset when auth.identity_schema is empty.
 func resolveIdentitySchema(cfg *config.Config) ([]byte, error) {
 	if cfg.Overrides.IdentitySchema != "" {
 		data, err := os.ReadFile(cfg.Overrides.IdentitySchema)
@@ -165,6 +174,13 @@ func resolveIdentitySchema(cfg *config.Config) ([]byte, error) {
 	schemaName := cfg.Auth.IdentitySchema
 	if schemaName == "" {
 		schemaName = presets.PresetEmailPassword
+	}
+
+	// Auto-upgrade to the social preset when social providers are configured
+	// and the operator has not explicitly chosen a schema other than the
+	// default email_password preset.
+	if len(cfg.Auth.SocialProviders) > 0 && schemaName == presets.PresetEmailPassword {
+		schemaName = presets.PresetSocial
 	}
 
 	data, err := presets.Resolve(schemaName)

--- a/internal/app/generate/service_test.go
+++ b/internal/app/generate/service_test.go
@@ -135,6 +135,11 @@ func TestGenerate_IdentitySchemaPresets(t *testing.T) {
 			identitySchema: "username_password",
 			wantSubstr:     []byte(`"username"`),
 		},
+		{
+			name:           "social preset",
+			identitySchema: "social",
+			wantSubstr:     []byte(`"picture"`),
+		},
 	}
 
 	for _, tt := range tests {
@@ -387,6 +392,86 @@ func TestGenerate_WithoutSocialProviders_NoMappersDir(t *testing.T) {
 	mappersDir := filepath.Join(outputDir, "kratos", "mappers")
 	if _, err := os.Stat(mappersDir); err == nil {
 		t.Errorf("expected mappers directory NOT to exist when no social providers configured, but it does: %q", mappersDir)
+	}
+}
+
+func TestGenerate_SocialProviders_AutoSelectsSocialSchema(t *testing.T) {
+	tests := []struct {
+		name             string
+		identitySchema   string
+		socialProviders  []config.SocialProviderConfig
+		wantSchemaSubstr []byte
+		wantNoSubstr     []byte
+	}{
+		{
+			name:           "auto-upgrades email_password to social when providers configured",
+			identitySchema: "email_password",
+			socialProviders: []config.SocialProviderConfig{
+				{Provider: "google", ClientID: "gid", ClientSecret: "gsecret"},
+			},
+			wantSchemaSubstr: []byte(`"picture"`),
+			wantNoSubstr:     nil,
+		},
+		{
+			name:           "auto-upgrades when identity_schema is empty (uses default)",
+			identitySchema: "",
+			socialProviders: []config.SocialProviderConfig{
+				{Provider: "github", ClientID: "ghid", ClientSecret: "ghsecret"},
+			},
+			wantSchemaSubstr: []byte(`"picture"`),
+			wantNoSubstr:     nil,
+		},
+		{
+			name:           "does not upgrade when explicit non-default schema is set",
+			identitySchema: "email_only",
+			socialProviders: []config.SocialProviderConfig{
+				{Provider: "google", ClientID: "gid", ClientSecret: "gsecret"},
+			},
+			wantSchemaSubstr: []byte(`"email"`),
+			wantNoSubstr:     []byte(`"picture"`),
+		},
+		{
+			name:           "explicit social schema is used as-is",
+			identitySchema: "social",
+			socialProviders: []config.SocialProviderConfig{
+				{Provider: "google", ClientID: "gid", ClientSecret: "gsecret"},
+			},
+			wantSchemaSubstr: []byte(`"picture"`),
+			wantNoSubstr:     nil,
+		},
+		{
+			name:             "no social providers keeps email_password schema",
+			identitySchema:   "email_password",
+			socialProviders:  nil,
+			wantSchemaSubstr: []byte(`"email"`),
+			wantNoSubstr:     []byte(`"picture"`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+			svc := generate.NewService(&fakeRenderer{})
+			cfg := minimalConfig()
+			cfg.Auth.IdentitySchema = tt.identitySchema
+			cfg.Auth.SocialProviders = tt.socialProviders
+
+			if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+				t.Fatalf("Generate() unexpected error: %v", err)
+			}
+
+			schemaPath := filepath.Join(outputDir, "kratos", "identity.schema.json")
+			data, err := os.ReadFile(schemaPath)
+			if err != nil {
+				t.Fatalf("reading identity.schema.json: %v", err)
+			}
+			if !bytes.Contains(data, tt.wantSchemaSubstr) {
+				t.Errorf("identity.schema.json does not contain %q; content: %s", tt.wantSchemaSubstr, data)
+			}
+			if tt.wantNoSubstr != nil && bytes.Contains(data, tt.wantNoSubstr) {
+				t.Errorf("identity.schema.json unexpectedly contains %q; content: %s", tt.wantNoSubstr, data)
+			}
+		})
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -179,7 +179,10 @@ type AuthConfig struct {
 
 	// IdentitySchema selects the identity schema to use.
 	// Accepted values: "email_password" (default), "email_only", "username_password",
-	// or a filesystem path to a custom JSON schema file.
+	// "social", or a filesystem path to a custom JSON schema file.
+	// When social_providers are configured and this field is left at its default
+	// ("email_password"), the generate service automatically upgrades to the
+	// "social" schema so that name and picture traits are available.
 	IdentitySchema string `mapstructure:"identity_schema"`
 
 	// PublicPaths is a list of URL path glob patterns that bypass auth.

--- a/internal/config/presets/presets.go
+++ b/internal/config/presets/presets.go
@@ -17,6 +17,9 @@ var emailOnly []byte
 //go:embed username_password.json
 var usernamePassword []byte
 
+//go:embed social.json
+var social []byte
+
 // Known preset names.
 const (
 	// PresetEmailPassword is the preset for email + password authentication.
@@ -25,12 +28,16 @@ const (
 	PresetEmailOnly = "email_only"
 	// PresetUsernamePassword is the preset for username + password authentication.
 	PresetUsernamePassword = "username_password"
+	// PresetSocial is the preset for social login (OAuth2/OIDC) combined with
+	// email + password. It extends email_password with name and picture traits
+	// populated by OIDC mappers.
+	PresetSocial = "social"
 )
 
 // Resolve returns the identity schema JSON for the given name.
 // name may be one of the built-in preset names (PresetEmailPassword,
-// PresetEmailOnly, PresetUsernamePassword) or a filesystem path to a
-// custom JSON schema file.
+// PresetEmailOnly, PresetUsernamePassword, PresetSocial) or a filesystem
+// path to a custom JSON schema file.
 // Returns an error when name is empty, unknown, or the custom file cannot
 // be read.
 func Resolve(name string) ([]byte, error) {
@@ -41,6 +48,8 @@ func Resolve(name string) ([]byte, error) {
 		return emailOnly, nil
 	case PresetUsernamePassword:
 		return usernamePassword, nil
+	case PresetSocial:
+		return social, nil
 	case "":
 		return nil, fmt.Errorf("identity schema name must not be empty")
 	default:
@@ -56,7 +65,7 @@ func Resolve(name string) ([]byte, error) {
 // IsPreset reports whether name is one of the built-in preset names.
 func IsPreset(name string) bool {
 	switch name {
-	case PresetEmailPassword, PresetEmailOnly, PresetUsernamePassword:
+	case PresetEmailPassword, PresetEmailOnly, PresetUsernamePassword, PresetSocial:
 		return true
 	default:
 		return false

--- a/internal/config/presets/presets_test.go
+++ b/internal/config/presets/presets_test.go
@@ -29,6 +29,21 @@ func TestResolve_BuiltinPresets(t *testing.T) {
 			preset:     presets.PresetUsernamePassword,
 			wantSubstr: `"username"`,
 		},
+		{
+			name:       "social preset contains email",
+			preset:     presets.PresetSocial,
+			wantSubstr: `"email"`,
+		},
+		{
+			name:       "social preset contains name",
+			preset:     presets.PresetSocial,
+			wantSubstr: `"name"`,
+		},
+		{
+			name:       "social preset contains picture",
+			preset:     presets.PresetSocial,
+			wantSubstr: `"picture"`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -87,6 +102,7 @@ func TestIsPreset(t *testing.T) {
 		{"email_password", presets.PresetEmailPassword, true},
 		{"email_only", presets.PresetEmailOnly, true},
 		{"username_password", presets.PresetUsernamePassword, true},
+		{"social", presets.PresetSocial, true},
 		{"custom path", "/path/to/schema.json", false},
 		{"unknown name", "magic_link", false},
 		{"empty", "", false},

--- a/internal/config/presets/social.json
+++ b/internal/config/presets/social.json
@@ -1,0 +1,53 @@
+{
+  "$id": "https://vibewarden.dev/schema/v1/identity.social.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "traits": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "format": "email",
+          "title": "E-Mail",
+          "minLength": 3,
+          "ory.sh/kratos": {
+            "credentials": {
+              "password": {
+                "identifier": true
+              }
+            },
+            "verification": {
+              "via": "email"
+            },
+            "recovery": {
+              "via": "email"
+            }
+          }
+        },
+        "name": {
+          "type": "object",
+          "title": "Name",
+          "properties": {
+            "first": {
+              "type": "string",
+              "title": "First Name"
+            },
+            "last": {
+              "type": "string",
+              "title": "Last Name"
+            }
+          }
+        },
+        "picture": {
+          "type": "string",
+          "format": "uri",
+          "title": "Profile Picture URL"
+        }
+      },
+      "required": ["email"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
Closes #167

## Summary

- Added `internal/config/presets/social.json`: a new Kratos identity schema preset that extends `email_password` with `name` (first/last) and `picture` (URI) traits. These fields are populated by OIDC claim mappers when users sign in via a social provider.
- Updated `internal/config/presets/presets.go`: registered the new `PresetSocial = "social"` constant, wired it into `Resolve()` and `IsPreset()`.
- Updated `internal/app/generate/service.go` (`resolveIdentitySchema`): when `auth.social_providers` are configured and `auth.identity_schema` is at the default (`email_password`), the service automatically upgrades to the `social` preset. Operators who explicitly choose a different schema (e.g., `email_only`, `username_password`, or a custom path) are not affected.
- Updated `auth.identity_schema` godoc in `internal/config/config.go` to document the new preset and the auto-selection behaviour.

## Test plan

- `TestResolve_BuiltinPresets` — three new sub-cases verify the social preset JSON contains `"email"`, `"name"`, and `"picture"`.
- `TestIsPreset` — one new sub-case for `"social"`.
- `TestGenerate_IdentitySchemaPresets` — one new sub-case exercises explicit `social` preset selection.
- `TestGenerate_SocialProviders_AutoSelectsSocialSchema` (new table-driven test, 5 cases):
  - auto-upgrades when schema is `email_password` and providers are set
  - auto-upgrades when schema is empty (falls through to default)
  - does NOT upgrade when schema is explicitly set to a non-default value
  - explicit `social` schema is used as-is
  - no social providers keeps `email_password`
- All existing tests continue to pass (`make check` green).