### PR TITLE
fix(#194): enable Caddy cert issuance for self-signed TLS

### DIFF
--- a/internal/adapters/caddy/config.go
+++ b/internal/adapters/caddy/config.go
@@ -134,12 +134,19 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 	})
 
 	// Build the main HTTPS (or plain HTTP) server configuration.
-	// Caddy's built-in automatic HTTPS negotiation is always disabled here;
-	// we control TLS completely through the explicit provider-based configuration.
 	server := map[string]any{
-		"listen":          []string{cfg.ListenAddr},
-		"routes":          routes,
-		"automatic_https": map[string]any{"disable": true},
+		"listen": []string{cfg.ListenAddr},
+		"routes": routes,
+	}
+
+	if cfg.TLS.Enabled {
+		// Disable only Caddy's automatic redirects — we manage the redirect
+		// server ourselves. Certificate issuance via the TLS automation policies
+		// must remain active so Caddy obtains certs from internal/ACME issuers.
+		server["automatic_https"] = map[string]any{"disable_redirects": true}
+	} else {
+		// No TLS at all — fully disable automatic HTTPS.
+		server["automatic_https"] = map[string]any{"disable": true}
 	}
 
 	// Configure TLS connection policies when TLS is enabled.
@@ -214,6 +221,16 @@ func buildTLSPolicy(cfg ports.TLSConfig) []map[string]any {
 				},
 			},
 		}
+	}
+
+	// For self-signed, set a default SNI so Caddy can match the certificate
+	// even when clients connect by IP (no SNI in the TLS handshake).
+	if cfg.Provider == ports.TLSProviderSelfSigned {
+		domain := cfg.Domain
+		if domain == "" {
+			domain = "localhost"
+		}
+		return []map[string]any{{"default_sni": domain}}
 	}
 
 	// Default policy — Caddy selects the certificate automatically.

--- a/internal/adapters/caddy/config_test.go
+++ b/internal/adapters/caddy/config_test.go
@@ -141,54 +141,51 @@ func TestBuildCaddyConfig_Validation(t *testing.T) {
 }
 
 func TestBuildCaddyConfig_AutomaticHTTPS(t *testing.T) {
-	tests := []struct {
-		name string
-		cfg  *ports.ProxyConfig
-	}{
-		{
-			name: "TLS disabled",
-			cfg: &ports.ProxyConfig{
-				ListenAddr:   "0.0.0.0:8080",
-				UpstreamAddr: "127.0.0.1:3000",
-				TLS:          ports.TLSConfig{Enabled: false},
+	t.Run("TLS disabled — automatic_https fully disabled", func(t *testing.T) {
+		cfg := &ports.ProxyConfig{
+			ListenAddr:   "0.0.0.0:8080",
+			UpstreamAddr: "127.0.0.1:3000",
+			TLS:          ports.TLSConfig{Enabled: false},
+		}
+		result, err := BuildCaddyConfig(cfg)
+		if err != nil {
+			t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+		}
+		server := extractServer(t, result)
+		autoHTTPS, ok := server["automatic_https"].(map[string]any)
+		if !ok {
+			t.Fatal("automatic_https not found in server config")
+		}
+		if disabled, _ := autoHTTPS["disable"].(bool); !disabled {
+			t.Error("automatic_https.disable must be true when TLS is disabled")
+		}
+	})
+
+	t.Run("TLS enabled — only redirects disabled", func(t *testing.T) {
+		cfg := &ports.ProxyConfig{
+			ListenAddr:   "127.0.0.1:8443",
+			UpstreamAddr: "127.0.0.1:3000",
+			TLS: ports.TLSConfig{
+				Enabled:  true,
+				Provider: ports.TLSProviderSelfSigned,
 			},
-		},
-		{
-			name: "TLS enabled with self-signed",
-			cfg: &ports.ProxyConfig{
-				ListenAddr:   "127.0.0.1:8443",
-				UpstreamAddr: "127.0.0.1:3000",
-				TLS: ports.TLSConfig{
-					Enabled:  true,
-					Provider: ports.TLSProviderSelfSigned,
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := BuildCaddyConfig(tt.cfg)
-			if err != nil {
-				t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
-			}
-
-			server := extractServer(t, result)
-			autoHTTPS, ok := server["automatic_https"].(map[string]any)
-			if !ok {
-				t.Fatal("automatic_https not found in server config")
-			}
-
-			disabled, ok := autoHTTPS["disable"].(bool)
-			if !ok {
-				t.Fatal("automatic_https.disable not found")
-			}
-
-			if !disabled {
-				t.Error("automatic_https.disable must always be true (TLS is managed explicitly)")
-			}
-		})
-	}
+		}
+		result, err := BuildCaddyConfig(cfg)
+		if err != nil {
+			t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+		}
+		server := extractServer(t, result)
+		autoHTTPS, ok := server["automatic_https"].(map[string]any)
+		if !ok {
+			t.Fatal("automatic_https not found in server config")
+		}
+		if redirectsDisabled, _ := autoHTTPS["disable_redirects"].(bool); !redirectsDisabled {
+			t.Error("automatic_https.disable_redirects must be true when TLS is enabled")
+		}
+		if fullDisable, _ := autoHTTPS["disable"].(bool); fullDisable {
+			t.Error("automatic_https.disable must NOT be true when TLS is enabled — cert issuance needs to work")
+		}
+	})
 }
 
 func TestBuildCaddyConfig_TLSProviders(t *testing.T) {


### PR DESCRIPTION
## Summary

- Use `disable_redirects` instead of `disable` for `automatic_https` when TLS is enabled — the previous setting prevented Caddy from obtaining certs entirely
- Add `default_sni` to self-signed TLS connection policy for IP-based connections

Closes #194

## Test plan

- [x] `make check` passes
- [x] Updated tests for automatic_https behavior
- [ ] Manual: Docker Compose local-demo stack with self-signed TLS
