### PR TITLE
fix(#194): default self-signed TLS subject to localhost

### DIFF
--- a/internal/adapters/caddy/config.go
+++ b/internal/adapters/caddy/config.go
@@ -272,10 +272,14 @@ func buildSelfSignedTLSApp(cfg ports.TLSConfig) map[string]any {
 		},
 	}
 
-	// Scope the policy to the domain when one is provided.
-	if cfg.Domain != "" {
-		policy["subjects"] = []string{cfg.Domain}
+	// Scope the policy to the domain. For self-signed certs, Caddy's internal
+	// issuer needs at least one subject to generate a certificate. Default to
+	// "localhost" when no domain is configured (typical for local development).
+	domain := cfg.Domain
+	if domain == "" {
+		domain = "localhost"
 	}
+	policy["subjects"] = []string{domain}
 
 	tlsApp := map[string]any{
 		"automation": map[string]any{

--- a/internal/adapters/caddy/config_test.go
+++ b/internal/adapters/caddy/config_test.go
@@ -406,6 +406,40 @@ func TestBuildCaddyConfig_LetsEncryptDomainInPolicy(t *testing.T) {
 	}
 }
 
+func TestBuildCaddyConfig_SelfSignedDefaultsToLocalhost(t *testing.T) {
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "0.0.0.0:8443",
+		UpstreamAddr: "127.0.0.1:3000",
+		TLS: ports.TLSConfig{
+			Enabled:  true,
+			Provider: ports.TLSProviderSelfSigned,
+			// No domain — should default to "localhost"
+		},
+	}
+
+	result, err := BuildCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+	}
+
+	apps := result["apps"].(map[string]any)
+	tlsApp := apps["tls"].(map[string]any)
+	automation := tlsApp["automation"].(map[string]any)
+	policies := automation["policies"].([]map[string]any)
+
+	if len(policies) == 0 {
+		t.Fatal("expected at least one automation policy")
+	}
+
+	subjects, ok := policies[0]["subjects"].([]string)
+	if !ok || len(subjects) == 0 {
+		t.Fatal("subjects not found — self-signed must default to localhost")
+	}
+	if subjects[0] != "localhost" {
+		t.Errorf("subjects[0] = %q, want %q", subjects[0], "localhost")
+	}
+}
+
 func TestBuildCaddyConfig_ExternalTLSPolicy(t *testing.T) {
 	cfg := &ports.ProxyConfig{
 		ListenAddr:   "0.0.0.0:443",


### PR DESCRIPTION
## Summary

When `tls.provider: self-signed` without a domain, Caddy's internal issuer had no subjects to generate a certificate for, causing TLS handshake failures. Now defaults to `localhost`.

Closes #194

## Test plan

- [x] `make check` passes
- [x] New test: `TestBuildCaddyConfig_SelfSignedDefaultsToLocalhost`
- [ ] Manual: `docker compose -f docker-compose.local-demo.yml up -d` + `curl -k https://localhost:8443/_vibewarden/health`
