### PR TITLE
feat(#217): per-path request body size limit config

### DIFF
--- a/cmd/vibewarden/serve.go
+++ b/cmd/vibewarden/serve.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vibewarden/vibewarden/internal/config"
 	"github.com/vibewarden/vibewarden/internal/plugins"
 	authplugin "github.com/vibewarden/vibewarden/internal/plugins/auth"
+	bodysizeplugin "github.com/vibewarden/vibewarden/internal/plugins/bodysize"
 	metricsplugin "github.com/vibewarden/vibewarden/internal/plugins/metrics"
 	ratelimitplugin "github.com/vibewarden/vibewarden/internal/plugins/ratelimit"
 	sechdrs "github.com/vibewarden/vibewarden/internal/plugins/securityheaders"
@@ -157,6 +158,37 @@ func registerPlugins(
 		SuppressViaHeader:            cfg.SecurityHeaders.SuppressViaHeader,
 	}, cfg.TLS.Enabled, logger))
 
+	// Body size limiting — priority 45
+	// Parse the configured size strings into bytes. Errors are already validated
+	// by config.Validate(), so we log-and-skip on any unexpected parse failure
+	// rather than failing startup.
+	globalMaxBytes, err := config.ParseBodySize(cfg.BodySize.Max)
+	if err != nil {
+		logger.Error("body_size.max parse error — body size limiting disabled",
+			slog.String("error", err.Error()),
+		)
+	} else {
+		bodySizeCfg := bodysizeplugin.Config{
+			Enabled:  globalMaxBytes > 0 || len(cfg.BodySize.Overrides) > 0,
+			MaxBytes: globalMaxBytes,
+		}
+		for _, ov := range cfg.BodySize.Overrides {
+			ovBytes, ovErr := config.ParseBodySize(ov.Max)
+			if ovErr != nil {
+				logger.Error("body_size override parse error — skipping override",
+					slog.String("path", ov.Path),
+					slog.String("error", ovErr.Error()),
+				)
+				continue
+			}
+			bodySizeCfg.Overrides = append(bodySizeCfg.Overrides, bodysizeplugin.OverrideConfig{
+				Path:     ov.Path,
+				MaxBytes: ovBytes,
+			})
+		}
+		registry.Register(bodysizeplugin.New(bodySizeCfg, logger))
+	}
+
 	// Metrics — priority 30
 	registry.Register(metricsplugin.New(metricsplugin.Config{
 		Enabled:      cfg.Metrics.Enabled,
@@ -280,8 +312,41 @@ func buildProxyConfig(cfg *config.Config, registry *plugins.Registry) *ports.Pro
 			Enabled: cfg.Admin.Enabled,
 			Token:   cfg.Admin.Token,
 		},
-		Admin: adminCfg,
+		Admin:    adminCfg,
+		BodySize: buildBodySizePortsConfig(cfg),
 	}
+}
+
+// buildBodySizePortsConfig constructs a ports.BodySizeConfig from the app config,
+// parsing human-readable size strings into bytes. Unparseable overrides are skipped.
+func buildBodySizePortsConfig(cfg *config.Config) ports.BodySizeConfig {
+	if cfg.BodySize.Max == "" {
+		return ports.BodySizeConfig{}
+	}
+
+	maxBytes, err := config.ParseBodySize(cfg.BodySize.Max)
+	if err != nil {
+		// Already validated in config.Validate(). Defensive fallback: no limit.
+		return ports.BodySizeConfig{}
+	}
+
+	bodySizeCfg := ports.BodySizeConfig{
+		Enabled:  maxBytes > 0 || len(cfg.BodySize.Overrides) > 0,
+		MaxBytes: maxBytes,
+	}
+
+	for _, ov := range cfg.BodySize.Overrides {
+		ovBytes, ovErr := config.ParseBodySize(ov.Max)
+		if ovErr != nil {
+			continue
+		}
+		bodySizeCfg.Overrides = append(bodySizeCfg.Overrides, ports.BodySizeOverride{
+			Path:     ov.Path,
+			MaxBytes: ovBytes,
+		})
+	}
+
+	return bodySizeCfg
 }
 
 // buildLogger creates an slog.Logger from the log configuration.

