### PR TITLE
feat(#174,#176): add settings page and custom UI escape hatch

### DIFF
--- a/internal/adapters/authui/handler.go
+++ b/internal/adapters/authui/handler.go
@@ -1,9 +1,10 @@
 // Package authui serves the built-in authentication UI pages for VibeWarden.
 //
-// It provides a Handler that renders four HTML pages — login, registration,
-// recovery, and verification — at the /_vibewarden/{login,registration,recovery,verification}
-// paths. All templates are embedded in the binary via embed.FS so that no
-// external assets are required at runtime.
+// It provides a Handler that renders five HTML pages — login, registration,
+// recovery, verification, and settings — at the
+// /_vibewarden/{login,registration,recovery,verification,settings} paths.
+// All templates are embedded in the binary via embed.FS so that no external
+// assets are required at runtime.
 //
 // Each page communicates with the Ory Kratos public API (proxied through
 // VibeWarden at /self-service/*) using plain HTML and vanilla JavaScript with
@@ -147,6 +148,7 @@ func (h *Handler) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/_vibewarden/registration", h.handleRegistration)
 	mux.HandleFunc("/_vibewarden/recovery", h.handleRecovery)
 	mux.HandleFunc("/_vibewarden/verification", h.handleVerification)
+	mux.HandleFunc("/_vibewarden/settings", h.handleSettings)
 }
 
 // handleLogin renders the login page.
@@ -167,6 +169,11 @@ func (h *Handler) handleRecovery(w http.ResponseWriter, r *http.Request) {
 // handleVerification renders the email verification page.
 func (h *Handler) handleVerification(w http.ResponseWriter, r *http.Request) {
 	h.renderPage(w, r, "verification.html")
+}
+
+// handleSettings renders the account settings page.
+func (h *Handler) handleSettings(w http.ResponseWriter, r *http.Request) {
+	h.renderPage(w, r, "settings.html")
 }
 
 // renderPage executes the named template with theme data derived from cfg

--- a/internal/adapters/authui/handler_test.go
+++ b/internal/adapters/authui/handler_test.go
@@ -132,6 +132,18 @@ func TestHandler_Pages(t *testing.T) {
 				"#7C3AED",
 			},
 		},
