### PR TITLE
feat(#168): add social login UI components to demo app

### DIFF
--- a/examples/demo-app/main.go
+++ b/examples/demo-app/main.go
@@ -56,6 +56,8 @@ func main() {
 	mux.HandleFunc("GET /headers", handleHeaders)
 	mux.HandleFunc("POST /spam", handleSpam)
 	mux.HandleFunc("GET /health", handleHealth)
+	mux.HandleFunc("GET /auth/login", handleAuthPage(staticFS, "login.html"))
+	mux.HandleFunc("GET /auth/registration", handleAuthPage(staticFS, "register.html"))
 	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
 
 	addr := ":" + port
@@ -180,6 +182,24 @@ func handleSpam(w http.ResponseWriter, r *http.Request) {
 // Demonstrates: a health endpoint excluded from auth and rate limiting.
 func handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"status": "ok"})
+}
+
+// handleAuthPage returns an http.HandlerFunc that serves a named HTML file
+// from the embedded static filesystem.  It is used for the Kratos self-service
+// UI pages (/auth/login, /auth/registration) so that VibeWarden can route
+// Kratos's ui_url redirects directly to the demo app.
+func handleAuthPage(staticFS fs.FS, filename string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		content, err := fs.ReadFile(staticFS, filename)
+		if err != nil {
+			http.Error(w, "page not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if _, err := w.Write(content); err != nil {
+			slog.Error("failed to write auth page response", "file", filename, "error", err)
+		}
+	}
 }
 
 // writeJSON serialises v as JSON and writes it to w with the given status code.

--- a/examples/demo-app/static/index.html
+++ b/examples/demo-app/static/index.html
@@ -99,9 +99,9 @@
   <div id="auth-status" class="auth-card">Checking...</div>
 
   <p>
-    <a href="/self-service/login/browser"><button>Log In</button></a>
+    <a href="/auth/login"><button>Log In</button></a>
     &nbsp;
-    <a href="/self-service/registration/browser"><button>Register</button></a>
+    <a href="/auth/registration"><button>Register</button></a>
     &nbsp;
     <button id="btn-logout" style="display:none">Log Out</button>
   </p>
@@ -136,6 +136,15 @@
       <p>
         Session management, login flows, and registration are handled by
         Ory Kratos. The app only sees injected <code>X-User-*</code> headers.
+      </p>
+    </div>
+    <div class="protection-card">
+      <h3>Social Login</h3>
+      <p>
+        When social providers (Google, GitHub, GitLab, Discord) are configured in
+        <code>vibewarden.yaml</code>, sign-in buttons appear automatically on the
+        <a href="/auth/login">login</a> and <a href="/auth/registration">registration</a>
+        pages — no code changes required.
       </p>
     </div>
     <div class="protection-card">

