### PR TITLE
feat(#218): IP filter plugin with allowlist/blocklist support

### DIFF
--- a/cmd/vibewarden/serve.go
+++ b/cmd/vibewarden/serve.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vibewarden/vibewarden/internal/plugins"
 	authplugin "github.com/vibewarden/vibewarden/internal/plugins/auth"
 	bodysizeplugin "github.com/vibewarden/vibewarden/internal/plugins/bodysize"
+	ipfilterplugin "github.com/vibewarden/vibewarden/internal/plugins/ipfilter"
 	metricsplugin "github.com/vibewarden/vibewarden/internal/plugins/metrics"
 	ratelimitplugin "github.com/vibewarden/vibewarden/internal/plugins/ratelimit"
 	sechdrs "github.com/vibewarden/vibewarden/internal/plugins/securityheaders"
@@ -131,6 +132,14 @@ func registerPlugins(
 	eventLogger ports.EventLogger,
 	logger *slog.Logger,
 ) {
+	// IP filter — priority 15 (must run before all other middleware)
+	registry.Register(ipfilterplugin.New(ipfilterplugin.Config{
+		Enabled:           cfg.IPFilter.Enabled,
+		Mode:              ipfilterplugin.FilterMode(cfg.IPFilter.Mode),
+		Addresses:         cfg.IPFilter.Addresses,
+		TrustProxyHeaders: cfg.IPFilter.TrustProxyHeaders,
+	}, logger))
+
 	// TLS — priority 10
 	registry.Register(tlsplugin.New(ports.TLSConfig{
 		Enabled:     cfg.TLS.Enabled,
@@ -314,6 +323,12 @@ func buildProxyConfig(cfg *config.Config, registry *plugins.Registry) *ports.Pro
 		},
 		Admin:    adminCfg,
 		BodySize: buildBodySizePortsConfig(cfg),
+		IPFilter: ports.IPFilterConfig{
+			Enabled:           cfg.IPFilter.Enabled,
+			Mode:              cfg.IPFilter.Mode,
+			Addresses:         cfg.IPFilter.Addresses,
+			TrustProxyHeaders: cfg.IPFilter.TrustProxyHeaders,
+		},
 	}
 }
 

--- a/internal/adapters/caddy/ipfilter_handler.go
+++ b/internal/adapters/caddy/ipfilter_handler.go
@@ -1,0 +1,171 @@
+// Package caddy implements the ProxyServer port using embedded Caddy.
+package caddy
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+
+	gocaddy "github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+
+	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/middleware"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+func init() {
+	gocaddy.RegisterModule(IPFilterHandler{})
+}
+
+// IPFilterHandlerConfig is the JSON-serialisable configuration for the
+// IPFilterHandler Caddy module. It is embedded in the Caddy JSON config
+// under the "config" key of the "vibewarden_ip_filter" handler entry.
+type IPFilterHandlerConfig struct {
+	// Mode is the filter mode: "allowlist" or "blocklist".
+	Mode string `json:"mode"`
+
+	// Addresses is the list of IP addresses or CIDR ranges to match against.
+	Addresses []string `json:"addresses"`
+
+	// TrustProxyHeaders enables reading X-Forwarded-For for the real client IP.
+	TrustProxyHeaders bool `json:"trust_proxy_headers"`
+}
+
+// IPFilterHandler is a Caddy HTTP middleware module that enforces IP-based
+// access control. It supports two modes:
+//
+//   - allowlist: only requests from addresses in Addresses are permitted.
+//   - blocklist: requests from addresses in Addresses are blocked.
+//
+// Blocked requests receive 403 Forbidden. A structured ip_filter.blocked event
+// is emitted for every blocked request.
+//
+// The module is registered under the name "vibewarden_ip_filter" and referenced
+// from the Caddy JSON configuration as:
+//
+//	{"handler": "vibewarden_ip_filter", ...}
+type IPFilterHandler struct {
+	// Config holds the handler configuration populated by Caddy's JSON unmarshaller.
+	Config IPFilterHandlerConfig `json:"config"`
+
+	// nets and ips hold the parsed address entries. Built during Provision.
+	nets []*net.IPNet
+	ips  []net.IP
+
+	// logger is used to emit error messages when event logging fails.
+	logger *slog.Logger
+
+	// eventLogger emits structured events for blocked requests.
+	eventLogger ports.EventLogger
+}
+
+// CaddyModule returns the module metadata used to register it with Caddy.
+func (IPFilterHandler) CaddyModule() gocaddy.ModuleInfo {
+	return gocaddy.ModuleInfo{
+		ID:  "http.handlers.vibewarden_ip_filter",
+		New: func() gocaddy.Module { return new(IPFilterHandler) },
+	}
+}
+
+// Provision implements gocaddy.Provisioner. It parses all configured address
+// strings into net.IP and *net.IPNet values for efficient per-request matching.
+func (h *IPFilterHandler) Provision(_ gocaddy.Context) error {
+	h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	h.eventLogger = logadapter.NewSlogEventLogger(os.Stdout)
+
+	h.nets = h.nets[:0]
+	h.ips = h.ips[:0]
+
+	for _, addr := range h.Config.Addresses {
+		if _, ipNet, err := net.ParseCIDR(addr); err == nil {
+			h.nets = append(h.nets, ipNet)
+			continue
+		}
+		if ip := net.ParseIP(addr); ip != nil {
+			h.ips = append(h.ips, ip)
+			continue
+		}
+		return fmt.Errorf("ip_filter: %q is not a valid IP address or CIDR", addr)
+	}
+
+	return nil
+}
+
+// ServeHTTP implements caddyhttp.MiddlewareHandler.
+// It extracts the client IP, evaluates the filter rule, and either blocks the
+// request with 403 or delegates to the next handler.
+func (h *IPFilterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+	clientIP := middleware.ExtractClientIP(r, h.Config.TrustProxyHeaders)
+
+	ip := net.ParseIP(clientIP)
+	matched := h.matchesAny(ip)
+
+	blocked := h.isBlocked(matched)
+	if blocked {
+		h.emitBlockedEvent(r.Context(), clientIP, r.Method, r.URL.Path)
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return nil
+	}
+
+	return next.ServeHTTP(w, r)
+}
+
+// matchesAny returns true when ip matches any configured address or CIDR.
+// A nil ip never matches.
+func (h *IPFilterHandler) matchesAny(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	for _, known := range h.ips {
+		if known.Equal(ip) {
+			return true
+		}
+	}
+	for _, cidr := range h.nets {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// isBlocked evaluates whether a request should be blocked given the match result.
+// In allowlist mode a non-matching IP is blocked.
+// In blocklist mode a matching IP is blocked.
+func (h *IPFilterHandler) isBlocked(matched bool) bool {
+	switch h.Config.Mode {
+	case "allowlist":
+		return !matched
+	default: // "blocklist" and any unrecognised value
+		return matched
+	}
+}
+
+// emitBlockedEvent emits a structured ip_filter.blocked event. Errors are
+// logged but do not affect the HTTP response.
+func (h *IPFilterHandler) emitBlockedEvent(ctx context.Context, clientIP, method, path string) {
+	if h.eventLogger == nil {
+		return
+	}
+	ev := events.NewIPFilterBlocked(events.IPFilterBlockedParams{
+		ClientIP: clientIP,
+		Mode:     h.Config.Mode,
+		Method:   method,
+		Path:     path,
+	})
+	if err := h.eventLogger.Log(ctx, ev); err != nil {
+		h.logger.Error("ip-filter: failed to emit blocked event", slog.String("error", err.Error()))
+	}
+}
+
+// Interface guards — ensure IPFilterHandler satisfies the required Caddy
+// interfaces at compile time.
+var (
+	_ gocaddy.Provisioner         = (*IPFilterHandler)(nil)
+	_ caddyhttp.MiddlewareHandler = (*IPFilterHandler)(nil)
+)

--- a/internal/adapters/caddy/ipfilter_handler_test.go
+++ b/internal/adapters/caddy/ipfilter_handler_test.go
@@ -1,0 +1,335 @@
+package caddy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gocaddy "github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+// TestIPFilterHandler_CaddyModule verifies the Caddy module metadata.
+func TestIPFilterHandler_CaddyModule(t *testing.T) {
+	info := IPFilterHandler{}.CaddyModule()
+
+	if info.ID != "http.handlers.vibewarden_ip_filter" {
+		t.Errorf("CaddyModule().ID = %q, want %q", info.ID, "http.handlers.vibewarden_ip_filter")
+	}
+	if info.New == nil {
+		t.Fatal("CaddyModule().New is nil")
+	}
+	mod := info.New()
+	if mod == nil {
+		t.Fatal("CaddyModule().New() returned nil")
+	}
+	if _, ok := mod.(*IPFilterHandler); !ok {
+		t.Errorf("CaddyModule().New() returned %T, want *IPFilterHandler", mod)
+	}
+}
+
+// TestIPFilterHandler_InterfaceGuards verifies the handler satisfies required Caddy interfaces.
+func TestIPFilterHandler_InterfaceGuards(t *testing.T) {
+	var _ gocaddy.Provisioner = (*IPFilterHandler)(nil)
+	var _ caddyhttp.MiddlewareHandler = (*IPFilterHandler)(nil)
+}
+
+// TestIPFilterHandler_Provision_ValidAddresses verifies that Provision succeeds
+// when all configured addresses are valid IPs or CIDRs.
+func TestIPFilterHandler_Provision_ValidAddresses(t *testing.T) {
+	tests := []struct {
+		name      string
+		addresses []string
+	}{
+		{"no addresses", []string{}},
+		{"plain IPv4", []string{"192.168.1.1"}},
+		{"IPv4 CIDR", []string{"10.0.0.0/8"}},
+		{"plain IPv6", []string{"2001:db8::1"}},
+		{"IPv6 CIDR", []string{"2001:db8::/32"}},
+		{"mixed", []string{"10.0.0.0/8", "192.168.1.100", "2001:db8::/32"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &IPFilterHandler{
+				Config: IPFilterHandlerConfig{
+					Mode:      "blocklist",
+					Addresses: tt.addresses,
+				},
+			}
+			if err := h.Provision(gocaddy.Context{}); err != nil {
+				t.Errorf("Provision() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestIPFilterHandler_Provision_InvalidAddress verifies that Provision returns
+// an error when a configured address cannot be parsed.
+func TestIPFilterHandler_Provision_InvalidAddress(t *testing.T) {
+	h := &IPFilterHandler{
+		Config: IPFilterHandlerConfig{
+			Mode:      "blocklist",
+			Addresses: []string{"not-an-ip"},
+		},
+	}
+	if err := h.Provision(gocaddy.Context{}); err == nil {
+		t.Error("Provision() expected error for invalid address, got nil")
+	}
+}
+
+// TestIPFilterHandler_ServeHTTP_Blocklist tests blocklist mode behaviour.
+func TestIPFilterHandler_ServeHTTP_Blocklist(t *testing.T) {
+	tests := []struct {
+		name           string
+		addresses      []string
+		remoteAddr     string
+		wantNextCalled bool
+		wantStatus     int
+	}{
+		{
+			name:           "blocked IP in list",
+			addresses:      []string{"192.168.1.100"},
+			remoteAddr:     "192.168.1.100:54321",
+			wantNextCalled: false,
+			wantStatus:     http.StatusForbidden,
+		},
+		{
+			name:           "blocked IP in CIDR",
+			addresses:      []string{"10.0.0.0/8"},
+			remoteAddr:     "10.1.2.3:54321",
+			wantNextCalled: false,
+			wantStatus:     http.StatusForbidden,
+		},
+		{
+			name:           "allowed IP not in list",
+			addresses:      []string{"192.168.1.100"},
+			remoteAddr:     "203.0.113.5:54321",
+			wantNextCalled: true,
+			wantStatus:     http.StatusOK,
+		},
+		{
+			name:           "allowed IP not in CIDR",
+			addresses:      []string{"10.0.0.0/8"},
+			remoteAddr:     "203.0.113.5:54321",
+			wantNextCalled: true,
+			wantStatus:     http.StatusOK,
+		},
+		{
+			name:           "empty address list — all allowed",
+			addresses:      []string{},
+			remoteAddr:     "192.168.1.100:54321",
+			wantNextCalled: true,
+			wantStatus:     http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &IPFilterHandler{
+				Config: IPFilterHandlerConfig{
+					Mode:      "blocklist",
+					Addresses: tt.addresses,
+				},
+			}
+			if err := h.Provision(gocaddy.Context{}); err != nil {
+				t.Fatalf("Provision() error: %v", err)
+			}
+
+			nextCalled := false
+			next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+				return nil
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			w := httptest.NewRecorder()
+
+			if err := h.ServeHTTP(w, req, next); err != nil {
+				t.Errorf("ServeHTTP() unexpected error: %v", err)
+			}
+
+			if nextCalled != tt.wantNextCalled {
+				t.Errorf("nextCalled = %v, want %v", nextCalled, tt.wantNextCalled)
+			}
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+// TestIPFilterHandler_ServeHTTP_Allowlist tests allowlist mode behaviour.
+func TestIPFilterHandler_ServeHTTP_Allowlist(t *testing.T) {
+	tests := []struct {
+		name           string
+		addresses      []string
+		remoteAddr     string
+		wantNextCalled bool
+		wantStatus     int
+	}{
+		{
+			name:           "allowed IP in list",
+			addresses:      []string{"203.0.113.5"},
+			remoteAddr:     "203.0.113.5:54321",
+			wantNextCalled: true,
+			wantStatus:     http.StatusOK,
+		},
+		{
+			name:           "allowed IP in CIDR",
+			addresses:      []string{"203.0.113.0/24"},
+			remoteAddr:     "203.0.113.42:54321",
+			wantNextCalled: true,
+			wantStatus:     http.StatusOK,
+		},
+		{
+			name:           "blocked IP not in list",
+			addresses:      []string{"203.0.113.5"},
+			remoteAddr:     "192.168.1.100:54321",
+			wantNextCalled: false,
+			wantStatus:     http.StatusForbidden,
+		},
+		{
+			name:           "blocked IP not in CIDR",
+			addresses:      []string{"203.0.113.0/24"},
+			remoteAddr:     "10.0.0.1:54321",
+			wantNextCalled: false,
+			wantStatus:     http.StatusForbidden,
+		},
+		{
+			name:           "empty allowlist — all blocked",
+			addresses:      []string{},
+			remoteAddr:     "203.0.113.5:54321",
+			wantNextCalled: false,
+			wantStatus:     http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &IPFilterHandler{
+				Config: IPFilterHandlerConfig{
+					Mode:      "allowlist",
+					Addresses: tt.addresses,
+				},
+			}
+			if err := h.Provision(gocaddy.Context{}); err != nil {
+				t.Fatalf("Provision() error: %v", err)
+			}
+
+			nextCalled := false
+			next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+				return nil
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			w := httptest.NewRecorder()
+
+			if err := h.ServeHTTP(w, req, next); err != nil {
+				t.Errorf("ServeHTTP() unexpected error: %v", err)
+			}
+
+			if nextCalled != tt.wantNextCalled {
+				t.Errorf("nextCalled = %v, want %v", nextCalled, tt.wantNextCalled)
+			}
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+// TestIPFilterHandler_MatchesAny tests the IP matching logic directly.
+func TestIPFilterHandler_MatchesAny(t *testing.T) {
+	tests := []struct {
+		name      string
+		addresses []string
+		clientIP  string
+		want      bool
+	}{
+		{"exact match", []string{"192.168.1.100"}, "192.168.1.100", true},
+		{"no match", []string{"192.168.1.100"}, "192.168.1.101", false},
+		{"CIDR match", []string{"10.0.0.0/8"}, "10.255.255.254", true},
+		{"CIDR no match", []string{"10.0.0.0/8"}, "11.0.0.1", false},
+		{"empty list", []string{}, "10.0.0.1", false},
+		{"IPv6 exact", []string{"2001:db8::1"}, "[2001:db8::1]", true},
+		{"IPv6 CIDR match", []string{"2001:db8::/32"}, "[2001:db8::cafe]", true},
+		{"IPv6 CIDR no match", []string{"2001:db8::/32"}, "[2001:db9::1]", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &IPFilterHandler{
+				Config: IPFilterHandlerConfig{
+					Mode:      "blocklist",
+					Addresses: tt.addresses,
+				},
+			}
+			if err := h.Provision(gocaddy.Context{}); err != nil {
+				t.Fatalf("Provision() error: %v", err)
+			}
+
+			// Build a request with the given client IP and let ServeHTTP decide.
+			// We verify indirectly via the response code in the blocklist scenario:
+			// matched => 403, not matched => 200 (next called).
+			nextCalled := false
+			next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+				return nil
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			// IPv6 addresses in RemoteAddr must be bracketed: [addr]:port.
+			req.RemoteAddr = tt.clientIP + ":12345"
+			w := httptest.NewRecorder()
+			_ = h.ServeHTTP(w, req, next)
+
+			// In blocklist mode: matched == blocked == !nextCalled.
+			if tt.want && nextCalled {
+				t.Errorf("IP %q matched list but next was called (expected block in blocklist mode)", tt.clientIP)
+			}
+			if !tt.want && !nextCalled {
+				t.Errorf("IP %q did not match list but next was not called (expected allow in blocklist mode)", tt.clientIP)
+			}
+		})
+	}
+}
+
+// TestIPFilterHandler_UnknownMode_TreatedAsBlocklist verifies that an
+// unrecognised mode value falls back to blocklist semantics.
+func TestIPFilterHandler_UnknownMode_TreatedAsBlocklist(t *testing.T) {
+	h := &IPFilterHandler{
+		Config: IPFilterHandlerConfig{
+			Mode:      "unknown",
+			Addresses: []string{"10.0.0.1"},
+		},
+	}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error: %v", err)
+	}
+
+	nextCalled := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:54321" // in list — should be blocked
+	w := httptest.NewRecorder()
+
+	_ = h.ServeHTTP(w, req, next)
+
+	if nextCalled {
+		t.Error("expected request to be blocked in unknown mode (blocklist fallback), but next was called")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,9 @@ type Config struct {
 	// BodySize configures request body size limits.
 	BodySize BodySizeConfig `mapstructure:"body_size"`
 
+	// IPFilter configures IP-based access control.
+	IPFilter IPFilterConfig `mapstructure:"ip_filter"`
+
 	// Overrides provides escape hatches for advanced users who need to supply
 	// hand-crafted config files instead of relying on VibeWarden's generation.
 	Overrides OverridesConfig `mapstructure:"overrides"`
@@ -377,6 +380,25 @@ type BodySizeOverrideConfig struct {
 	Max string `mapstructure:"max"`
 }
 
+// IPFilterConfig holds IP-based access control settings.
+type IPFilterConfig struct {
+	// Enabled toggles the IP filter plugin (default: false).
+	Enabled bool `mapstructure:"enabled"`
+
+	// Mode selects the filter behaviour: "allowlist" or "blocklist" (default: "blocklist").
+	// allowlist: only listed IPs/CIDRs may access the service.
+	// blocklist: listed IPs/CIDRs are blocked; all others are permitted.
+	Mode string `mapstructure:"mode"`
+
+	// Addresses is the list of IP addresses or CIDR ranges to match against.
+	// Examples: "10.0.0.0/8", "192.168.1.100", "2001:db8::/32".
+	Addresses []string `mapstructure:"addresses"`
+
+	// TrustProxyHeaders enables reading X-Forwarded-For for the real client IP.
+	// Only enable when VibeWarden runs behind a trusted reverse proxy.
+	TrustProxyHeaders bool `mapstructure:"trust_proxy_headers"`
+}
+
 // OverridesConfig provides escape hatches for users who need to supply
 // hand-crafted configuration files instead of relying on VibeWarden's
 // auto-generation. All fields are optional.
@@ -473,6 +495,19 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// ip_filter.mode validation.
+	if c.IPFilter.Enabled {
+		switch c.IPFilter.Mode {
+		case "", "allowlist", "blocklist":
+			// valid
+		default:
+			errs = append(errs, fmt.Sprintf(
+				"ip_filter.mode %q is invalid; accepted values: \"allowlist\", \"blocklist\"",
+				c.IPFilter.Mode,
+			))
+		}
+	}
+
 	// body_size.overrides validation.
 	for i, ov := range c.BodySize.Overrides {
 		prefix := fmt.Sprintf("body_size.overrides[%d]", i)
@@ -556,6 +591,10 @@ func Load(configPath string) (*Config, error) {
 	v.SetDefault("metrics.path_patterns", []string{})
 	v.SetDefault("body_size.max", "1MB")
 	v.SetDefault("body_size.overrides", []BodySizeOverrideConfig{})
+	v.SetDefault("ip_filter.enabled", false)
+	v.SetDefault("ip_filter.mode", "blocklist")
+	v.SetDefault("ip_filter.addresses", []string{})
+	v.SetDefault("ip_filter.trust_proxy_headers", false)
 	v.SetDefault("database.url", "")
 	v.SetDefault("overrides.kratos_config", "")
 	v.SetDefault("overrides.compose_file", "")

--- a/internal/domain/events/events.go
+++ b/internal/domain/events/events.go
@@ -73,6 +73,11 @@ const (
 	// persisted to the backing store (e.g. PostgreSQL is unavailable).
 	// The operation that triggered the audit entry is not rolled back.
 	EventTypeAuditLogFailure = "audit.log_failure"
+
+	// EventTypeIPFilterBlocked is emitted when a request is rejected by the
+	// IP filter plugin because the client IP is not in the allowlist or is
+	// in the blocklist.
+	EventTypeIPFilterBlocked = "ip_filter.blocked"
 )
 
 // Event is the base structured log event.

--- a/internal/domain/events/ipfilter.go
+++ b/internal/domain/events/ipfilter.go
@@ -1,0 +1,42 @@
+package events
+
+import (
+	"fmt"
+	"time"
+)
+
+// IPFilterBlockedParams contains the parameters needed to construct an
+// ip_filter.blocked event.
+type IPFilterBlockedParams struct {
+	// ClientIP is the IP address that was blocked.
+	ClientIP string
+
+	// Mode is the filter mode in effect: "allowlist" or "blocklist".
+	Mode string
+
+	// Method is the HTTP method of the blocked request (e.g. "GET").
+	Method string
+
+	// Path is the URL path of the blocked request.
+	Path string
+}
+
+// NewIPFilterBlocked creates an ip_filter.blocked event indicating that a
+// request was rejected because the client IP did not pass the IP filter check.
+func NewIPFilterBlocked(params IPFilterBlockedParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeIPFilterBlocked,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"Request from %s blocked by IP filter (%s mode): %s %s",
+			params.ClientIP, params.Mode, params.Method, params.Path,
+		),
+		Payload: map[string]any{
+			"client_ip": params.ClientIP,
+			"mode":      params.Mode,
+			"method":    params.Method,
+			"path":      params.Path,
+		},
+	}
+}

--- a/internal/domain/events/ipfilter_test.go
+++ b/internal/domain/events/ipfilter_test.go
@@ -1,0 +1,97 @@
+package events_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+)
+
+func TestNewIPFilterBlocked(t *testing.T) {
+	tests := []struct {
+		name           string
+		params         events.IPFilterBlockedParams
+		wantEventType  string
+		wantSchema     string
+		wantSummary    string
+		wantPayloadKey string
+	}{
+		{
+			name: "blocklist mode",
+			params: events.IPFilterBlockedParams{
+				ClientIP: "10.1.2.3",
+				Mode:     "blocklist",
+				Method:   "GET",
+				Path:     "/api/data",
+			},
+			wantEventType:  events.EventTypeIPFilterBlocked,
+			wantSchema:     events.SchemaVersion,
+			wantSummary:    "10.1.2.3",
+			wantPayloadKey: "client_ip",
+		},
+		{
+			name: "allowlist mode",
+			params: events.IPFilterBlockedParams{
+				ClientIP: "203.0.113.5",
+				Mode:     "allowlist",
+				Method:   "POST",
+				Path:     "/submit",
+			},
+			wantEventType:  events.EventTypeIPFilterBlocked,
+			wantSchema:     events.SchemaVersion,
+			wantSummary:    "allowlist",
+			wantPayloadKey: "mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := time.Now().UTC()
+			ev := events.NewIPFilterBlocked(tt.params)
+			after := time.Now().UTC()
+
+			if ev.EventType != tt.wantEventType {
+				t.Errorf("EventType = %q, want %q", ev.EventType, tt.wantEventType)
+			}
+			if ev.SchemaVersion != tt.wantSchema {
+				t.Errorf("SchemaVersion = %q, want %q", ev.SchemaVersion, tt.wantSchema)
+			}
+			if !strings.Contains(ev.AISummary, tt.wantSummary) {
+				t.Errorf("AISummary = %q, want it to contain %q", ev.AISummary, tt.wantSummary)
+			}
+			if ev.Timestamp.Before(before) || ev.Timestamp.After(after) {
+				t.Errorf("Timestamp %v not in expected range [%v, %v]", ev.Timestamp, before, after)
+			}
+			if _, ok := ev.Payload[tt.wantPayloadKey]; !ok {
+				t.Errorf("Payload missing key %q; got %v", tt.wantPayloadKey, ev.Payload)
+			}
+
+			// Verify all core payload fields are present.
+			for _, key := range []string{"client_ip", "mode", "method", "path"} {
+				if _, ok := ev.Payload[key]; !ok {
+					t.Errorf("Payload missing key %q", key)
+				}
+			}
+
+			if ev.Payload["client_ip"] != tt.params.ClientIP {
+				t.Errorf("Payload[client_ip] = %v, want %q", ev.Payload["client_ip"], tt.params.ClientIP)
+			}
+			if ev.Payload["mode"] != tt.params.Mode {
+				t.Errorf("Payload[mode] = %v, want %q", ev.Payload["mode"], tt.params.Mode)
+			}
+			if ev.Payload["method"] != tt.params.Method {
+				t.Errorf("Payload[method] = %v, want %q", ev.Payload["method"], tt.params.Method)
+			}
+			if ev.Payload["path"] != tt.params.Path {
+				t.Errorf("Payload[path] = %v, want %q", ev.Payload["path"], tt.params.Path)
+			}
+		})
+	}
+}
+
+func TestEventTypeIPFilterBlocked_Value(t *testing.T) {
+	if events.EventTypeIPFilterBlocked != "ip_filter.blocked" {
+		t.Errorf("EventTypeIPFilterBlocked = %q, want %q", events.EventTypeIPFilterBlocked, "ip_filter.blocked")
+	}
+}

--- a/internal/plugins/catalog.go
+++ b/internal/plugins/catalog.go
@@ -24,6 +24,22 @@ type PluginDescriptor struct {
 // The order reflects the recommended initialisation priority.
 var Catalog = []PluginDescriptor{
 	{
+		Name:        "ip-filter",
+		Description: "IP allowlist/blocklist filter: reject or permit requests by client IP or CIDR range",
+		ConfigSchema: map[string]string{
+			"enabled":             "Enable IP filtering (default: false)",
+			"mode":                "Filter mode: \"allowlist\" (only listed IPs allowed) or \"blocklist\" (listed IPs blocked, default: \"blocklist\")",
+			"addresses":           "List of IP addresses or CIDR ranges to match (e.g. \"10.0.0.0/8\", \"192.168.1.100\")",
+			"trust_proxy_headers": "Read X-Forwarded-For for real client IP when behind a trusted proxy (default: false)",
+		},
+		Example: `  ip_filter:
+    enabled: true
+    mode: blocklist
+    addresses:
+      - "10.0.0.0/8"
+      - "192.168.1.100"`,
+	},
+	{
 		Name:        "tls",
 		Description: "TLS termination with Let's Encrypt, self-signed, or external certificates",
 		ConfigSchema: map[string]string{

--- a/internal/plugins/ipfilter/config.go
+++ b/internal/plugins/ipfilter/config.go
@@ -1,0 +1,46 @@
+// Package ipfilter implements the VibeWarden IP filter plugin.
+//
+// It supports two mutually exclusive modes:
+//
+//   - allowlist: only requests from listed IPs/CIDRs are permitted; all others
+//     receive 403 Forbidden before any further middleware runs.
+//   - blocklist: requests from listed IPs/CIDRs are blocked with 403 Forbidden;
+//     all other clients are allowed through.
+//
+// IP matching uses net.ParseIP for exact addresses and net.IPNet.Contains for
+// CIDR ranges. IPv4-mapped IPv6 addresses (e.g. ::ffff:192.168.1.1) are handled
+// transparently by the Go net package.
+//
+// The filter is applied before authentication so that blocked clients never
+// trigger Kratos round-trips.
+package ipfilter
+
+// FilterMode selects the IP filter behaviour.
+type FilterMode string
+
+const (
+	// FilterModeAllowlist permits only addresses in the list; all others are blocked.
+	FilterModeAllowlist FilterMode = "allowlist"
+
+	// FilterModeBlocklist blocks addresses in the list; all others are permitted.
+	FilterModeBlocklist FilterMode = "blocklist"
+)
+
+// Config holds all settings for the IP filter plugin.
+// It maps to the ip_filter section of vibewarden.yaml.
+type Config struct {
+	// Enabled toggles the IP filter plugin.
+	Enabled bool
+
+	// Mode selects the filter behaviour: "allowlist" or "blocklist".
+	// Defaults to "blocklist" when empty.
+	Mode FilterMode
+
+	// Addresses is the list of IP addresses or CIDR ranges to match against.
+	// Examples: "10.0.0.0/8", "192.168.1.100", "2001:db8::/32".
+	Addresses []string
+
+	// TrustProxyHeaders, when true, reads X-Forwarded-For to determine the
+	// real client IP. Only enable when VibeWarden runs behind a trusted proxy.
+	TrustProxyHeaders bool
+}

--- a/internal/plugins/ipfilter/meta.go
+++ b/internal/plugins/ipfilter/meta.go
@@ -1,0 +1,31 @@
+package ipfilter
+
+import "github.com/vibewarden/vibewarden/internal/ports"
+
+// Description returns a short description of the ip-filter plugin.
+func (p *Plugin) Description() string {
+	return "IP allowlist/blocklist filter: reject or permit requests by client IP or CIDR range"
+}
+
+// ConfigSchema returns the configuration field descriptions for the ip-filter plugin.
+func (p *Plugin) ConfigSchema() map[string]string {
+	return map[string]string{
+		"enabled":             "Enable IP filtering (default: false)",
+		"mode":                "Filter mode: \"allowlist\" (only listed IPs allowed) or \"blocklist\" (listed IPs blocked, default: \"blocklist\")",
+		"addresses":           "List of IP addresses or CIDR ranges to match (e.g. \"10.0.0.0/8\", \"192.168.1.100\")",
+		"trust_proxy_headers": "Read X-Forwarded-For for real client IP when behind a trusted proxy (default: false)",
+	}
+}
+
+// Example returns an example YAML configuration for the ip-filter plugin.
+func (p *Plugin) Example() string {
+	return `  ip_filter:
+    enabled: true
+    mode: blocklist
+    addresses:
+      - "10.0.0.0/8"
+      - "192.168.1.100"`
+}
+
+// Interface guard — ip-filter Plugin implements PluginMeta.
+var _ ports.PluginMeta = (*Plugin)(nil)

--- a/internal/plugins/ipfilter/plugin.go
+++ b/internal/plugins/ipfilter/plugin.go
@@ -1,0 +1,180 @@
+package ipfilter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// Plugin is the IP filter plugin for VibeWarden.
+// It implements ports.Plugin and ports.CaddyContributor.
+//
+// When enabled, it injects a vibewarden_ip_filter Caddy handler at priority 15
+// (before security headers at 20) so that disallowed clients are rejected
+// before any further middleware — including authentication — runs.
+type Plugin struct {
+	cfg    Config
+	nets   []*net.IPNet
+	ips    []net.IP
+	logger *slog.Logger
+}
+
+// New creates a new IP filter Plugin.
+func New(cfg Config, logger *slog.Logger) *Plugin {
+	return &Plugin{
+		cfg:    cfg,
+		logger: logger,
+	}
+}
+
+// Name returns the canonical plugin identifier "ip-filter".
+// This must match the key used under plugins: in vibewarden.yaml.
+func (p *Plugin) Name() string { return "ip-filter" }
+
+// Priority returns 15 — ip-filter runs before all other middleware so that
+// blocked clients are rejected as early as possible.
+func (p *Plugin) Priority() int { return 15 }
+
+// Init validates the configuration and parses IP/CIDR address entries.
+// Returns an error if any address cannot be parsed, or if Mode is invalid.
+func (p *Plugin) Init(_ context.Context) error {
+	if !p.cfg.Enabled {
+		return nil
+	}
+
+	mode := p.cfg.Mode
+	if mode == "" {
+		mode = FilterModeBlocklist
+	}
+	if mode != FilterModeAllowlist && mode != FilterModeBlocklist {
+		return fmt.Errorf("ip_filter.mode %q is invalid; accepted values: %q, %q",
+			mode, FilterModeAllowlist, FilterModeBlocklist)
+	}
+
+	// Parse all configured addresses, distinguishing CIDRs from plain IPs.
+	p.nets = p.nets[:0]
+	p.ips = p.ips[:0]
+
+	for _, addr := range p.cfg.Addresses {
+		if _, ipNet, err := net.ParseCIDR(addr); err == nil {
+			p.nets = append(p.nets, ipNet)
+			continue
+		}
+		if ip := net.ParseIP(addr); ip != nil {
+			p.ips = append(p.ips, ip)
+			continue
+		}
+		return fmt.Errorf("ip_filter.addresses: %q is not a valid IP address or CIDR", addr)
+	}
+
+	p.logger.Info("ip-filter plugin initialised",
+		slog.String("mode", string(mode)),
+		slog.Int("address_count", len(p.cfg.Addresses)),
+	)
+	return nil
+}
+
+// Start is a no-op for the ip-filter plugin. No background work is needed.
+func (p *Plugin) Start(_ context.Context) error { return nil }
+
+// Stop is a no-op for the ip-filter plugin. No resources need releasing.
+func (p *Plugin) Stop(_ context.Context) error { return nil }
+
+// Health returns the current health status of the ip-filter plugin.
+func (p *Plugin) Health() ports.HealthStatus {
+	if !p.cfg.Enabled {
+		return ports.HealthStatus{
+			Healthy: true,
+			Message: "ip-filter disabled",
+		}
+	}
+
+	mode := p.cfg.Mode
+	if mode == "" {
+		mode = FilterModeBlocklist
+	}
+
+	return ports.HealthStatus{
+		Healthy: true,
+		Message: fmt.Sprintf(
+			"ip-filter active (%s mode, %d addresses)",
+			mode, len(p.cfg.Addresses),
+		),
+	}
+}
+
+// ContributeCaddyRoutes returns nil.
+// The ip-filter plugin does not add named routes.
+func (p *Plugin) ContributeCaddyRoutes() []ports.CaddyRoute { return nil }
+
+// ContributeCaddyHandlers returns the vibewarden_ip_filter Caddy handler
+// fragment at priority 15. Returns an empty slice when the plugin is disabled.
+func (p *Plugin) ContributeCaddyHandlers() []ports.CaddyHandler {
+	if !p.cfg.Enabled {
+		return nil
+	}
+
+	handler, err := buildIPFilterHandlerJSON(p.cfg)
+	if err != nil {
+		// JSON marshalling of a known struct cannot fail in practice.
+		p.logger.Error("ip-filter plugin: building handler JSON", slog.String("err", err.Error()))
+		return nil
+	}
+
+	return []ports.CaddyHandler{
+		{
+			Handler:  handler,
+			Priority: 15,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Internal builder — pure function, no side effects.
+// ---------------------------------------------------------------------------
+
+// ipFilterHandlerConfig is the JSON-serialisable config sent to the
+// vibewarden_ip_filter Caddy module.
+type ipFilterHandlerConfig struct {
+	Mode              string   `json:"mode"`
+	Addresses         []string `json:"addresses"`
+	TrustProxyHeaders bool     `json:"trust_proxy_headers"`
+}
+
+// buildIPFilterHandlerJSON serialises cfg into the Caddy handler JSON map
+// expected by the vibewarden_ip_filter module.
+func buildIPFilterHandlerJSON(cfg Config) (map[string]any, error) {
+	mode := cfg.Mode
+	if mode == "" {
+		mode = FilterModeBlocklist
+	}
+
+	hcfg := ipFilterHandlerConfig{
+		Mode:              string(mode),
+		Addresses:         cfg.Addresses,
+		TrustProxyHeaders: cfg.TrustProxyHeaders,
+	}
+
+	cfgBytes, err := json.Marshal(hcfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ip filter handler config: %w", err)
+	}
+
+	return map[string]any{
+		"handler": "vibewarden_ip_filter",
+		"config":  json.RawMessage(cfgBytes),
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Interface guards.
+// ---------------------------------------------------------------------------
+
+var (
+	_ ports.Plugin           = (*Plugin)(nil)
+	_ ports.CaddyContributor = (*Plugin)(nil)
+)

--- a/internal/plugins/ipfilter/plugin_test.go
+++ b/internal/plugins/ipfilter/plugin_test.go
@@ -1,0 +1,347 @@
+package ipfilter_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/plugins/ipfilter"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type noopWriter struct{}
+
+func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(noopWriter{}, nil))
+}
+
+func defaultConfig() ipfilter.Config {
+	return ipfilter.Config{
+		Enabled:   true,
+		Mode:      ipfilter.FilterModeBlocklist,
+		Addresses: []string{"10.0.0.0/8", "192.168.1.100"},
+	}
+}
+
+func newPlugin(cfg ipfilter.Config) *ipfilter.Plugin {
+	return ipfilter.New(cfg, discardLogger())
+}
+
+// ---------------------------------------------------------------------------
+// Name / Priority
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Name(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if got := p.Name(); got != "ip-filter" {
+		t.Errorf("Name() = %q, want %q", got, "ip-filter")
+	}
+}
+
+func TestPlugin_Priority(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if got := p.Priority(); got != 15 {
+		t.Errorf("Priority() = %d, want 15", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Init(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     ipfilter.Config
+		wantErr bool
+	}{
+		{
+			name:    "disabled — no-op",
+			cfg:     ipfilter.Config{Enabled: false},
+			wantErr: false,
+		},
+		{
+			name:    "blocklist mode with CIDRs",
+			cfg:     defaultConfig(),
+			wantErr: false,
+		},
+		{
+			name: "allowlist mode with plain IPs",
+			cfg: ipfilter.Config{
+				Enabled:   true,
+				Mode:      ipfilter.FilterModeAllowlist,
+				Addresses: []string{"203.0.113.1", "198.51.100.0/24"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty addresses list",
+			cfg: ipfilter.Config{
+				Enabled:   true,
+				Mode:      ipfilter.FilterModeBlocklist,
+				Addresses: []string{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid mode",
+			cfg: ipfilter.Config{
+				Enabled:   true,
+				Mode:      "invalid",
+				Addresses: []string{"10.0.0.0/8"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid address",
+			cfg: ipfilter.Config{
+				Enabled:   true,
+				Mode:      ipfilter.FilterModeBlocklist,
+				Addresses: []string{"not-an-ip"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "default mode (empty string) treated as blocklist",
+			cfg: ipfilter.Config{
+				Enabled:   true,
+				Mode:      "",
+				Addresses: []string{"10.0.0.1"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			err := p.Init(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Start / Stop — no-op
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Start_IsNoop(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if err := p.Start(context.Background()); err != nil {
+		t.Errorf("Start() unexpected error: %v", err)
+	}
+}
+
+func TestPlugin_Stop_IsNoop(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  ipfilter.Config
+	}{
+		{"disabled", ipfilter.Config{Enabled: false}},
+		{"enabled", defaultConfig()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			if err := p.Stop(context.Background()); err != nil {
+				t.Errorf("Stop() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Health(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            ipfilter.Config
+		wantHealthy    bool
+		wantMsgContain string
+	}{
+		{
+			name:           "disabled",
+			cfg:            ipfilter.Config{Enabled: false},
+			wantHealthy:    true,
+			wantMsgContain: "disabled",
+		},
+		{
+			name:           "enabled blocklist",
+			cfg:            defaultConfig(),
+			wantHealthy:    true,
+			wantMsgContain: "active",
+		},
+		{
+			name: "enabled allowlist",
+			cfg: ipfilter.Config{
+				Enabled:   true,
+				Mode:      ipfilter.FilterModeAllowlist,
+				Addresses: []string{"10.0.0.0/8"},
+			},
+			wantHealthy:    true,
+			wantMsgContain: "allowlist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			h := p.Health()
+			if h.Healthy != tt.wantHealthy {
+				t.Errorf("Health().Healthy = %v, want %v", h.Healthy, tt.wantHealthy)
+			}
+			if !strings.Contains(h.Message, tt.wantMsgContain) {
+				t.Errorf("Health().Message = %q, want it to contain %q", h.Message, tt.wantMsgContain)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyRoutes
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyRoutes_AlwaysEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  ipfilter.Config
+	}{
+		{"disabled", ipfilter.Config{Enabled: false}},
+		{"enabled", defaultConfig()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			if routes := p.ContributeCaddyRoutes(); len(routes) != 0 {
+				t.Errorf("ContributeCaddyRoutes() = %v, want empty", routes)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyHandlers
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyHandlers_DisabledReturnsNil(t *testing.T) {
+	p := newPlugin(ipfilter.Config{Enabled: false})
+	if handlers := p.ContributeCaddyHandlers(); len(handlers) != 0 {
+		t.Errorf("ContributeCaddyHandlers() = %v, want empty when disabled", handlers)
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_EnabledReturnsOne(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 1 {
+		t.Fatalf("ContributeCaddyHandlers() len = %d, want 1", len(handlers))
+	}
+	if handlers[0].Priority != 15 {
+		t.Errorf("handler Priority = %d, want 15", handlers[0].Priority)
+	}
+	if handlers[0].Handler["handler"] != "vibewarden_ip_filter" {
+		t.Errorf("handler[\"handler\"] = %v, want %q", handlers[0].Handler["handler"], "vibewarden_ip_filter")
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_HandlerHasConfig(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) == 0 {
+		t.Fatal("expected at least one handler")
+	}
+	if _, ok := handlers[0].Handler["config"]; !ok {
+		t.Error("expected \"config\" key in handler map")
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_ConfigRoundTrips(t *testing.T) {
+	cfg := ipfilter.Config{
+		Enabled:           true,
+		Mode:              ipfilter.FilterModeBlocklist,
+		Addresses:         []string{"10.0.0.0/8", "192.168.1.100"},
+		TrustProxyHeaders: true,
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) == 0 {
+		t.Fatal("expected at least one handler")
+	}
+
+	rawConfig := handlers[0].Handler["config"]
+	b, err := json.Marshal(rawConfig)
+	if err != nil {
+		t.Fatalf("json.Marshal(config) error: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(config) error: %v", err)
+	}
+
+	if mode, ok := decoded["mode"].(string); !ok || mode != "blocklist" {
+		t.Errorf("decoded config mode = %v, want %q", decoded["mode"], "blocklist")
+	}
+
+	addrs, ok := decoded["addresses"].([]any)
+	if !ok {
+		t.Fatalf("decoded config addresses is %T, want []any", decoded["addresses"])
+	}
+	if len(addrs) != 2 {
+		t.Errorf("decoded config addresses len = %d, want 2", len(addrs))
+	}
+
+	if trust, ok := decoded["trust_proxy_headers"].(bool); !ok || !trust {
+		t.Errorf("decoded config trust_proxy_headers = %v, want true", decoded["trust_proxy_headers"])
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_AllowlistMode(t *testing.T) {
+	cfg := ipfilter.Config{
+		Enabled:   true,
+		Mode:      ipfilter.FilterModeAllowlist,
+		Addresses: []string{"203.0.113.0/24"},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) == 0 {
+		t.Fatal("expected at least one handler")
+	}
+
+	rawConfig := handlers[0].Handler["config"]
+	b, _ := json.Marshal(rawConfig)
+	var decoded map[string]any
+	_ = json.Unmarshal(b, &decoded)
+
+	if mode, ok := decoded["mode"].(string); !ok || mode != "allowlist" {
+		t.Errorf("decoded config mode = %v, want %q", decoded["mode"], "allowlist")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Interface compliance
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ImplementsPortsPlugin(t *testing.T) {
+	var _ ports.Plugin = (*ipfilter.Plugin)(nil)
+}
+
+func TestPlugin_ImplementsCaddyContributor(t *testing.T) {
+	var _ ports.CaddyContributor = (*ipfilter.Plugin)(nil)
+}
+
+func TestPlugin_ImplementsPluginMeta(t *testing.T) {
+	var _ ports.PluginMeta = (*ipfilter.Plugin)(nil)
+}

--- a/internal/ports/proxy.go
+++ b/internal/ports/proxy.go
@@ -56,6 +56,24 @@ type ProxyConfig struct {
 
 	// BodySize configuration — controls request body size limiting.
 	BodySize BodySizeConfig
+
+	// IPFilter configuration — controls IP-based access control.
+	IPFilter IPFilterConfig
+}
+
+// IPFilterConfig holds configuration for IP-based access control.
+type IPFilterConfig struct {
+	// Enabled toggles IP filtering.
+	Enabled bool
+
+	// Mode selects the filter behaviour: "allowlist" or "blocklist".
+	Mode string
+
+	// Addresses is the list of IP addresses or CIDR ranges to evaluate.
+	Addresses []string
+
+	// TrustProxyHeaders, when true, reads X-Forwarded-For for the real client IP.
+	TrustProxyHeaders bool
 }
 
 // BodySizeConfig holds configuration for the request body size limiting middleware.


### PR DESCRIPTION
Closes #218

## Summary

- New `ip-filter` plugin at `internal/plugins/ipfilter/` (priority 15 — runs before all other middleware including auth)
- Allowlist mode: only IPs/CIDRs in `addresses` are permitted; all others receive 403
- Blocklist mode: IPs/CIDRs in `addresses` are blocked; all others pass through
- Caddy handler at `internal/adapters/caddy/ipfilter_handler.go` — uses `net.ParseIP` and `net.IPNet.Contains` for matching
- Structured `ip_filter.blocked` domain event emitted for every blocked request
- `IPFilterConfig` added to `internal/config/config.go` (validated in `Validate()`, defaults in `Load()`)
- `IPFilterConfig` added to `internal/ports/proxy.go` (`ProxyConfig`)
- Plugin registered in `cmd/vibewarden/serve.go` and listed in `internal/plugins/catalog.go`

## Test plan

- `internal/plugins/ipfilter/plugin_test.go` — Name, Priority, Init, Health, Caddy handler contribution
- `internal/adapters/caddy/ipfilter_handler_test.go` — CaddyModule, Provision, ServeHTTP blocklist/allowlist, IPv6, unknown-mode fallback
- `internal/domain/events/ipfilter_test.go` — event type value, payload fields, AISummary, timestamp

All checks pass (gofmt, go vet, go build, go test -race ./...).