--- a/internal/adapters/caddy/bodysize_handler.go
+++ b/internal/adapters/caddy/bodysize_handler.go
@@ -1,0 +1,145 @@
+// Package caddy implements the ProxyServer port using embedded Caddy.
+package caddy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	gocaddy "github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+func init() {
+	gocaddy.RegisterModule(BodySizeHandler{})
+}
+
+// BodySizeHandlerConfig is the JSON-serialisable configuration for the
+// BodySizeHandler Caddy module. It is embedded in the Caddy JSON config
+// under the "config" key of the "vibewarden_body_size" handler entry.
+type BodySizeHandlerConfig struct {
+	// MaxBytes is the global default maximum request body size in bytes.
+	// A value of 0 or less disables the global limit.
+	MaxBytes int64 `json:"max_bytes"`
+
+	// Overrides defines per-path limits that take precedence over MaxBytes.
+	Overrides []BodySizeOverrideHandlerConfig `json:"overrides,omitempty"`
+}
+
+// BodySizeOverrideHandlerConfig is the JSON-serialisable form of a single
+// per-path body size override.
+type BodySizeOverrideHandlerConfig struct {
+	// Path is the URL path prefix to match (e.g. "/api/upload").
+	Path string `json:"path"`
+
+	// MaxBytes is the maximum body size for this path in bytes.
+	// A value of 0 means no limit for this path.
+	MaxBytes int64 `json:"max_bytes"`
+}
+
+// BodySizeHandler is a Caddy HTTP middleware module that enforces request body
+// size limits with optional per-path overrides.
+//
+// It wraps net/http.MaxBytesReader to constrain how many bytes the downstream
+// handler may read from the request body. When the limit is exceeded,
+// net/http.MaxBytesReader causes the next handler to receive an error with
+// HTTP status 413 Payload Too Large.
+//
+// Per-path overrides are evaluated by longest-prefix match before the global
+// default is applied. Overrides with MaxBytes == 0 suppress the global limit
+// for that path (no limit).
+//
+// The module is registered under the name "vibewarden_body_size" and referenced
+// from the Caddy JSON configuration as:
+//
+//	{"handler": "vibewarden_body_size", ...}
+type BodySizeHandler struct {
+	// Config holds the body size configuration, populated by Caddy's JSON
+	// unmarshaller during the Provision lifecycle.
+	Config BodySizeHandlerConfig `json:"config"`
+}
+
+// CaddyModule returns the module metadata used to register it with Caddy.
+func (BodySizeHandler) CaddyModule() gocaddy.ModuleInfo {
+	return gocaddy.ModuleInfo{
+		ID:  "http.handlers.vibewarden_body_size",
+		New: func() gocaddy.Module { return new(BodySizeHandler) },
+	}
+}
+
+// Provision implements gocaddy.Provisioner. It is a no-op for this handler
+// because all configuration is applied at request time.
+func (h *BodySizeHandler) Provision(_ gocaddy.Context) error {
+	return nil
+}
+
+// ServeHTTP implements caddyhttp.MiddlewareHandler. It determines the
+// applicable body size limit for the request path, wraps the request body
+// with http.MaxBytesReader if a limit applies, and delegates to next.
+func (h *BodySizeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+	limit := h.resolveLimit(r.URL.Path)
+	if limit > 0 && r.Body != nil {
+		r.Body = http.MaxBytesReader(w, r.Body, limit)
+	}
+	return next.ServeHTTP(w, r)
+}
+
+// resolveLimit returns the effective body size limit in bytes for the given
+// request path. Per-path overrides are evaluated by longest prefix match.
+// A return value of 0 means no limit should be applied.
+func (h *BodySizeHandler) resolveLimit(path string) int64 {
+	// Find the best (longest) matching override.
+	var bestLen int
+	var bestOverride *BodySizeOverrideHandlerConfig
+
+	for i := range h.Config.Overrides {
+		ov := &h.Config.Overrides[i]
+		if strings.HasPrefix(path, ov.Path) && len(ov.Path) > bestLen {
+			bestLen = len(ov.Path)
+			bestOverride = ov
+		}
+	}
+
+	if bestOverride != nil {
+		// An override matched. Its MaxBytes value takes precedence —
+		// 0 means "no limit for this path", not "use the global default".
+		return bestOverride.MaxBytes
+	}
+
+	return h.Config.MaxBytes
+}
+
+// buildBodySizeHandlerJSON serialises a BodySizeHandlerConfig to the Caddy
+// handler JSON fragment used in BuildCaddyConfig.
+func buildBodySizeHandlerJSON(cfg ports.BodySizeConfig) (map[string]any, error) {
+	handlerCfg := BodySizeHandlerConfig{
+		MaxBytes: cfg.MaxBytes,
+	}
+
+	for _, ov := range cfg.Overrides {
+		handlerCfg.Overrides = append(handlerCfg.Overrides, BodySizeOverrideHandlerConfig{
+			Path:     ov.Path,
+			MaxBytes: ov.MaxBytes,
+		})
+	}
+
+	cfgBytes, err := json.Marshal(handlerCfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling body size handler config: %w", err)
+	}
+
+	return map[string]any{
+		"handler": "vibewarden_body_size",
+		"config":  json.RawMessage(cfgBytes),
+	}, nil
+}
+
+// Interface guards — ensure BodySizeHandler satisfies required Caddy interfaces
+// at compile time.
+var (
+	_ gocaddy.Provisioner         = (*BodySizeHandler)(nil)
+	_ caddyhttp.MiddlewareHandler = (*BodySizeHandler)(nil)
+)

