### PR TITLE
feat(#241,#242): add reflected XSS and stored XSS demos to vulnerability lab

### DIFF
--- a/examples/demo-app/main.go
+++ b/examples/demo-app/main.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -33,6 +34,15 @@ var staticFiles embed.FS
 
 // spamCounter counts POST /spam requests to demonstrate rate limiting.
 var spamCounter atomic.Int64
+
+// guestbook holds submitted messages for the stored XSS demo.
+// Access is protected by guestbookMu.
+//
+// INTENTIONALLY VULNERABLE — messages are stored and rendered without sanitisation.
+var (
+	guestbook   []string
+	guestbookMu sync.Mutex
+)
 
 func main() {
 	port := os.Getenv("PORT")
@@ -59,6 +69,9 @@ func main() {
 	mux.HandleFunc("GET /auth/login", handleAuthPage(staticFS, "login.html"))
 	mux.HandleFunc("GET /auth/registration", handleAuthPage(staticFS, "register.html"))
 	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
+	mux.HandleFunc("GET /vuln/xss-reflected", handleXSSReflected)
+	mux.HandleFunc("GET /vuln/xss-stored", handleXSSStoredGet)
+	mux.HandleFunc("POST /vuln/xss-stored", handleXSSStoredPost)
 	mux.HandleFunc("GET /vuln/", handleVulnLab)
 
 	addr := ":" + port
@@ -209,6 +222,112 @@ func handleVulnLab(w http.ResponseWriter, r *http.Request) {
 		"status":        "demo page coming soon",
 		"lab":           "/static/vulnlab.html",
 	})
+}
+
+// handleXSSReflected is the INTENTIONALLY VULNERABLE reflected XSS endpoint.
+//
+// It renders the value of the "q" query parameter directly into the HTML
+// response without any escaping.  This lets an attacker craft a URL that
+// executes arbitrary JavaScript in the victim's browser.
+//
+// VibeWarden mitigation: the CSP header "default-src 'self'" set by the
+// sidecar prevents inline scripts from executing, so the injected payload
+// is blocked even though the app itself does nothing to stop it.
+//
+// INTENTIONALLY VULNERABLE — do not sanitise this endpoint.
+func handleXSSReflected(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("q")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Search Results — Reflected XSS Demo</title>
+  <link rel="stylesheet" href="/static/water.css">
+</head>
+<body>
+  <nav>
+    <strong>VibeWarden Demo</strong> &nbsp;|&nbsp;
+    <a href="/">Home</a>
+    <a href="/static/vulnlab.html">Vulnerability Lab</a>
+    <a href="/static/xss-reflected.html">Reflected XSS Explained</a>
+  </nav>
+  <h1>Search Results</h1>
+  <!-- INTENTIONALLY VULNERABLE: q is rendered without escaping -->
+  <p>Search results for: %s</p>
+  <p><a href="/static/xss-reflected.html">Back to explanation</a></p>
+</body>
+</html>`, q)
+}
+
+// handleXSSStoredGet renders the guestbook WITHOUT escaping stored messages.
+//
+// INTENTIONALLY VULNERABLE — messages are rendered raw so that any HTML/JS
+// that was stored via POST /vuln/xss-stored is executed in the browser.
+//
+// VibeWarden mitigation: CSP blocks inline event handlers (e.g. onerror=),
+// reducing the blast radius, but the app still must sanitise input at write
+// time to be fully safe.
+func handleXSSStoredGet(w http.ResponseWriter, r *http.Request) {
+	guestbookMu.Lock()
+	entries := make([]string, len(guestbook))
+	copy(entries, guestbook)
+	guestbookMu.Unlock()
+
+	var rows strings.Builder
+	if len(entries) == 0 {
+		rows.WriteString("<li><em>No messages yet. Be the first!</em></li>")
+	}
+	for _, msg := range entries {
+		// INTENTIONALLY VULNERABLE: msg is written without escaping.
+		fmt.Fprintf(&rows, "<li>%s</li>\n", msg)
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Guestbook — Stored XSS Demo</title>
+  <link rel="stylesheet" href="/static/water.css">
+</head>
+<body>
+  <nav>
+    <strong>VibeWarden Demo</strong> &nbsp;|&nbsp;
+    <a href="/">Home</a>
+    <a href="/static/vulnlab.html">Vulnerability Lab</a>
+    <a href="/static/xss-stored.html">Stored XSS Explained</a>
+  </nav>
+  <h1>Guestbook</h1>
+  <!-- INTENTIONALLY VULNERABLE: messages are rendered without escaping -->
+  <ul>
+    %s
+  </ul>
+  <p><a href="/static/xss-stored.html">Back to explanation</a></p>
+</body>
+</html>`, rows.String())
+}
+
+// handleXSSStoredPost stores a guestbook message without sanitisation.
+//
+// INTENTIONALLY VULNERABLE — the message from the form body is appended to
+// the in-memory guestbook as-is and later rendered raw by handleXSSStoredGet.
+func handleXSSStoredPost(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	msg := r.FormValue("message")
+	if msg == "" {
+		http.Redirect(w, r, "/static/xss-stored.html", http.StatusSeeOther)
+		return
+	}
+
+	guestbookMu.Lock()
+	guestbook = append(guestbook, msg)
+	guestbookMu.Unlock()
+
+	http.Redirect(w, r, "/static/xss-stored.html", http.StatusSeeOther)
 }
 
 // handleAuthPage returns an http.HandlerFunc that serves a named HTML file

