### PR TITLE
feat(#173): add AuthUIConfig for auth page theme configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,10 +3,14 @@ package config
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/viper"
 )
+
+// hexColorRE matches valid CSS hex color values: #RGB or #RRGGBB.
+var hexColorRE = regexp.MustCompile(`^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$`)
 
 // Config holds all configuration for VibeWarden.
 // Fields are loaded from vibewarden.yaml and can be overridden by environment variables.
@@ -169,6 +173,44 @@ type SocialProviderConfig struct {
 	IssuerURL string `mapstructure:"issuer_url"`
 }
 
+// AuthUIConfig holds theme and URL settings for the built-in authentication UI.
+// It configures the visual appearance of the login, registration, recovery, and
+// settings pages rendered by VibeWarden, as well as the optional custom URL
+// overrides used when mode is "custom".
+type AuthUIConfig struct {
+	// Mode selects whether VibeWarden renders its own auth pages or defers to
+	// custom URLs. Accepted values: "built-in" (default) or "custom".
+	Mode string `mapstructure:"mode"`
+
+	// AppName is the application name shown on the built-in login page.
+	AppName string `mapstructure:"app_name"`
+
+	// LogoURL is an optional URL to a logo image displayed on built-in pages.
+	LogoURL string `mapstructure:"logo_url"`
+
+	// PrimaryColor is the accent color used on built-in pages (hex, default: "#7C3AED").
+	PrimaryColor string `mapstructure:"primary_color"`
+
+	// BackgroundColor is the page background color for built-in pages (hex, default: "#1a1a2e").
+	BackgroundColor string `mapstructure:"background_color"`
+
+	// LoginURL is the URL of the custom login page.
+	// Required when Mode is "custom".
+	LoginURL string `mapstructure:"login_url"`
+
+	// RegistrationURL is the URL of the custom registration page.
+	// Only used when Mode is "custom".
+	RegistrationURL string `mapstructure:"registration_url"`
+
+	// SettingsURL is the URL of the custom account settings page.
+	// Only used when Mode is "custom".
+	SettingsURL string `mapstructure:"settings_url"`
+
+	// RecoveryURL is the URL of the custom account recovery page.
+	// Only used when Mode is "custom".
+	RecoveryURL string `mapstructure:"recovery_url"`
+}
+
 // AuthConfig holds auth middleware settings.
 // Authentication is enabled automatically when Kratos.PublicURL is non-empty.
 type AuthConfig struct {
@@ -201,6 +243,9 @@ type AuthConfig struct {
 	// SocialProviders is a list of OAuth2/OIDC social login providers to enable.
 	// Each entry requires at minimum a provider name, client_id, and client_secret.
 	SocialProviders []SocialProviderConfig `mapstructure:"social_providers"`
+
+	// UI holds theme and URL settings for the built-in or custom auth pages.
+	UI AuthUIConfig `mapstructure:"ui"`
 }
 
 // RateLimitConfig holds rate limiting settings.
@@ -353,6 +398,21 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// Auth UI validation.
+	ui := c.Auth.UI
+	if ui.Mode != "" && ui.Mode != "built-in" && ui.Mode != "custom" {
+		errs = append(errs, fmt.Sprintf("auth.ui.mode %q is invalid; accepted values: \"built-in\", \"custom\"", ui.Mode))
+	}
+	if ui.PrimaryColor != "" && !hexColorRE.MatchString(ui.PrimaryColor) {
+		errs = append(errs, fmt.Sprintf("auth.ui.primary_color %q is not a valid hex color (expected #RGB or #RRGGBB)", ui.PrimaryColor))
+	}
+	if ui.BackgroundColor != "" && !hexColorRE.MatchString(ui.BackgroundColor) {
+		errs = append(errs, fmt.Sprintf("auth.ui.background_color %q is not a valid hex color (expected #RGB or #RRGGBB)", ui.BackgroundColor))
+	}
+	if ui.Mode == "custom" && ui.LoginURL == "" {
+		errs = append(errs, "auth.ui.login_url is required when auth.ui.mode is \"custom\"")
+	}
+
 	if len(errs) > 0 {
 		return fmt.Errorf("%s", strings.Join(errs, "; "))
 	}
@@ -385,6 +445,15 @@ func Load(configPath string) (*Config, error) {
 	v.SetDefault("auth.session_cookie_name", "ory_kratos_session")
 	v.SetDefault("auth.login_url", "")
 	v.SetDefault("auth.social_providers", []SocialProviderConfig{})
+	v.SetDefault("auth.ui.mode", "built-in")
+	v.SetDefault("auth.ui.app_name", "")
+	v.SetDefault("auth.ui.logo_url", "")
+	v.SetDefault("auth.ui.primary_color", "#7C3AED")
+	v.SetDefault("auth.ui.background_color", "#1a1a2e")
+	v.SetDefault("auth.ui.login_url", "")
+	v.SetDefault("auth.ui.registration_url", "")
+	v.SetDefault("auth.ui.settings_url", "")
+	v.SetDefault("auth.ui.recovery_url", "")
 	v.SetDefault("rate_limit.enabled", true)
 	v.SetDefault("rate_limit.per_ip.requests_per_second", 10)
 	v.SetDefault("rate_limit.per_ip.burst", 20)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -992,3 +992,402 @@ log:
 		t.Errorf("overrides.kratos_config = %q, want empty (backward compat default)", cfg.Overrides.KratosConfig)
 	}
 }