--- a/internal/adapters/caddy/bodysize_handler_test.go
+++ b/internal/adapters/caddy/bodysize_handler_test.go
@@ -1,0 +1,400 @@
+package caddy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gocaddy "github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// TestBodySizeHandler_CaddyModule verifies the Caddy module metadata.
+func TestBodySizeHandler_CaddyModule(t *testing.T) {
+	info := BodySizeHandler{}.CaddyModule()
+
+	if info.ID != "http.handlers.vibewarden_body_size" {
+		t.Errorf("CaddyModule().ID = %q, want %q", info.ID, "http.handlers.vibewarden_body_size")
+	}
+	if info.New == nil {
+		t.Fatal("CaddyModule().New is nil")
+	}
+	mod := info.New()
+	if mod == nil {
+		t.Fatal("CaddyModule().New() returned nil")
+	}
+	if _, ok := mod.(*BodySizeHandler); !ok {
+		t.Errorf("CaddyModule().New() returned %T, want *BodySizeHandler", mod)
+	}
+}
+
+// TestBodySizeHandler_InterfaceGuards verifies the handler satisfies required Caddy interfaces.
+func TestBodySizeHandler_InterfaceGuards(t *testing.T) {
+	var _ gocaddy.Provisioner = (*BodySizeHandler)(nil)
+	var _ caddyhttp.MiddlewareHandler = (*BodySizeHandler)(nil)
+}
+
+// TestBodySizeHandler_Provision verifies that Provision is a no-op and returns no error.
+func TestBodySizeHandler_Provision(t *testing.T) {
+	h := &BodySizeHandler{
+		Config: BodySizeHandlerConfig{MaxBytes: 1048576},
+	}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Errorf("Provision() unexpected error: %v", err)
+	}
+}
+
+// TestBodySizeHandler_ResolveLimit tests the path-based limit resolution logic.
+func TestBodySizeHandler_ResolveLimit(t *testing.T) {
+	tests := []struct {
+		name      string
+		handler   BodySizeHandler
+		path      string
+		wantLimit int64
+	}{
+		{
+			name: "no overrides — returns global max",
+			handler: BodySizeHandler{
+				Config: BodySizeHandlerConfig{MaxBytes: 1048576},
+			},
+			path:      "/any/path",
+			wantLimit: 1048576,
+		},
+		{
+			name: "override matches — returns override max",
+			handler: BodySizeHandler{
+				Config: BodySizeHandlerConfig{
+					MaxBytes: 1048576,
+					Overrides: []BodySizeOverrideHandlerConfig{
+						{Path: "/api/upload", MaxBytes: 52428800},
+					},
+				},
+			},
+			path:      "/api/upload",
+			wantLimit: 52428800,
+		},
+		{
+			name: "override prefix matches sub-path",
+			handler: BodySizeHandler{
+				Config: BodySizeHandlerConfig{
+					MaxBytes: 1048576,
+					Overrides: []BodySizeOverrideHandlerConfig{
+						{Path: "/api/upload", MaxBytes: 52428800},
+					},
+				},
+			},
+			path:      "/api/upload/profile-picture",
+			wantLimit: 52428800,
+		},
+		{
+			name: "no override match — returns global max",
+			handler: BodySizeHandler{
+				Config: BodySizeHandlerConfig{
+					MaxBytes: 1048576,
+					Overrides: []BodySizeOverrideHandlerConfig{
+						{Path: "/api/upload", MaxBytes: 52428800},
+					},
+				},
+			},
+			path:      "/api/other",
+			wantLimit: 1048576,
+		},
+		{
+			name: "longest prefix match wins",
+			handler: BodySizeHandler{
+				Config: BodySizeHandlerConfig{
+					MaxBytes: 1048576,
+					Overrides: []BodySizeOverrideHandlerConfig{
+						{Path: "/api", MaxBytes: 5242880},
+						{Path: "/api/upload", MaxBytes: 52428800},
+					},
+				},
+			},
+			path:      "/api/upload",
+			wantLimit: 52428800,
+		},
+		{
+			name: "override with zero max means no limit for that path",
+			handler: BodySizeHandler{
+				Config: BodySizeHandlerConfig{
+					MaxBytes: 1048576,
+					Overrides: []BodySizeOverrideHandlerConfig{
+						{Path: "/api/stream", MaxBytes: 0},
+					},
+				},
+			},
+			path:      "/api/stream",
+			wantLimit: 0,
+		},
+		{
+			name: "zero global max and no overrides — no limit",
+			handler: BodySizeHandler{
+				Config: BodySizeHandlerConfig{MaxBytes: 0},
+			},
+			path:      "/anything",
+			wantLimit: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.handler.resolveLimit(tt.path)
+			if got != tt.wantLimit {
+				t.Errorf("resolveLimit(%q) = %d, want %d", tt.path, got, tt.wantLimit)
+			}
+		})
+	}
+}
+
+// TestBodySizeHandler_ServeHTTP_NoLimit verifies that when MaxBytes is 0 the
+// handler passes the request through unmodified and next is called.
+func TestBodySizeHandler_ServeHTTP_NoLimit(t *testing.T) {
+	nextCalled := false
+
+	h := &BodySizeHandler{
+		Config: BodySizeHandlerConfig{MaxBytes: 0},
+	}
+
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/upload", bytes.NewBufferString("hello"))
+	w := httptest.NewRecorder()
+
+	if err := h.ServeHTTP(w, req, next); err != nil {
+		t.Errorf("ServeHTTP() unexpected error: %v", err)
+	}
+	if !nextCalled {
+		t.Error("ServeHTTP() did not call next")
+	}
+}
+
+// TestBodySizeHandler_ServeHTTP_WithinLimit verifies that a request body within
+// the configured limit passes through successfully.
+func TestBodySizeHandler_ServeHTTP_WithinLimit(t *testing.T) {
+	nextCalled := false
+
+	h := &BodySizeHandler{
+		Config: BodySizeHandlerConfig{MaxBytes: 1024},
+	}
+
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		// Read the full body to trigger MaxBytesReader enforcement.
+		_, err := io.ReadAll(r.Body)
+		return err
+	})
+
+	body := bytes.Repeat([]byte("x"), 512) // 512 bytes — within the 1KB limit
+	req := httptest.NewRequest(http.MethodPost, "/upload", bytes.NewBuffer(body))
+	w := httptest.NewRecorder()
+
+	if err := h.ServeHTTP(w, req, next); err != nil {
+		t.Errorf("ServeHTTP() unexpected error: %v", err)
+	}
+	if !nextCalled {
+		t.Error("ServeHTTP() did not call next")
+	}
+}
+
+// TestBodySizeHandler_ServeHTTP_ExceedsLimit verifies that reading beyond the
+// limit returns an error (which net/http turns into a 413 response).
+func TestBodySizeHandler_ServeHTTP_ExceedsLimit(t *testing.T) {
+	h := &BodySizeHandler{
+		Config: BodySizeHandlerConfig{MaxBytes: 10},
+	}
+
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		// Read the full body to trigger MaxBytesReader enforcement.
+		_, err := io.ReadAll(r.Body)
+		return err
+	})
+
+	body := bytes.Repeat([]byte("x"), 100) // 100 bytes — exceeds 10-byte limit
+	req := httptest.NewRequest(http.MethodPost, "/upload", bytes.NewBuffer(body))
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err == nil {
+		t.Error("ServeHTTP() expected error when body exceeds limit, got nil")
+	}
+}
+
+// TestBodySizeHandler_ServeHTTP_NilBody verifies that a request with no body
+// passes through without error.
+func TestBodySizeHandler_ServeHTTP_NilBody(t *testing.T) {
+	nextCalled := false
+
+	h := &BodySizeHandler{
+		Config: BodySizeHandlerConfig{MaxBytes: 1024},
+	}
+
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/data", nil)
+	req.Body = nil
+	w := httptest.NewRecorder()
+
+	if err := h.ServeHTTP(w, req, next); err != nil {
+		t.Errorf("ServeHTTP() unexpected error: %v", err)
+	}
+	if !nextCalled {
+		t.Error("ServeHTTP() did not call next")
+	}
+}
+
+// TestBodySizeHandler_ServeHTTP_PerPathOverride verifies that the per-path
+// override is applied instead of the global limit.
+func TestBodySizeHandler_ServeHTTP_PerPathOverride(t *testing.T) {
+	h := &BodySizeHandler{
+		Config: BodySizeHandlerConfig{
+			MaxBytes: 10, // tight global limit
+			Overrides: []BodySizeOverrideHandlerConfig{
+				{Path: "/api/upload", MaxBytes: 1024 * 1024}, // generous override
+			},
+		},
+	}
+
+	nextCalled := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		_, err := io.ReadAll(r.Body)
+		return err
+	})
+
+	// 100 bytes — exceeds global limit (10) but within override limit (1MB)
+	body := bytes.Repeat([]byte("x"), 100)
+	req := httptest.NewRequest(http.MethodPost, "/api/upload", bytes.NewBuffer(body))
+	w := httptest.NewRecorder()
+
+	if err := h.ServeHTTP(w, req, next); err != nil {
+		t.Errorf("ServeHTTP() unexpected error on override path: %v", err)
+	}
+	if !nextCalled {
+		t.Error("ServeHTTP() did not call next on override path")
+	}
+}
+
+// TestBuildBodySizeHandlerJSON verifies the JSON serialisation of the handler config.
+func TestBuildBodySizeHandlerJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     ports.BodySizeConfig
+		wantErr bool
+		checks  func(t *testing.T, result map[string]any)
+	}{
+		{
+			name: "produces correct handler name",
+			cfg: ports.BodySizeConfig{
+				Enabled:  true,
+				MaxBytes: 1048576,
+			},
+			wantErr: false,
+			checks: func(t *testing.T, result map[string]any) {
+				t.Helper()
+				handler, ok := result["handler"]
+				if !ok {
+					t.Fatal("result missing 'handler' key")
+				}
+				if handler != "vibewarden_body_size" {
+					t.Errorf("handler = %q, want %q", handler, "vibewarden_body_size")
+				}
+			},
+		},
+		{
+			name: "config key is present and valid JSON",
+			cfg: ports.BodySizeConfig{
+				Enabled:  true,
+				MaxBytes: 1048576,
+			},
+			wantErr: false,
+			checks: func(t *testing.T, result map[string]any) {
+				t.Helper()
+				raw, ok := result["config"]
+				if !ok {
+					t.Fatal("result missing 'config' key")
+				}
+				rawBytes, err := json.Marshal(raw)
+				if err != nil {
+					t.Fatalf("config value is not JSON-serialisable: %v", err)
+				}
+				var parsed map[string]any
+				if err := json.Unmarshal(rawBytes, &parsed); err != nil {
+					t.Fatalf("config value is not valid JSON: %v", err)
+				}
+				maxBytes, ok := parsed["max_bytes"].(float64)
+				if !ok {
+					t.Fatalf("config.max_bytes is %T, want float64", parsed["max_bytes"])
+				}
+				if int64(maxBytes) != 1048576 {
+					t.Errorf("config.max_bytes = %v, want 1048576", maxBytes)
+				}
+			},
+		},
+		{
+			name: "overrides round-trip",
+			cfg: ports.BodySizeConfig{
+				Enabled:  true,
+				MaxBytes: 1048576,
+				Overrides: []ports.BodySizeOverride{
+					{Path: "/api/upload", MaxBytes: 52428800},
+					{Path: "/api/avatar", MaxBytes: 5242880},
+				},
+			},
+			wantErr: false,
+			checks: func(t *testing.T, result map[string]any) {
+				t.Helper()
+				rawBytes, _ := json.Marshal(result["config"])
+				var parsed map[string]any
+				_ = json.Unmarshal(rawBytes, &parsed)
+				overrides, ok := parsed["overrides"].([]any)
+				if !ok {
+					t.Fatal("config.overrides missing or wrong type")
+				}
+				if len(overrides) != 2 {
+					t.Errorf("len(overrides) = %d, want 2", len(overrides))
+				}
+			},
+		},
+		{
+			name: "no overrides omits field",
+			cfg: ports.BodySizeConfig{
+				Enabled:  true,
+				MaxBytes: 1048576,
+			},
+			wantErr: false,
+			checks: func(t *testing.T, result map[string]any) {
+				t.Helper()
+				rawBytes, _ := json.Marshal(result["config"])
+				var parsed map[string]any
+				_ = json.Unmarshal(rawBytes, &parsed)
+				if _, present := parsed["overrides"]; present {
+					t.Error("expected \"overrides\" to be omitted when empty")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := buildBodySizeHandlerJSON(tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildBodySizeHandlerJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.checks != nil {
+				tt.checks(t, result)
+			}
+		})
+	}
+}

--- a/internal/adapters/caddy/config.go
+++ b/internal/adapters/caddy/config.go
@@ -62,7 +62,7 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 	}
 
 	// Build route handlers (middleware chain + reverse proxy).