--- a/examples/demo-app/main_test.go
+++ b/examples/demo-app/main_test.go
@@ -378,6 +378,8 @@ func TestStaticFilesEmbedded(t *testing.T) {
 		"static/headers.html",
 		"static/ratelimit.html",
 		"static/vulnlab.html",
+		"static/xss-reflected.html",
+		"static/xss-stored.html",
 	}
 	for _, path := range wantFiles {
 		t.Run(path, func(t *testing.T) {
@@ -388,4 +390,152 @@ func TestStaticFilesEmbedded(t *testing.T) {
 			f.Close()
 		})
 	}
+}
+
+func TestHandleXSSReflected(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		wantInBody string
+		wantStatus int
+		wantCT     string
+	}{
+		{
+			name:       "plain text query is reflected verbatim",
+			query:      "hello",
+			wantInBody: "Search results for: hello",
+			wantStatus: http.StatusOK,
+			wantCT:     "text/html; charset=utf-8",
+		},
+		{
+			name:       "XSS payload is reflected unescaped",
+			query:      `<script>alert('XSS')</script>`,
+			wantInBody: `<script>alert('XSS')</script>`,
+			wantStatus: http.StatusOK,
+			wantCT:     "text/html; charset=utf-8",
+		},
+		{
+			name:       "empty query is handled without error",
+			query:      "",
+			wantInBody: "Search results for: ",
+			wantStatus: http.StatusOK,
+			wantCT:     "text/html; charset=utf-8",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/vuln/xss-reflected?q="+tt.query, nil)
+			rr := httptest.NewRecorder()
+
+			handleXSSReflected(rr, req)
+
+			if rr.Code != tt.wantStatus {
+				t.Fatalf("want status %d, got %d", tt.wantStatus, rr.Code)
+			}
+			if ct := rr.Header().Get("Content-Type"); ct != tt.wantCT {
+				t.Errorf("Content-Type: want %q, got %q", tt.wantCT, ct)
+			}
+			if body := rr.Body.String(); !strings.Contains(body, tt.wantInBody) {
+				t.Errorf("response body does not contain %q; body: %s", tt.wantInBody, body)
+			}
+		})
+	}
+}
+
+func TestHandleXSSStoredGetPost(t *testing.T) {
+	// Reset the global guestbook before this test so it is isolated.
+	guestbookMu.Lock()
+	guestbook = nil
+	guestbookMu.Unlock()
+
+	t.Run("GET empty guestbook shows no-messages placeholder", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/vuln/xss-stored", nil)
+		rr := httptest.NewRecorder()
+
+		handleXSSStoredGet(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("want status 200, got %d", rr.Code)
+		}
+		if ct := rr.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
+			t.Errorf("Content-Type: want text/html, got %q", ct)
+		}
+		if body := rr.Body.String(); !strings.Contains(body, "No messages yet") {
+			t.Errorf("expected empty guestbook message; body: %s", body)
+		}
+	})
+
+	t.Run("POST stores message and redirects", func(t *testing.T) {
+		form := strings.NewReader("message=hello+world")
+		req := httptest.NewRequest(http.MethodPost, "/vuln/xss-stored", form)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rr := httptest.NewRecorder()
+
+		handleXSSStoredPost(rr, req)
+
+		if rr.Code != http.StatusSeeOther {
+			t.Fatalf("want status 303, got %d", rr.Code)
+		}
+	})
+
+	t.Run("GET after POST shows stored message unescaped", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/vuln/xss-stored", nil)
+		rr := httptest.NewRecorder()
+
+		handleXSSStoredGet(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("want status 200, got %d", rr.Code)
+		}
+		if body := rr.Body.String(); !strings.Contains(body, "hello world") {
+			t.Errorf("expected stored message in body; body: %s", body)
+		}
+	})
+
+	t.Run("POST stores XSS payload unescaped", func(t *testing.T) {
+		// Reset guestbook first.
+		guestbookMu.Lock()
+		guestbook = nil
+		guestbookMu.Unlock()
+
+		payload := `<img src=x onerror=alert('XSS')>`
+		form := strings.NewReader("message=" + payload)
+		req := httptest.NewRequest(http.MethodPost, "/vuln/xss-stored", form)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rr := httptest.NewRecorder()
+		handleXSSStoredPost(rr, req)
+
+		// Now GET should reflect the payload verbatim.
+		req2 := httptest.NewRequest(http.MethodGet, "/vuln/xss-stored", nil)
+		rr2 := httptest.NewRecorder()
+		handleXSSStoredGet(rr2, req2)
+
+		if body := rr2.Body.String(); !strings.Contains(body, payload) {
+			t.Errorf("expected XSS payload in body (unescaped); body: %s", body)
+		}
+	})
+
+	t.Run("POST with empty message redirects without storing", func(t *testing.T) {
+		guestbookMu.Lock()
+		before := len(guestbook)
+		guestbookMu.Unlock()
+
+		form := strings.NewReader("message=")
+		req := httptest.NewRequest(http.MethodPost, "/vuln/xss-stored", form)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rr := httptest.NewRecorder()
+
+		handleXSSStoredPost(rr, req)
+
+		if rr.Code != http.StatusSeeOther {
+			t.Fatalf("want status 303, got %d", rr.Code)
+		}
+		guestbookMu.Lock()
+		after := len(guestbook)
+		guestbookMu.Unlock()
+		if after != before {
+			t.Errorf("empty message should not be stored; before=%d after=%d", before, after)
+		}
+	})
 }

