### PR TITLE
feat(#171): built-in auth UI pages (login, registration, recovery, verification)

### DIFF
--- a/internal/adapters/authui/handler.go
+++ b/internal/adapters/authui/handler.go
@@ -1,0 +1,250 @@
+// Package authui serves the built-in authentication UI pages for VibeWarden.
+//
+// It provides a Handler that renders four HTML pages — login, registration,
+// recovery, and verification — at the /_vibewarden/{login,registration,recovery,verification}
+// paths. All templates are embedded in the binary via embed.FS so that no
+// external assets are required at runtime.
+//
+// Each page communicates with the Ory Kratos public API (proxied through
+// VibeWarden at /self-service/*) using plain HTML and vanilla JavaScript with
+// no external framework dependencies.
+//
+// Theming is achieved via CSS custom properties injected at render time from
+// the AuthUIConfig. The values are safely HTML-escaped before insertion.
+package authui
+
+import (
+	"bytes"
+	"context"
+	"embed"
+	"fmt"
+	"html/template"
+	"log/slog"
+	"net"
+	"net/http"
+)
+
+//go:embed templates/*.html
+var templateFS embed.FS
+
+// AuthUIConfig holds the theming and behavioural configuration for the
+// built-in auth UI pages.
+type AuthUIConfig struct {
+	// Mode selects the UI serving strategy.
+	// "built-in" (default) — VibeWarden serves its own pages.
+	// "custom"   — the operator provides their own pages; this handler is not mounted.
+	Mode string
+
+	// PrimaryColor is the CSS value for the --vw-primary custom property.
+	// Defaults to "#7C3AED" (VibeWarden purple) when empty.
+	PrimaryColor string
+
+	// BackgroundColor is the CSS value for the --vw-bg custom property.
+	// Defaults to "#F3F4F6" when empty.
+	BackgroundColor string
+
+	// TextColor is the CSS value for the --vw-text custom property.
+	// Defaults to "#111827" when empty.
+	TextColor string
+
+	// ErrorColor is the CSS value for the --vw-error custom property.
+	// Defaults to "#DC2626" when empty.
+	ErrorColor string
+}
+
+// templateData is passed to every HTML template at render time.
+type templateData struct {
+	// PrimaryColor is the CSS color string for --vw-primary.
+	PrimaryColor string
+	// BackgroundColor is the CSS color string for --vw-bg.
+	BackgroundColor string
+	// TextColor is the CSS color string for --vw-text.
+	TextColor string
+	// ErrorColor is the CSS color string for --vw-error.
+	ErrorColor string
+	// ReturnToQuery is the optional ?return_to=... query string fragment
+	// (including the leading "?") to append to inter-page links so the
+	// original destination is preserved. Empty string when not set.
+	ReturnToQuery string
+}
+
+// Handler serves the built-in auth UI pages and implements
+// ports.InternalServerPlugin (via Addr) so the registry can reverse-proxy
+// the /_vibewarden/login|registration|recovery|verification routes to it.
+type Handler struct {
+	cfg      AuthUIConfig
+	tmpls    *template.Template
+	listener net.Listener
+	server   *http.Server
+	logger   *slog.Logger
+}
+
+// NewHandler constructs an auth UI Handler. cfg controls theming; logger is
+// used for startup and serve errors. Call Start to bind the listener.
+func NewHandler(cfg AuthUIConfig, logger *slog.Logger) (*Handler, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	applyDefaults(&cfg)
+
+	tmpls, err := loadTemplates()
+	if err != nil {
+		return nil, fmt.Errorf("authui: loading templates: %w", err)
+	}
+
+	return &Handler{
+		cfg:    cfg,
+		tmpls:  tmpls,
+		logger: logger,
+	}, nil
+}
+
+// Start binds a random localhost TCP port, registers the auth UI routes, and
+// begins serving. It returns immediately; the server runs until Stop is called.
+// Start must be called before Addr.
+func (h *Handler) Start() error {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("authui: binding listener: %w", err)
+	}
+	h.listener = ln
+
+	mux := http.NewServeMux()
+	h.registerRoutes(mux)
+
+	h.server = &http.Server{Handler: mux} //nolint:gosec // internal-only localhost listener
+	go func() {
+		if serveErr := h.server.Serve(ln); serveErr != nil && serveErr != http.ErrServerClosed {
+			h.logger.Error("authui server stopped unexpectedly", "err", serveErr)
+		}
+	}()
+
+	h.logger.Info("authui server started", slog.String("addr", ln.Addr().String()))
+	return nil
+}
+
+// Stop gracefully shuts down the auth UI HTTP server.
+func (h *Handler) Stop(ctx context.Context) error {
+	if h.server == nil {
+		return nil
+	}
+	if err := h.server.Shutdown(ctx); err != nil {
+		return fmt.Errorf("authui: shutting down server: %w", err)
+	}
+	return nil
+}
+
+// Addr returns the host:port the internal HTTP server is listening on.
+// Addr must only be called after a successful Start.
+func (h *Handler) Addr() string {
+	return h.listener.Addr().String()
+}
+
+// registerRoutes mounts all auth UI page handlers onto mux.
+func (h *Handler) registerRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/_vibewarden/login", h.handleLogin)
+	mux.HandleFunc("/_vibewarden/registration", h.handleRegistration)
+	mux.HandleFunc("/_vibewarden/recovery", h.handleRecovery)
+	mux.HandleFunc("/_vibewarden/verification", h.handleVerification)
+}
+
+// handleLogin renders the login page.
+func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
+	h.renderPage(w, r, "login.html")
+}
+
+// handleRegistration renders the registration page.
+func (h *Handler) handleRegistration(w http.ResponseWriter, r *http.Request) {
+	h.renderPage(w, r, "registration.html")
+}
+
+// handleRecovery renders the account recovery page.
+func (h *Handler) handleRecovery(w http.ResponseWriter, r *http.Request) {
+	h.renderPage(w, r, "recovery.html")
+}
+
+// handleVerification renders the email verification page.
+func (h *Handler) handleVerification(w http.ResponseWriter, r *http.Request) {
+	h.renderPage(w, r, "verification.html")
+}
+
+// renderPage executes the named template with theme data derived from cfg
+// and writes the result to w. On template error a 500 is returned.
+func (h *Handler) renderPage(w http.ResponseWriter, r *http.Request, tmplName string) {
+	data := templateData{
+		PrimaryColor:    h.cfg.PrimaryColor,
+		BackgroundColor: h.cfg.BackgroundColor,
+		TextColor:       h.cfg.TextColor,
+		ErrorColor:      h.cfg.ErrorColor,
+		ReturnToQuery:   returnToQuery(r),
+	}
+
+	var buf bytes.Buffer
+	if err := h.tmpls.ExecuteTemplate(&buf, tmplName, data); err != nil {
+		h.logger.Error("authui: executing template", slog.String("template", tmplName), "err", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(buf.Bytes())
+}
+
+// loadTemplates parses all embedded HTML templates from templateFS.
+// The templates are named by their base filename (e.g. "login.html").
+func loadTemplates() (*template.Template, error) {
+	entries, err := templateFS.ReadDir("templates")
+	if err != nil {
+		return nil, fmt.Errorf("reading templates dir: %w", err)
+	}
+
+	root := template.New("")
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		src, err := templateFS.ReadFile("templates/" + name)
+		if err != nil {
+			return nil, fmt.Errorf("reading template %q: %w", name, err)
+		}
+		if _, err := root.New(name).Parse(string(src)); err != nil {
+			return nil, fmt.Errorf("parsing template %q: %w", name, err)
+		}
+	}
+
+	return root, nil
+}
+
+// applyDefaults fills in zero-value fields in cfg with sensible defaults.
+func applyDefaults(cfg *AuthUIConfig) {
+	if cfg.Mode == "" {
+		cfg.Mode = "built-in"
+	}
+	if cfg.PrimaryColor == "" {
+		cfg.PrimaryColor = "#7C3AED"
+	}
+	if cfg.BackgroundColor == "" {
+		cfg.BackgroundColor = "#F3F4F6"
+	}
+	if cfg.TextColor == "" {
+		cfg.TextColor = "#111827"
+	}
+	if cfg.ErrorColor == "" {
+		cfg.ErrorColor = "#DC2626"
+	}
+}
+
+// returnToQuery extracts the return_to query parameter from r and returns
+// a ready-to-append query string fragment like "?return_to=%2Fdashboard",
+// or an empty string when the parameter is absent or empty.
+func returnToQuery(r *http.Request) string {
+	v := r.URL.Query().Get("return_to")
+	if v == "" {
+		return ""
+	}
+	return "?return_to=" + v
+}

--- a/internal/adapters/authui/handler_test.go
+++ b/internal/adapters/authui/handler_test.go
@@ -1,0 +1,327 @@
+package authui_test
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/adapters/authui"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newHandler(t *testing.T, cfg authui.AuthUIConfig) *authui.Handler {
+	t.Helper()
+	h, err := authui.NewHandler(cfg, discardLogger())
+	if err != nil {
+		t.Fatalf("NewHandler() error: %v", err)
+	}
+	return h
+}
+
+func defaultConfig() authui.AuthUIConfig {
+	return authui.AuthUIConfig{
+		Mode:            "built-in",
+		PrimaryColor:    "#7C3AED",
+		BackgroundColor: "#F3F4F6",
+		TextColor:       "#111827",
+		ErrorColor:      "#DC2626",
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NewHandler
+// ---------------------------------------------------------------------------
+
+func TestNewHandler_DefaultConfig(t *testing.T) {
+	h, err := authui.NewHandler(authui.AuthUIConfig{}, discardLogger())
+	if err != nil {
+		t.Fatalf("NewHandler() unexpected error: %v", err)
+	}
+	if h == nil {
+		t.Fatal("NewHandler() returned nil handler")
+	}
+}
+
+func TestNewHandler_NilLoggerIsAccepted(t *testing.T) {
+	_, err := authui.NewHandler(defaultConfig(), nil)
+	if err != nil {
+		t.Fatalf("NewHandler() with nil logger unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Start / Addr / Stop
+// ---------------------------------------------------------------------------
+
+func TestHandler_StartAndAddr(t *testing.T) {
+	h := newHandler(t, defaultConfig())
+	if err := h.Start(); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer h.Stop(nil) //nolint: errcheck
+
+	addr := h.Addr()
+	if addr == "" {
+		t.Fatal("Addr() returned empty string after Start")
+	}
+	if !strings.Contains(addr, "127.0.0.1") {
+		t.Errorf("Addr() = %q, want to contain 127.0.0.1", addr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTP page responses — table-driven
+// ---------------------------------------------------------------------------
+
+func TestHandler_Pages(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		wantStatus   int
+		wantContains []string
+	}{
+		{
+			name:       "login page",
+			path:       "/_vibewarden/login",
+			wantStatus: http.StatusOK,
+			wantContains: []string{
+				"Log in",
+				"/_vibewarden/registration",
+				"/_vibewarden/recovery",
+				"#7C3AED",
+			},
+		},
+		{
+			name:       "registration page",
+			path:       "/_vibewarden/registration",
+			wantStatus: http.StatusOK,
+			wantContains: []string{
+				"Create account",
+				"/_vibewarden/login",
+				"#7C3AED",
+			},
+		},
+		{
+			name:       "recovery page",
+			path:       "/_vibewarden/recovery",
+			wantStatus: http.StatusOK,
+			wantContains: []string{
+				"Recover account",
+				"/_vibewarden/login",
+				"#7C3AED",
+			},
+		},
+		{
+			name:       "verification page",
+			path:       "/_vibewarden/verification",
+			wantStatus: http.StatusOK,
+			wantContains: []string{
+				"Verify email",
+				"/_vibewarden/login",
+				"#7C3AED",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newHandler(t, defaultConfig())
+			if err := h.Start(); err != nil {
+				t.Fatalf("Start() error: %v", err)
+			}
+			defer h.Stop(nil) //nolint: errcheck
+
+			resp, err := http.Get("http://" + h.Addr() + tt.path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", tt.path, err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+
+			body, _ := io.ReadAll(resp.Body)
+			bodyStr := string(body)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(bodyStr, want) {
+					t.Errorf("body missing %q", want)
+				}
+			}
+
+			ct := resp.Header.Get("Content-Type")
+			if !strings.HasPrefix(ct, "text/html") {
+				t.Errorf("Content-Type = %q, want text/html", ct)
+			}
+
+			cc := resp.Header.Get("Cache-Control")
+			if cc != "no-store" {
+				t.Errorf("Cache-Control = %q, want no-store", cc)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Theme injection
+// ---------------------------------------------------------------------------
+
+func TestHandler_ThemeColorsInjected(t *testing.T) {
+	cfg := authui.AuthUIConfig{
+		PrimaryColor:    "#AABBCC",
+		BackgroundColor: "#112233",
+		TextColor:       "#445566",
+		ErrorColor:      "#778899",
+	}
+	h := newHandler(t, cfg)
+	if err := h.Start(); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer h.Stop(nil) //nolint: errcheck
+
+	pages := []string{
+		"/_vibewarden/login",
+		"/_vibewarden/registration",
+		"/_vibewarden/recovery",
+		"/_vibewarden/verification",
+	}
+
+	for _, path := range pages {
+		t.Run(path, func(t *testing.T) {
+			resp, err := http.Get("http://" + h.Addr() + path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", path, err)
+			}
+			defer resp.Body.Close()
+
+			body, _ := io.ReadAll(resp.Body)
+			bodyStr := string(body)
+
+			for _, color := range []string{"#AABBCC", "#112233", "#445566", "#778899"} {
+				if !strings.Contains(bodyStr, color) {
+					t.Errorf("page %s missing color %q in body", path, color)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ReturnToQuery preservation
+// ---------------------------------------------------------------------------
+
+func TestHandler_ReturnToQueryPropagated(t *testing.T) {
+	h := newHandler(t, defaultConfig())
+	if err := h.Start(); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer h.Stop(nil) //nolint: errcheck
+
+	// The login page should include the return_to value in registration link.
+	resp, err := http.Get(fmt.Sprintf("http://%s/_vibewarden/login?return_to=%%2Fdashboard", h.Addr()))
+	if err != nil {
+		t.Fatalf("GET login with return_to: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "return_to") {
+		t.Error("login page body does not contain return_to when it is set")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Default colors applied when config is empty
+// ---------------------------------------------------------------------------
+
+func TestHandler_DefaultColorsApplied(t *testing.T) {
+	h := newHandler(t, authui.AuthUIConfig{})
+	if err := h.Start(); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer h.Stop(nil) //nolint: errcheck
+
+	resp, err := http.Get("http://" + h.Addr() + "/_vibewarden/login")
+	if err != nil {
+		t.Fatalf("GET login: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+
+	defaults := map[string]string{
+		"primary":    "#7C3AED",
+		"background": "#F3F4F6",
+		"text":       "#111827",
+		"error":      "#DC2626",
+	}
+	for name, color := range defaults {
+		if !strings.Contains(bodyStr, color) {
+			t.Errorf("default %s color %q not found in login page body", name, color)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Handler via httptest.Server — unit-level without Start/Stop
+// ---------------------------------------------------------------------------
+
+func TestHandler_ServeHTTP_ViaRecorder(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		wantOK bool
+	}{
+		{"login", "/_vibewarden/login", true},
+		{"registration", "/_vibewarden/registration", true},
+		{"recovery", "/_vibewarden/recovery", true},
+		{"verification", "/_vibewarden/verification", true},
+	}
+
+	h := newHandler(t, defaultConfig())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Route manually, mirroring registerRoutes.
+		switch r.URL.Path {
+		case "/_vibewarden/login":
+			r2 := r.Clone(r.Context())
+			r2.URL.Path = "/_vibewarden/login"
+			http.Redirect(w, r2, "/_vibewarden/login", http.StatusOK)
+		}
+		_ = h
+		// Delegate by starting the real handler.
+	}))
+	defer srv.Close()
+
+	// Use the real handler directly via a started server.
+	realH := newHandler(t, defaultConfig())
+	if err := realH.Start(); err != nil {
+		t.Fatalf("Start(): %v", err)
+	}
+	defer realH.Stop(nil) //nolint: errcheck
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := http.Get("http://" + realH.Addr() + tt.path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", tt.path, err)
+			}
+			defer resp.Body.Close()
+
+			if tt.wantOK && resp.StatusCode != http.StatusOK {
+				t.Errorf("status = %d, want 200", resp.StatusCode)
+			}
+		})
+	}
+}

--- a/internal/adapters/authui/templates/login.html
+++ b/internal/adapters/authui/templates/login.html
@@ -1,0 +1,353 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Log In</title>
+  <style>
+    :root {
+      --vw-primary: {{.PrimaryColor}};
+      --vw-bg: {{.BackgroundColor}};
+      --vw-text: {{.TextColor}};
+      --vw-error: {{.ErrorColor}};
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: var(--vw-bg);
+      color: var(--vw-text);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1rem;
+    }
+    .card {
+      background: #fff;
+      border-radius: 0.75rem;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.10);
+      padding: 2.5rem 2rem;
+      width: 100%;
+      max-width: 400px;
+    }
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      margin-bottom: 1.5rem;
+      color: var(--vw-text);
+    }
+    .field { margin-bottom: 1rem; }
+    label {
+      display: block;
+      font-size: 0.875rem;
+      font-weight: 500;
+      margin-bottom: 0.375rem;
+      color: var(--vw-text);
+    }
+    input[type="email"],
+    input[type="password"],
+    input[type="text"] {
+      width: 100%;
+      padding: 0.625rem 0.875rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.5rem;
+      font-size: 1rem;
+      color: var(--vw-text);
+      background: #f9fafb;
+      transition: border-color 0.15s;
+    }
+    input:focus {
+      outline: none;
+      border-color: var(--vw-primary);
+      background: #fff;
+    }
+    .btn-primary {
+      display: block;
+      width: 100%;
+      padding: 0.75rem;
+      background: var(--vw-primary);
+      color: #fff;
+      border: none;
+      border-radius: 0.5rem;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      margin-top: 1.25rem;
+      transition: opacity 0.15s;
+    }
+    .btn-primary:hover { opacity: 0.9; }
+    .btn-social {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      width: 100%;
+      padding: 0.65rem;
+      background: #f9fafb;
+      border: 1px solid #d1d5db;
+      border-radius: 0.5rem;
+      font-size: 0.9375rem;
+      font-weight: 500;
+      color: var(--vw-text);
+      cursor: pointer;
+      margin-bottom: 0.5rem;
+      text-decoration: none;
+      transition: background 0.15s;
+    }
+    .btn-social:hover { background: #f3f4f6; }
+    .divider {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin: 1.25rem 0;
+      color: #9ca3af;
+      font-size: 0.8125rem;
+    }
+    .divider::before, .divider::after {
+      content: "";
+      flex: 1;
+      height: 1px;
+      background: #e5e7eb;
+    }
+    .error-box {
+      background: #fef2f2;
+      border: 1px solid #fecaca;
+      border-radius: 0.5rem;
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      color: var(--vw-error);
+      font-size: 0.875rem;
+    }
+    .links {
+      margin-top: 1.25rem;
+      text-align: center;
+      font-size: 0.875rem;
+      color: #6b7280;
+    }
+    .links a {
+      color: var(--vw-primary);
+      text-decoration: none;
+      font-weight: 500;
+    }
+    .links a:hover { text-decoration: underline; }
+    .forgot { text-align: right; margin-top: 0.25rem; }
+    .forgot a { font-size: 0.8125rem; color: var(--vw-primary); text-decoration: none; }
+    .forgot a:hover { text-decoration: underline; }
+    @media (max-width: 480px) { .card { padding: 2rem 1.25rem; } }
+  </style>
+</head>
+<body>
+<div class="card">
+  <h1>Log in</h1>
+
+  <div id="error-box" class="error-box" style="display:none"></div>
+
+  <div id="social-buttons"></div>
+  <div id="social-divider" class="divider" style="display:none">or</div>
+
+  <form id="login-form">
+    <input type="hidden" id="csrf-token" name="csrf_token" value="">
+    <input type="hidden" id="flow-id" name="flow_id" value="">
+    <div class="field">
+      <label for="email">Email address</label>
+      <input type="email" id="email" name="identifier" autocomplete="email" required placeholder="you@example.com">
+    </div>
+    <div class="field">
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password" autocomplete="current-password" required placeholder="••••••••">
+      <div class="forgot"><a href="/_vibewarden/recovery">Forgot password?</a></div>
+    </div>
+    <button type="submit" class="btn-primary">Log in</button>
+  </form>
+
+  <div class="links">
+    Don't have an account? <a href="/_vibewarden/registration{{.ReturnToQuery}}">Register</a>
+  </div>
+</div>
+
+<script>
+(function () {
+  const kratosBase = '';
+  const params = new URLSearchParams(window.location.search);
+  const returnTo = params.get('return_to') || '/';
+
+  function showError(msg) {
+    const box = document.getElementById('error-box');
+    box.textContent = msg;
+    box.style.display = 'block';
+  }
+
+  function hideError() {
+    document.getElementById('error-box').style.display = 'none';
+  }
+
+  async function initFlow() {
+    let flowId = params.get('flow');
+    let flow;
+
+    try {
+      if (flowId) {
+        const res = await fetch(kratosBase + '/self-service/login/flows?id=' + encodeURIComponent(flowId), {
+          headers: { Accept: 'application/json' },
+          credentials: 'include',
+        });
+        if (!res.ok) throw new Error('flow_expired');
+        flow = await res.json();
+      } else {
+        // Initiate a new browser login flow.
+        const initRes = await fetch(
+          kratosBase + '/self-service/login/browser?return_to=' + encodeURIComponent(returnTo),
+          { redirect: 'manual', credentials: 'include' }
+        );
+        // Kratos responds with a redirect to ?flow=<id>; extract the flow id.
+        const location = initRes.headers.get('location') || '';
+        const m = location.match(/[?&]flow=([^&]+)/);
+        if (!m) throw new Error('no_flow_id');
+        flowId = m[1];
+        history.replaceState(null, '', '?flow=' + flowId + (returnTo !== '/' ? '&return_to=' + encodeURIComponent(returnTo) : ''));
+
+        const res = await fetch(kratosBase + '/self-service/login/flows?id=' + encodeURIComponent(flowId), {
+          headers: { Accept: 'application/json' },
+          credentials: 'include',
+        });
+        if (!res.ok) throw new Error('fetch_flow_failed');
+        flow = await res.json();
+      }
+    } catch (e) {
+      if (e.message === 'flow_expired') {
+        window.location.href = '/_vibewarden/login?return_to=' + encodeURIComponent(returnTo);
+        return;
+      }
+      showError('Could not start login session. Please try again.');
+      return;
+    }
+
+    applyFlow(flow);
+  }
+
+  function applyFlow(flow) {
+    const nodes = (flow.ui && flow.ui.nodes) || [];
+
+    // Extract csrf token.
+    const csrfNode = nodes.find(n => n.attributes && n.attributes.name === 'csrf_token');
+    if (csrfNode) {
+      document.getElementById('csrf-token').value = csrfNode.attributes.value || '';
+    }
+    document.getElementById('flow-id').value = flow.id || '';
+
+    // Show flow-level messages.
+    const messages = (flow.ui && flow.ui.messages) || [];
+    if (messages.length > 0) {
+      showError(messages.map(m => m.text).join(' '));
+    }
+
+    // Show per-field messages.
+    for (const node of nodes) {
+      const msgs = (node.messages || []).filter(m => m.type === 'error');
+      if (msgs.length > 0 && node.attributes && node.attributes.name) {
+        const el = document.querySelector('[name="' + node.attributes.name + '"]');
+        if (el) {
+          el.style.borderColor = 'var(--vw-error)';
+        }
+        showError(msgs.map(m => m.text).join(' '));
+      }
+    }
+
+    // Render OIDC social buttons.
+    const oidcNodes = nodes.filter(n => n.group === 'oidc' && n.attributes && n.attributes.type === 'submit');
+    const socialDiv = document.getElementById('social-buttons');
+    const divider = document.getElementById('social-divider');
+    for (const node of oidcNodes) {
+      const label = (node.meta && node.meta.label && node.meta.label.text) || node.attributes.value;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'btn-social';
+      btn.textContent = 'Continue with ' + label;
+      btn.addEventListener('click', function () {
+        submitOIDC(flow, node.attributes.value);
+      });
+      socialDiv.appendChild(btn);
+    }
+    if (oidcNodes.length > 0) {
+      divider.style.display = 'flex';
+    }
+  }
+
+  async function submitOIDC(flow, provider) {
+    try {
+      const res = await fetch(flow.ui.action, {
+        method: flow.ui.method || 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          csrf_token: document.getElementById('csrf-token').value,
+          method: 'oidc',
+          provider: provider,
+        }),
+      });
+      if (res.ok || res.redirected) {
+        window.location.href = res.url || returnTo;
+        return;
+      }
+      const body = await res.json();
+      applyFlow(body);
+    } catch (_) {
+      showError('Social login failed. Please try again.');
+    }
+  }
+
+  document.getElementById('login-form').addEventListener('submit', async function (e) {
+    e.preventDefault();
+    hideError();
+
+    const form = e.target;
+    const flowId = document.getElementById('flow-id').value;
+    if (!flowId) { showError('Login session expired. Please refresh.'); return; }
+
+    // Re-fetch the flow to get the action URL.
+    let flow;
+    try {
+      const res = await fetch(kratosBase + '/self-service/login/flows?id=' + encodeURIComponent(flowId), {
+        headers: { Accept: 'application/json' },
+        credentials: 'include',
+      });
+      flow = await res.json();
+    } catch (_) {
+      showError('Login session expired. Please refresh.');
+      return;
+    }
+
+    const payload = {
+      csrf_token: document.getElementById('csrf-token').value,
+      method: 'password',
+      identifier: form.identifier.value,
+      password: form.password.value,
+    };
+
+    try {
+      const res = await fetch(flow.ui.action, {
+        method: flow.ui.method || 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+      });
+      if (res.status === 422 || res.status === 400) {
+        const body = await res.json();
+        applyFlow(body);
+        return;
+      }
+      if (res.ok || res.status === 303) {
+        window.location.href = returnTo;
+        return;
+      }
+      showError('Login failed. Please check your credentials and try again.');
+    } catch (_) {
+      showError('Network error. Please check your connection and try again.');
+    }
+  });
+
+  initFlow();
+}());
+</script>
+</body>
+</html>

--- a/internal/adapters/authui/templates/recovery.html
+++ b/internal/adapters/authui/templates/recovery.html
@@ -1,0 +1,339 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Recover Account</title>
+  <style>
+    :root {
+      --vw-primary: {{.PrimaryColor}};
+      --vw-bg: {{.BackgroundColor}};
+      --vw-text: {{.TextColor}};
+      --vw-error: {{.ErrorColor}};
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: var(--vw-bg);
+      color: var(--vw-text);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1rem;
+    }
+    .card {
+      background: #fff;
+      border-radius: 0.75rem;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.10);
+      padding: 2.5rem 2rem;
+      width: 100%;
+      max-width: 400px;
+    }
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      color: var(--vw-text);
+    }
+    .subtitle {
+      font-size: 0.9375rem;
+      color: #6b7280;
+      margin-bottom: 1.5rem;
+    }
+    .field { margin-bottom: 1rem; }
+    label {
+      display: block;
+      font-size: 0.875rem;
+      font-weight: 500;
+      margin-bottom: 0.375rem;
+      color: var(--vw-text);
+    }
+    input[type="email"],
+    input[type="password"],
+    input[type="text"] {
+      width: 100%;
+      padding: 0.625rem 0.875rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.5rem;
+      font-size: 1rem;
+      color: var(--vw-text);
+      background: #f9fafb;
+      transition: border-color 0.15s;
+    }
+    input:focus {
+      outline: none;
+      border-color: var(--vw-primary);
+      background: #fff;
+    }
+    .btn-primary {
+      display: block;
+      width: 100%;
+      padding: 0.75rem;
+      background: var(--vw-primary);
+      color: #fff;
+      border: none;
+      border-radius: 0.5rem;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      margin-top: 1.25rem;
+      transition: opacity 0.15s;
+    }
+    .btn-primary:hover { opacity: 0.9; }
+    .error-box {
+      background: #fef2f2;
+      border: 1px solid #fecaca;
+      border-radius: 0.5rem;
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      color: var(--vw-error);
+      font-size: 0.875rem;
+    }
+    .success-box {
+      background: #f0fdf4;
+      border: 1px solid #bbf7d0;
+      border-radius: 0.5rem;
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      color: #15803d;
+      font-size: 0.875rem;
+    }
+    .links {
+      margin-top: 1.25rem;
+      text-align: center;
+      font-size: 0.875rem;
+      color: #6b7280;
+    }
+    .links a {
+      color: var(--vw-primary);
+      text-decoration: none;
+      font-weight: 500;
+    }
+    .links a:hover { text-decoration: underline; }
+    @media (max-width: 480px) { .card { padding: 2rem 1.25rem; } }
+  </style>
+</head>
+<body>
+<div class="card">
+  <h1>Recover account</h1>
+  <p class="subtitle">Enter your email and we'll send you a recovery link.</p>
+
+  <div id="error-box" class="error-box" style="display:none"></div>
+  <div id="success-box" class="success-box" style="display:none">
+    If an account exists for that email, a recovery link has been sent.
+  </div>
+
+  <!-- Email request form (state: choose_method) -->
+  <form id="recovery-form">
+    <input type="hidden" id="csrf-token" name="csrf_token" value="">
+    <input type="hidden" id="flow-id" name="flow_id" value="">
+    <div class="field">
+      <label for="email">Email address</label>
+      <input type="email" id="email" name="email" autocomplete="email" required placeholder="you@example.com">
+    </div>
+    <button type="submit" class="btn-primary">Send recovery link</button>
+  </form>
+
+  <!-- Password reset form (state: sent_email with token) -->
+  <form id="reset-form" style="display:none">
+    <input type="hidden" id="reset-csrf-token" name="csrf_token" value="">
+    <input type="hidden" id="reset-flow-id" name="flow_id" value="">
+    <div class="field">
+      <label for="new-password">New password</label>
+      <input type="password" id="new-password" name="password" autocomplete="new-password" required placeholder="••••••••">
+    </div>
+    <div class="field">
+      <label for="confirm-password">Confirm new password</label>
+      <input type="password" id="confirm-password" name="password_confirm" autocomplete="new-password" required placeholder="••••••••">
+    </div>
+    <button type="submit" class="btn-primary">Reset password</button>
+  </form>
+
+  <div class="links">
+    <a href="/_vibewarden/login">Back to login</a>
+  </div>
+</div>
+
+<script>
+(function () {
+  const kratosBase = '';
+  const params = new URLSearchParams(window.location.search);
+
+  function showError(msg) {
+    const box = document.getElementById('error-box');
+    box.textContent = msg;
+    box.style.display = 'block';
+  }
+
+  function hideError() {
+    document.getElementById('error-box').style.display = 'none';
+  }
+
+  function showSuccess() {
+    document.getElementById('success-box').style.display = 'block';
+    document.getElementById('recovery-form').style.display = 'none';
+  }
+
+  async function initFlow() {
+    const flowId = params.get('flow');
+    if (!flowId) return; // No flow — fresh page, nothing to pre-load.
+
+    try {
+      const res = await fetch(kratosBase + '/self-service/recovery/flows?id=' + encodeURIComponent(flowId), {
+        headers: { Accept: 'application/json' },
+        credentials: 'include',
+      });
+      if (!res.ok) throw new Error('flow_not_found');
+      const flow = await res.json();
+      applyFlow(flow);
+    } catch (_) {
+      showError('Recovery session expired or invalid. Please request a new link.');
+    }
+  }
+
+  function applyFlow(flow) {
+    const nodes = (flow.ui && flow.ui.nodes) || [];
+    const state = flow.state || 'choose_method';
+
+    // Set CSRF token and flow ID for whichever form is active.
+    const csrfNode = nodes.find(n => n.attributes && n.attributes.name === 'csrf_token');
+    const csrfVal = csrfNode ? (csrfNode.attributes.value || '') : '';
+
+    const messages = (flow.ui && flow.ui.messages) || [];
+    if (messages.length > 0) {
+      showError(messages.map(m => m.text).join(' '));
+    }
+
+    if (state === 'sent_email') {
+      // Show the password reset form if the token has been validated
+      // and Kratos now expects a new password. Otherwise show sent message.
+      const pwNode = nodes.find(n => n.attributes && n.attributes.name === 'password');
+      if (pwNode) {
+        document.getElementById('recovery-form').style.display = 'none';
+        const resetForm = document.getElementById('reset-form');
+        resetForm.style.display = 'block';
+        document.getElementById('reset-csrf-token').value = csrfVal;
+        document.getElementById('reset-flow-id').value = flow.id || '';
+
+        // Store the action URL for submit.
+        resetForm.dataset.action = (flow.ui && flow.ui.action) || '';
+        resetForm.dataset.method = (flow.ui && flow.ui.method) || 'POST';
+      } else {
+        // Email sent state — show success.
+        document.getElementById('csrf-token').value = csrfVal;
+        document.getElementById('flow-id').value = flow.id || '';
+        showSuccess();
+      }
+    } else {
+      // choose_method state.
+      document.getElementById('csrf-token').value = csrfVal;
+      document.getElementById('flow-id').value = flow.id || '';
+
+      // Store action URL.
+      const recovForm = document.getElementById('recovery-form');
+      recovForm.dataset.action = (flow.ui && flow.ui.action) || '';
+      recovForm.dataset.method = (flow.ui && flow.ui.method) || 'POST';
+    }
+  }
+
+  document.getElementById('recovery-form').addEventListener('submit', async function (e) {
+    e.preventDefault();
+    hideError();
+
+    let flowId = document.getElementById('flow-id').value;
+    let action = e.target.dataset.action;
+    let method = e.target.dataset.method || 'POST';
+
+    // If no flow yet, initiate one.
+    if (!flowId || !action) {
+      try {
+        const initRes = await fetch(kratosBase + '/self-service/recovery/browser', {
+          redirect: 'manual', credentials: 'include'
+        });
+        const location = initRes.headers.get('location') || '';
+        const m = location.match(/[?&]flow=([^&]+)/);
+        if (!m) throw new Error('no_flow');
+        flowId = m[1];
+
+        const res = await fetch(kratosBase + '/self-service/recovery/flows?id=' + encodeURIComponent(flowId), {
+          headers: { Accept: 'application/json' },
+          credentials: 'include',
+        });
+        const flow = await res.json();
+        action = (flow.ui && flow.ui.action) || '';
+        method = (flow.ui && flow.ui.method) || 'POST';
+        const csrfNode = (flow.ui && flow.ui.nodes || []).find(n => n.attributes && n.attributes.name === 'csrf_token');
+        document.getElementById('csrf-token').value = csrfNode ? (csrfNode.attributes.value || '') : '';
+        document.getElementById('flow-id').value = flowId;
+      } catch (_) {
+        showError('Could not start recovery session. Please try again.');
+        return;
+      }
+    }
+
+    const payload = {
+      csrf_token: document.getElementById('csrf-token').value,
+      method: 'link',
+      email: document.getElementById('email').value,
+    };
+
+    try {
+      const res = await fetch(action, {
+        method: method,
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+      });
+      // Always show the same generic success message regardless of whether
+      // the email exists (security: don't reveal account existence).
+      showSuccess();
+    } catch (_) {
+      showError('Network error. Please check your connection and try again.');
+    }
+  });
+
+  document.getElementById('reset-form').addEventListener('submit', async function (e) {
+    e.preventDefault();
+    hideError();
+
+    const pw = document.getElementById('new-password').value;
+    const pwc = document.getElementById('confirm-password').value;
+    if (pw !== pwc) {
+      showError('Passwords do not match.');
+      return;
+    }
+
+    const action = e.target.dataset.action;
+    const method = e.target.dataset.method || 'POST';
+
+    const payload = {
+      csrf_token: document.getElementById('reset-csrf-token').value,
+      method: 'password',
+      password: pw,
+    };
+
+    try {
+      const res = await fetch(action, {
+        method: method,
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+      });
+      if (res.status === 422 || res.status === 400) {
+        const body = await res.json();
+        applyFlow(body);
+        return;
+      }
+      // Redirect to login with success hint.
+      window.location.href = '/_vibewarden/login?message=password_reset';
+    } catch (_) {
+      showError('Network error. Please check your connection and try again.');
+    }
+  });
+
+  initFlow();
+}());
+</script>
+</body>
+</html>

--- a/internal/adapters/authui/templates/registration.html
+++ b/internal/adapters/authui/templates/registration.html
@@ -1,0 +1,368 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Create Account</title>
+  <style>
+    :root {
+      --vw-primary: {{.PrimaryColor}};
+      --vw-bg: {{.BackgroundColor}};
+      --vw-text: {{.TextColor}};
+      --vw-error: {{.ErrorColor}};
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: var(--vw-bg);
+      color: var(--vw-text);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1rem;
+    }
+    .card {
+      background: #fff;
+      border-radius: 0.75rem;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.10);
+      padding: 2.5rem 2rem;
+      width: 100%;
+      max-width: 400px;
+    }
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      margin-bottom: 1.5rem;
+      color: var(--vw-text);
+    }
+    .field { margin-bottom: 1rem; }
+    label {
+      display: block;
+      font-size: 0.875rem;
+      font-weight: 500;
+      margin-bottom: 0.375rem;
+      color: var(--vw-text);
+    }
+    input[type="email"],
+    input[type="password"],
+    input[type="text"] {
+      width: 100%;
+      padding: 0.625rem 0.875rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.5rem;
+      font-size: 1rem;
+      color: var(--vw-text);
+      background: #f9fafb;
+      transition: border-color 0.15s;
+    }
+    input:focus {
+      outline: none;
+      border-color: var(--vw-primary);
+      background: #fff;
+    }
+    input.error { border-color: var(--vw-error); }
+    .field-error {
+      font-size: 0.8125rem;
+      color: var(--vw-error);
+      margin-top: 0.25rem;
+    }
+    .btn-primary {
+      display: block;
+      width: 100%;
+      padding: 0.75rem;
+      background: var(--vw-primary);
+      color: #fff;
+      border: none;
+      border-radius: 0.5rem;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      margin-top: 1.25rem;
+      transition: opacity 0.15s;
+    }
+    .btn-primary:hover { opacity: 0.9; }
+    .btn-social {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      width: 100%;
+      padding: 0.65rem;
+      background: #f9fafb;
+      border: 1px solid #d1d5db;
+      border-radius: 0.5rem;
+      font-size: 0.9375rem;
+      font-weight: 500;
+      color: var(--vw-text);
+      cursor: pointer;
+      margin-bottom: 0.5rem;
+      text-decoration: none;
+      transition: background 0.15s;
+    }
+    .btn-social:hover { background: #f3f4f6; }
+    .divider {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin: 1.25rem 0;
+      color: #9ca3af;
+      font-size: 0.8125rem;
+    }
+    .divider::before, .divider::after {
+      content: "";
+      flex: 1;
+      height: 1px;
+      background: #e5e7eb;
+    }
+    .error-box {
+      background: #fef2f2;
+      border: 1px solid #fecaca;
+      border-radius: 0.5rem;
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      color: var(--vw-error);
+      font-size: 0.875rem;
+    }
+    .links {
+      margin-top: 1.25rem;
+      text-align: center;
+      font-size: 0.875rem;
+      color: #6b7280;
+    }
+    .links a {
+      color: var(--vw-primary);
+      text-decoration: none;
+      font-weight: 500;
+    }
+    .links a:hover { text-decoration: underline; }
+    @media (max-width: 480px) { .card { padding: 2rem 1.25rem; } }
+  </style>
+</head>
+<body>
+<div class="card">
+  <h1>Create account</h1>
+
+  <div id="error-box" class="error-box" style="display:none"></div>
+
+  <div id="social-buttons"></div>
+  <div id="social-divider" class="divider" style="display:none">or</div>
+
+  <form id="reg-form">
+    <input type="hidden" id="csrf-token" name="csrf_token" value="">
+    <input type="hidden" id="flow-id" name="flow_id" value="">
+    <div class="field">
+      <label for="email">Email address</label>
+      <input type="email" id="email" name="traits.email" autocomplete="email" required placeholder="you@example.com">
+    </div>
+    <div class="field">
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password" autocomplete="new-password" required placeholder="••••••••">
+    </div>
+    <div class="field">
+      <label for="password-confirm">Confirm password</label>
+      <input type="password" id="password-confirm" name="password_confirm" autocomplete="new-password" required placeholder="••••••••">
+      <div id="confirm-error" class="field-error" style="display:none">Passwords do not match.</div>
+    </div>
+    <button type="submit" class="btn-primary">Create account</button>
+  </form>
+
+  <div class="links">
+    Already have an account? <a href="/_vibewarden/login{{.ReturnToQuery}}">Log in</a>
+  </div>
+</div>
+
+<script>
+(function () {
+  const kratosBase = '';
+  const params = new URLSearchParams(window.location.search);
+  const returnTo = params.get('return_to') || '/';
+
+  function showError(msg) {
+    const box = document.getElementById('error-box');
+    box.textContent = msg;
+    box.style.display = 'block';
+  }
+
+  function hideError() {
+    document.getElementById('error-box').style.display = 'none';
+  }
+
+  async function initFlow() {
+    let flowId = params.get('flow');
+    let flow;
+
+    try {
+      if (flowId) {
+        const res = await fetch(kratosBase + '/self-service/registration/flows?id=' + encodeURIComponent(flowId), {
+          headers: { Accept: 'application/json' },
+          credentials: 'include',
+        });
+        if (!res.ok) throw new Error('flow_expired');
+        flow = await res.json();
+      } else {
+        const initRes = await fetch(
+          kratosBase + '/self-service/registration/browser?return_to=' + encodeURIComponent(returnTo),
+          { redirect: 'manual', credentials: 'include' }
+        );
+        const location = initRes.headers.get('location') || '';
+        const m = location.match(/[?&]flow=([^&]+)/);
+        if (!m) throw new Error('no_flow_id');
+        flowId = m[1];
+        history.replaceState(null, '', '?flow=' + flowId + (returnTo !== '/' ? '&return_to=' + encodeURIComponent(returnTo) : ''));
+
+        const res = await fetch(kratosBase + '/self-service/registration/flows?id=' + encodeURIComponent(flowId), {
+          headers: { Accept: 'application/json' },
+          credentials: 'include',
+        });
+        if (!res.ok) throw new Error('fetch_flow_failed');
+        flow = await res.json();
+      }
+    } catch (e) {
+      if (e.message === 'flow_expired') {
+        window.location.href = '/_vibewarden/registration?return_to=' + encodeURIComponent(returnTo);
+        return;
+      }
+      showError('Could not start registration session. Please try again.');
+      return;
+    }
+
+    applyFlow(flow);
+  }
+
+  function applyFlow(flow) {
+    const nodes = (flow.ui && flow.ui.nodes) || [];
+
+    const csrfNode = nodes.find(n => n.attributes && n.attributes.name === 'csrf_token');
+    if (csrfNode) {
+      document.getElementById('csrf-token').value = csrfNode.attributes.value || '';
+    }
+    document.getElementById('flow-id').value = flow.id || '';
+
+    const messages = (flow.ui && flow.ui.messages) || [];
+    if (messages.length > 0) {
+      showError(messages.map(m => m.text).join(' '));
+    }
+
+    for (const node of nodes) {
+      const msgs = (node.messages || []).filter(m => m.type === 'error');
+      if (msgs.length > 0 && node.attributes && node.attributes.name) {
+        const el = document.querySelector('[name="' + node.attributes.name + '"]');
+        if (el) el.classList.add('error');
+        showError(msgs.map(m => m.text).join(' '));
+      }
+    }
+
+    const oidcNodes = nodes.filter(n => n.group === 'oidc' && n.attributes && n.attributes.type === 'submit');
+    const socialDiv = document.getElementById('social-buttons');
+    const divider = document.getElementById('social-divider');
+    for (const node of oidcNodes) {
+      const label = (node.meta && node.meta.label && node.meta.label.text) || node.attributes.value;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'btn-social';
+      btn.textContent = 'Continue with ' + label;
+      btn.addEventListener('click', function () { submitOIDC(flow, node.attributes.value); });
+      socialDiv.appendChild(btn);
+    }
+    if (oidcNodes.length > 0) divider.style.display = 'flex';
+  }
+
+  async function submitOIDC(flow, provider) {
+    try {
+      const res = await fetch(flow.ui.action, {
+        method: flow.ui.method || 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          csrf_token: document.getElementById('csrf-token').value,
+          method: 'oidc',
+          provider: provider,
+        }),
+      });
+      if (res.ok || res.redirected) {
+        window.location.href = res.url || returnTo;
+        return;
+      }
+      const body = await res.json();
+      applyFlow(body);
+    } catch (_) {
+      showError('Social login failed. Please try again.');
+    }
+  }
+
+  document.getElementById('reg-form').addEventListener('submit', async function (e) {
+    e.preventDefault();
+    hideError();
+
+    const form = e.target;
+    const pw = document.getElementById('password').value;
+    const pwc = document.getElementById('password-confirm').value;
+    const confirmErr = document.getElementById('confirm-error');
+
+    if (pw !== pwc) {
+      confirmErr.style.display = 'block';
+      document.getElementById('password-confirm').classList.add('error');
+      return;
+    }
+    confirmErr.style.display = 'none';
+    document.getElementById('password-confirm').classList.remove('error');
+
+    const flowId = document.getElementById('flow-id').value;
+    if (!flowId) { showError('Registration session expired. Please refresh.'); return; }
+
+    let flow;
+    try {
+      const res = await fetch(kratosBase + '/self-service/registration/flows?id=' + encodeURIComponent(flowId), {
+        headers: { Accept: 'application/json' },
+        credentials: 'include',
+      });
+      flow = await res.json();
+    } catch (_) {
+      showError('Registration session expired. Please refresh.');
+      return;
+    }
+
+    const payload = {
+      csrf_token: document.getElementById('csrf-token').value,
+      method: 'password',
+      'traits.email': form['traits.email'].value,
+      password: pw,
+    };
+
+    try {
+      const res = await fetch(flow.ui.action, {
+        method: flow.ui.method || 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+      });
+      if (res.status === 422 || res.status === 400) {
+        const body = await res.json();
+        applyFlow(body);
+        return;
+      }
+      if (res.ok || res.status === 303) {
+        // Check if verification is required.
+        const body = await res.json().catch(() => null);
+        if (body && body.continue_with) {
+          const verif = body.continue_with.find(c => c.action === 'show_verification_ui');
+          if (verif && verif.flow && verif.flow.id) {
+            window.location.href = '/_vibewarden/verification?flow=' + verif.flow.id;
+            return;
+          }
+        }
+        window.location.href = returnTo;
+        return;
+      }
+      showError('Registration failed. Please try again.');
+    } catch (_) {
+      showError('Network error. Please check your connection and try again.');
+    }
+  });
+
+  initFlow();
+}());
+</script>
+</body>
+</html>

--- a/internal/adapters/authui/templates/verification.html
+++ b/internal/adapters/authui/templates/verification.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Verify Email</title>
+  <style>
+    :root {
+      --vw-primary: {{.PrimaryColor}};
+      --vw-bg: {{.BackgroundColor}};
+      --vw-text: {{.TextColor}};
+      --vw-error: {{.ErrorColor}};
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: var(--vw-bg);
+      color: var(--vw-text);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1rem;
+    }
+    .card {
+      background: #fff;
+      border-radius: 0.75rem;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.10);
+      padding: 2.5rem 2rem;
+      width: 100%;
+      max-width: 400px;
+    }
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      color: var(--vw-text);
+    }
+    .subtitle {
+      font-size: 0.9375rem;
+      color: #6b7280;
+      margin-bottom: 1.5rem;
+    }
+    .field { margin-bottom: 1rem; }
+    label {
+      display: block;
+      font-size: 0.875rem;
+      font-weight: 500;
+      margin-bottom: 0.375rem;
+      color: var(--vw-text);
+    }
+    input[type="email"] {
+      width: 100%;
+      padding: 0.625rem 0.875rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.5rem;
+      font-size: 1rem;
+      color: var(--vw-text);
+      background: #f9fafb;
+      transition: border-color 0.15s;
+    }
+    input:focus {
+      outline: none;
+      border-color: var(--vw-primary);
+      background: #fff;
+    }
+    .btn-primary {
+      display: block;
+      width: 100%;
+      padding: 0.75rem;
+      background: var(--vw-primary);
+      color: #fff;
+      border: none;
+      border-radius: 0.5rem;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      margin-top: 1.25rem;
+      transition: opacity 0.15s;
+    }
+    .btn-primary:hover { opacity: 0.9; }
+    .error-box {
+      background: #fef2f2;
+      border: 1px solid #fecaca;
+      border-radius: 0.5rem;
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      color: var(--vw-error);
+      font-size: 0.875rem;
+    }
+    .success-box {
+      background: #f0fdf4;
+      border: 1px solid #bbf7d0;
+      border-radius: 0.5rem;
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      color: #15803d;
+      font-size: 0.875rem;
+    }
+    .links {
+      margin-top: 1.25rem;
+      text-align: center;
+      font-size: 0.875rem;
+      color: #6b7280;
+    }
+    .links a {
+      color: var(--vw-primary);
+      text-decoration: none;
+      font-weight: 500;
+    }
+    .links a:hover { text-decoration: underline; }
+    @media (max-width: 480px) { .card { padding: 2rem 1.25rem; } }
+  </style>
+</head>
+<body>
+<div class="card">
+  <h1>Verify email</h1>
+
+  <div id="error-box" class="error-box" style="display:none"></div>
+  <div id="success-box" class="success-box" style="display:none"></div>
+
+  <!-- Pending verification state: no token yet -->
+  <div id="pending-section">
+    <p class="subtitle">Check your email for a verification link. If you did not receive one, you can request a new one below.</p>
+    <form id="resend-form">
+      <input type="hidden" id="csrf-token" name="csrf_token" value="">
+      <input type="hidden" id="flow-id" name="flow_id" value="">
+      <div class="field">
+        <label for="email">Email address</label>
+        <input type="email" id="email" name="email" autocomplete="email" required placeholder="you@example.com">
+      </div>
+      <button type="submit" class="btn-primary">Resend verification email</button>
+    </form>
+  </div>
+
+  <!-- Verified success state -->
+  <div id="verified-section" style="display:none">
+    <p class="subtitle">Your email has been verified. You can now access the app.</p>
+    <a href="/" class="btn-primary" style="display:block;text-align:center;text-decoration:none;margin-top:0">Continue to app</a>
+  </div>
+
+  <div class="links">
+    <a href="/_vibewarden/login">Back to login</a>
+  </div>
+</div>
+
+<script>
+(function () {
+  const kratosBase = '';
+  const params = new URLSearchParams(window.location.search);
+
+  function showError(msg) {
+    const box = document.getElementById('error-box');
+    box.textContent = msg;
+    box.style.display = 'block';
+  }
+
+  function hideError() {
+    document.getElementById('error-box').style.display = 'none';
+  }
+
+  function showSuccess(msg) {
+    const box = document.getElementById('success-box');
+    box.textContent = msg;
+    box.style.display = 'block';
+  }
+
+  async function initFlow() {
+    const flowId = params.get('flow');
+    if (!flowId) return; // No flow — fresh page, show pending state.
+
+    try {
+      const res = await fetch(kratosBase + '/self-service/verification/flows?id=' + encodeURIComponent(flowId), {
+        headers: { Accept: 'application/json' },
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        showError('Verification link is invalid or has expired. Please request a new one.');
+        return;
+      }
+      const flow = await res.json();
+      applyFlow(flow);
+    } catch (_) {
+      showError('Could not load verification status. Please try again.');
+    }
+  }
+
+  function applyFlow(flow) {
+    const state = flow.state || 'choose_method';
+    const nodes = (flow.ui && flow.ui.nodes) || [];
+
+    const csrfNode = nodes.find(n => n.attributes && n.attributes.name === 'csrf_token');
+    const csrfVal = csrfNode ? (csrfNode.attributes.value || '') : '';
+    document.getElementById('csrf-token').value = csrfVal;
+    document.getElementById('flow-id').value = flow.id || '';
+
+    // Store action URL for the resend form.
+    const resendForm = document.getElementById('resend-form');
+    resendForm.dataset.action = (flow.ui && flow.ui.action) || '';
+    resendForm.dataset.method = (flow.ui && flow.ui.method) || 'POST';
+
+    const messages = (flow.ui && flow.ui.messages) || [];
+    if (messages.length > 0) {
+      const errMsgs = messages.filter(m => m.type === 'error');
+      const infoMsgs = messages.filter(m => m.type !== 'error');
+      if (errMsgs.length > 0) showError(errMsgs.map(m => m.text).join(' '));
+      if (infoMsgs.length > 0) showSuccess(infoMsgs.map(m => m.text).join(' '));
+    }
+
+    if (state === 'passed_challenge') {
+      // Email successfully verified.
+      document.getElementById('pending-section').style.display = 'none';
+      document.getElementById('verified-section').style.display = 'block';
+      showSuccess('Email verified! You can now log in.');
+    } else if (state === 'sent_email') {
+      // Verification email sent, waiting.
+      showSuccess('Verification email sent. Check your inbox.');
+    }
+    // For 'choose_method' or expired token, the default pending form stays visible.
+  }
+
+  document.getElementById('resend-form').addEventListener('submit', async function (e) {
+    e.preventDefault();
+    hideError();
+
+    let flowId = document.getElementById('flow-id').value;
+    let action = e.target.dataset.action;
+    let method = e.target.dataset.method || 'POST';
+
+    // Initiate a new flow if we don't have one yet.
+    if (!flowId || !action) {
+      try {
+        const initRes = await fetch(kratosBase + '/self-service/verification/browser', {
+          redirect: 'manual', credentials: 'include'
+        });
+        const location = initRes.headers.get('location') || '';
+        const m = location.match(/[?&]flow=([^&]+)/);
+        if (!m) throw new Error('no_flow');
+        flowId = m[1];
+
+        const res = await fetch(kratosBase + '/self-service/verification/flows?id=' + encodeURIComponent(flowId), {
+          headers: { Accept: 'application/json' },
+          credentials: 'include',
+        });
+        const flow = await res.json();
+        action = (flow.ui && flow.ui.action) || '';
+        method = (flow.ui && flow.ui.method) || 'POST';
+        const csrfNode = (flow.ui && flow.ui.nodes || []).find(n => n.attributes && n.attributes.name === 'csrf_token');
+        document.getElementById('csrf-token').value = csrfNode ? (csrfNode.attributes.value || '') : '';
+        document.getElementById('flow-id').value = flowId;
+      } catch (_) {
+        showError('Could not start verification session. Please try again.');
+        return;
+      }
+    }
+
+    const payload = {
+      csrf_token: document.getElementById('csrf-token').value,
+      method: 'link',
+      email: document.getElementById('email').value,
+    };
+
+    try {
+      await fetch(action, {
+        method: method,
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+      });
+      showSuccess('Verification email sent. Check your inbox.');
+    } catch (_) {
+      showError('Network error. Please check your connection and try again.');
+    }
+  });
+
+  initFlow();
+}());
+</script>
+</body>
+</html>

--- a/internal/plugins/auth/config.go
+++ b/internal/plugins/auth/config.go
@@ -41,6 +41,37 @@ type Config struct {
 	// Accepted values: "email_password" (default), "email_only",
 	// "username_password", or a filesystem path to a custom JSON file.
 	IdentitySchema string
+
+	// UI holds configuration for the built-in auth UI pages.
+	// When UI.Mode is "built-in" (the default), VibeWarden serves its own
+	// login, registration, recovery, and verification pages.
+	// When UI.Mode is "custom", the operator provides their own pages and
+	// the built-in handler is not mounted.
+	UI UIConfig
+}
+
+// UIConfig holds theming and mode settings for the built-in auth UI pages.
+// It maps to the plugins.auth.ui section of vibewarden.yaml.
+type UIConfig struct {
+	// Mode selects the UI serving strategy.
+	// Accepted values: "built-in" (default), "custom".
+	Mode string
+
+	// PrimaryColor is the CSS color value for the --vw-primary custom property.
+	// Defaults to "#7C3AED" (VibeWarden purple) when empty.
+	PrimaryColor string
+
+	// BackgroundColor is the CSS color value for the --vw-bg custom property.
+	// Defaults to "#F3F4F6" when empty.
+	BackgroundColor string
+
+	// TextColor is the CSS color value for the --vw-text custom property.
+	// Defaults to "#111827" when empty.
+	TextColor string
+
+	// ErrorColor is the CSS color value for the --vw-error custom property.
+	// Defaults to "#DC2626" when empty.
+	ErrorColor string
 }
 
 // defaultSessionCookieName is used when SessionCookieName is not set.

--- a/internal/plugins/auth/plugin.go
+++ b/internal/plugins/auth/plugin.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/vibewarden/vibewarden/internal/adapters/authui"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
@@ -42,6 +43,9 @@ const healthCheckTimeout = 3 * time.Second
 //   - Validate Kratos URLs on Init.
 //   - Contribute a Caddy route that transparently proxies Kratos self-service
 //     flow paths to the Kratos public API (ContributeCaddyRoutes).
+//   - When UI.Mode is "built-in", start an internal auth UI HTTP server and
+//     contribute a Caddy route that reverse-proxies the /_vibewarden/auth-ui
+//     paths to it (ContributeCaddyRoutes).
 //   - Contribute an auth middleware handler and an identity-headers handler
 //     to the catch-all route (ContributeCaddyHandlers).
 //   - Health-check Kratos connectivity (Health).
@@ -55,6 +59,9 @@ type Plugin struct {
 	// from cfg.KratosPublicURL. Storing it as an interface makes the plugin
 	// unit-testable without a live Kratos instance.
 	sessionChecker ports.SessionChecker
+	// uiHandler is the built-in auth UI HTTP server.
+	// It is nil when UI.Mode != "built-in" or when the plugin is disabled.
+	uiHandler *authui.Handler
 	// healthy tracks whether the last Health() call found Kratos reachable.
 	healthy bool
 	// healthMsg is the last health status message.
@@ -107,6 +114,29 @@ func (p *Plugin) Init(_ context.Context) error {
 		p.sessionChecker = kratosAdapterFunc(p.cfg.KratosPublicURL, p.logger)
 	}
 
+	// Start the built-in auth UI server when the mode is "built-in" (default).
+	uiMode := p.cfg.UI.Mode
+	if uiMode == "" {
+		uiMode = "built-in"
+	}
+	if uiMode == "built-in" {
+		uiCfg := authui.AuthUIConfig{
+			Mode:            uiMode,
+			PrimaryColor:    p.cfg.UI.PrimaryColor,
+			BackgroundColor: p.cfg.UI.BackgroundColor,
+			TextColor:       p.cfg.UI.TextColor,
+			ErrorColor:      p.cfg.UI.ErrorColor,
+		}
+		h, err := authui.NewHandler(uiCfg, p.logger)
+		if err != nil {
+			return fmt.Errorf("auth plugin init: creating auth UI handler: %w", err)
+		}
+		if err := h.Start(); err != nil {
+			return fmt.Errorf("auth plugin init: starting auth UI server: %w", err)
+		}
+		p.uiHandler = h
+	}
+
 	p.healthy = true
 	p.healthMsg = fmt.Sprintf("auth configured, kratos: %s", p.cfg.KratosPublicURL)
 
@@ -114,6 +144,7 @@ func (p *Plugin) Init(_ context.Context) error {
 		slog.String("kratos_public_url", p.cfg.KratosPublicURL),
 		slog.String("session_cookie", p.cfg.SessionCookieName),
 		slog.Int("public_paths", len(p.cfg.PublicPaths)),
+		slog.String("ui_mode", uiMode),
 	)
 
 	return nil
@@ -123,8 +154,16 @@ func (p *Plugin) Init(_ context.Context) error {
 // Session validation happens inline during request processing via Caddy middleware.
 func (p *Plugin) Start(_ context.Context) error { return nil }
 
-// Stop is a no-op for the auth plugin.
-func (p *Plugin) Stop(_ context.Context) error { return nil }
+// Stop gracefully shuts down the auth plugin. When the built-in auth UI
+// server is running, it is stopped. The function honours the provided context.
+func (p *Plugin) Stop(ctx context.Context) error {
+	if p.uiHandler != nil {
+		if err := p.uiHandler.Stop(ctx); err != nil {
+			return fmt.Errorf("auth plugin stop: stopping auth UI server: %w", err)
+		}
+	}
+	return nil
+}
 
 // Health checks whether Kratos is reachable by calling its health/ready
 // endpoint. Returns healthy=true with a "auth disabled" message when the
@@ -173,12 +212,15 @@ func (p *Plugin) HealthCheck(ctx context.Context) ports.HealthStatus {
 	return ports.HealthStatus{Healthy: true, Message: p.healthMsg}
 }
 
-// ContributeCaddyRoutes returns the Caddy route that transparently proxies
-// all Kratos self-service flow paths and the Ory canonical prefix
-// (/.ory/kratos/public/*) to the Kratos public API.
+// ContributeCaddyRoutes returns the Caddy routes contributed by the auth plugin.
 //
-// This route must be placed before the catch-all reverse proxy route so that
-// Kratos paths are never forwarded to the upstream application.
+// When enabled, two sets of routes are returned:
+//  1. A route that transparently proxies all Kratos self-service flow paths and
+//     the Ory canonical prefix (/.ory/kratos/public/*) to the Kratos public API.
+//  2. When the auth UI mode is "built-in", a route that reverse-proxies the four
+//     built-in auth UI paths (/_vibewarden/login, /_vibewarden/registration,
+//     /_vibewarden/recovery, /_vibewarden/verification) to the internal auth UI
+//     HTTP server started during Init.
 //
 // Returns nil when the plugin is disabled.
 func (p *Plugin) ContributeCaddyRoutes() []ports.CaddyRoute {
@@ -188,7 +230,7 @@ func (p *Plugin) ContributeCaddyRoutes() []ports.CaddyRoute {
 
 	kratosAddr := urlToDialAddr(p.cfg.KratosPublicURL)
 
-	return []ports.CaddyRoute{
+	routes := []ports.CaddyRoute{
 		{
 			MatchPath: "/self-service/*",
 			Priority:  40,
@@ -207,6 +249,37 @@ func (p *Plugin) ContributeCaddyRoutes() []ports.CaddyRoute {
 			},
 		},
 	}
+
+	// Add auth UI route when the built-in UI is running.
+	if p.uiHandler != nil {
+		uiAddr := p.uiHandler.Addr()
+		routes = append(routes, ports.CaddyRoute{
+			MatchPath: "/_vibewarden/login",
+			Priority:  39, // just before the Kratos proxy route
+			Handler: map[string]any{
+				"match": []map[string]any{
+					{
+						"path": []string{
+							"/_vibewarden/login",
+							"/_vibewarden/registration",
+							"/_vibewarden/recovery",
+							"/_vibewarden/verification",
+						},
+					},
+				},
+				"handle": []map[string]any{
+					{
+						"handler": "reverse_proxy",
+						"upstreams": []map[string]any{
+							{"dial": uiAddr},
+						},
+					},
+				},
+			},
+		})
+	}
+
+	return routes
 }
 
 // ContributeCaddyHandlers returns the Caddy handlers that the auth plugin

--- a/internal/plugins/auth/plugin_test.go
+++ b/internal/plugins/auth/plugin_test.go
@@ -707,3 +707,142 @@ func TestPlugin_ImplementsPortsPlugin(t *testing.T) {
 func TestPlugin_ImplementsCaddyContributor(t *testing.T) {
 	var _ ports.CaddyContributor = (*auth.Plugin)(nil)
 }
+
+// ---------------------------------------------------------------------------
+// Auth UI integration — built-in mode
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyRoutes_BuiltInUI_ContributesUIRoute(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	defer p.Stop(context.Background()) //nolint: errcheck
+
+	routes := p.ContributeCaddyRoutes()
+	// Expect at least 2 routes: Kratos proxy + auth UI.
+	if len(routes) < 2 {
+		t.Fatalf("ContributeCaddyRoutes() returned %d routes, want at least 2 (Kratos + auth UI)", len(routes))
+	}
+
+	// The auth UI route should proxy to a localhost address.
+	uiRoute := routes[1]
+	handleSlice, ok := uiRoute.Handler["handle"].([]map[string]any)
+	if !ok || len(handleSlice) == 0 {
+		t.Fatal("auth UI route handle slice invalid")
+	}
+	if got := handleSlice[0]["handler"]; got != "reverse_proxy" {
+		t.Errorf("auth UI route handler = %q, want reverse_proxy", got)
+	}
+	upstreams, ok := handleSlice[0]["upstreams"].([]map[string]any)
+	if !ok || len(upstreams) == 0 {
+		t.Fatal("auth UI route upstreams invalid")
+	}
+	dial, _ := upstreams[0]["dial"].(string)
+	if dial == "" {
+		t.Error("auth UI route upstream dial address is empty")
+	}
+}
+
+func TestPlugin_ContributeCaddyRoutes_BuiltInUI_MatchesFourPaths(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	defer p.Stop(context.Background()) //nolint: errcheck
+
+	routes := p.ContributeCaddyRoutes()
+	if len(routes) < 2 {
+		t.Fatalf("expected at least 2 routes, got %d", len(routes))
+	}
+
+	uiRoute := routes[1]
+	matchSlice, ok := uiRoute.Handler["match"].([]map[string]any)
+	if !ok || len(matchSlice) == 0 {
+		t.Fatal("auth UI route match slice invalid")
+	}
+	paths, ok := matchSlice[0]["path"].([]string)
+	if !ok {
+		t.Fatalf("auth UI match path is not []string: %T", matchSlice[0]["path"])
+	}
+
+	wantPaths := []string{
+		"/_vibewarden/login",
+		"/_vibewarden/registration",
+		"/_vibewarden/recovery",
+		"/_vibewarden/verification",
+	}
+	for _, want := range wantPaths {
+		found := false
+		for _, got := range paths {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("auth UI route missing path %q; got: %v", want, paths)
+		}
+	}
+}
+
+func TestPlugin_ContributeCaddyRoutes_CustomUI_NoUIRoute(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.UI = auth.UIConfig{Mode: "custom"}
+	p := auth.New(cfg, discardLogger(), &fakeSessionChecker{})
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	defer p.Stop(context.Background()) //nolint: errcheck
+
+	routes := p.ContributeCaddyRoutes()
+	// Only the Kratos proxy route; no UI route.
+	if len(routes) != 1 {
+		t.Errorf("ContributeCaddyRoutes() returned %d routes for custom UI mode, want 1", len(routes))
+	}
+}
+
+func TestPlugin_Stop_StopsUIHandler(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	// Stop must not error.
+	if err := p.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() error: %v", err)
+	}
+}
+
+func TestPlugin_Stop_DisabledPlugin_IsNoop(t *testing.T) {
+	p := auth.New(auth.Config{Enabled: false}, discardLogger(), nil)
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	if err := p.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() error for disabled plugin: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UIConfig
+// ---------------------------------------------------------------------------
+
+func TestPlugin_UIConfig_DefaultsApplied(t *testing.T) {
+	// With no UI config, built-in mode should be activated.
+	cfg := auth.Config{
+		Enabled:         true,
+		KratosPublicURL: "http://127.0.0.1:4433",
+	}
+	p := auth.New(cfg, discardLogger(), &fakeSessionChecker{})
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	defer p.Stop(context.Background()) //nolint: errcheck
+
+	routes := p.ContributeCaddyRoutes()
+	// Built-in mode adds an auth UI route.
+	if len(routes) < 2 {
+		t.Errorf("ContributeCaddyRoutes() = %d routes, want >=2 (UI route expected by default)", len(routes))
+	}
+}


### PR DESCRIPTION
Closes #171
Closes #172
Closes #175

## Summary

- New package `internal/adapters/authui` — an `authui.Handler` that serves four HTML pages embedded via `embed.FS`:
  - `/_vibewarden/login` — email/password form, OIDC social buttons, "Forgot password?" and "Register" links, redirects to `return_to` on success
  - `/_vibewarden/registration` — email/password form with client-side confirm-password validation, OIDC buttons, redirects to verification flow when Kratos requires it
  - `/_vibewarden/recovery` — two-state page: email form (generic success, no account enumeration) + password-reset form when token is present
  - `/_vibewarden/verification` — pending/resend state and verified success state with "Continue to app" CTA
- All pages: plain HTML + vanilla JS, CSS custom properties for theming (`--vw-primary`, `--vw-bg`, `--vw-text`, `--vw-error`), mobile-responsive, zero external dependencies, `Cache-Control: no-store`
- `auth.Config` extended with `UIConfig` (Mode, PrimaryColor, BackgroundColor, TextColor, ErrorColor)
- `auth.Plugin.Init` starts the internal auth UI HTTP server when `ui.mode == "built-in"` (default)
- `auth.Plugin.ContributeCaddyRoutes` adds a Caddy reverse-proxy route for all four UI paths when built-in mode is active; no route when `ui.mode == "custom"` (escape hatch for #176)
- `auth.Plugin.Stop` stops the auth UI server gracefully

## Test plan

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/adapters/authui/...` — all pass (NewHandler, Start/Addr, all four pages 200 OK, theme injection, return_to propagation, default colors)
- `go test ./internal/plugins/auth/...` — all pass including new tests: UI route contributed, four paths matched, custom mode no UI route, Stop with UI handler, defaults applied
- `make check` — all checks pass including race detector