-	// Middleware order: StripUserHeaders → SecurityHeaders → AdminAuth → RateLimit → ReverseProxy
+	// Middleware order: StripUserHeaders → SecurityHeaders → AdminAuth → BodySize → RateLimit → ReverseProxy
 	//
 	// The header strip handler MUST be first so that spoofed X-User-* headers sent
 	// by clients are removed before any other handler (including auth) runs.
@@ -83,6 +83,16 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 		return nil, fmt.Errorf("building admin auth handler config: %w", err)
 	}
 	handlers = append(handlers, adminAuthHandler)
+
+	// Add body size handler if enabled. It must run before the reverse proxy
+	// so that oversized request bodies are rejected before any upstream I/O.
+	if cfg.BodySize.Enabled {
+		bsHandler, err := buildBodySizeHandlerJSON(cfg.BodySize)
+		if err != nil {
+			return nil, fmt.Errorf("building body size handler config: %w", err)
+		}
+		handlers = append(handlers, bsHandler)
+	}
 
 	// Add rate limit handler if enabled.
 	if cfg.RateLimit.Enabled {

--- a/internal/config/bodysize.go
+++ b/internal/config/bodysize.go
@@ -1,0 +1,65 @@
+// Package config provides configuration loading and validation for VibeWarden.
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParseBodySize parses a human-readable size string and returns the number of bytes.
+// Supported units (case-insensitive): B, KB, MB, GB, TB.
+// An empty string or "0" returns 0 (no limit).
+//
+// Examples:
+//
+//	ParseBodySize("1MB")   → 1048576, nil
+//	ParseBodySize("512KB") → 524288, nil
+//	ParseBodySize("50MB")  → 52428800, nil
+//	ParseBodySize("0")     → 0, nil
+//	ParseBodySize("")      → 0, nil
+func ParseBodySize(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "0" {
+		return 0, nil
+	}
+
+	// Find where the numeric part ends and the unit begins.
+	i := 0
+	for i < len(s) && (s[i] == '.' || (s[i] >= '0' && s[i] <= '9')) {
+		i++
+	}
+
+	numStr := strings.TrimSpace(s[:i])
+	unit := strings.TrimSpace(strings.ToUpper(s[i:]))
+
+	if numStr == "" {
+		return 0, fmt.Errorf("invalid body size %q: no numeric value", s)
+	}
+
+	n, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid body size %q: %w", s, err)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("invalid body size %q: value must be non-negative", s)
+	}
+
+	var multiplier float64
+	switch unit {
+	case "", "B":
+		multiplier = 1
+	case "KB":
+		multiplier = 1024
+	case "MB":
+		multiplier = 1024 * 1024
+	case "GB":
+		multiplier = 1024 * 1024 * 1024
+	case "TB":
+		multiplier = 1024 * 1024 * 1024 * 1024
+	default:
+		return 0, fmt.Errorf("invalid body size %q: unknown unit %q (supported: B, KB, MB, GB, TB)", s, unit)
+	}
+
+	return int64(n * multiplier), nil
+}

