### PR TITLE
fix: switch Docker images to alpine for healthcheck support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 # ---------------------------------------------------------------------------
 # Stage 2: runtime
 # ---------------------------------------------------------------------------
-# gcr.io/distroless/static-debian12 is the smallest possible base that still
-# has TLS root certificates and timezone data (needed by Caddy and Kratos client).
-FROM gcr.io/distroless/static-debian12:nonroot
+# Alpine provides wget for Docker healthchecks while remaining lightweight.
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates wget
 
 # Copy the statically linked binary.
 COPY --from=builder /vibewarden /vibewarden

--- a/examples/demo-app/Dockerfile
+++ b/examples/demo-app/Dockerfile
@@ -28,7 +28,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 # ---------------------------------------------------------------------------
 # Stage 2: runtime
 # ---------------------------------------------------------------------------
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates wget
 
 COPY --from=builder /demo-app /demo-app
 

--- a/examples/demo-app/main.go
+++ b/examples/demo-app/main.go
@@ -58,7 +58,7 @@ func main() {
 	mux.HandleFunc("GET /health", handleHealth)
 	mux.HandleFunc("GET /auth/login", handleAuthPage(staticFS, "login.html"))
 	mux.HandleFunc("GET /auth/registration", handleAuthPage(staticFS, "register.html"))
-	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
+	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
 
 	addr := ":" + port
 	slog.Info("demo-app starting", "addr", addr)


### PR DESCRIPTION
## Summary

- Switch VibeWarden and demo-app Dockerfiles from distroless to alpine:3.21 (adds wget for healthchecks)
- Fix route conflict in demo-app: `GET /static/` vs `GET /` pattern conflict in Go 1.22+ mux

Found while testing the demo stack locally — containers were stuck in "health: starting" because wget wasn't available in distroless images.

## Test plan

- [x] `make check` passes
- [x] Docker Compose stack starts with healthy containers
- [x] Demo-app no longer panics on startup