+		{
+			name:       "settings page",
+			path:       "/_vibewarden/settings",
+			wantStatus: http.StatusOK,
+			wantContains: []string{
+				"Account settings",
+				"Change password",
+				"Email verification",
+				"/_vibewarden/login",
+				"#7C3AED",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -195,6 +207,7 @@ func TestHandler_ThemeColorsInjected(t *testing.T) {
 		"/_vibewarden/registration",
 		"/_vibewarden/recovery",
 		"/_vibewarden/verification",
+		"/_vibewarden/settings",
 	}
 
 	for _, path := range pages {
@@ -288,6 +301,7 @@ func TestHandler_ServeHTTP_ViaRecorder(t *testing.T) {
 		{"registration", "/_vibewarden/registration", true},
 		{"recovery", "/_vibewarden/recovery", true},
 		{"verification", "/_vibewarden/verification", true},
+		{"settings", "/_vibewarden/settings", true},
 	}
 
 	h := newHandler(t, defaultConfig())

--- a/internal/adapters/authui/templates/settings.html
+++ b/internal/adapters/authui/templates/settings.html
@@ -1,0 +1,546 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Account Settings</title>
+  <style>
+    :root {
+      --vw-primary: {{.PrimaryColor}};
+      --vw-bg: {{.BackgroundColor}};
+      --vw-text: {{.TextColor}};
+      --vw-error: {{.ErrorColor}};
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: var(--vw-bg);
+      color: var(--vw-text);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1rem;
+    }
+    .card {
+      background: #fff;
+      border-radius: 0.75rem;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.10);
+      padding: 2.5rem 2rem;
+      width: 100%;
+      max-width: 480px;
+    }
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      margin-bottom: 0.25rem;
+      color: var(--vw-text);
+    }
+    .subtitle {
+      font-size: 0.9375rem;
+      color: #6b7280;
+      margin-bottom: 1.75rem;
+    }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--vw-text);
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid #e5e7eb;
+    }
+    .section { margin-bottom: 2rem; }
+    .field { margin-bottom: 1rem; }
+    label {
+      display: block;
+      font-size: 0.875rem;
+      font-weight: 500;
+      margin-bottom: 0.375rem;
+      color: var(--vw-text);
+    }
+    input[type="email"],
+    input[type="password"],
+    input[type="text"] {
+      width: 100%;
+      padding: 0.625rem 0.875rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.5rem;
+      font-size: 1rem;
+      color: var(--vw-text);
+      background: #f9fafb;
+      transition: border-color 0.15s;
+    }
+    input:focus {
+      outline: none;
+      border-color: var(--vw-primary);
+      background: #fff;
+    }
+    .btn-primary {
+      display: inline-block;
+      padding: 0.625rem 1.25rem;
+      background: var(--vw-primary);
+      color: #fff;
+      border: none;
+      border-radius: 0.5rem;
+      font-size: 0.9375rem;
+      font-weight: 600;
+      cursor: pointer;
+      margin-top: 0.75rem;
+      transition: opacity 0.15s;
+    }
+    .btn-primary:hover { opacity: 0.9; }
+    .btn-social {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      width: 100%;
+      padding: 0.65rem;
+      background: #f9fafb;
+      border: 1px solid #d1d5db;
+      border-radius: 0.5rem;
+      font-size: 0.9375rem;
+      font-weight: 500;
+      color: var(--vw-text);
+      cursor: pointer;
+      margin-bottom: 0.5rem;
+      text-decoration: none;
+      transition: background 0.15s;
+    }
+    .btn-social:hover { background: #f3f4f6; }
+    .btn-unlink {
+      display: inline-block;
+      padding: 0.5rem 1rem;
+      background: #fee2e2;
+      color: #b91c1c;
+      border: 1px solid #fecaca;
+      border-radius: 0.5rem;
+      font-size: 0.875rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    .btn-unlink:hover { background: #fecaca; }
+    .error-box {
+      background: #fef2f2;
+      border: 1px solid #fecaca;
+      border-radius: 0.5rem;
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      color: var(--vw-error);
+      font-size: 0.875rem;
+    }
+    .success-box {
+      background: #f0fdf4;
+      border: 1px solid #bbf7d0;
+      border-radius: 0.5rem;
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      color: #15803d;
+      font-size: 0.875rem;
+    }
+    .linked-provider {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.625rem 0.875rem;
+      background: #f0fdf4;
+      border: 1px solid #bbf7d0;
+      border-radius: 0.5rem;
+      margin-bottom: 0.5rem;
+      font-size: 0.9375rem;
+    }
+    .linked-provider span { color: #15803d; font-weight: 500; }
+    .verification-status {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.625rem 0.875rem;
+      border-radius: 0.5rem;
+      font-size: 0.9375rem;
+      margin-bottom: 1rem;
+    }
+    .verification-status.verified {
+      background: #f0fdf4;
+      border: 1px solid #bbf7d0;
+      color: #15803d;
+    }
+    .verification-status.unverified {
+      background: #fefce8;
+      border: 1px solid #fde68a;
+      color: #92400e;
+    }
+    .links {
+      margin-top: 1.5rem;
+      text-align: center;
+      font-size: 0.875rem;
+      color: #6b7280;
+    }
+    .links a {
+      color: var(--vw-primary);
+      text-decoration: none;
+      font-weight: 500;
+    }
+    .links a:hover { text-decoration: underline; }
+    @media (max-width: 480px) { .card { padding: 2rem 1.25rem; } }
+  </style>
+</head>
+<body>
+<div class="card">
+  <h1>Account settings</h1>
+  <p class="subtitle">Manage your password, connected accounts, and email verification.</p>
+
+  <div id="error-box" class="error-box" style="display:none"></div>
+  <div id="success-box" class="success-box" style="display:none"></div>
+
+  <!-- Email verification status -->
+  <div class="section">
+    <h2>Email verification</h2>
+    <div id="verification-status" class="verification-status unverified">
+      Checking verification status...
+    </div>
+    <button id="send-verification-btn" type="button" class="btn-primary" style="display:none">
+      Send verification email
+    </button>
+  </div>
+
+  <!-- Change password section -->
+  <div class="section">
+    <h2>Change password</h2>
+    <form id="password-form">
+      <input type="hidden" id="password-csrf-token" name="csrf_token" value="">
+      <div class="field">
+        <label for="new-password">New password</label>
+        <input type="password" id="new-password" name="password" autocomplete="new-password" required placeholder="••••••••">
+      </div>
+      <div class="field">
+        <label for="confirm-password">Confirm new password</label>
+        <input type="password" id="confirm-password" name="password_confirm" autocomplete="new-password" required placeholder="••••••••">
+      </div>
+      <button type="submit" class="btn-primary">Update password</button>
+    </form>
+  </div>
+
+  <!-- Social providers section -->
+  <div class="section" id="social-section" style="display:none">
+    <h2>Connected accounts</h2>
+    <div id="linked-providers"></div>
+    <div id="available-providers"></div>
+  </div>
+
+  <div class="links">
+    <a href="/_vibewarden/login">Back to login</a>
+  </div>
+</div>
+
+<script>
+(function () {
+  const kratosBase = '';
+  const params = new URLSearchParams(window.location.search);
+
+  function showError(msg) {
+    const box = document.getElementById('error-box');
+    box.textContent = msg;
+    box.style.display = 'block';
+    document.getElementById('success-box').style.display = 'none';
+  }
+
+  function hideError() {
+    document.getElementById('error-box').style.display = 'none';
+  }
+
+  function showSuccess(msg) {
+    const box = document.getElementById('success-box');
+    box.textContent = msg;
+    box.style.display = 'block';
+    document.getElementById('error-box').style.display = 'none';
+  }
+
+  // ---------------------------------------------------------------------------
+  // Session / identity — determine email verification status
+  // ---------------------------------------------------------------------------
+
+  async function loadIdentity() {
+    try {
+      const res = await fetch(kratosBase + '/sessions/whoami', {
+        headers: { Accept: 'application/json' },
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        window.location.href = '/_vibewarden/login';
+        return;
+      }
+      const session = await res.json();
+      renderVerificationStatus(session);
+    } catch (_) {
+      // Non-fatal: verification status stays "checking".
+    }
+  }
+
+  function renderVerificationStatus(session) {
+    const identity = session.identity || {};
+    const verifiableAddresses = identity.verifiable_addresses || [];
+    const emailAddr = verifiableAddresses.find(a => a.via === 'email');
+    const statusEl = document.getElementById('verification-status');
+    const sendBtn = document.getElementById('send-verification-btn');
+
+    if (!emailAddr) {
+      statusEl.textContent = 'No email address found.';
+      return;
+    }
+
+    if (emailAddr.verified) {
+      statusEl.className = 'verification-status verified';
+      statusEl.textContent = emailAddr.value + ' — verified';
+    } else {
+      statusEl.className = 'verification-status unverified';
+      statusEl.textContent = emailAddr.value + ' — not verified';
+      sendBtn.style.display = 'inline-block';
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Settings flow — change password + social providers
+  // ---------------------------------------------------------------------------
+
+  let currentFlow = null;
+
+  async function initSettingsFlow() {
+    let flowId = params.get('flow');
+    try {
+      if (flowId) {
+        const res = await fetch(
+          kratosBase + '/self-service/settings/flows?id=' + encodeURIComponent(flowId),
+          { headers: { Accept: 'application/json' }, credentials: 'include' }
+        );
+        if (!res.ok) throw new Error('flow_expired');
+        currentFlow = await res.json();
+      } else {
+        const initRes = await fetch(kratosBase + '/self-service/settings/browser', {
+          redirect: 'manual',
+          credentials: 'include',
+        });
+        // Kratos redirects to ?flow=<id>.
+        const location = initRes.headers.get('location') || '';
+        const m = location.match(/[?&]flow=([^&]+)/);
+        if (!m) throw new Error('no_flow_id');
+        flowId = m[1];
+        history.replaceState(null, '', '?flow=' + flowId);
+
+        const res = await fetch(
+          kratosBase + '/self-service/settings/flows?id=' + encodeURIComponent(flowId),
+          { headers: { Accept: 'application/json' }, credentials: 'include' }
+        );
+        if (!res.ok) throw new Error('fetch_flow_failed');
+        currentFlow = await res.json();
+      }
+    } catch (e) {
+      if (e.message === 'flow_expired') {
+        window.location.href = '/_vibewarden/settings';
+        return;
+      }
+      showError('Could not load settings. Please refresh the page.');
+      return;
+    }
+
+    applyFlow(currentFlow);
+  }
+
+  function applyFlow(flow) {
+    const nodes = (flow.ui && flow.ui.nodes) || [];
+
+    // Extract CSRF token.
+    const csrfNode = nodes.find(n => n.attributes && n.attributes.name === 'csrf_token');
+    const csrfVal = csrfNode ? (csrfNode.attributes.value || '') : '';
+    document.getElementById('password-csrf-token').value = csrfVal;
+
+    // Store action/method on the password form.
+    const form = document.getElementById('password-form');
+    form.dataset.action = (flow.ui && flow.ui.action) || '';
+    form.dataset.method = (flow.ui && flow.ui.method) || 'POST';
+
+    // Flow-level messages.
+    const messages = (flow.ui && flow.ui.messages) || [];
+    if (messages.length > 0) {
+      const errorMsgs = messages.filter(m => m.type === 'error');
+      const successMsgs = messages.filter(m => m.type !== 'error');
+      if (errorMsgs.length > 0) showError(errorMsgs.map(m => m.text).join(' '));
+      if (successMsgs.length > 0) showSuccess(successMsgs.map(m => m.text).join(' '));
+    }
+
+    // Render OIDC (social) provider nodes.
+    renderSocialProviders(nodes, flow, csrfVal);
+  }
+
+  function renderSocialProviders(nodes, flow, csrfVal) {
+    const oidcNodes = nodes.filter(n => n.group === 'oidc' && n.attributes);
+    if (oidcNodes.length === 0) return;
+
+    document.getElementById('social-section').style.display = 'block';
+
+    const linkedDiv = document.getElementById('linked-providers');
+    const availableDiv = document.getElementById('available-providers');
+
+    // Unlink buttons (type=submit with value indicating a provider to unlink).
+    const unlinkNodes = oidcNodes.filter(n => n.attributes.type === 'submit' && n.attributes.name === 'unlink');
+    for (const node of unlinkNodes) {
+      const label = (node.meta && node.meta.label && node.meta.label.text) || node.attributes.value;
+      const row = document.createElement('div');
+      row.className = 'linked-provider';
+      const span = document.createElement('span');
+      span.textContent = label;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'btn-unlink';
+      btn.textContent = 'Unlink';
+      btn.addEventListener('click', function () {
+        submitOIDC(flow, 'unlink', node.attributes.value, csrfVal);
+      });
+      row.appendChild(span);
+      row.appendChild(btn);
+      linkedDiv.appendChild(row);
+    }
+
+    // Link buttons (type=submit with value indicating a provider to link).
+    const linkNodes = oidcNodes.filter(n => n.attributes.type === 'submit' && n.attributes.name === 'link');
+    for (const node of linkNodes) {
+      const label = (node.meta && node.meta.label && node.meta.label.text) || node.attributes.value;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'btn-social';
+      btn.textContent = 'Link ' + label;
+      btn.addEventListener('click', function () {
+        submitOIDC(flow, 'link', node.attributes.value, csrfVal);
+      });
+      availableDiv.appendChild(btn);
+    }
+  }
+
+  async function submitOIDC(flow, method, provider, csrfVal) {
+    hideError();
+    try {
+      const res = await fetch(flow.ui.action, {
+        method: flow.ui.method || 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ csrf_token: csrfVal, method: method, provider: provider }),
+      });
+      if (res.ok || res.redirected) {
+        window.location.reload();
+        return;
+      }
+      const body = await res.json();
+      applyFlow(body);
+    } catch (_) {
+      showError('Social provider action failed. Please try again.');
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Email verification — send verification link
+  // ---------------------------------------------------------------------------
+
+  document.getElementById('send-verification-btn').addEventListener('click', async function () {
+    hideError();
+    try {
+      const initRes = await fetch(kratosBase + '/self-service/verification/browser', {
+        redirect: 'manual',
+        credentials: 'include',
+      });
+      const location = initRes.headers.get('location') || '';
+      const m = location.match(/[?&]flow=([^&]+)/);
+      if (!m) throw new Error('no_flow');
+      const flowId = m[1];
+
+      const res = await fetch(
+        kratosBase + '/self-service/verification/flows?id=' + encodeURIComponent(flowId),
+        { headers: { Accept: 'application/json' }, credentials: 'include' }
+      );
+      const flow = await res.json();
+      const nodes = (flow.ui && flow.ui.nodes) || [];
+      const csrfNode = nodes.find(n => n.attributes && n.attributes.name === 'csrf_token');
+
+      // Submit email from session.
+      const sessionRes = await fetch(kratosBase + '/sessions/whoami', {
+        headers: { Accept: 'application/json' },
+        credentials: 'include',
+      });
+      const session = await sessionRes.json();
+      const identity = session.identity || {};
+      const verifiableAddresses = identity.verifiable_addresses || [];
+      const emailAddr = verifiableAddresses.find(a => a.via === 'email');
+      if (!emailAddr) { showError('No email address found for verification.'); return; }
+
+      await fetch(flow.ui.action, {
+        method: flow.ui.method || 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          csrf_token: csrfNode ? (csrfNode.attributes.value || '') : '',
+          method: 'link',
+          email: emailAddr.value,
+        }),
+      });
+      showSuccess('Verification email sent. Please check your inbox.');
+      document.getElementById('send-verification-btn').style.display = 'none';
+    } catch (_) {
+      showError('Could not send verification email. Please try again.');
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Change password form submit
+  // ---------------------------------------------------------------------------
+
+  document.getElementById('password-form').addEventListener('submit', async function (e) {
+    e.preventDefault();
+    hideError();
+
+    const pw = document.getElementById('new-password').value;
+    const pwc = document.getElementById('confirm-password').value;
+    if (pw !== pwc) { showError('Passwords do not match.'); return; }
+
+    const form = e.target;
+    const action = form.dataset.action;
+    const method = form.dataset.method || 'POST';
+
+    if (!action) { showError('Settings session expired. Please refresh.'); return; }
+
+    try {
+      const res = await fetch(action, {
+        method: method,
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          csrf_token: document.getElementById('password-csrf-token').value,
+          method: 'password',
+          password: pw,
+        }),
+      });
+      if (res.status === 422 || res.status === 400) {
+        const body = await res.json();
+        applyFlow(body);
+        return;
+      }
+      if (res.ok) {
+        showSuccess('Password updated successfully.');
+        document.getElementById('new-password').value = '';
+        document.getElementById('confirm-password').value = '';
+        return;
+      }
+      showError('Password update failed. Please try again.');
+    } catch (_) {
+      showError('Network error. Please check your connection and try again.');
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Boot
+  // ---------------------------------------------------------------------------
+
+  loadIdentity();
+  initSettingsFlow();
+}());
+</script>
+</body>
+</html>

--- a/internal/plugins/auth/config.go
+++ b/internal/plugins/auth/config.go
@@ -55,22 +55,48 @@ type Config struct {
 type UIConfig struct {
 	// Mode selects the UI serving strategy.
 	// Accepted values: "built-in" (default), "custom".
+	//
+	// When Mode is "custom", the built-in auth UI server is not started and no
+	// /_vibewarden/ui routes are contributed to Caddy. The auth middleware
+	// instead redirects unauthenticated requests to the operator-supplied
+	// LoginURL. RegistrationURL, SettingsURL, and RecoveryURL are optional.
 	Mode string
+
+	// LoginURL is the URL unauthenticated users are redirected to when
+	// Mode is "custom". Required when Mode is "custom".
+	// Ignored when Mode is "built-in".
+	LoginURL string
+
+	// RegistrationURL is the URL for the registration page when Mode is
+	// "custom". Optional.
+	RegistrationURL string
+
+	// SettingsURL is the URL for the account settings page when Mode is
+	// "custom". Optional.
+	SettingsURL string
+
+	// RecoveryURL is the URL for the account recovery page when Mode is
+	// "custom". Optional.
+	RecoveryURL string
 
 	// PrimaryColor is the CSS color value for the --vw-primary custom property.
 	// Defaults to "#7C3AED" (VibeWarden purple) when empty.
+	// Only used when Mode is "built-in".
 	PrimaryColor string
 
 	// BackgroundColor is the CSS color value for the --vw-bg custom property.
 	// Defaults to "#F3F4F6" when empty.
+	// Only used when Mode is "built-in".
 	BackgroundColor string
 
 	// TextColor is the CSS color value for the --vw-text custom property.
 	// Defaults to "#111827" when empty.
+	// Only used when Mode is "built-in".
 	TextColor string
 
 	// ErrorColor is the CSS color value for the --vw-error custom property.
 	// Defaults to "#DC2626" when empty.
+	// Only used when Mode is "built-in".
 	ErrorColor string
 }
 

--- a/internal/plugins/auth/plugin.go
+++ b/internal/plugins/auth/plugin.go
@@ -105,8 +105,22 @@ func (p *Plugin) Init(_ context.Context) error {
 	if p.cfg.SessionCookieName == "" {
 		p.cfg.SessionCookieName = defaultSessionCookieName
 	}
-	if p.cfg.LoginURL == "" {
-		p.cfg.LoginURL = defaultLoginURL
+
+	// Determine the effective login URL.
+	// In custom mode, UI.LoginURL takes precedence (already validated above).
+	// In built-in mode, the top-level LoginURL is used (or the built-in default).
+	uiMode := p.cfg.UI.Mode
+	if uiMode == "" {
+		uiMode = "built-in"
+	}
+	if uiMode == "custom" {
+		// Custom mode: redirect to operator-supplied login URL.
+		p.cfg.LoginURL = p.cfg.UI.LoginURL
+	} else {
+		// Built-in mode: use the configured LoginURL or the built-in default.
+		if p.cfg.LoginURL == "" {
+			p.cfg.LoginURL = defaultLoginURL
+		}
 	}
 
 	// Create the real Kratos adapter when no fake was injected.
@@ -115,10 +129,6 @@ func (p *Plugin) Init(_ context.Context) error {
 	}
 
 	// Start the built-in auth UI server when the mode is "built-in" (default).
-	uiMode := p.cfg.UI.Mode
-	if uiMode == "" {
-		uiMode = "built-in"
-	}
 	if uiMode == "built-in" {
 		uiCfg := authui.AuthUIConfig{
 			Mode:            uiMode,
@@ -264,6 +274,7 @@ func (p *Plugin) ContributeCaddyRoutes() []ports.CaddyRoute {
 							"/_vibewarden/registration",
 							"/_vibewarden/recovery",
 							"/_vibewarden/verification",
+							"/_vibewarden/settings",
 						},
 					},
 				},
@@ -355,6 +366,9 @@ func validateConfig(cfg Config) error {
 	}
 	if _, err := url.ParseRequestURI(cfg.KratosPublicURL); err != nil {
 		return fmt.Errorf("kratos_public_url %q is not a valid URL: %w", cfg.KratosPublicURL, err)
+	}
+	if cfg.UI.Mode == "custom" && cfg.UI.LoginURL == "" {
+		return fmt.Errorf("ui.login_url is required when ui.mode is \"custom\"")
 	}
 	return nil
 }

--- a/internal/plugins/auth/plugin_test.go
+++ b/internal/plugins/auth/plugin_test.go
@@ -788,7 +788,7 @@ func TestPlugin_ContributeCaddyRoutes_BuiltInUI_MatchesFourPaths(t *testing.T) {
 
 func TestPlugin_ContributeCaddyRoutes_CustomUI_NoUIRoute(t *testing.T) {
 	cfg := defaultConfig()
-	cfg.UI = auth.UIConfig{Mode: "custom"}
+	cfg.UI = auth.UIConfig{Mode: "custom", LoginURL: "https://example.com/login"}
 	p := auth.New(cfg, discardLogger(), &fakeSessionChecker{})
 	if err := p.Init(context.Background()); err != nil {
 		t.Fatalf("Init() error: %v", err)
@@ -844,5 +844,138 @@ func TestPlugin_UIConfig_DefaultsApplied(t *testing.T) {
 	// Built-in mode adds an auth UI route.
 	if len(routes) < 2 {
 		t.Errorf("ContributeCaddyRoutes() = %d routes, want >=2 (UI route expected by default)", len(routes))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Settings page route — built-in mode
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyRoutes_BuiltInUI_MatchesFivePaths(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+	defer p.Stop(context.Background()) //nolint: errcheck
+
+	routes := p.ContributeCaddyRoutes()
+	if len(routes) < 2 {
+		t.Fatalf("expected at least 2 routes, got %d", len(routes))
+	}
+
+	uiRoute := routes[1]
+	matchSlice, ok := uiRoute.Handler["match"].([]map[string]any)
+	if !ok || len(matchSlice) == 0 {
+		t.Fatal("auth UI route match slice invalid")
+	}
+	paths, ok := matchSlice[0]["path"].([]string)
+	if !ok {
+		t.Fatalf("auth UI match path is not []string: %T", matchSlice[0]["path"])
+	}
+
+	wantPaths := []string{
+		"/_vibewarden/login",
+		"/_vibewarden/registration",
+		"/_vibewarden/recovery",
+		"/_vibewarden/verification",
+		"/_vibewarden/settings",
+	}
+	for _, want := range wantPaths {
+		found := false
+		for _, got := range paths {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("auth UI route missing path %q; got: %v", want, paths)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Custom mode — config validation
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Init_CustomUI_RequiresLoginURL(t *testing.T) {
+	cfg := auth.Config{
+		Enabled:         true,
+		KratosPublicURL: "http://127.0.0.1:4433",
+		UI:              auth.UIConfig{Mode: "custom"},
+	}
+	p := auth.New(cfg, discardLogger(), &fakeSessionChecker{})
+	err := p.Init(context.Background())
+	if err == nil {
+		t.Fatal("Init() expected error for custom mode without login_url, got nil")
+	}
+	if !strings.Contains(err.Error(), "login_url") {
+		t.Errorf("Init() error = %q, want to mention login_url", err.Error())
+	}
+}
+
+func TestPlugin_Init_CustomUI_WithLoginURL_Succeeds(t *testing.T) {
+	cfg := auth.Config{
+		Enabled:         true,
+		KratosPublicURL: "http://127.0.0.1:4433",
+		UI:              auth.UIConfig{Mode: "custom", LoginURL: "https://example.com/login"},
+	}
+	p := auth.New(cfg, discardLogger(), &fakeSessionChecker{})
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Custom mode — auth handler uses custom login URL
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyHandlers_CustomUI_UsesConfiguredLoginURL(t *testing.T) {
+	customLoginURL := "https://example.com/my-login"
+	cfg := auth.Config{
+		Enabled:         true,
+		KratosPublicURL: "http://127.0.0.1:4433",
+		UI:              auth.UIConfig{Mode: "custom", LoginURL: customLoginURL},
+	}
+	p := auth.New(cfg, discardLogger(), &fakeSessionChecker{})
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) < 1 {
+		t.Fatal("no handlers contributed")
+	}
+
+	loginURL, ok := handlers[0].Handler["login_url"].(string)
+	if !ok {
+		t.Fatalf("login_url is not string: %T", handlers[0].Handler["login_url"])
+	}
+	if loginURL != customLoginURL {
+		t.Errorf("login_url = %q, want %q", loginURL, customLoginURL)
+	}
+}
+
+func TestPlugin_ContributeCaddyRoutes_CustomUI_OnlyKratosRoute(t *testing.T) {
+	cfg := auth.Config{
+		Enabled:         true,
+		KratosPublicURL: "http://127.0.0.1:4433",
+		UI: auth.UIConfig{
+			Mode:            "custom",
+			LoginURL:        "https://example.com/login",
+			RegistrationURL: "https://example.com/register",
+			SettingsURL:     "https://example.com/settings",
+			RecoveryURL:     "https://example.com/recovery",
+		},
+	}
+	p := auth.New(cfg, discardLogger(), &fakeSessionChecker{})
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	routes := p.ContributeCaddyRoutes()
+	// Custom mode must not add an auth UI route — only the Kratos proxy.
+	if len(routes) != 1 {
+		t.Errorf("ContributeCaddyRoutes() = %d routes for custom UI, want 1", len(routes))
 	}
 }


### PR DESCRIPTION
Closes #174
Closes #176

## Summary

- Add \`/_vibewarden/settings\` HTML page (\`settings.html\`) with three sections: email verification status (with send-verification-email button), change password form, and social provider link/unlink; styled consistently with existing auth UI pages.
- Register \`handleSettings\` in \`authui.Handler\` and include \`/_vibewarden/settings\` in the Caddy UI reverse-proxy route path list (previously four paths, now five).
- Extend \`UIConfig\` with \`LoginURL\`, \`RegistrationURL\`, \`SettingsURL\`, and \`RecoveryURL\` fields for \`mode: custom\`.
- Add config validation: \`ui.login_url\` is required when \`ui.mode\` is \`"custom"\`.
- In custom mode: skip starting the built-in auth UI server, skip contributing \`/_vibewarden/*\` routes to Caddy, and use \`UI.LoginURL\` as the auth-middleware redirect target instead of the built-in default.
- Update the one existing test that used \`Mode: "custom"\` without a \`LoginURL\` to satisfy the new validation.
- Add new tests: settings page renders with correct content and theme colors; custom mode validation rejects missing \`login_url\`; custom \`login_url\` propagates to the auth handler config; five-path UI route matcher; custom mode produces exactly one Caddy route.

## Test plan

- \`make check\` passes (all race-detected tests green, formatting clean, vet clean, build succeeds).
- \`GET /_vibewarden/settings\` returns 200 with "Account settings", "Change password", "Email verification" in body.
- Theme colors injected into settings page match configured values.
- Auth plugin with \`ui.mode: custom\` and no \`ui.login_url\` returns init error containing "login_url".
- Auth plugin with \`ui.mode: custom\` and \`ui.login_url: https://example.com/login\` inits successfully, contributes one Caddy route (Kratos proxy only), and sets \`login_url\` to the configured value in the auth handler.