### PR TITLE
feat(#240): add Vulnerability Lab landing page for demo app

### DIFF
--- a/examples/demo-app/main.go
+++ b/examples/demo-app/main.go
@@ -59,6 +59,7 @@ func main() {
 	mux.HandleFunc("GET /auth/login", handleAuthPage(staticFS, "login.html"))
 	mux.HandleFunc("GET /auth/registration", handleAuthPage(staticFS, "register.html"))
 	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
+	mux.HandleFunc("GET /vuln/", handleVulnLab)
 
 	addr := ":" + port
 	slog.Info("demo-app starting", "addr", addr)
@@ -182,6 +183,32 @@ func handleSpam(w http.ResponseWriter, r *http.Request) {
 // Demonstrates: a health endpoint excluded from auth and rate limiting.
 func handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"status": "ok"})
+}
+
+// handleVulnLab handles GET /vuln/* requests for the Vulnerability Lab.
+//
+// The individual vulnerability demo pages under /vuln/ are placeholder routes
+// that return a JSON response describing the vulnerability until the full demo
+// pages are implemented.  The route is listed in public_paths so it requires
+// no authentication.
+//
+// Demonstrates: VibeWarden public path bypass, CSP, X-Frame-Options, and
+// X-Content-Type-Options mitigations visible on these pages.
+func handleVulnLab(w http.ResponseWriter, r *http.Request) {
+	// Strip the /vuln/ prefix to get the vulnerability slug.
+	slug := strings.TrimPrefix(r.URL.Path, "/vuln/")
+	slug = strings.TrimSuffix(slug, "/")
+
+	if slug == "" {
+		http.Redirect(w, r, "/static/vulnlab.html", http.StatusFound)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"vulnerability": slug,
+		"status":        "demo page coming soon",
+		"lab":           "/static/vulnlab.html",
+	})
 }
 
 // handleAuthPage returns an http.HandlerFunc that serves a named HTML file

--- a/examples/demo-app/main_test.go
+++ b/examples/demo-app/main_test.go
@@ -302,6 +302,74 @@ func TestHandleRootUnknownPath(t *testing.T) {
 	}
 }
 
