### PR TITLE
feat(#224,#225): OpenAPI 3.0 spec and /_vibewarden/api/docs endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,401 @@
+openapi: "3.0.3"
+info:
+  title: VibeWarden Admin API
+  version: "1.0"
+  description: |
+    The VibeWarden Admin API provides user management operations for the
+    local security sidecar. All endpoints require the X-Admin-Key header
+    containing the configured admin bearer token, except for the health
+    check and this API spec endpoint.
+
+    The sidecar always runs locally next to your application. It is never
+    hosted remotely.
+  contact:
+    url: https://vibewarden.dev
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  - url: http://localhost:8080
+    description: Default local sidecar address (plain HTTP)
+  - url: https://localhost:8443
+    description: Default local sidecar address (TLS)
+
+tags:
+  - name: health
+    description: Sidecar health and readiness
+  - name: users
+    description: Admin user management
+
+paths:
+  /_vibewarden/health:
+    get:
+      summary: Health check
+      description: |
+        Returns the sidecar status and binary version. This endpoint is public —
+        no authentication is required. Suitable for use as a liveness or
+        readiness probe.
+      operationId: getHealth
+      tags: [health]
+      responses:
+        "200":
+          description: Sidecar is healthy.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+              example:
+                status: ok
+                version: "v0.1.0"
+
+  /_vibewarden/api/docs:
+    get:
+      summary: OpenAPI specification
+      description: |
+        Returns this OpenAPI 3.0 specification as YAML. Public endpoint —
+        no authentication required.
+      operationId: getApiDocs
+      tags: [health]
+      responses:
+        "200":
+          description: OpenAPI specification in YAML format.
+          content:
+            application/yaml:
+              schema:
+                type: string
+                format: binary
+
+  /_vibewarden/admin/users:
+    get:
+      summary: List users
+      description: Returns a paginated list of all user identities from the identity provider.
+      operationId: listUsers
+      tags: [users]
+      security:
+        - AdminKey: []
+      parameters:
+        - $ref: "#/components/parameters/PageParam"
+        - $ref: "#/components/parameters/PerPageParam"
+      responses:
+        "200":
+          description: Paginated list of users.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListUsersResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/AdminDisabled"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+    post:
+      summary: Invite / create user
+      description: |
+        Creates a new user identity for the given email address and returns a
+        one-time recovery link the admin can forward to the new user so they
+        can set their password.
+      operationId: inviteUser
+      tags: [users]
+      security:
+        - AdminKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InviteUserRequest"
+            example:
+              email: "alice@example.com"
+      responses:
+        "201":
+          description: User created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InviteUserResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/AdminDisabled"
+        "409":
+          description: A user with this email already exists.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: user_exists
+                message: "a user with this email already exists"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /_vibewarden/admin/users/{id}:
+    parameters:
+      - $ref: "#/components/parameters/UserIDParam"
+
+    get:
+      summary: Get user
+      description: Returns a single user identity by its UUID.
+      operationId: getUser
+      tags: [users]
+      security:
+        - AdminKey: []
+      responses:
+        "200":
+          description: User found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+    delete:
+      summary: Deactivate user
+      description: |
+        Sets the user's state to inactive, preventing further authentication.
+        The identity record is retained — this operation is not a hard delete.
+      operationId: deactivateUser
+      tags: [users]
+      security:
+        - AdminKey: []
+      responses:
+        "200":
+          description: User deactivated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeactivateUserResponse"
+              example:
+                status: deactivated
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+components:
+  securitySchemes:
+    AdminKey:
+      type: apiKey
+      in: header
+      name: X-Admin-Key
+      description: |
+        Bearer token configured in vibewarden.yaml under `admin.token`.
+        Required for all /_vibewarden/admin/* endpoints.
+
+  parameters:
+    UserIDParam:
+      name: id
+      in: path
+      required: true
+      description: The UUID of the user identity.
+      schema:
+        type: string
+        format: uuid
+        example: "550e8400-e29b-41d4-a716-446655440000"
+
+    PageParam:
+      name: page
+      in: query
+      required: false
+      description: 1-based page number. Defaults to 1.
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+        example: 1
+
+    PerPageParam:
+      name: per_page
+      in: query
+      required: false
+      description: Number of items per page. Defaults to 20, maximum 100.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+        example: 20
+
+  schemas:
+    HealthResponse:
+      type: object
+      required: [status, version]
+      properties:
+        status:
+          type: string
+          description: Sidecar health status.
+          enum: [ok]
+          example: ok
+        version:
+          type: string
+          description: Binary version string.
+          example: "v0.1.0"
+
+    UserResponse:
+      type: object
+      required: [id, email, status, created_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identity UUID.
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        email:
+          type: string
+          format: email
+          description: User email address.
+          example: "alice@example.com"
+        status:
+          type: string
+          description: Identity state.
+          enum: [active, inactive]
+          example: active
+        created_at:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp of identity creation.
+          example: "2026-01-15T10:30:00Z"
+
+    ListUsersResponse:
+      type: object
+      required: [users, total, page, per_page]
+      properties:
+        users:
+          type: array
+          items:
+            $ref: "#/components/schemas/UserResponse"
+        total:
+          type: integer
+          description: Total number of users across all pages. -1 when unknown.
+          example: 42
+        page:
+          type: integer
+          description: Current page number (1-based).
+          example: 1
+        per_page:
+          type: integer
+          description: Number of items per page.
+          example: 20
+
+    InviteUserRequest:
+      type: object
+      required: [email]
+      properties:
+        email:
+          type: string
+          format: email
+          description: Email address for the new user.
+          example: "alice@example.com"
+
+    InviteUserResponse:
+      type: object
+      required: [id, email, recovery_link]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: UUID of the newly created user identity.
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        email:
+          type: string
+          format: email
+          description: Email address of the created user.
+          example: "alice@example.com"
+        recovery_link:
+          type: string
+          format: uri
+          description: |
+            One-time recovery link the admin should forward to the invited user
+            so they can set their password. Empty string when the identity
+            provider does not support recovery links.
+          example: "http://localhost:4433/self-service/recovery?flow=abc123&token=xyz"
+
+    DeactivateUserResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          description: Confirmation of deactivation.
+          enum: [deactivated]
+          example: deactivated
+
+    ErrorResponse:
+      type: object
+      required: [error, message]
+      properties:
+        error:
+          type: string
+          description: Machine-readable error code.
+          example: invalid_uuid
+        message:
+          type: string
+          description: Human-readable error description.
+          example: "user ID must be a valid UUID"
+
+  responses:
+    Unauthorized:
+      description: Missing or invalid X-Admin-Key header.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: unauthorized
+            message: "missing or invalid admin token"
+
+    BadRequest:
+      description: The request is malformed or contains invalid parameters.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: invalid_uuid
+            message: "user ID must be a valid UUID"
+
+    NotFound:
+      description: The requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: user_not_found
+            message: "user not found"
+
+    AdminDisabled:
+      description: The admin API is disabled in vibewarden.yaml.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: not_found
+            message: "not found"
+
+    ServiceUnavailable:
+      description: The identity provider is unreachable.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: service_unavailable
+            message: "service unavailable"

--- a/internal/adapters/caddy/config.go
+++ b/internal/adapters/caddy/config.go
@@ -142,6 +142,8 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 	if cfg.Admin.Enabled && cfg.Admin.InternalAddr != "" {
 		adminRoute := buildAdminRoute(cfg.Admin.InternalAddr)
 		routes = append(routes, adminRoute)
+		docsRoute := buildDocsRoute(cfg.Admin.InternalAddr)
+		routes = append(routes, docsRoute)
 	}
 
 	catchAllRoute := map[string]any{
@@ -448,6 +450,30 @@ func buildAdminRoute(internalAddr string) map[string]any {
 	return map[string]any{
 		"match": []map[string]any{
 			{"path": []string{"/_vibewarden/admin/*"}},
+		},
+		"handle": []map[string]any{
+			{
+				"handler": "reverse_proxy",
+				"upstreams": []map[string]any{
+					{"dial": internalAddr},
+				},
+			},
+		},
+	}
+}
+
+// buildDocsRoute constructs a Caddy route that reverse-proxies requests to
+// /_vibewarden/api/docs to the internal admin HTTP server at internalAddr.
+// This endpoint is public — no authentication is required and it must not be
+// gated by the AdminAuthHandler. The route is inserted before the catch-all
+// proxy route so that the AdminAuth middleware (which lives in the catch-all
+// handler chain) never runs for doc requests.
+//
+// The internalAddr must be a host:port string (e.g., "127.0.0.1:9092").
+func buildDocsRoute(internalAddr string) map[string]any {
+	return map[string]any{
+		"match": []map[string]any{
+			{"path": []string{"/_vibewarden/api/docs"}},
 		},
 		"handle": []map[string]any{
 			{

--- a/internal/adapters/caddy/config_test.go
+++ b/internal/adapters/caddy/config_test.go
@@ -1724,3 +1724,169 @@ func TestBuildCaddyConfig_AdminRoute(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildDocsRoute(t *testing.T) {
+	tests := []struct {
+		name         string
+		internalAddr string
+		wantPath     string
+		wantDialAddr string
+	}{
+		{
+			name:         "builds correct route for internal addr",
+			internalAddr: "127.0.0.1:9092",
+			wantPath:     "/_vibewarden/api/docs",
+			wantDialAddr: "127.0.0.1:9092",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			route := buildDocsRoute(tt.internalAddr)
+
+			match, ok := route["match"].([]map[string]any)
+			if !ok || len(match) == 0 {
+				t.Fatal("match not found in docs route")
+			}
+			paths, ok := match[0]["path"].([]string)
+			if !ok || len(paths) == 0 {
+				t.Fatal("path not found in docs route match")
+			}
+			if paths[0] != tt.wantPath {
+				t.Errorf("path = %q, want %q", paths[0], tt.wantPath)
+			}
+
+			handles, ok := route["handle"].([]map[string]any)
+			if !ok || len(handles) == 0 {
+				t.Fatal("handle not found in docs route")
+			}
+			var rpHandler map[string]any
+			for _, h := range handles {
+				if h["handler"] == "reverse_proxy" {
+					rpHandler = h
+					break
+				}
+			}
+			if rpHandler == nil {
+				t.Fatal("reverse_proxy handler not found in docs route")
+			}
+			upstreams, ok := rpHandler["upstreams"].([]map[string]any)
+			if !ok || len(upstreams) == 0 {
+				t.Fatal("upstreams not found in docs route reverse_proxy handler")
+			}
+			if upstreams[0]["dial"] != tt.wantDialAddr {
+				t.Errorf("upstream dial = %v, want %q", upstreams[0]["dial"], tt.wantDialAddr)
+			}
+		})
+	}
+}
+
+func TestBuildCaddyConfig_DocsRoute(t *testing.T) {
+	tests := []struct {
+		name             string
+		cfg              *ports.ProxyConfig
+		wantDocsRoute    bool
+		wantDocsDialAddr string
+	}{
+		{
+			name: "docs route present when admin enabled with internal addr",
+			cfg: &ports.ProxyConfig{
+				ListenAddr:   "127.0.0.1:8080",
+				UpstreamAddr: "127.0.0.1:3000",
+				Admin: ports.AdminProxyConfig{
+					Enabled:      true,
+					InternalAddr: "127.0.0.1:9092",
+				},
+			},
+			wantDocsRoute:    true,
+			wantDocsDialAddr: "127.0.0.1:9092",
+		},
+		{
+			name: "docs route absent when admin disabled",
+			cfg: &ports.ProxyConfig{
+				ListenAddr:   "127.0.0.1:8080",
+				UpstreamAddr: "127.0.0.1:3000",
+				Admin: ports.AdminProxyConfig{
+					Enabled: false,
+				},
+			},
+			wantDocsRoute: false,
+		},
+		{
+			name: "docs route absent when admin enabled but internal addr empty",
+			cfg: &ports.ProxyConfig{
+				ListenAddr:   "127.0.0.1:8080",
+				UpstreamAddr: "127.0.0.1:3000",
+				Admin: ports.AdminProxyConfig{
+					Enabled:      true,
+					InternalAddr: "",
+				},
+			},
+			wantDocsRoute: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := BuildCaddyConfig(tt.cfg)
+			if err != nil {
+				t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+			}
+
+			server := extractServer(t, result)
+			routes, ok := server["routes"].([]map[string]any)
+			if !ok {
+				t.Fatal("routes not found in server config")
+			}
+
+			var docsRoute map[string]any
+			for _, route := range routes {
+				match, ok := route["match"].([]map[string]any)
+				if !ok || len(match) == 0 {
+					continue
+				}
+				paths, ok := match[0]["path"].([]string)
+				if !ok || len(paths) == 0 {
+					continue
+				}
+				if paths[0] == "/_vibewarden/api/docs" {
+					docsRoute = route
+					break
+				}
+			}
+
+			if tt.wantDocsRoute && docsRoute == nil {
+				t.Fatal("expected docs route to be present but not found")
+			}
+			if !tt.wantDocsRoute && docsRoute != nil {
+				t.Fatal("expected no docs route but found one")
+			}
+
+			if !tt.wantDocsRoute {
+				return
+			}
+
+			handles, ok := docsRoute["handle"].([]map[string]any)
+			if !ok || len(handles) == 0 {
+				t.Fatal("handle not found in docs route")
+			}
+			var rpHandler map[string]any
+			for _, h := range handles {
+				if h["handler"] == "reverse_proxy" {
+					rpHandler = h
+					break
+				}
+			}
+			if rpHandler == nil {
+				t.Fatal("reverse_proxy handler not found in docs route")
+			}
+			upstreams, ok := rpHandler["upstreams"].([]map[string]any)
+			if !ok || len(upstreams) == 0 {
+				t.Fatal("upstreams not found in reverse_proxy handler")
+			}
+			if upstreams[0]["dial"] != tt.wantDocsDialAddr {
+				t.Errorf("docs upstream dial = %v, want %q", upstreams[0]["dial"], tt.wantDocsDialAddr)
+			}
+		})
+	}
+}

--- a/internal/adapters/http/admin_server.go
+++ b/internal/adapters/http/admin_server.go
@@ -48,6 +48,7 @@ func (s *AdminServer) Start() error {
 
 	mux := http.NewServeMux()
 	s.handlers.RegisterRoutes(mux)
+	RegisterDocsRoute(mux)
 
 	s.server = &http.Server{
 		Handler:           mux,

--- a/internal/adapters/http/openapi.go
+++ b/internal/adapters/http/openapi.go
@@ -1,0 +1,21 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/vibewarden/vibewarden/internal/apispec"
+)
+
+// RegisterDocsRoute registers the public OpenAPI spec endpoint on mux.
+// GET /_vibewarden/api/docs returns the embedded openapi.yaml with
+// Content-Type: application/yaml. No authentication is required for this route.
+func RegisterDocsRoute(mux *http.ServeMux) {
+	mux.HandleFunc("GET /_vibewarden/api/docs", serveOpenAPISpec)
+}
+
+// serveOpenAPISpec writes the embedded OpenAPI YAML specification to the response.
+func serveOpenAPISpec(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/yaml")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(apispec.Spec)
+}

--- a/internal/adapters/http/openapi_test.go
+++ b/internal/adapters/http/openapi_test.go
@@ -1,0 +1,89 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/apispec"
+)
+
+func TestServeOpenAPISpec(t *testing.T) {
+	tests := []struct {
+		name            string
+		method          string
+		wantStatus      int
+		wantContentType string
+		wantBodyPrefix  string
+	}{
+		{
+			name:            "GET returns YAML with correct content type",
+			method:          http.MethodGet,
+			wantStatus:      http.StatusOK,
+			wantContentType: "application/yaml",
+			wantBodyPrefix:  "openapi:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/_vibewarden/api/docs", nil)
+			rr := httptest.NewRecorder()
+
+			serveOpenAPISpec(rr, req)
+
+			if rr.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rr.Code, tt.wantStatus)
+			}
+			ct := rr.Header().Get("Content-Type")
+			if ct != tt.wantContentType {
+				t.Errorf("Content-Type = %q, want %q", ct, tt.wantContentType)
+			}
+			body := rr.Body.String()
+			if !strings.HasPrefix(strings.TrimSpace(body), tt.wantBodyPrefix) {
+				t.Errorf("body does not start with %q, got: %s", tt.wantBodyPrefix, body[:min(len(body), 80)])
+			}
+		})
+	}
+}
+
+func TestServeOpenAPISpec_BodyMatchesEmbeddedSpec(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/api/docs", nil)
+	rr := httptest.NewRecorder()
+
+	serveOpenAPISpec(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	want := string(apispec.Spec)
+	got := rr.Body.String()
+	if got != want {
+		t.Errorf("response body does not match embedded spec\ngot  len=%d\nwant len=%d", len(got), len(want))
+	}
+}
+
+func TestRegisterDocsRoute(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterDocsRoute(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/api/docs", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200 from registered docs route, got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/yaml" {
+		t.Errorf("Content-Type = %q, want application/yaml", ct)
+	}
+}
+
+// min returns the smaller of a and b.
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/apispec/openapi.yaml
+++ b/internal/apispec/openapi.yaml
@@ -1,0 +1,401 @@
+openapi: "3.0.3"
+info:
+  title: VibeWarden Admin API
+  version: "1.0"
+  description: |
+    The VibeWarden Admin API provides user management operations for the
+    local security sidecar. All endpoints require the X-Admin-Key header
+    containing the configured admin bearer token, except for the health
+    check and this API spec endpoint.
+
+    The sidecar always runs locally next to your application. It is never
+    hosted remotely.
+  contact:
+    url: https://vibewarden.dev
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  - url: http://localhost:8080
+    description: Default local sidecar address (plain HTTP)
+  - url: https://localhost:8443
+    description: Default local sidecar address (TLS)
+
+tags:
+  - name: health
+    description: Sidecar health and readiness
+  - name: users
+    description: Admin user management
+
+paths:
+  /_vibewarden/health:
+    get:
+      summary: Health check
+      description: |
+        Returns the sidecar status and binary version. This endpoint is public —
+        no authentication is required. Suitable for use as a liveness or
+        readiness probe.
+      operationId: getHealth
+      tags: [health]
+      responses:
+        "200":
+          description: Sidecar is healthy.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+              example:
+                status: ok
+                version: "v0.1.0"
+
+  /_vibewarden/api/docs:
+    get:
+      summary: OpenAPI specification
+      description: |
+        Returns this OpenAPI 3.0 specification as YAML. Public endpoint —
+        no authentication required.
+      operationId: getApiDocs
+      tags: [health]
+      responses:
+        "200":
+          description: OpenAPI specification in YAML format.
+          content:
+            application/yaml:
+              schema:
+                type: string
+                format: binary
+
+  /_vibewarden/admin/users:
+    get:
+      summary: List users
+      description: Returns a paginated list of all user identities from the identity provider.
+      operationId: listUsers
+      tags: [users]
+      security:
+        - AdminKey: []
+      parameters:
+        - $ref: "#/components/parameters/PageParam"
+        - $ref: "#/components/parameters/PerPageParam"
+      responses:
+        "200":
+          description: Paginated list of users.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListUsersResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/AdminDisabled"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+    post:
+      summary: Invite / create user
+      description: |
+        Creates a new user identity for the given email address and returns a
+        one-time recovery link the admin can forward to the new user so they
+        can set their password.
+      operationId: inviteUser
+      tags: [users]
+      security:
+        - AdminKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InviteUserRequest"
+            example:
+              email: "alice@example.com"
+      responses:
+        "201":
+          description: User created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InviteUserResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/AdminDisabled"
+        "409":
+          description: A user with this email already exists.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: user_exists
+                message: "a user with this email already exists"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /_vibewarden/admin/users/{id}:
+    parameters:
+      - $ref: "#/components/parameters/UserIDParam"
+
+    get:
+      summary: Get user
+      description: Returns a single user identity by its UUID.
+      operationId: getUser
+      tags: [users]
+      security:
+        - AdminKey: []
+      responses:
+        "200":
+          description: User found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+    delete:
+      summary: Deactivate user
+      description: |
+        Sets the user's state to inactive, preventing further authentication.
+        The identity record is retained — this operation is not a hard delete.
+      operationId: deactivateUser
+      tags: [users]
+      security:
+        - AdminKey: []
+      responses:
+        "200":
+          description: User deactivated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeactivateUserResponse"
+              example:
+                status: deactivated
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+components:
+  securitySchemes:
+    AdminKey:
+      type: apiKey
+      in: header
+      name: X-Admin-Key
+      description: |
+        Bearer token configured in vibewarden.yaml under `admin.token`.
+        Required for all /_vibewarden/admin/* endpoints.
+
+  parameters:
+    UserIDParam:
+      name: id
+      in: path
+      required: true
+      description: The UUID of the user identity.
+      schema:
+        type: string
+        format: uuid
+        example: "550e8400-e29b-41d4-a716-446655440000"
+
+    PageParam:
+      name: page
+      in: query
+      required: false
+      description: 1-based page number. Defaults to 1.
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+        example: 1
+
+    PerPageParam:
+      name: per_page
+      in: query
+      required: false
+      description: Number of items per page. Defaults to 20, maximum 100.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+        example: 20
+
+  schemas:
+    HealthResponse:
+      type: object
+      required: [status, version]
+      properties:
+        status:
+          type: string
+          description: Sidecar health status.
+          enum: [ok]
+          example: ok
+        version:
+          type: string
+          description: Binary version string.
+          example: "v0.1.0"
+
+    UserResponse:
+      type: object
+      required: [id, email, status, created_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identity UUID.
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        email:
+          type: string
+          format: email
+          description: User email address.
+          example: "alice@example.com"
+        status:
+          type: string
+          description: Identity state.
+          enum: [active, inactive]
+          example: active
+        created_at:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp of identity creation.
+          example: "2026-01-15T10:30:00Z"
+
+    ListUsersResponse:
+      type: object
+      required: [users, total, page, per_page]
+      properties:
+        users:
+          type: array
+          items:
+            $ref: "#/components/schemas/UserResponse"
+        total:
+          type: integer
+          description: Total number of users across all pages. -1 when unknown.
+          example: 42
+        page:
+          type: integer
+          description: Current page number (1-based).
+          example: 1
+        per_page:
+          type: integer
+          description: Number of items per page.
+          example: 20
+
+    InviteUserRequest:
+      type: object
+      required: [email]
+      properties:
+        email:
+          type: string
+          format: email
+          description: Email address for the new user.
+          example: "alice@example.com"
+
+    InviteUserResponse:
+      type: object
+      required: [id, email, recovery_link]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: UUID of the newly created user identity.
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        email:
+          type: string
+          format: email
+          description: Email address of the created user.
+          example: "alice@example.com"
+        recovery_link:
+          type: string
+          format: uri
+          description: |
+            One-time recovery link the admin should forward to the invited user
+            so they can set their password. Empty string when the identity
+            provider does not support recovery links.
+          example: "http://localhost:4433/self-service/recovery?flow=abc123&token=xyz"
+
+    DeactivateUserResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          description: Confirmation of deactivation.
+          enum: [deactivated]
+          example: deactivated
+
+    ErrorResponse:
+      type: object
+      required: [error, message]
+      properties:
+        error:
+          type: string
+          description: Machine-readable error code.
+          example: invalid_uuid
+        message:
+          type: string
+          description: Human-readable error description.
+          example: "user ID must be a valid UUID"
+
+  responses:
+    Unauthorized:
+      description: Missing or invalid X-Admin-Key header.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: unauthorized
+            message: "missing or invalid admin token"
+
+    BadRequest:
+      description: The request is malformed or contains invalid parameters.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: invalid_uuid
+            message: "user ID must be a valid UUID"
+
+    NotFound:
+      description: The requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: user_not_found
+            message: "user not found"
+
+    AdminDisabled:
+      description: The admin API is disabled in vibewarden.yaml.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: not_found
+            message: "not found"
+
+    ServiceUnavailable:
+      description: The identity provider is unreachable.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: service_unavailable
+            message: "service unavailable"

--- a/internal/apispec/spec.go
+++ b/internal/apispec/spec.go
@@ -1,0 +1,16 @@
+// Package apispec embeds the OpenAPI 3.0 specification for the VibeWarden
+// admin API. The canonical human-readable copy lives at docs/openapi.yaml in
+// the repository root; this package provides a compiled-in copy for the
+// /_vibewarden/api/docs endpoint.
+//
+// When the spec is updated, docs/openapi.yaml and internal/apispec/openapi.yaml
+// must be kept in sync.
+package apispec
+
+import _ "embed"
+
+// Spec holds the raw YAML bytes of the OpenAPI 3.0 specification.
+// It is embedded at build time from openapi.yaml in this package directory.
+//
+//go:embed openapi.yaml
+var Spec []byte


### PR DESCRIPTION
Closes #224
Closes #225

## Summary

- **docs/openapi.yaml** — OpenAPI 3.0 spec documenting all five admin API endpoints: `GET /_vibewarden/admin/users`, `GET /_vibewarden/admin/users/{id}`, `POST /_vibewarden/admin/users`, `DELETE /_vibewarden/admin/users/{id}`, `GET /_vibewarden/health`. Includes request/response schemas, pagination parameters, error responses (400/401/404/409/503), and the `X-Admin-Key` security scheme.
- **internal/apispec/** — new package that embeds `openapi.yaml` at build time via `embed.FS`, exporting `apispec.Spec []byte`. The canonical copy lives in `docs/`; `internal/apispec/openapi.yaml` is the compiled-in copy kept in sync.
- **internal/adapters/http/openapi.go** — `RegisterDocsRoute` registers `GET /_vibewarden/api/docs` on the admin server mux; `serveOpenAPISpec` writes the embedded YAML with `Content-Type: application/yaml`. No authentication required.
- **internal/adapters/http/admin_server.go** — `RegisterDocsRoute` called in `Start()` alongside `RegisterRoutes`.
- **internal/adapters/caddy/config.go** — `buildDocsRoute` added; when `Admin.Enabled && Admin.InternalAddr != ""`, a dedicated pre-catch-all Caddy route for `/_vibewarden/api/docs` is inserted, reverse-proxying to the internal admin server. This route is placed before the catch-all so the `AdminAuthHandler` middleware never runs for doc requests.

## Test plan

- `TestServeOpenAPISpec` — verifies 200, `Content-Type: application/yaml`, body starts with `openapi:`
- `TestServeOpenAPISpec_BodyMatchesEmbeddedSpec` — response body byte-for-byte matches `apispec.Spec`
- `TestRegisterDocsRoute` — end-to-end via mux
- `TestBuildDocsRoute` — unit test for the new Caddy route builder
- `TestBuildCaddyConfig_DocsRoute` — table-driven: present when admin enabled/addr set; absent otherwise

All pass: `make check` green including demo-app.