--- a/internal/config/bodysize_test.go
+++ b/internal/config/bodysize_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestParseBodySize(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int64
+		wantErr bool
+	}{
+		{
+			name:  "empty string returns zero (no limit)",
+			input: "",
+			want:  0,
+		},
+		{
+			name:  "zero string returns zero (no limit)",
+			input: "0",
+			want:  0,
+		},
+		{
+			name:  "bytes",
+			input: "100B",
+			want:  100,
+		},
+		{
+			name:  "bytes without unit",
+			input: "512",
+			want:  512,
+		},
+		{
+			name:  "kilobytes",
+			input: "1KB",
+			want:  1024,
+		},
+		{
+			name:  "kilobytes lowercase",
+			input: "1kb",
+			want:  1024,
+		},
+		{
+			name:  "512 kilobytes",
+			input: "512KB",
+			want:  524288,
+		},
+		{
+			name:  "1 megabyte",
+			input: "1MB",
+			want:  1048576,
+		},
+		{
+			name:  "50 megabytes",
+			input: "50MB",
+			want:  52428800,
+		},
+		{
+			name:  "1 gigabyte",
+			input: "1GB",
+			want:  1073741824,
+		},
+		{
+			name:  "1 terabyte",
+			input: "1TB",
+			want:  1099511627776,
+		},
+		{
+			name:  "whitespace trimmed",
+			input: " 10 MB ",
+			want:  10485760,
+		},
+		{
+			name:    "invalid unit",
+			input:   "10PB",
+			wantErr: true,
+		},
+		{
+			name:    "no numeric value",
+			input:   "MB",
+			wantErr: true,
+		},
+		{
+			name:    "negative value",
+			input:   "-1MB",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseBodySize(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseBodySize(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ParseBodySize(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,9 @@ type Config struct {
 	// Database configuration
 	Database DatabaseConfig `mapstructure:"database"`
 
+	// BodySize configures request body size limits.
+	BodySize BodySizeConfig `mapstructure:"body_size"`
+
 	// Overrides provides escape hatches for advanced users who need to supply
 	// hand-crafted config files instead of relying on VibeWarden's generation.
 	Overrides OverridesConfig `mapstructure:"overrides"`
@@ -352,6 +355,28 @@ type MetricsConfig struct {
 	PathPatterns []string `mapstructure:"path_patterns"`
 }
 
+// BodySizeConfig holds request body size limit settings.
+type BodySizeConfig struct {
+	// Max is the global default maximum request body size as a human-readable
+	// string (e.g. "1MB", "512KB"). Parsed at startup.
+	// An empty string or "0" means no limit.
+	Max string `mapstructure:"max"`
+
+	// Overrides defines per-path body size limits.
+	// Each entry can increase or decrease the global limit for a specific path.
+	Overrides []BodySizeOverrideConfig `mapstructure:"overrides"`
+}
+
+// BodySizeOverrideConfig defines a per-path body size limit.
+type BodySizeOverrideConfig struct {
+	// Path is the URL path prefix to match (e.g. "/api/upload").
+	Path string `mapstructure:"path"`
+
+	// Max is the maximum request body size for this path as a human-readable
+	// string (e.g. "50MB"). An empty string or "0" means no limit for this path.
+	Max string `mapstructure:"max"`
+}
+
 // OverridesConfig provides escape hatches for users who need to supply
 // hand-crafted configuration files instead of relying on VibeWarden's
 // auto-generation. All fields are optional.
@@ -441,6 +466,26 @@ func (c *Config) Validate() error {
 		errs = append(errs, "auth.ui.login_url is required when auth.ui.mode is \"custom\"")
 	}
 
+	// body_size.max validation.
+	if c.BodySize.Max != "" {
+		if _, err := ParseBodySize(c.BodySize.Max); err != nil {
+			errs = append(errs, fmt.Sprintf("body_size.max: %s", err.Error()))
+		}
+	}
+
+	// body_size.overrides validation.
+	for i, ov := range c.BodySize.Overrides {
+		prefix := fmt.Sprintf("body_size.overrides[%d]", i)
+		if ov.Path == "" {
+			errs = append(errs, fmt.Sprintf("%s.path is required", prefix))
+		}
+		if ov.Max != "" {
+			if _, err := ParseBodySize(ov.Max); err != nil {
+				errs = append(errs, fmt.Sprintf("%s.max: %s", prefix, err.Error()))
+			}
+		}
+	}
+
 	if len(errs) > 0 {
 		return fmt.Errorf("%s", strings.Join(errs, "; "))
 	}
@@ -509,6 +554,8 @@ func Load(configPath string) (*Config, error) {
 	v.SetDefault("security_headers.suppress_via_header", true)
 	v.SetDefault("metrics.enabled", true)
 	v.SetDefault("metrics.path_patterns", []string{})
+	v.SetDefault("body_size.max", "1MB")
+	v.SetDefault("body_size.overrides", []BodySizeOverrideConfig{})
 	v.SetDefault("database.url", "")
 	v.SetDefault("overrides.kratos_config", "")
 	v.SetDefault("overrides.compose_file", "")

--- a/internal/plugins/bodysize/config.go
+++ b/internal/plugins/bodysize/config.go
@@ -1,0 +1,34 @@
+// Package bodysize implements the VibeWarden request body size limiting plugin.
+//
+// It enforces a global maximum request body size and supports per-path overrides.
+// Requests that exceed the configured limit receive a 413 Payload Too Large response
+// before the body is forwarded to the upstream application.
+//
+// Body size limiting is implemented via Caddy's native request_body handler,
+// which wraps net/http.MaxBytesReader. The VibeWarden plugin contributes a custom
+// Caddy module (vibewarden_body_size) that handles per-path dispatch internally.
+package bodysize
+
+// Config holds all settings for the body size limiting plugin.
+// It maps to the body_size section of vibewarden.yaml.
+type Config struct {
+	// Enabled toggles the body size limiting plugin.
+	Enabled bool
+
+	// MaxBytes is the global default maximum request body size in bytes.
+	// A value of 0 disables the global limit.
+	MaxBytes int64
+
+	// Overrides defines per-path body size limits that take precedence over MaxBytes.
+	Overrides []OverrideConfig
+}
+
+// OverrideConfig defines a per-path body size limit.
+type OverrideConfig struct {
+	// Path is the URL path prefix to match (e.g. "/api/upload").
+	Path string
+
+	// MaxBytes is the maximum request body size for this path in bytes.
+	// A value of 0 means no limit for this path.
+	MaxBytes int64
+}

--- a/internal/plugins/bodysize/meta.go
+++ b/internal/plugins/bodysize/meta.go
@@ -1,0 +1,25 @@
+package bodysize
+
+// Description returns a short description of the body-size plugin.
+func (p *Plugin) Description() string {
+	return "Request body size limiting with global default and per-path overrides"
+}
+
+// ConfigSchema returns the configuration field descriptions for the body-size plugin.
+func (p *Plugin) ConfigSchema() map[string]string {
+	return map[string]string{
+		"enabled":          "Enable body size limiting (default: true)",
+		"max":              "Global default maximum body size (e.g. \"1MB\", \"512KB\"; default: \"1MB\")",
+		"overrides[].path": "URL path prefix for the override (e.g. \"/api/upload\")",
+		"overrides[].max":  "Maximum body size for the path (e.g. \"50MB\")",
+	}
+}
+
+// Example returns an example YAML configuration for the body-size plugin.
+func (p *Plugin) Example() string {
+	return `  body_size:
+    max: "1MB"
+    overrides:
+      - path: /api/upload
+        max: "50MB"`
+}

--- a/internal/plugins/bodysize/plugin.go
+++ b/internal/plugins/bodysize/plugin.go
@@ -1,0 +1,156 @@
+package bodysize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// Plugin is the request body size limiting plugin for VibeWarden.
+// It implements ports.Plugin and ports.CaddyContributor.
+//
+// ContributeCaddyHandlers returns the vibewarden_body_size Caddy handler fragment
+// so the middleware is injected into the catch-all handler chain and enforces
+// body size limits with optional per-path overrides.
+type Plugin struct {
+	cfg    Config
+	logger *slog.Logger
+}
+
+// New creates a new body size limiting Plugin.
+func New(cfg Config, logger *slog.Logger) *Plugin {
+	return &Plugin{
+		cfg:    cfg,
+		logger: logger,
+	}
+}
+
+// Name returns the canonical plugin identifier "body-size".
+// This must match the key used under plugins: in vibewarden.yaml.
+func (p *Plugin) Name() string { return "body-size" }
+
+// Priority returns the plugin's initialisation priority.
+// Body size limiting is assigned priority 45 so it runs after security headers (20)
+// and admin auth (30) but before rate limiting (50) and application-layer middleware.
+func (p *Plugin) Priority() int { return 45 }
+
+// Init validates the plugin configuration. It is a no-op when the plugin is disabled.
+func (p *Plugin) Init(_ context.Context) error {
+	if !p.cfg.Enabled {
+		return nil
+	}
+
+	overrideCount := len(p.cfg.Overrides)
+	p.logger.Info("body-size plugin initialised",
+		slog.Int64("max_bytes", p.cfg.MaxBytes),
+		slog.Int("override_count", overrideCount),
+	)
+	return nil
+}
+
+// Start is a no-op for the body-size plugin. No background work is needed.
+func (p *Plugin) Start(_ context.Context) error { return nil }
+
+// Stop is a no-op for the body-size plugin. No resources need releasing.
+func (p *Plugin) Stop(_ context.Context) error { return nil }
+
+// Health returns the current health status of the body-size plugin.
+func (p *Plugin) Health() ports.HealthStatus {
+	if !p.cfg.Enabled {
+		return ports.HealthStatus{
+			Healthy: true,
+			Message: "body-size limiting disabled",
+		}
+	}
+	return ports.HealthStatus{
+		Healthy: true,
+		Message: fmt.Sprintf(
+			"body-size limiting active (global max: %d bytes, %d path overrides)",
+			p.cfg.MaxBytes, len(p.cfg.Overrides),
+		),
+	}
+}
+
+// ContributeCaddyRoutes returns nil.
+// The body-size plugin does not add named routes; it contributes a catch-all
+// handler via ContributeCaddyHandlers.
+func (p *Plugin) ContributeCaddyRoutes() []ports.CaddyRoute { return nil }
+
+// ContributeCaddyHandlers returns the Caddy vibewarden_body_size handler
+// fragment that enforces body size limits on every request. Returns an empty
+// slice when the plugin is disabled.
+//
+// The returned handler has Priority 45 so it is placed after security headers (20)
+// but before rate limiting (50) in the catch-all handler chain.
+func (p *Plugin) ContributeCaddyHandlers() []ports.CaddyHandler {
+	if !p.cfg.Enabled {
+		return nil
+	}
+	handler, err := buildBodySizeHandlerJSON(p.cfg)
+	if err != nil {
+		// buildBodySizeHandlerJSON only fails on JSON marshal of a known struct;
+		// this cannot happen in practice. Log and return nothing to avoid panicking
+		// in library code.
+		p.logger.Error("body-size plugin: building handler JSON", slog.String("err", err.Error()))
+		return nil
+	}
+	return []ports.CaddyHandler{
+		{
+			Handler:  handler,
+			Priority: 45,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Internal builders — pure functions, no side effects.
+// ---------------------------------------------------------------------------
+
+// bodySizeHandlerConfig is the JSON-serialisable configuration sent to the
+// vibewarden_body_size Caddy module.
+type bodySizeHandlerConfig struct {
+	MaxBytes  int64                      `json:"max_bytes"`
+	Overrides []bodySizeOverrideJSONItem `json:"overrides,omitempty"`
+}
+
+// bodySizeOverrideJSONItem is the JSON shape of a single per-path override.
+type bodySizeOverrideJSONItem struct {
+	Path     string `json:"path"`
+	MaxBytes int64  `json:"max_bytes"`
+}
+
+// buildBodySizeHandlerJSON serialises cfg into the Caddy handler JSON map
+// expected by the vibewarden_body_size module.
+func buildBodySizeHandlerJSON(cfg Config) (map[string]any, error) {
+	hcfg := bodySizeHandlerConfig{
+		MaxBytes: cfg.MaxBytes,
+	}
+	for _, ov := range cfg.Overrides {
+		hcfg.Overrides = append(hcfg.Overrides, bodySizeOverrideJSONItem{
+			Path:     ov.Path,
+			MaxBytes: ov.MaxBytes,
+		})
+	}
+
+	cfgBytes, err := json.Marshal(hcfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling body size handler config: %w", err)
+	}
+
+	return map[string]any{
+		"handler": "vibewarden_body_size",
+		"config":  json.RawMessage(cfgBytes),
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Interface guards.
+// ---------------------------------------------------------------------------
+
+var (
+	_ ports.Plugin           = (*Plugin)(nil)
+	_ ports.CaddyContributor = (*Plugin)(nil)
+)

--- a/internal/plugins/bodysize/plugin_test.go
+++ b/internal/plugins/bodysize/plugin_test.go
@@ -1,0 +1,335 @@
+package bodysize_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/plugins/bodysize"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// discardLogger returns an slog.Logger that discards all output.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(noopWriter{}, nil))
+}
+
+type noopWriter struct{}
+
+func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// defaultConfig returns a fully-enabled Config for tests.
+func defaultConfig() bodysize.Config {
+	return bodysize.Config{
+		Enabled:  true,
+		MaxBytes: 1048576, // 1MB
+	}
+}
+
+func newPlugin(cfg bodysize.Config) *bodysize.Plugin {
+	return bodysize.New(cfg, discardLogger())
+}
+
+// ---------------------------------------------------------------------------
+// Name / Priority
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Name(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if got := p.Name(); got != "body-size" {
+		t.Errorf("Name() = %q, want %q", got, "body-size")
+	}
+}
+
+func TestPlugin_Priority(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if got := p.Priority(); got != 45 {
+		t.Errorf("Priority() = %d, want 45", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Init(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     bodysize.Config
+		wantErr bool
+	}{
+		{
+			name:    "disabled — no-op",
+			cfg:     bodysize.Config{Enabled: false},
+			wantErr: false,
+		},
+		{
+			name:    "enabled with global limit only",
+			cfg:     defaultConfig(),
+			wantErr: false,
+		},
+		{
+			name: "enabled with overrides",
+			cfg: bodysize.Config{
+				Enabled:  true,
+				MaxBytes: 1048576,
+				Overrides: []bodysize.OverrideConfig{
+					{Path: "/api/upload", MaxBytes: 52428800},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "enabled with zero max bytes (no global limit)",
+			cfg: bodysize.Config{
+				Enabled:  true,
+				MaxBytes: 0,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			err := p.Init(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Start — no-op
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Start_IsNoop(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if err := p.Start(context.Background()); err != nil {
+		t.Errorf("Start() unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Stop — no-op
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Stop_IsNoop(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  bodysize.Config
+	}{
+		{"disabled", bodysize.Config{Enabled: false}},
+		{"enabled", defaultConfig()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			if err := p.Stop(context.Background()); err != nil {
+				t.Errorf("Stop() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Health(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            bodysize.Config
+		wantHealthy    bool
+		wantMsgContain string
+	}{
+		{
+			name:           "disabled",
+			cfg:            bodysize.Config{Enabled: false},
+			wantHealthy:    true,
+			wantMsgContain: "disabled",
+		},
+		{
+			name:           "enabled",
+			cfg:            defaultConfig(),
+			wantHealthy:    true,
+			wantMsgContain: "active",
+		},
+		{
+			name: "enabled with overrides",
+			cfg: bodysize.Config{
+				Enabled:  true,
+				MaxBytes: 1048576,
+				Overrides: []bodysize.OverrideConfig{
+					{Path: "/api/upload", MaxBytes: 52428800},
+					{Path: "/api/avatar", MaxBytes: 5242880},
+				},
+			},
+			wantHealthy:    true,
+			wantMsgContain: "2 path overrides",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			h := p.Health()
+			if h.Healthy != tt.wantHealthy {
+				t.Errorf("Health().Healthy = %v, want %v", h.Healthy, tt.wantHealthy)
+			}
+			if !strings.Contains(h.Message, tt.wantMsgContain) {
+				t.Errorf("Health().Message = %q, want it to contain %q", h.Message, tt.wantMsgContain)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyRoutes
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyRoutes_AlwaysEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  bodysize.Config
+	}{
+		{"disabled", bodysize.Config{Enabled: false}},
+		{"enabled", defaultConfig()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			if routes := p.ContributeCaddyRoutes(); len(routes) != 0 {
+				t.Errorf("ContributeCaddyRoutes() = %v, want empty", routes)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyHandlers
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyHandlers_DisabledReturnsNil(t *testing.T) {
+	p := newPlugin(bodysize.Config{Enabled: false})
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 0 {
+		t.Errorf("ContributeCaddyHandlers() = %v, want empty when disabled", handlers)
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_EnabledReturnsOne(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 1 {
+		t.Fatalf("ContributeCaddyHandlers() len = %d, want 1", len(handlers))
+	}
+	if handlers[0].Priority != 45 {
+		t.Errorf("handler Priority = %d, want 45", handlers[0].Priority)
+	}
+	if handlers[0].Handler["handler"] != "vibewarden_body_size" {
+		t.Errorf("handler[\"handler\"] = %v, want %q", handlers[0].Handler["handler"], "vibewarden_body_size")
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_HandlerHasConfig(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) == 0 {
+		t.Fatal("expected at least one handler")
+	}
+	if _, ok := handlers[0].Handler["config"]; !ok {
+		t.Error("expected \"config\" key in handler map")
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_ConfigDeserialises(t *testing.T) {
+	cfg := bodysize.Config{
+		Enabled:  true,
+		MaxBytes: 1048576,
+		Overrides: []bodysize.OverrideConfig{
+			{Path: "/api/upload", MaxBytes: 52428800},
+		},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) == 0 {
+		t.Fatal("expected at least one handler")
+	}
+
+	rawConfig := handlers[0].Handler["config"]
+	b, err := json.Marshal(rawConfig)
+	if err != nil {
+		t.Fatalf("json.Marshal(config) error: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(config) error: %v", err)
+	}
+
+	// Verify max_bytes round-trips.
+	maxBytes, ok := decoded["max_bytes"].(float64)
+	if !ok {
+		t.Fatalf("decoded config max_bytes is %T, want float64", decoded["max_bytes"])
+	}
+	if int64(maxBytes) != 1048576 {
+		t.Errorf("decoded config max_bytes = %v, want 1048576", maxBytes)
+	}
+
+	// Verify overrides round-trip.
+	overrides, ok := decoded["overrides"].([]any)
+	if !ok {
+		t.Fatalf("decoded config overrides is %T, want []any", decoded["overrides"])
+	}
+	if len(overrides) != 1 {
+		t.Errorf("decoded config overrides len = %d, want 1", len(overrides))
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_NoOverridesOmitsField(t *testing.T) {
+	p := newPlugin(bodysize.Config{Enabled: true, MaxBytes: 1048576})
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) == 0 {
+		t.Fatal("expected at least one handler")
+	}
+
+	rawConfig := handlers[0].Handler["config"]
+	b, err := json.Marshal(rawConfig)
+	if err != nil {
+		t.Fatalf("json.Marshal(config) error: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(config) error: %v", err)
+	}
+
+	// When no overrides are set, the "overrides" key should be absent (omitempty).
+	if _, present := decoded["overrides"]; present {
+		t.Error("expected \"overrides\" to be omitted when empty, but it was present")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Interface compliance
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ImplementsPortsPlugin(t *testing.T) {
+	var _ ports.Plugin = (*bodysize.Plugin)(nil)
+}
+
+func TestPlugin_ImplementsCaddyContributor(t *testing.T) {
+	var _ ports.CaddyContributor = (*bodysize.Plugin)(nil)
+}
+
+func TestPlugin_ImplementsPluginMeta(t *testing.T) {
+	var _ ports.PluginMeta = (*bodysize.Plugin)(nil)
+}

--- a/internal/plugins/catalog.go
+++ b/internal/plugins/catalog.go
@@ -59,6 +59,20 @@ var Catalog = []PluginDescriptor{
     content_security_policy: "default-src 'self'"`,
 	},
 	{
+		Name:        "body-size",
+		Description: "Request body size limiting with global default and per-path overrides",
+		ConfigSchema: map[string]string{
+			"max":              "Global default maximum body size (e.g. \"1MB\", \"512KB\"; default: \"1MB\")",
+			"overrides[].path": "URL path prefix for the override (e.g. \"/api/upload\")",
+			"overrides[].max":  "Maximum body size for the path (e.g. \"50MB\")",
+		},
+		Example: `  body_size:
+    max: "1MB"
+    overrides:
+      - path: /api/upload
+        max: "50MB"`,
+	},
+	{
 		Name:        "rate-limiting",
 		Description: "Per-IP and per-user token-bucket rate limiting on every proxied request",
 		ConfigSchema: map[string]string{

--- a/internal/ports/proxy.go
+++ b/internal/ports/proxy.go
@@ -53,6 +53,33 @@ type ProxyConfig struct {
 	// Admin configuration — controls the admin HTTP API server that serves
 	// /_vibewarden/admin/* routes via an internal reverse proxy.
 	Admin AdminProxyConfig
+
+	// BodySize configuration — controls request body size limiting.
+	BodySize BodySizeConfig
+}
+
+// BodySizeConfig holds configuration for the request body size limiting middleware.
+type BodySizeConfig struct {
+	// Enabled toggles body size limiting.
+	Enabled bool
+
+	// MaxBytes is the global default maximum request body size in bytes.
+	// Requests with a larger body receive 413 Payload Too Large.
+	// A value of 0 means no limit.
+	MaxBytes int64
+
+	// Overrides defines per-path body size limits that take precedence over MaxBytes.
+	Overrides []BodySizeOverride
+}
+
+// BodySizeOverride defines a path-specific body size limit.
+type BodySizeOverride struct {
+	// Path is the URL path prefix to match (e.g. "/api/upload").
+	Path string
+
+	// MaxBytes is the maximum request body size for this path in bytes.
+	// A value of 0 means no limit for this path.
+	MaxBytes int64
 }
 
 // AdminProxyConfig holds configuration for exposing the admin API through

--- a/vibewarden.example.yaml
+++ b/vibewarden.example.yaml
@@ -122,6 +122,30 @@ auth:
   # Defaults to /self-service/login/browser (Kratos browser login flow).
   login_url: ""
 
+# Request body size limiting
+# VibeWarden can reject oversized request bodies before they reach the upstream.
+# This protects against payload-based denial-of-service attacks and enforces
+# upload limits without any application-level changes.
+#
+# Requests with a body larger than the configured limit receive:
+#   HTTP 413 Payload Too Large
+body_size:
+  # Global default maximum request body size.
+  # Supported units: B, KB, MB, GB, TB (case-insensitive).
+  # Set to "0" or empty to disable the global limit.
+  max: "1MB"
+
+  # Per-path overrides — takes precedence over the global max.
+  # Useful for upload endpoints that need to accept larger payloads.
+  # A path override with max "0" or empty means no limit for that path.
+  # Example:
+  #   overrides:
+  #     - path: /api/upload
+  #       max: "50MB"
+  #     - path: /api/avatar
+  #       max: "5MB"
+  overrides: []
+
 # Rate limiting
 # VibeWarden enforces two independent token-bucket rate limits:
 #   per_ip   — applied to every request, keyed by client IP address.


### PR DESCRIPTION
Closes #217

## Summary

- Added `body_size` config section to `vibewarden.yaml` with `max` (global default) and `overrides` (per-path list)
- Human-readable size strings (e.g. `1MB`, `50MB`, `512KB`) parsed by `config.ParseBodySize` in `internal/config/bodysize.go`
- Config validation in `Config.Validate()` rejects invalid size strings and overrides with missing paths
- New `BodySizeConfig` / `BodySizeOverride` types added to `internal/ports/proxy.go`
- Custom Caddy module `vibewarden_body_size` registered in `internal/adapters/caddy/bodysize_handler.go`; enforces limits via `http.MaxBytesReader` with longest-prefix match for overrides; returns 413 Payload Too Large when exceeded
- New plugin at `internal/plugins/bodysize/` implementing `ports.Plugin`, `ports.CaddyContributor`, and `ports.PluginMeta`; priority 45 (after security headers, before rate limiting)
- Wired into `cmd/vibewarden/serve.go` (`registerPlugins` + `buildProxyConfig`)
- Catalog entry added to `internal/plugins/catalog.go`
- `vibewarden.example.yaml` updated with full documentation for the `body_size` section
- Default global limit: `1MB`; per-path override with `max: "0"` suppresses the global limit for that path

## Test plan

- `internal/config/bodysize_test.go` — 14 table-driven cases for `ParseBodySize` (units, edge cases, errors)
- `internal/adapters/caddy/bodysize_handler_test.go` — CaddyModule metadata, Provision, resolveLimit (7 cases), ServeHTTP (no limit, within limit, exceeds limit, nil body, per-path override), `buildBodySizeHandlerJSON` (4 cases)
- `internal/plugins/bodysize/plugin_test.go` — Name, Priority, Init, Start, Stop, Health, ContributeCaddyRoutes, ContributeCaddyHandlers (disabled, enabled, config deserialise, omitempty overrides), interface guards
- `make check` passes (format, vet, build, race tests, demo-app)