+
+// TestLoad_AuthUIDefaults verifies that auth.ui fields default to the expected values.
+func TestLoad_AuthUIDefaults(t *testing.T) {
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"auth.ui.mode", cfg.Auth.UI.Mode, "built-in"},
+		{"auth.ui.app_name", cfg.Auth.UI.AppName, ""},
+		{"auth.ui.logo_url", cfg.Auth.UI.LogoURL, ""},
+		{"auth.ui.primary_color", cfg.Auth.UI.PrimaryColor, "#7C3AED"},
+		{"auth.ui.background_color", cfg.Auth.UI.BackgroundColor, "#1a1a2e"},
+		{"auth.ui.login_url", cfg.Auth.UI.LoginURL, ""},
+		{"auth.ui.registration_url", cfg.Auth.UI.RegistrationURL, ""},
+		{"auth.ui.settings_url", cfg.Auth.UI.SettingsURL, ""},
+		{"auth.ui.recovery_url", cfg.Auth.UI.RecoveryURL, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("default %s = %v, want %v", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoad_AuthUIFromFile verifies that auth.ui fields are loaded correctly from a config file.
+func TestLoad_AuthUIFromFile(t *testing.T) {
+	content := `
+auth:
+  ui:
+    mode: built-in
+    app_name: "My App"
+    logo_url: "https://example.com/logo.png"
+    primary_color: "#7C3AED"
+    background_color: "#1a1a2e"
+`
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "vibewarden.yaml")
+	if err := os.WriteFile(cfgFile, []byte(content), 0600); err != nil {
+		t.Fatalf("writing temp config file: %v", err)
+	}
+
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"auth.ui.mode", cfg.Auth.UI.Mode, "built-in"},
+		{"auth.ui.app_name", cfg.Auth.UI.AppName, "My App"},
+		{"auth.ui.logo_url", cfg.Auth.UI.LogoURL, "https://example.com/logo.png"},
+		{"auth.ui.primary_color", cfg.Auth.UI.PrimaryColor, "#7C3AED"},
+		{"auth.ui.background_color", cfg.Auth.UI.BackgroundColor, "#1a1a2e"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s = %v, want %v", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoad_AuthUICustomMode verifies that mode=custom with all URLs loads correctly.
+func TestLoad_AuthUICustomMode(t *testing.T) {
+	content := `
+auth:
+  ui:
+    mode: custom
+    login_url: "https://myapp.example.com/login"
+    registration_url: "https://myapp.example.com/register"
+    settings_url: "https://myapp.example.com/settings"
+    recovery_url: "https://myapp.example.com/recovery"
+`
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "vibewarden.yaml")
+	if err := os.WriteFile(cfgFile, []byte(content), 0600); err != nil {
+		t.Fatalf("writing temp config file: %v", err)
+	}
+
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"auth.ui.mode", cfg.Auth.UI.Mode, "custom"},
+		{"auth.ui.login_url", cfg.Auth.UI.LoginURL, "https://myapp.example.com/login"},
+		{"auth.ui.registration_url", cfg.Auth.UI.RegistrationURL, "https://myapp.example.com/register"},
+		{"auth.ui.settings_url", cfg.Auth.UI.SettingsURL, "https://myapp.example.com/settings"},
+		{"auth.ui.recovery_url", cfg.Auth.UI.RecoveryURL, "https://myapp.example.com/recovery"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s = %v, want %v", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidate_AuthUIMode verifies validation of auth.ui.mode.
+func TestValidate_AuthUIMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config.Config
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "default empty mode is valid",
+			cfg:     config.Config{},
+			wantErr: false,
+		},
+		{
+			name: "built-in mode is valid",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					UI: config.AuthUIConfig{Mode: "built-in"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "custom mode with login_url is valid",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					UI: config.AuthUIConfig{Mode: "custom", LoginURL: "/login"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "custom mode without login_url fails",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					UI: config.AuthUIConfig{Mode: "custom"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "auth.ui.login_url is required when auth.ui.mode is \"custom\"",
+		},
+		{
+			name: "unknown mode fails",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					UI: config.AuthUIConfig{Mode: "hosted"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "auth.ui.mode \"hosted\" is invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.errMsg != "" {
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+// TestValidate_AuthUIColors verifies hex color validation for primary_color and background_color.
+func TestValidate_AuthUIColors(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config.Config
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid #RRGGBB primary color",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					UI: config.AuthUIConfig{PrimaryColor: "#7C3AED"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid #RGB primary color",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					UI: config.AuthUIConfig{PrimaryColor: "#F0A"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid #RRGGBB background color",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					UI: config.AuthUIConfig{BackgroundColor: "#1a1a2e"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid #RGB background color",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					UI: config.AuthUIConfig{BackgroundColor: "#abc"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty primary color is valid (uses default)",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					UI: config.AuthUIConfig{PrimaryColor: ""},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty background color is valid (uses default)",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					UI: config.AuthUIConfig{BackgroundColor: ""},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid primary color without hash",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					UI: config.AuthUIConfig{PrimaryColor: "7C3AED"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "auth.ui.primary_color",
+		},
+		{
+			name: "invalid primary color wrong length",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					UI: config.AuthUIConfig{PrimaryColor: "#7C3AE"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "auth.ui.primary_color",
+		},
+		{
+			name: "invalid primary color with non-hex chars",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					UI: config.AuthUIConfig{PrimaryColor: "#GGGGGG"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "auth.ui.primary_color",
+		},
+		{
+			name: "invalid background color",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					UI: config.AuthUIConfig{BackgroundColor: "not-a-color"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "auth.ui.background_color",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.errMsg != "" {
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+// TestLoad_AuthUIValidationFromFile verifies that auth.ui validation errors surface through Load.
+func TestLoad_AuthUIValidationFromFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid built-in config",
+			yaml: `
+auth:
+  ui:
+    mode: built-in
+    primary_color: "#7C3AED"
+    background_color: "#1a1a2e"
+`,
+			wantErr: false,
+		},
+		{
+			name: "valid custom config with login_url",
+			yaml: `
+auth:
+  ui:
+    mode: custom
+    login_url: "/auth/login"
+`,
+			wantErr: false,
+		},
+		{
+			name: "custom mode without login_url fails",
+			yaml: `
+auth:
+  ui:
+    mode: custom
+`,
+			wantErr: true,
+			errMsg:  "auth.ui.login_url is required",
+		},
+		{
+			name: "invalid mode fails",
+			yaml: `
+auth:
+  ui:
+    mode: external
+`,
+			wantErr: true,
+			errMsg:  "auth.ui.mode",
+		},
+		{
+			name: "invalid primary_color fails",
+			yaml: `
+auth:
+  ui:
+    primary_color: "purple"
+`,
+			wantErr: true,
+			errMsg:  "auth.ui.primary_color",
+		},
+		{
+			name: "invalid background_color fails",
+			yaml: `
+auth:
+  ui:
+    background_color: "dark"
+`,
+			wantErr: true,
+			errMsg:  "auth.ui.background_color",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgFile := filepath.Join(dir, "vibewarden.yaml")
+			if err := os.WriteFile(cfgFile, []byte(tt.yaml), 0600); err != nil {
+				t.Fatalf("writing temp config file: %v", err)
+			}
+			_, err := config.Load(cfgFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Load() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.errMsg != "" {
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("Load() error = %q, want it to contain %q", err.Error(), tt.errMsg)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #173

## Summary

- Added `AuthUIConfig` struct to `internal/config/config.go` with fields for `Mode`, `AppName`, `LogoURL`, `PrimaryColor`, `BackgroundColor`, `LoginURL`, `RegistrationURL`, `SettingsURL`, and `RecoveryURL`
- Wired `UI AuthUIConfig` into `AuthConfig` under the `auth.ui` YAML key
- Added defaults in `Load()`: mode=`built-in`, primary_color=`#7C3AED`, background_color=`#1a1a2e`, all URL fields empty
- Added validation in `Validate()`: mode must be `built-in` or `custom`; colors must match `#RGB` or `#RRGGBB`; `login_url` is required when mode is `custom`
- Added hex color regex `hexColorRE` as a package-level compiled regexp

## Test plan

- `TestLoad_AuthUIDefaults` — verifies all nine default values
- `TestLoad_AuthUIFromFile` — verifies field loading from YAML (built-in mode)
- `TestLoad_AuthUICustomMode` — verifies all four URL fields load correctly for custom mode
- `TestValidate_AuthUIMode` — table-driven: empty, built-in, custom+URL, custom without URL, unknown mode
- `TestValidate_AuthUIColors` — table-driven: valid #RRGGBB, valid #RGB, empty (OK), invalid inputs for both primary and background
- `TestLoad_AuthUIValidationFromFile` — end-to-end validation through `Load()` with YAML files