--- a/examples/demo-app/static/login.html
+++ b/examples/demo-app/static/login.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Log In — VibeWarden Demo</title>
+  <link rel="stylesheet" href="/static/water.css">
+  <style>
+    .badge {
+      display: inline-block;
+      padding: 0.2em 0.6em;
+      border-radius: 4px;
+      font-size: 0.85em;
+      font-weight: bold;
+    }
+    .badge-error { background: #dc2626; color: #fff; }
+    nav a { margin-right: 1em; }
+
+    .auth-box {
+      max-width: 420px;
+      margin: 2em auto;
+      padding: 2em;
+      border: 1px solid #d1d5db;
+      border-radius: 8px;
+    }
+    .auth-box h1 {
+      margin-top: 0;
+      font-size: 1.5em;
+    }
+
+    .form-group {
+      margin-bottom: 1em;
+    }
+    .form-group label {
+      display: block;
+      margin-bottom: 0.3em;
+      font-weight: bold;
+      font-size: 0.95em;
+    }
+    .form-group input {
+      width: 100%;
+      box-sizing: border-box;
+    }
+
+    .btn-primary {
+      width: 100%;
+      padding: 0.6em 1em;
+      background: #7C3AED;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      font-size: 1em;
+      cursor: pointer;
+    }
+    .btn-primary:hover {
+      background: #6d28d9;
+    }
+
+    .divider {
+      display: flex;
+      align-items: center;
+      gap: 0.75em;
+      margin: 1.25em 0;
+      color: #9ca3af;
+      font-size: 0.9em;
+    }
+    .divider::before,
+    .divider::after {
+      content: "";
+      flex: 1;
+      border-top: 1px solid #e5e7eb;
+    }
+
+    .social-btn {
+      display: block;
+      width: 100%;
+      box-sizing: border-box;
+      padding: 0.55em 1em;
+      margin-bottom: 0.6em;
+      border: 1px solid #d1d5db;
+      border-radius: 4px;
+      background: #fff;
+      font-size: 0.95em;
+      cursor: pointer;
+      text-align: center;
+    }
+    .social-btn:hover {
+      background: #f9fafb;
+    }
+    /* Provider accent colours (left border) */
+    .social-btn[data-provider="google"]  { border-left: 4px solid #4285F4; }
+    .social-btn[data-provider="github"]  { border-left: 4px solid #24292e; }
+    .social-btn[data-provider="gitlab"]  { border-left: 4px solid #FC6D26; }
+    .social-btn[data-provider="discord"] { border-left: 4px solid #5865F2; }
+
+    .register-link {
+      text-align: center;
+      margin-top: 1.25em;
+      font-size: 0.9em;
+    }
+    #error-msg {
+      margin-bottom: 1em;
+    }
+    .vw-footer {
+      margin-top: 3em;
+      padding: 1em 1.2em;
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 6px;
+      font-size: 0.9em;
+      color: #374151;
+      text-align: center;
+    }
+    .vw-footer strong { color: #7C3AED; }
+  </style>
+</head>
+<body>
+  <nav>
+    <strong>VibeWarden Demo</strong> &nbsp;|&nbsp;
+    <a href="/">Home</a>
+    <a href="/static/me.html">My Profile</a>
+    <a href="/static/headers.html">Headers Inspector</a>
+    <a href="/static/ratelimit.html">Rate Limit Test</a>
+  </nav>
+
+  <div class="auth-box">
+    <h1>Log In</h1>
+    <div id="error-msg"></div>
+    <div id="form-container">Loading flow...</div>
+    <div class="register-link">
+      Don't have an account? <a href="/auth/registration">Register</a>
+    </div>
+  </div>
+
+  <div class="vw-footer">
+    <strong>This app has zero custom security code.</strong>
+    Auth is handled by <strong>VibeWarden</strong> + Ory Kratos.
+    &mdash; <a href="/">Back to Home</a>
+  </div>
+
+  <script>
+    // Label overrides per provider slug.
+    var PROVIDER_LABELS = {
+      google:  'Continue with Google',
+      github:  'Continue with GitHub',
+      gitlab:  'Continue with GitLab',
+      discord: 'Continue with Discord',
+    };
+
+    function escapeHtml(str) {
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+    }
+
+    function showError(msg) {
+      var el = document.getElementById('error-msg');
+      el.innerHTML = '<p><span class="badge badge-error">Error</span> ' + escapeHtml(msg) + '</p>';
+    }
+
+    // Kratos browser flows communicate via cookies and form POSTs.
+    // We initialise the flow, then render the UI nodes returned by Kratos.
+    (async function () {
+      var container = document.getElementById('form-container');
+
+      // Parse flow id from URL if Kratos redirected back with ?flow=<id>.
+      var params = new URLSearchParams(window.location.search);
+      var flowId = params.get('flow');
+
+      try {
+        var flowUrl = flowId
+          ? '/self-service/login/flows?id=' + encodeURIComponent(flowId)
+          : '/self-service/login/browser';
+
+        var resp = await fetch(flowUrl, {
+          credentials: 'include',
+          headers: { 'Accept': 'application/json' },
+          redirect: 'follow',
+        });
+
+        // Kratos may redirect to the UI URL — fetch will follow but end at
+        // our page again with ?flow=<id>. If we get a non-JSON response it
+        // means we followed a redirect; reload to pick up the new flow param.
+        var contentType = resp.headers.get('Content-Type') || '';
+        if (!contentType.includes('application/json')) {
+          window.location.reload();
+          return;
+        }
+
+        if (!resp.ok) {
+          var errData = await resp.json().catch(function () { return {}; });
+          showError((errData.error && errData.error.message) || 'Failed to load login flow (HTTP ' + resp.status + ').');
+          container.innerHTML = '';
+          return;
+        }
+
+        var flow = await resp.json();
+        renderFlow(flow);
+      } catch (err) {
+        showError('Network error: ' + String(err));
+        container.innerHTML = '';
+      }
+    })();
+
+    function renderFlow(flow) {
+      var container = document.getElementById('form-container');
+      var nodes = (flow.ui && flow.ui.nodes) || [];
+      var action = (flow.ui && flow.ui.action) || '';
+      var method = (flow.ui && flow.ui.method) || 'POST';
+
+      // Display any flow-level messages (e.g. "invalid credentials").
+      var messages = (flow.ui && flow.ui.messages) || [];
+      if (messages.length > 0) {
+        var errorEl = document.getElementById('error-msg');
+        errorEl.innerHTML = messages.map(function (m) {
+          var cls = m.type === 'error' ? 'badge-error' : 'badge badge-info';
+          return '<p><span class="badge ' + cls + '">' + escapeHtml(m.type) + '</span> ' + escapeHtml(m.text) + '</p>';
+        }).join('');
+      }
+
+      // Separate OIDC (social) nodes from password nodes.
+      var oidcNodes = nodes.filter(function (n) {
+        return n.group === 'oidc';
+      });
+      var passwordNodes = nodes.filter(function (n) {
+        return n.group !== 'oidc';
+      });
+
+      var html = '';
+
+      // --- Password form ---
+      html += '<form method="POST" action="' + escapeHtml(action) + '">';
+      passwordNodes.forEach(function (node) {
+        html += renderNode(node);
+      });
+      html += '</form>';
+
+      // --- Social login buttons ---
+      if (oidcNodes.length > 0) {
+        html += '<div class="divider">or continue with</div>';
+        // Each OIDC node is a button inside its own form (Kratos submits provider via button value).
+        oidcNodes.forEach(function (node) {
+          if (node.type !== 'input' || !node.attributes) return;
+          var attrs = node.attributes;
+          var provider = (attrs.value || '').toLowerCase();
+          var label = PROVIDER_LABELS[provider] || escapeHtml(attrs.value || provider);
+          html += '<form method="POST" action="' + escapeHtml(action) + '">';
+          // Include hidden fields from the password form (csrf_token, flow id).
+          passwordNodes.forEach(function (n) {
+            if (n.type === 'input' && n.attributes && n.attributes.type === 'hidden') {
+              html += '<input type="hidden" name="' + escapeHtml(n.attributes.name) + '" value="' + escapeHtml(n.attributes.value || '') + '">';
+            }
+          });
+          html += '<button type="submit" class="social-btn" data-provider="' + escapeHtml(provider) + '" name="' + escapeHtml(attrs.name || 'provider') + '" value="' + escapeHtml(attrs.value || '') + '">' + label + '</button>';
+          html += '</form>';
+        });
+      }
+
+      container.innerHTML = html;
+    }
+
+    function renderNode(node) {
+      if (!node.attributes) return '';
+      var attrs = node.attributes;
+
+      // Hidden fields.
+      if (attrs.type === 'hidden') {
+        return '<input type="hidden" name="' + escapeHtml(attrs.name) + '" value="' + escapeHtml(attrs.value || '') + '">';
+      }
+
+      // Submit button.
+      if (attrs.type === 'submit') {
+        return '<button type="submit" class="btn-primary">' + escapeHtml((node.meta && node.meta.label && node.meta.label.text) || 'Submit') + '</button>';
+      }
+
+      // Other inputs (email, password, text).
+      var labelText = (node.meta && node.meta.label && node.meta.label.text) || attrs.name;
+      var messages = (node.messages || []).map(function (m) {
+        return '<small style="color:#dc2626">' + escapeHtml(m.text) + '</small>';
+      }).join(' ');
+
+      return '<div class="form-group">'
+        + '<label for="node-' + escapeHtml(attrs.name) + '">' + escapeHtml(labelText) + '</label>'
+        + '<input id="node-' + escapeHtml(attrs.name) + '" type="' + escapeHtml(attrs.type || 'text') + '" name="' + escapeHtml(attrs.name) + '" value="' + escapeHtml(attrs.value || '') + '" ' + (attrs.required ? 'required' : '') + ' ' + (attrs.disabled ? 'disabled' : '') + '>'
+        + messages
+        + '</div>';
+    }
+  </script>
+</body>
+</html>

--- a/examples/demo-app/static/me.html
+++ b/examples/demo-app/static/me.html
@@ -69,8 +69,8 @@
           container.innerHTML =
             '<p><span class="badge badge-warn">Not authenticated</span></p>' +
             '<p>You need to log in to view your profile.</p>' +
-            '<p><a href="/self-service/login/browser"><button>Log In</button></a> ' +
-            '<a href="/self-service/registration/browser"><button>Register</button></a></p>';
+            '<p><a href="/auth/login"><button>Log In</button></a> ' +
+            '<a href="/auth/registration"><button>Register</button></a></p>';
           return;
         }
 

--- a/examples/demo-app/static/register.html
+++ b/examples/demo-app/static/register.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Register — VibeWarden Demo</title>
+  <link rel="stylesheet" href="/static/water.css">
+  <style>
+    .badge {
+      display: inline-block;
+      padding: 0.2em 0.6em;
+      border-radius: 4px;
+      font-size: 0.85em;
+      font-weight: bold;
+    }
+    .badge-error { background: #dc2626; color: #fff; }
+    nav a { margin-right: 1em; }
+
+    .auth-box {
+      max-width: 420px;
+      margin: 2em auto;
+      padding: 2em;
+      border: 1px solid #d1d5db;
+      border-radius: 8px;
+    }
+    .auth-box h1 {
+      margin-top: 0;
+      font-size: 1.5em;
+    }
+
+    .form-group {
+      margin-bottom: 1em;
+    }
+    .form-group label {
+      display: block;
+      margin-bottom: 0.3em;
+      font-weight: bold;
+      font-size: 0.95em;
+    }
+    .form-group input {
+      width: 100%;
+      box-sizing: border-box;
+    }
+
+    .btn-primary {
+      width: 100%;
+      padding: 0.6em 1em;
+      background: #7C3AED;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      font-size: 1em;
+      cursor: pointer;
+    }
+    .btn-primary:hover {
+      background: #6d28d9;
+    }
+
+    .divider {
+      display: flex;
+      align-items: center;
+      gap: 0.75em;
+      margin: 1.25em 0;
+      color: #9ca3af;
+      font-size: 0.9em;
+    }
+    .divider::before,
+    .divider::after {
+      content: "";
+      flex: 1;
+      border-top: 1px solid #e5e7eb;
+    }
+
+    .social-btn {
+      display: block;
+      width: 100%;
+      box-sizing: border-box;
+      padding: 0.55em 1em;
+      margin-bottom: 0.6em;
+      border: 1px solid #d1d5db;
+      border-radius: 4px;
+      background: #fff;
+      font-size: 0.95em;
+      cursor: pointer;
+      text-align: center;
+    }
+    .social-btn:hover {
+      background: #f9fafb;
+    }
+    /* Provider accent colours (left border) */
+    .social-btn[data-provider="google"]  { border-left: 4px solid #4285F4; }
+    .social-btn[data-provider="github"]  { border-left: 4px solid #24292e; }
+    .social-btn[data-provider="gitlab"]  { border-left: 4px solid #FC6D26; }
+    .social-btn[data-provider="discord"] { border-left: 4px solid #5865F2; }
+
+    .login-link {
+      text-align: center;
+      margin-top: 1.25em;
+      font-size: 0.9em;
+    }
+    #error-msg {
+      margin-bottom: 1em;
+    }
+    .vw-footer {
+      margin-top: 3em;
+      padding: 1em 1.2em;
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 6px;
+      font-size: 0.9em;
+      color: #374151;
+      text-align: center;
+    }
+    .vw-footer strong { color: #7C3AED; }
+  </style>
+</head>
+<body>
+  <nav>
+    <strong>VibeWarden Demo</strong> &nbsp;|&nbsp;
+    <a href="/">Home</a>
+    <a href="/static/me.html">My Profile</a>
+    <a href="/static/headers.html">Headers Inspector</a>
+    <a href="/static/ratelimit.html">Rate Limit Test</a>
+  </nav>
+
+  <div class="auth-box">
+    <h1>Create account</h1>
+    <div id="error-msg"></div>
+    <div id="form-container">Loading flow...</div>
+    <div class="login-link">
+      Already have an account? <a href="/auth/login">Log in</a>
+    </div>
+  </div>
+
+  <div class="vw-footer">
+    <strong>This app has zero custom security code.</strong>
+    Auth is handled by <strong>VibeWarden</strong> + Ory Kratos.
+    &mdash; <a href="/">Back to Home</a>
+  </div>
+
+  <script>
+    // Label overrides per provider slug.
+    var PROVIDER_LABELS = {
+      google:  'Sign up with Google',
+      github:  'Sign up with GitHub',
+      gitlab:  'Sign up with GitLab',
+      discord: 'Sign up with Discord',
+    };
+
+    function escapeHtml(str) {
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+    }
+
+    function showError(msg) {
+      var el = document.getElementById('error-msg');
+      el.innerHTML = '<p><span class="badge badge-error">Error</span> ' + escapeHtml(msg) + '</p>';
+    }
+
+    (async function () {
+      var container = document.getElementById('form-container');
+
+      var params = new URLSearchParams(window.location.search);
+      var flowId = params.get('flow');
+
+      try {
+        var flowUrl = flowId
+          ? '/self-service/registration/flows?id=' + encodeURIComponent(flowId)
+          : '/self-service/registration/browser';
+
+        var resp = await fetch(flowUrl, {
+          credentials: 'include',
+          headers: { 'Accept': 'application/json' },
+          redirect: 'follow',
+        });
+
+        var contentType = resp.headers.get('Content-Type') || '';
+        if (!contentType.includes('application/json')) {
+          window.location.reload();
+          return;
+        }
+
+        if (!resp.ok) {
+          var errData = await resp.json().catch(function () { return {}; });
+          showError((errData.error && errData.error.message) || 'Failed to load registration flow (HTTP ' + resp.status + ').');
+          container.innerHTML = '';
+          return;
+        }
+
+        var flow = await resp.json();
+        renderFlow(flow);
+      } catch (err) {
+        showError('Network error: ' + String(err));
+        container.innerHTML = '';
+      }
+    })();
+
+    function renderFlow(flow) {
+      var container = document.getElementById('form-container');
+      var nodes = (flow.ui && flow.ui.nodes) || [];
+      var action = (flow.ui && flow.ui.action) || '';
+
+      // Display any flow-level messages.
+      var messages = (flow.ui && flow.ui.messages) || [];
+      if (messages.length > 0) {
+        var errorEl = document.getElementById('error-msg');
+        errorEl.innerHTML = messages.map(function (m) {
+          var cls = m.type === 'error' ? 'badge-error' : 'badge badge-info';
+          return '<p><span class="badge ' + cls + '">' + escapeHtml(m.type) + '</span> ' + escapeHtml(m.text) + '</p>';
+        }).join('');
+      }
+
+      var oidcNodes = nodes.filter(function (n) { return n.group === 'oidc'; });
+      var passwordNodes = nodes.filter(function (n) { return n.group !== 'oidc'; });
+
+      var html = '';
+
+      // --- Password / email form ---
+      html += '<form method="POST" action="' + escapeHtml(action) + '">';
+      passwordNodes.forEach(function (node) {
+        html += renderNode(node);
+      });
+      html += '</form>';
+
+      // --- Social sign-up buttons ---
+      if (oidcNodes.length > 0) {
+        html += '<div class="divider">or sign up with</div>';
+        oidcNodes.forEach(function (node) {
+          if (node.type !== 'input' || !node.attributes) return;
+          var attrs = node.attributes;
+          var provider = (attrs.value || '').toLowerCase();
+          var label = PROVIDER_LABELS[provider] || escapeHtml(attrs.value || provider);
+          html += '<form method="POST" action="' + escapeHtml(action) + '">';
+          // Include hidden fields (csrf_token etc.) from the main form.
+          passwordNodes.forEach(function (n) {
+            if (n.type === 'input' && n.attributes && n.attributes.type === 'hidden') {
+              html += '<input type="hidden" name="' + escapeHtml(n.attributes.name) + '" value="' + escapeHtml(n.attributes.value || '') + '">';
+            }
+          });
+          html += '<button type="submit" class="social-btn" data-provider="' + escapeHtml(provider) + '" name="' + escapeHtml(attrs.name || 'provider') + '" value="' + escapeHtml(attrs.value || '') + '">' + label + '</button>';
+          html += '</form>';
+        });
+      }
+
+      container.innerHTML = html;
+    }
+
+    function renderNode(node) {
+      if (!node.attributes) return '';
+      var attrs = node.attributes;
+
+      if (attrs.type === 'hidden') {
+        return '<input type="hidden" name="' + escapeHtml(attrs.name) + '" value="' + escapeHtml(attrs.value || '') + '">';
+      }
+
+      if (attrs.type === 'submit') {
+        return '<button type="submit" class="btn-primary">' + escapeHtml((node.meta && node.meta.label && node.meta.label.text) || 'Submit') + '</button>';
+      }
+
+      var labelText = (node.meta && node.meta.label && node.meta.label.text) || attrs.name;
+      var messages = (node.messages || []).map(function (m) {
+        return '<small style="color:#dc2626">' + escapeHtml(m.text) + '</small>';
+      }).join(' ');
+
+      return '<div class="form-group">'
+        + '<label for="node-' + escapeHtml(attrs.name) + '">' + escapeHtml(labelText) + '</label>'
+        + '<input id="node-' + escapeHtml(attrs.name) + '" type="' + escapeHtml(attrs.type || 'text') + '" name="' + escapeHtml(attrs.name) + '" value="' + escapeHtml(attrs.value || '') + '" ' + (attrs.required ? 'required' : '') + ' ' + (attrs.disabled ? 'disabled' : '') + '>'
+        + messages
+        + '</div>';
+    }
+  </script>
+</body>
+</html>

--- a/examples/demo-app/vibewarden.local-demo.yaml
+++ b/examples/demo-app/vibewarden.local-demo.yaml
@@ -34,6 +34,7 @@ auth:
     - "/public"
     - "/health"
     - "/static"
+    - "/auth"
   session_cookie_name: "ory_kratos_session"
   login_url: ""
 

--- a/examples/demo-app/vibewarden.yaml
+++ b/examples/demo-app/vibewarden.yaml
@@ -31,6 +31,7 @@ auth:
     - "/public"
     - "/health"
     - "/static"
+    - "/auth"
   session_cookie_name: "ory_kratos_session"
   login_url: ""
 


### PR DESCRIPTION
Closes #168

## Summary

- Created `examples/demo-app/static/login.html` — fetches the Kratos login flow, renders email/password fields, and conditionally renders social provider buttons (Google, GitHub, GitLab, Discord) from OIDC nodes in the flow response. Each button has a provider-coloured left border and a human-readable label.
- Created `examples/demo-app/static/register.html` — same pattern for registration flows with "Sign up with" labels.
- Updated `examples/demo-app/static/index.html` — added a "Social Login" protection card explaining the feature; re-pointed Log In / Register buttons from the raw Kratos browser-flow redirect URLs to the new `/auth/login` and `/auth/registration` pages.
- Updated `examples/demo-app/static/me.html` — auth prompt links now go to `/auth/login` and `/auth/registration`.
- Updated `examples/demo-app/main.go` — added `GET /auth/login` and `GET /auth/registration` routes via the new `handleAuthPage` helper that reads a named file from the embedded static FS.
- Updated `examples/demo-app/vibewarden.yaml` and `vibewarden.local-demo.yaml` — added `/auth` to `auth.public_paths` so the login/register pages are reachable before authentication.

## Design notes

- Pages use vanilla JS only, no build step, consistent with the rest of the demo app.
- Social buttons are rendered only when Kratos returns OIDC nodes — if no social providers are configured the divider and buttons are simply absent.
- The pages follow the Kratos browser flow pattern: initialise or fetch an existing flow (via `?flow=<id>`), then POST back to the flow's `ui.action` URL with the selected provider or credentials.

## Test plan

- `go build ./...`, `go vet ./...`, and `go test -race ./...` all pass (verified by pre-push hook).
- Manual: `docker compose -f examples/demo-app/docker-compose.local-demo.yml up -d --build`, visit `https://localhost:8443/auth/login` — email/password form renders; if OIDC providers are wired in `vibewarden.yaml` the social buttons appear below the divider.