--- a/examples/demo-app/static/vulnlab.html
+++ b/examples/demo-app/static/vulnlab.html
@@ -124,7 +124,7 @@
 
   <div class="vuln-grid">
 
-    <a class="vuln-card" href="/vuln/xss-reflected">
+    <a class="vuln-card" href="/static/xss-reflected.html">
       <div class="vuln-card-header">
         <h3>Reflected XSS</h3>
         <span class="badge badge-high">High</span>
@@ -135,7 +135,7 @@
       </div>
     </a>
 
-    <a class="vuln-card" href="/vuln/xss-stored">
+    <a class="vuln-card" href="/static/xss-stored.html">
       <div class="vuln-card-header">
         <h3>Stored XSS</h3>
         <span class="badge badge-high">High</span>

--- a/examples/demo-app/static/xss-reflected.html
+++ b/examples/demo-app/static/xss-reflected.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reflected XSS — VibeWarden Vulnerability Lab</title>
+  <link rel="stylesheet" href="/static/water.css">
+  <style>
+    nav a { margin-right: 1em; }
+
+    .warning-banner {
+      padding: 1em 1.2em;
+      background: #fef2f2;
+      border: 2px solid #dc2626;
+      border-radius: 6px;
+      color: #991b1b;
+      font-weight: bold;
+      font-size: 1em;
+      margin-bottom: 1.5em;
+    }
+
+    .hero {
+      margin: 1.5em 0 2em;
+      padding: 2em;
+      border-left: 4px solid #7C3AED;
+      background: rgba(124, 58, 237, 0.04);
+      border-radius: 0 6px 6px 0;
+    }
+    .hero h1 { margin-top: 0; }
+    .hero .tagline {
+      font-size: 1.1em;
+      color: #555;
+      margin-bottom: 0;
+    }
+
+    .badge {
+      display: inline-block;
+      padding: 0.2em 0.6em;
+      border-radius: 4px;
+      font-size: 0.8em;
+      font-weight: bold;
+    }
+    .badge-high   { background: #dc2626; color: #fff; }
+    .badge-mitigated { background: #16a34a; color: #fff; }
+
+    .section {
+      margin: 2em 0;
+    }
+
+    .try-it-box {
+      padding: 1.2em;
+      border: 1px solid #d1d5db;
+      border-radius: 6px;
+      background: #fafafa;
+    }
+    .try-it-box h3 { margin-top: 0; }
+
+    .result-panel {
+      margin-top: 1em;
+      padding: 1em;
+      border: 1px solid #e5e7eb;
+      border-radius: 4px;
+      background: #fff;
+      min-height: 3em;
+      font-family: monospace;
+      font-size: 0.9em;
+      color: #374151;
+    }
+
+    .protection-box {
+      padding: 1.2em;
+      border: 2px solid #16a34a;
+      border-radius: 6px;
+      background: rgba(22, 163, 74, 0.04);
+    }
+    .protection-box h3 { margin-top: 0; color: #15803d; }
+
+    .code-block {
+      font-family: monospace;
+      background: #1e1e2e;
+      color: #cdd6f4;
+      padding: 1em;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 0.9em;
+      line-height: 1.5;
+    }
+
+    .vuln-code {
+      font-family: monospace;
+      background: #fff5f5;
+      color: #9b2335;
+      padding: 1em;
+      border-radius: 6px;
+      border-left: 4px solid #dc2626;
+      overflow-x: auto;
+      font-size: 0.9em;
+      line-height: 1.5;
+    }
+
+    .step { margin: 0.5em 0; }
+    .step code { background: #f3f4f6; padding: 0.1em 0.4em; border-radius: 3px; }
+
+    .vw-footer {
+      margin-top: 3em;
+      padding: 1em 1.2em;
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 6px;
+      font-size: 0.9em;
+      color: #374151;
+      text-align: center;
+    }
+    .vw-footer strong { color: #7C3AED; }
+  </style>
+</head>
+<body>
+  <nav>
+    <strong>VibeWarden Demo</strong> &nbsp;|&nbsp;
+    <a href="/">Home</a>
+    <a href="/static/me.html">My Profile</a>
+    <a href="/static/headers.html">Headers Inspector</a>
+    <a href="/static/ratelimit.html">Rate Limit Test</a>
+    <a href="/static/vulnlab.html">Vulnerability Lab</a>
+  </nav>
+
+  <div class="warning-banner">
+    &#9888;&#65039; This page contains an INTENTIONAL security vulnerability for demonstration purposes.
+    The endpoint at <code>/vuln/xss-reflected</code> is deliberately insecure.
+    Do not deploy this in production.
+  </div>
+
+  <div class="hero">
+    <h1>Reflected XSS &nbsp;<span class="badge badge-high">High</span>&nbsp;<span class="badge badge-mitigated">Mitigated by VibeWarden</span></h1>
+    <p class="tagline">
+      User-supplied input is reflected directly into the HTML response without escaping,
+      allowing an attacker to inject and execute arbitrary JavaScript in the victim's browser.
+    </p>
+  </div>
+
+  <div class="section">
+    <h2>What is Reflected XSS?</h2>
+    <p>
+      Reflected Cross-Site Scripting (XSS) occurs when a web application takes input from an
+      HTTP request and immediately includes it in the response without sanitisation or escaping.
+      The malicious script is "reflected" off the server back to the user's browser, where it
+      executes in the context of the vulnerable site.
+    </p>
+    <p>
+      An attacker crafts a URL with a malicious payload in a query parameter and tricks a victim
+      into clicking it — via phishing email, social media, or a short link.  Because the script
+      comes from a trusted domain, the browser executes it with full access to cookies, local
+      storage, and the DOM.
+    </p>
+    <p>
+      Common consequences include: session hijacking, credential theft, defacement, and
+      redirecting users to malicious sites.
+    </p>
+  </div>
+
+  <div class="section">
+    <h2>The Vulnerable Code</h2>
+    <p>
+      The endpoint <code>/vuln/xss-reflected?q=...</code> in this demo app is intentionally
+      written without output encoding:
+    </p>
+    <div class="vuln-code">// INTENTIONALLY VULNERABLE — demonstrates reflected XSS<br>
+fmt.Fprintf(w, "&lt;p&gt;Search results for: %s&lt;/p&gt;", r.URL.Query().Get("q"))</div>
+    <p>
+      When a browser requests <code>/vuln/xss-reflected?q=hello</code>, the response contains
+      <code>&lt;p&gt;Search results for: hello&lt;/p&gt;</code>.  If the value of
+      <code>q</code> is <code>&lt;script&gt;alert('XSS')&lt;/script&gt;</code>, that script
+      tag lands verbatim in the HTML and the browser executes it — unless a Content Security
+      Policy prevents it.
+    </p>
+  </div>
+
+  <div class="section">
+    <h2>Try It</h2>
+    <div class="try-it-box">
+      <h3>Search Demo</h3>
+      <p>
+        Enter a search term.  The value is sent to the vulnerable endpoint and reflected
+        back into the page.  Try entering:
+        <code>&lt;script&gt;alert('XSS')&lt;/script&gt;</code>
+      </p>
+      <form id="search-form">
+        <label for="search-input">Search:</label>
+        <input type="text" id="search-input" placeholder="try: &lt;script&gt;alert('XSS')&lt;/script&gt;" style="width:100%;max-width:420px">
+        <button type="submit">Search</button>
+      </form>
+      <h4>Result from <code>/vuln/xss-reflected</code></h4>
+      <div class="result-panel" id="result-panel">
+        <em>Submit a search above to see the raw response from the vulnerable endpoint.</em>
+      </div>
+      <p id="csp-note" style="display:none;color:#15803d;font-weight:bold;margin-top:0.5em;">
+        &#10003; CSP blocked the script. The raw HTML contains the injected tag, but the browser
+        refused to execute it because VibeWarden's <code>Content-Security-Policy</code> header
+        does not permit inline scripts.
+      </p>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>VibeWarden Protection</h2>
+    <div class="protection-box">
+      <h3>Content Security Policy blocks inline script execution</h3>
+      <p>
+        VibeWarden adds the following header to every response from your app:
+      </p>
+      <div class="code-block">Content-Security-Policy: default-src 'self'; ...</div>
+      <p>
+        Because <code>default-src 'self'</code> does not include <code>'unsafe-inline'</code>,
+        the browser refuses to execute any inline <code>&lt;script&gt;</code> tags injected by
+        the attacker.  The malicious HTML is written into the page, but the script never runs.
+      </p>
+      <p>
+        You can verify this in the browser's developer console: when you submit the XSS payload,
+        you will see a CSP violation message such as:
+      </p>
+      <div class="code-block">Refused to execute inline script because it violates the following
+Content Security Policy directive: "default-src 'self'"</div>
+      <p>
+        <strong>Important:</strong> CSP is a defence-in-depth measure.  The correct fix at the
+        application layer is to always HTML-encode output — e.g. use
+        <code>html/template</code> in Go instead of <code>fmt.Fprintf</code>.  CSP protects
+        against mistakes; it is not a substitute for correct encoding.
+      </p>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>How to Fix This in Your App</h2>
+    <p>Use Go's <code>html/template</code> package, which escapes output by default:</p>
+    <div class="code-block">// SAFE: html/template escapes all values automatically<br>
+tmpl := template.Must(template.New("").Parse(`&lt;p&gt;Search results for: {{.}}&lt;/p&gt;`))<br>
+tmpl.Execute(w, r.URL.Query().Get("q"))</div>
+    <p>
+      Never use <code>fmt.Fprintf</code> to write user-supplied data into an HTML response.
+      If you must build HTML strings, call <code>html.EscapeString()</code> on every
+      untrusted value first.
+    </p>
+  </div>
+
+  <!-- Footer banner -->
+  <div class="vw-footer">
+    <strong>VibeWarden</strong> — security sidecar for vibe-coded apps.
+    CSP and other security headers are applied automatically to every response.
+    &mdash; <a href="/static/vulnlab.html">Back to Vulnerability Lab</a> &mdash;
+    <a href="https://github.com/vibewarden/vibewarden" target="_blank" rel="noopener">GitHub</a>
+  </div>
+
+  <script>
+    document.getElementById('search-form').addEventListener('submit', async function (e) {
+      e.preventDefault();
+      const q = document.getElementById('search-input').value;
+      const panel = document.getElementById('result-panel');
+      const note  = document.getElementById('csp-note');
+
+      panel.textContent = 'Loading...';
+      note.style.display = 'none';
+
+      try {
+        const resp = await fetch('/vuln/xss-reflected?q=' + encodeURIComponent(q));
+        const text = await resp.text();
+        // Show the raw HTML the server returned — displayed as text, not rendered.
+        panel.textContent = text;
+
+        // Heuristic: if q contained a script tag and we got a 200, CSP should have blocked it.
+        if (q.toLowerCase().includes('<script') || q.toLowerCase().includes('onerror')) {
+          note.style.display = 'block';
+        }
+      } catch (err) {
+        panel.textContent = 'Error: ' + String(err);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/examples/demo-app/static/xss-stored.html
+++ b/examples/demo-app/static/xss-stored.html
@@ -1,0 +1,347 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Stored XSS — VibeWarden Vulnerability Lab</title>
+  <link rel="stylesheet" href="/static/water.css">
+  <style>
+    nav a { margin-right: 1em; }
+
+    .warning-banner {
+      padding: 1em 1.2em;
+      background: #fef2f2;
+      border: 2px solid #dc2626;
+      border-radius: 6px;
+      color: #991b1b;
+      font-weight: bold;
+      font-size: 1em;
+      margin-bottom: 1.5em;
+    }
+
+    .hero {
+      margin: 1.5em 0 2em;
+      padding: 2em;
+      border-left: 4px solid #7C3AED;
+      background: rgba(124, 58, 237, 0.04);
+      border-radius: 0 6px 6px 0;
+    }
+    .hero h1 { margin-top: 0; }
+    .hero .tagline {
+      font-size: 1.1em;
+      color: #555;
+      margin-bottom: 0;
+    }
+
+    .badge {
+      display: inline-block;
+      padding: 0.2em 0.6em;
+      border-radius: 4px;
+      font-size: 0.8em;
+      font-weight: bold;
+    }
+    .badge-high      { background: #dc2626; color: #fff; }
+    .badge-partial   { background: #d97706; color: #fff; }
+
+    .section {
+      margin: 2em 0;
+    }
+
+    .try-it-box {
+      padding: 1.2em;
+      border: 1px solid #d1d5db;
+      border-radius: 6px;
+      background: #fafafa;
+    }
+    .try-it-box h3 { margin-top: 0; }
+
+    .guestbook-frame {
+      margin-top: 1.2em;
+      border: 1px solid #e5e7eb;
+      border-radius: 6px;
+      overflow: hidden;
+    }
+    .guestbook-frame iframe {
+      width: 100%;
+      border: none;
+      min-height: 200px;
+    }
+
+    .protection-box {
+      padding: 1.2em;
+      border: 2px solid #d97706;
+      border-radius: 6px;
+      background: rgba(217, 119, 6, 0.04);
+    }
+    .protection-box h3 { margin-top: 0; color: #b45309; }
+
+    .code-block {
+      font-family: monospace;
+      background: #1e1e2e;
+      color: #cdd6f4;
+      padding: 1em;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 0.9em;
+      line-height: 1.5;
+    }
+
+    .vuln-code {
+      font-family: monospace;
+      background: #fff5f5;
+      color: #9b2335;
+      padding: 1em;
+      border-radius: 6px;
+      border-left: 4px solid #dc2626;
+      overflow-x: auto;
+      font-size: 0.9em;
+      line-height: 1.5;
+    }
+
+    .status-msg {
+      margin-top: 0.5em;
+      padding: 0.5em 0.8em;
+      border-radius: 4px;
+      font-size: 0.9em;
+    }
+    .status-ok  { background: #f0fdf4; color: #15803d; border: 1px solid #86efac; }
+    .status-err { background: #fef2f2; color: #991b1b; border: 1px solid #fca5a5; }
+
+    .guestbook-list {
+      margin: 0;
+      padding: 0.5em 1em;
+      list-style: disc;
+      font-size: 0.95em;
+    }
+    .guestbook-list li { margin: 0.3em 0; }
+
+    .vw-footer {
+      margin-top: 3em;
+      padding: 1em 1.2em;
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 6px;
+      font-size: 0.9em;
+      color: #374151;
+      text-align: center;
+    }
+    .vw-footer strong { color: #7C3AED; }
+  </style>
+</head>
+<body>
+  <nav>
+    <strong>VibeWarden Demo</strong> &nbsp;|&nbsp;
+    <a href="/">Home</a>
+    <a href="/static/me.html">My Profile</a>
+    <a href="/static/headers.html">Headers Inspector</a>
+    <a href="/static/ratelimit.html">Rate Limit Test</a>
+    <a href="/static/vulnlab.html">Vulnerability Lab</a>
+  </nav>
+
+  <div class="warning-banner">
+    &#9888;&#65039; This page contains an INTENTIONAL security vulnerability for demonstration purposes.
+    The guestbook at <code>/vuln/xss-stored</code> stores and renders messages without sanitisation.
+    Do not deploy this in production.
+  </div>
+
+  <div class="hero">
+    <h1>Stored XSS &nbsp;<span class="badge badge-high">High</span>&nbsp;<span class="badge badge-partial">Partially Mitigated by VibeWarden</span></h1>
+    <p class="tagline">
+      Malicious scripts are persisted in the backend and executed in every user's browser
+      whenever the affected page is loaded — with no attacker interaction required after
+      the initial submission.
+    </p>
+  </div>
+
+  <div class="section">
+    <h2>What is Stored XSS?</h2>
+    <p>
+      Stored (or "persistent") XSS is more dangerous than reflected XSS because the payload
+      is saved server-side — in a database, log, comment field, or any other persistent store —
+      and served to every user who later views the affected page, not just the user who submitted
+      the original request.
+    </p>
+    <p>
+      Classic targets include: comment sections, forum posts, user profiles, chat messages,
+      product reviews, and any other user-generated content that is later rendered in a browser.
+    </p>
+    <p>
+      Consequences are the same as reflected XSS but amplified: one malicious submission can
+      compromise every visitor, indefinitely, until the payload is removed from the store.
+    </p>
+  </div>
+
+  <div class="section">
+    <h2>The Vulnerable Code</h2>
+    <p>
+      This demo has an in-memory guestbook.  Messages are stored as raw strings and rendered
+      directly into HTML without escaping:
+    </p>
+    <div class="vuln-code">// INTENTIONALLY VULNERABLE — messages are stored without sanitisation<br>
+var guestbook []string<br>
+<br>
+// POST handler stores the raw message<br>
+guestbook = append(guestbook, r.FormValue("message"))<br>
+<br>
+// GET handler renders every message without escaping<br>
+fmt.Fprintf(&amp;rows, "&lt;li&gt;%s&lt;/li&gt;", msg)</div>
+    <p>
+      If you submit <code>&lt;img src=x onerror=alert('XSS')&gt;</code>, that tag is stored
+      and written verbatim into the HTML for every subsequent visitor.  Any browser that
+      renders the guestbook will attempt to execute the <code>onerror</code> handler —
+      unless a CSP prevents it.
+    </p>
+  </div>
+
+  <div class="section">
+    <h2>Try It</h2>
+    <div class="try-it-box">
+      <h3>Guestbook</h3>
+      <p>
+        Post a message.  It is stored server-side and shown to every visitor.  Try:
+        <code>&lt;img src=x onerror=alert('XSS')&gt;</code> or
+        <code>&lt;b&gt;bold&lt;/b&gt;</code>
+      </p>
+      <form id="post-form">
+        <label for="message-input">Message:</label>
+        <input type="text" id="message-input" placeholder="try: &lt;img src=x onerror=alert('XSS')&gt;" style="width:100%;max-width:500px">
+        <button type="submit">Post Message</button>
+      </form>
+      <div id="status-msg" style="display:none" class="status-msg"></div>
+      <h4>Current Guestbook (loaded from <code>/vuln/xss-stored</code>)</h4>
+      <div id="guestbook-container">
+        <em>Click "Reload Guestbook" to fetch and display current messages.</em>
+      </div>
+      <p>
+        <button id="btn-reload">Reload Guestbook (raw HTML)</button>
+      </p>
+      <p id="csp-note" style="display:none;color:#b45309;font-weight:bold;margin-top:0.5em;">
+        &#9888; CSP may block inline event handlers (e.g. <code>onerror=</code>).
+        Open DevTools to see the CSP violation report.  Note that the raw HTML still contains
+        the injected payload — CSP reduces impact but does not prevent storage or remove the
+        need for server-side sanitisation.
+      </p>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>VibeWarden Protection</h2>
+    <div class="protection-box">
+      <h3>CSP reduces impact — but cannot fully prevent stored XSS</h3>
+      <p>
+        VibeWarden adds a <code>Content-Security-Policy</code> header to every response.
+        This blocks many XSS vectors:
+      </p>
+      <ul>
+        <li><code>&lt;script&gt;alert()&lt;/script&gt;</code> — inline scripts blocked by CSP</li>
+        <li><code>&lt;img onerror=...&gt;</code> — inline event handlers blocked by CSP</li>
+        <li>External script loads from non-whitelisted origins — blocked by <code>default-src 'self'</code></li>
+      </ul>
+      <p>
+        However, CSP cannot undo the fact that the payload was stored.  A very narrow CSP
+        might still allow certain injected HTML to alter page layout or trick users visually
+        (UI redressing), even if script execution is blocked.
+      </p>
+      <p>
+        <strong>The correct fix is sanitisation at write time</strong> — before storing the
+        message.  Strip or encode HTML tags in the input before it reaches the database.
+        CSP is defence-in-depth, not a substitute for input sanitisation.
+      </p>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>How to Fix This in Your App</h2>
+    <p>Two complementary layers of defence are required:</p>
+    <ol>
+      <li>
+        <strong>Sanitise on write:</strong> strip or encode HTML before storing user input.
+        For Go, use <code>html.EscapeString()</code> or a dedicated sanitiser library.
+      </li>
+      <li>
+        <strong>Encode on read:</strong> use <code>html/template</code> to render stored
+        content so any residual markup is escaped at display time.
+      </li>
+    </ol>
+    <div class="code-block">// SAFE: sanitise before storing<br>
+msg := html.EscapeString(r.FormValue("message"))<br>
+guestbook = append(guestbook, msg)<br>
+<br>
+// SAFE: html/template auto-escapes on render<br>
+tmpl := template.Must(template.New("").Parse(`&lt;li&gt;{{.}}&lt;/li&gt;`))<br>
+for _, entry := range guestbook &#123;<br>
+&nbsp;&nbsp;tmpl.Execute(w, entry)<br>
+&#125;</div>
+  </div>
+
+  <!-- Footer banner -->
+  <div class="vw-footer">
+    <strong>VibeWarden</strong> — security sidecar for vibe-coded apps.
+    CSP is applied automatically; sanitise user input at the application layer too.
+    &mdash; <a href="/static/vulnlab.html">Back to Vulnerability Lab</a> &mdash;
+    <a href="https://github.com/vibewarden/vibewarden" target="_blank" rel="noopener">GitHub</a>
+  </div>
+
+  <script>
+    const postForm   = document.getElementById('post-form');
+    const statusMsg  = document.getElementById('status-msg');
+    const container  = document.getElementById('guestbook-container');
+    const cspNote    = document.getElementById('csp-note');
+
+    postForm.addEventListener('submit', async function (e) {
+      e.preventDefault();
+      const msg = document.getElementById('message-input').value.trim();
+      if (!msg) return;
+
+      statusMsg.style.display = 'none';
+
+      const body = new URLSearchParams();
+      body.set('message', msg);
+
+      try {
+        // POST stores the message; server redirects back here.
+        // We do the POST via fetch so we stay on this page.
+        await fetch('/vuln/xss-stored', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: body.toString(),
+          redirect: 'manual',  // don't follow the server redirect
+        });
+        showStatus('Message posted. Click "Reload Guestbook" to see it.', 'ok');
+
+        if (msg.toLowerCase().includes('onerror') || msg.toLowerCase().includes('<script')) {
+          cspNote.style.display = 'block';
+        }
+      } catch (err) {
+        showStatus('Error: ' + String(err), 'err');
+      }
+    });
+
+    document.getElementById('btn-reload').addEventListener('click', loadGuestbook);
+
+    async function loadGuestbook() {
+      container.textContent = 'Loading...';
+      try {
+        const resp = await fetch('/vuln/xss-stored');
+        const text = await resp.text();
+        // Display the raw HTML returned by the vulnerable endpoint as plain text
+        // so this explanation page is not itself rendered insecurely.
+        const pre = document.createElement('pre');
+        pre.style.cssText = 'font-family:monospace;font-size:0.85em;background:#f9fafb;' +
+          'border:1px solid #e5e7eb;border-radius:4px;padding:0.6em;overflow-x:auto;white-space:pre-wrap;';
+        pre.textContent = text;
+        container.innerHTML = '';
+        container.appendChild(pre);
+      } catch (err) {
+        container.textContent = 'Error loading guestbook: ' + String(err);
+      }
+    }
+
+    function showStatus(text, type) {
+      statusMsg.textContent = text;
+      statusMsg.className = 'status-msg status-' + type;
+      statusMsg.style.display = 'block';
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Closes #241
Closes #242

## Summary

- Adds `GET /vuln/xss-reflected?q=...` — reflects the query parameter directly into HTML using `fmt.Fprintf` without any escaping (intentionally vulnerable per spec)
- Adds `GET /vuln/xss-stored` — renders an in-memory guestbook with all messages written raw into the HTML response (intentionally vulnerable)
- Adds `POST /vuln/xss-stored` — stores a form message in a mutex-protected `[]string` slice without sanitisation
- Adds `static/xss-reflected.html` — explanation page with search form, try-it demo that fetches the raw response, the vulnerable code excerpt, CSP protection section, and `html/template` fix guidance; red warning banner at top
- Adds `static/xss-stored.html` — explanation page with guestbook post form, reload-raw-HTML panel, CSP partial-mitigation section noting that sanitisation on write is still required, and two-layer fix guidance; red warning banner at top
- Updates `static/vulnlab.html` — Reflected XSS and Stored XSS card links now point to the static explanation pages instead of the bare `/vuln/` API routes

## Test plan

- `make check` passes (pre-push hook ran it on push)
- `TestHandleXSSReflected` — table-driven, covers plain text, XSS payload reflected unescaped, empty query
- `TestHandleXSSStoredGetPost` — covers empty guestbook, POST stores message, GET reflects it unescaped, XSS payload stored verbatim, empty message is not stored
- `TestStaticFilesEmbedded` — now includes `xss-reflected.html` and `xss-stored.html`
- Manual: browse to `/static/vulnlab.html`, click Reflected XSS and Stored XSS cards, use the try-it forms, observe CSP violation in DevTools console