+func TestHandleVulnLab(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		wantStatus   int
+		wantLocation string
+		wantSlug     string
+	}{
+		{
+			name:         "bare /vuln/ redirects to vulnlab.html",
+			path:         "/vuln/",
+			wantStatus:   http.StatusFound,
+			wantLocation: "/static/vulnlab.html",
+		},
+		{
+			name:       "xss-reflected returns JSON with slug",
+			path:       "/vuln/xss-reflected",
+			wantStatus: http.StatusOK,
+			wantSlug:   "xss-reflected",
+		},
+		{
+			name:       "sqli returns JSON with slug",
+			path:       "/vuln/sqli",
+			wantStatus: http.StatusOK,
+			wantSlug:   "sqli",
+		},
+		{
+			name:       "clickjacking returns JSON with slug",
+			path:       "/vuln/clickjacking",
+			wantStatus: http.StatusOK,
+			wantSlug:   "clickjacking",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rr := httptest.NewRecorder()
+
+			handleVulnLab(rr, req)
+
+			if rr.Code != tt.wantStatus {
+				t.Fatalf("want status %d, got %d", tt.wantStatus, rr.Code)
+			}
+
+			if tt.wantLocation != "" {
+				loc := rr.Header().Get("Location")
+				if loc != tt.wantLocation {
+					t.Errorf("Location: want %q, got %q", tt.wantLocation, loc)
+				}
+				return
+			}
+
+			var body map[string]any
+			if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+
+			if got := body["vulnerability"]; got != tt.wantSlug {
+				t.Errorf("vulnerability: want %q, got %v", tt.wantSlug, got)
+			}
+			if got, ok := body["status"].(string); !ok || got == "" {
+				t.Error("want non-empty status field")
+			}
+		})
+	}
+}
+
 func TestStaticFilesEmbedded(t *testing.T) {
 	// Verify that the expected HTML files are present in the embedded FS.
 	wantFiles := []string{
@@ -309,6 +377,7 @@ func TestStaticFilesEmbedded(t *testing.T) {
 		"static/me.html",
 		"static/headers.html",
 		"static/ratelimit.html",
+		"static/vulnlab.html",
 	}
 	for _, path := range wantFiles {
 		t.Run(path, func(t *testing.T) {

--- a/examples/demo-app/static/index.html
+++ b/examples/demo-app/static/index.html
@@ -82,6 +82,7 @@
     <a href="/static/me.html">My Profile</a>
     <a href="/static/headers.html">Headers Inspector</a>
     <a href="/static/ratelimit.html">Rate Limit Test</a>
+    <a href="/static/vulnlab.html">Vulnerability Lab</a>
   </nav>
 
   <!-- Hero -->
@@ -193,6 +194,10 @@
     <li>
       <a href="/static/ratelimit.html">Rate Limit Test</a> —
       fire 20 rapid requests and watch the 429s appear.
+    </li>
+    <li>
+      <a href="/static/vulnlab.html">Vulnerability Lab</a> —
+      intentional vulnerabilities with VibeWarden mitigation status for each.
     </li>
     <li>
       <a href="http://dashboard.vibewarden.dev" target="_blank" rel="noopener">Grafana Dashboard</a> —

--- a/examples/demo-app/static/vulnlab.html
+++ b/examples/demo-app/static/vulnlab.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vulnerability Lab — VibeWarden Demo</title>
+  <link rel="stylesheet" href="/static/water.css">
+  <style>
+    nav a { margin-right: 1em; }
+
+    .hero {
+      margin: 2em 0 2.5em;
+      padding: 2em;
+      border-left: 4px solid #7C3AED;
+      background: rgba(124, 58, 237, 0.04);
+      border-radius: 0 6px 6px 0;
+    }
+    .hero h1 { margin-top: 0; }
+    .hero .tagline {
+      font-size: 1.1em;
+      color: #555;
+      margin-bottom: 0;
+    }
+
+    .badge {
+      display: inline-block;
+      padding: 0.2em 0.6em;
+      border-radius: 4px;
+      font-size: 0.8em;
+      font-weight: bold;
+    }
+    .badge-high   { background: #dc2626; color: #fff; }
+    .badge-medium { background: #d97706; color: #fff; }
+    .badge-low    { background: #2563eb; color: #fff; }
+
+    .vuln-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1.2em;
+      margin: 1.5em 0;
+    }
+
+    .vuln-card {
+      padding: 1.2em;
+      border: 1px solid #d1d5db;
+      border-radius: 6px;
+      text-decoration: none;
+      color: inherit;
+      display: block;
+      transition: border-color 0.15s, box-shadow 0.15s;
+    }
+    .vuln-card:hover {
+      border-color: #7C3AED;
+      box-shadow: 0 2px 8px rgba(124, 58, 237, 0.12);
+      text-decoration: none;
+    }
+
+    .vuln-card-header {
+      display: flex;
+      align-items: center;
+      gap: 0.6em;
+      margin-bottom: 0.5em;
+    }
+    .vuln-card-header h3 {
+      margin: 0;
+      font-size: 1em;
+      flex: 1;
+    }
+
+    .vuln-card p {
+      margin: 0.4em 0 0.8em;
+      font-size: 0.9em;
+      color: #555;
+    }
+
+    .mitigation {
+      font-size: 0.85em;
+      font-weight: bold;
+      display: flex;
+      align-items: center;
+      gap: 0.3em;
+    }
+    .mitigation-yes { color: #16a34a; }
+    .mitigation-no  { color: #dc2626; }
+
+    .vw-footer {
+      margin-top: 3em;
+      padding: 1em 1.2em;
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 6px;
+      font-size: 0.9em;
+      color: #374151;
+      text-align: center;
+    }
+    .vw-footer strong { color: #7C3AED; }
+  </style>
+</head>
+<body>
+  <nav>
+    <strong>VibeWarden Demo</strong> &nbsp;|&nbsp;
+    <a href="/">Home</a>
+    <a href="/static/me.html">My Profile</a>
+    <a href="/static/headers.html">Headers Inspector</a>
+    <a href="/static/ratelimit.html">Rate Limit Test</a>
+    <a href="/static/vulnlab.html">Vulnerability Lab</a>
+  </nav>
+
+  <!-- Hero -->
+  <div class="hero">
+    <h1>Vulnerability Lab</h1>
+    <p class="tagline">
+      This app has intentional security vulnerabilities. VibeWarden mitigates most of them.
+      Try to exploit them.
+    </p>
+  </div>
+
+  <p>
+    Each page below demonstrates a real vulnerability class. Where VibeWarden provides
+    mitigation, the protection is applied automatically — no code changes needed in the app.
+    Where it does not, the demo shows what can still go wrong and what you should fix at the
+    application layer.
+  </p>
+
+  <div class="vuln-grid">
+
+    <a class="vuln-card" href="/vuln/xss-reflected">
+      <div class="vuln-card-header">
+        <h3>Reflected XSS</h3>
+        <span class="badge badge-high">High</span>
+      </div>
+      <p>User-supplied input is reflected directly into the page without escaping, allowing arbitrary script execution in the victim's browser.</p>
+      <div class="mitigation mitigation-yes">
+        <span>&#10003;</span> Mitigated by VibeWarden (CSP blocks inline scripts from untrusted sources)
+      </div>
+    </a>
+
+    <a class="vuln-card" href="/vuln/xss-stored">
+      <div class="vuln-card-header">
+        <h3>Stored XSS</h3>
+        <span class="badge badge-high">High</span>
+      </div>
+      <p>Malicious scripts are persisted in the database and executed whenever the affected page is loaded by any user.</p>
+      <div class="mitigation mitigation-yes">
+        <span>&#10003;</span> Partially mitigated by VibeWarden (CSP reduces impact; app must sanitise input)
+      </div>
+    </a>
+
+    <a class="vuln-card" href="/vuln/sqli">
+      <div class="vuln-card-header">
+        <h3>SQL Injection</h3>
+        <span class="badge badge-high">High</span>
+      </div>
+      <p>Unsanitised query parameters are interpolated directly into SQL statements, allowing data exfiltration and database manipulation.</p>
+      <div class="mitigation mitigation-no">
+        <span>&#10007;</span> Not mitigated by VibeWarden (fix at the application layer: use parameterised queries)
+      </div>
+    </a>
+
+    <a class="vuln-card" href="/vuln/clickjacking">
+      <div class="vuln-card-header">
+        <h3>Clickjacking</h3>
+        <span class="badge badge-medium">Medium</span>
+      </div>
+      <p>The page can be embedded in a hidden iframe, tricking users into clicking UI elements they cannot see.</p>
+      <div class="mitigation mitigation-yes">
+        <span>&#10003;</span> Mitigated by VibeWarden (<code>X-Frame-Options: DENY</code> and CSP <code>frame-ancestors</code>)
+      </div>
+    </a>
+
+    <a class="vuln-card" href="/vuln/csrf">
+      <div class="vuln-card-header">
+        <h3>CSRF</h3>
+        <span class="badge badge-medium">Medium</span>
+      </div>
+      <p>A forged cross-origin request can trigger state-changing actions on behalf of an authenticated user without their knowledge.</p>
+      <div class="mitigation mitigation-yes">
+        <span>&#10003;</span> Mitigated by VibeWarden (Kratos session cookies carry <code>SameSite=Strict</code>)
+      </div>
+    </a>
+
+    <a class="vuln-card" href="/vuln/redirect">
+      <div class="vuln-card-header">
+        <h3>Open Redirect</h3>
+        <span class="badge badge-medium">Medium</span>
+      </div>
+      <p>An unvalidated redirect parameter allows attackers to redirect users to malicious sites using a trusted domain as a stepping stone.</p>
+      <div class="mitigation mitigation-no">
+        <span>&#10007;</span> Not mitigated by VibeWarden (validate redirect targets at the application layer)
+      </div>
+    </a>
+
+    <a class="vuln-card" href="/vuln/info-leak">
+      <div class="vuln-card-header">
+        <h3>Information Disclosure</h3>
+        <span class="badge badge-low">Low</span>
+      </div>
+      <p>Verbose error messages, stack traces, or misconfigured headers expose internal details that aid further attacks.</p>
+      <div class="mitigation mitigation-yes">
+        <span>&#10003;</span> Partially mitigated by VibeWarden (security headers strip server banners; app must suppress stack traces)
+      </div>
+    </a>
+
+    <a class="vuln-card" href="/vuln/mime-sniff">
+      <div class="vuln-card-header">
+        <h3>MIME Sniffing</h3>
+        <span class="badge badge-low">Low</span>
+      </div>
+      <p>Browsers that ignore declared Content-Type and infer the type from content can be tricked into executing a malicious payload as a script.</p>
+      <div class="mitigation mitigation-yes">
+        <span>&#10003;</span> Mitigated by VibeWarden (<code>X-Content-Type-Options: nosniff</code> on every response)
+      </div>
+    </a>
+
+  </div>
+
+  <!-- Footer banner -->
+  <div class="vw-footer">
+    <strong>VibeWarden</strong> — security sidecar for vibe-coded apps.
+    Protections are applied automatically; no custom security code needed in the app.
+  </div>
+</body>
+</html>

--- a/examples/demo-app/vibewarden.local-demo.yaml
+++ b/examples/demo-app/vibewarden.local-demo.yaml
@@ -35,6 +35,7 @@ auth:
     - "/health"
     - "/static"
     - "/auth"
+    - "/vuln"
   session_cookie_name: "ory_kratos_session"
   login_url: ""
 

--- a/examples/demo-app/vibewarden.yaml
+++ b/examples/demo-app/vibewarden.yaml
@@ -32,6 +32,7 @@ auth:
     - "/health"
     - "/static"
     - "/auth"
+    - "/vuln"
   session_cookie_name: "ory_kratos_session"
   login_url: ""
 


### PR DESCRIPTION
Closes #240

## Summary

- Added `examples/demo-app/static/vulnlab.html` — a Vulnerability Lab landing page with a responsive grid of 8 vulnerability cards: Reflected XSS, Stored XSS, SQL Injection, Clickjacking, CSRF, Open Redirect, Information Disclosure, and MIME Sniffing. Each card shows the vulnerability name, severity badge (high/medium/low), a one-line description, and a green checkmark or red X indicating whether VibeWarden mitigates it.
- Added a navigation link to Vulnerability Lab in `index.html` (nav bar and Explore section).
- Added `GET /vuln/` route in `main.go` (`handleVulnLab`): bare `/vuln/` redirects to `vulnlab.html`; `/vuln/<slug>` returns a JSON placeholder response until individual demo pages are built.
- Added `/vuln` to `public_paths` in both `vibewarden.yaml` and `vibewarden.local-demo.yaml` so all vuln lab pages are accessible without authentication.
- Added table-driven tests for `handleVulnLab` covering redirect behaviour and JSON slug responses; extended `TestStaticFilesEmbedded` to include `vulnlab.html`.

## Test plan

- [ ] `make check` passes (all format, vet, build, and test checks green)
- [ ] `GET /vuln/` redirects to `/static/vulnlab.html`
- [ ] `GET /vuln/xss-reflected` returns JSON with vulnerability slug
- [ ] `/static/vulnlab.html` renders with all 8 vulnerability cards, severity badges, and mitigation status
- [ ] Nav bar on index.html and vulnlab.html both show the Vulnerability Lab link
- [ ] `/vuln/*` paths are accessible without authentication in both config files

Generated with Claude Code
