### PR TITLE
feat(#236,#237,#238,#239): consolidate demo into profile-based setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ observability-down:
 
 # Open Grafana dashboard in the default browser (macOS/Linux)
 grafana-open:
-	open http://localhost:3000 2>/dev/null || xdg-open http://localhost:3000
+	open http://localhost:3001 2>/dev/null || xdg-open http://localhost:3001
 
 # Open Prometheus UI in the default browser (macOS/Linux)
 prometheus-open:
@@ -71,21 +71,29 @@ check: ## Run all quality checks (build, format, vet, tests)
 	cd examples/demo-app && go vet ./... && go build ./... && go test -race ./...
 	@echo "==> All checks passed!"
 
-# Start the full local demo stack (builds from source, includes observability)
-demo: ## Start the full local demo stack (https://localhost:8443, Grafana http://localhost:3000)
-	docker compose -f examples/demo-app/docker-compose.local-demo.yml up -d --build
+# Start the full local demo stack (observability profile + self-signed TLS)
+demo: ## Start the full local demo stack (https://localhost:8443, Grafana http://localhost:3001)
+	cd examples/demo-app && \
+	  VIBEWARDEN_PROFILE=tls \
+	  VIBEWARDEN_HTTP_PORT=8443 \
+	  VIBEWARDEN_SERVER_PORT=8443 \
+	  VIBEWARDEN_TLS_ENABLED=true \
+	  VIBEWARDEN_TLS_PROVIDER=self-signed \
+	  KRATOS_PUBLIC_BASE_URL=https://localhost:8443/ \
+	  COMPOSE_PROFILES=observability \
+	  docker compose up -d
 	@echo ""
 	@echo "Demo stack is starting — wait ~30 s for all services to be healthy."
 	@echo ""
-	@echo "  App:      https://localhost:8443   (accept the self-signed cert warning)"
-	@echo "  Grafana:  http://localhost:3000    (admin / admin)"
+	@echo "  App:        https://localhost:8443   (accept the self-signed cert warning)"
+	@echo "  Grafana:    http://localhost:3001    (admin / admin)"
 	@echo "  Prometheus: http://localhost:9090"
 	@echo ""
 	@echo "Demo credentials: demo@vibewarden.dev / demo1234"
 
 # Stop the full local demo stack
 demo-down: ## Stop the full local demo stack
-	docker compose -f examples/demo-app/docker-compose.local-demo.yml down
+	cd examples/demo-app && COMPOSE_PROFILES=observability docker compose down
 
 # Deploy the public demo to a remote VM via SSH.
 # Usage: make deploy-demo SSH=root@challenge.vibewarden.dev

--- a/examples/demo-app/.env.example
+++ b/examples/demo-app/.env.example
@@ -1,0 +1,71 @@
+# VibeWarden Demo App — environment variable reference
+#
+# Copy this file to .env and fill in values for the profile you want to run.
+# Most values have sensible defaults for local demo use.
+#
+# Usage:
+#   cp .env.example .env
+#   # edit .env
+#   docker compose up -d
+
+# --------------------------------------------------------------------------
+# Profile selection
+# --------------------------------------------------------------------------
+
+# VIBEWARDEN_PROFILE controls which config mode the sidecar and landing page use.
+# Accepted values: dev | tls | prod
+# Default: dev
+VIBEWARDEN_PROFILE=dev
+
+# COMPOSE_PROFILES enables optional service groups.
+# Accepted values: observability | full
+# Default: (empty — basic stack only)
+# COMPOSE_PROFILES=observability
+
+# --------------------------------------------------------------------------
+# Sidecar port overrides (change when VIBEWARDEN_PROFILE != dev)
+# --------------------------------------------------------------------------
+
+# HTTP port exposed to the host for the dev profile.
+# Default: 8080
+# VIBEWARDEN_HTTP_PORT=8080
+
+# For tls profile: override the port to 8443 and enable TLS.
+# VIBEWARDEN_HTTP_PORT=8443
+# VIBEWARDEN_SERVER_PORT=8443
+# VIBEWARDEN_TLS_ENABLED=true
+# VIBEWARDEN_TLS_PROVIDER=self-signed
+
+# For prod profile: standard HTTP+HTTPS ports and Let's Encrypt.
+# VIBEWARDEN_HTTP_PORT=443
+# VIBEWARDEN_SERVER_PORT=443
+# VIBEWARDEN_TLS_ENABLED=true
+# VIBEWARDEN_TLS_PROVIDER=letsencrypt
+# VIBEWARDEN_TLS_DOMAIN=your.domain.example.com
+
+# --------------------------------------------------------------------------
+# Postgres credentials
+# Defaults are suitable for local demo only.  Override for prod.
+# --------------------------------------------------------------------------
+# POSTGRES_USER=demo
+# POSTGRES_PASSWORD=demo
+# POSTGRES_DB=demo
+
+# --------------------------------------------------------------------------
+# Kratos public URL visible in browser redirects.
+# For the tls profile: https://localhost:8443/
+# For the prod profile: https://your.domain.example.com/
+# --------------------------------------------------------------------------
+# KRATOS_PUBLIC_BASE_URL=http://localhost:4433/
+
+# --------------------------------------------------------------------------
+# Grafana admin password (observability / full profile)
+# Default: admin  (change for prod)
+# --------------------------------------------------------------------------
+# GRAFANA_ADMIN_PASSWORD=admin
+
+# --------------------------------------------------------------------------
+# Rate limit overrides (prod profile uses higher thresholds)
+# --------------------------------------------------------------------------
+# VIBEWARDEN_RATE_LIMIT_PER_IP_REQUESTS_PER_SECOND=20
+# VIBEWARDEN_RATE_LIMIT_PER_IP_BURST=40

--- a/examples/demo-app/README.md
+++ b/examples/demo-app/README.md
@@ -4,7 +4,13 @@ A minimal Go HTTP server (stdlib only) that demonstrates every major VibeWarden
 feature.  The app itself performs no authentication — it simply trusts the
 headers injected by the VibeWarden sidecar.
 
-## Quickstart
+## Profiles
+
+All demo variants now live in a single `docker-compose.yml`.
+Pick a profile with the `VIBEWARDEN_PROFILE` and `COMPOSE_PROFILES` environment
+variables.
+
+### Default — HTTP dev stack
 
 ```bash
 cd examples/demo-app
@@ -15,49 +21,116 @@ docker compose up -d
 Wait ~15 seconds for the full stack to be healthy.  Your browser will be
 redirected to the demo UI at `http://localhost:8080/static/index.html`.
 
-## Full Demo Stack
+| Service | URL | Credentials |
+|---|---|---|
+| Demo app (via VibeWarden) | http://localhost:8080 | see Demo credentials below |
+| Kratos public API | http://localhost:4433 | — |
+| Kratos admin API | http://localhost:4434 | — |
+| Mailslurper (email UI) | http://localhost:4437 | — |
 
-The full demo stack adds Prometheus metrics, Grafana dashboards, and Loki log
-aggregation on top of the basic stack.  It also enables self-signed TLS so you
-can exercise the HTTPS path locally.
+### TLS — self-signed HTTPS
 
 ```bash
 cd examples/demo-app
-docker compose -f docker-compose.local-demo.yml up -d
+VIBEWARDEN_PROFILE=tls \
+VIBEWARDEN_HTTP_PORT=8443 \
+VIBEWARDEN_SERVER_PORT=8443 \
+VIBEWARDEN_TLS_ENABLED=true \
+VIBEWARDEN_TLS_PROVIDER=self-signed \
+KRATOS_PUBLIC_BASE_URL=https://localhost:8443/ \
+docker compose up -d
 # Visit https://localhost:8443  (accept the self-signed certificate warning)
+```
+
+Or put the variables in a `.env` file (copy `.env.example` as a starting point):
+
+```bash
+cp .env.example .env
+# Set VIBEWARDEN_PROFILE=tls and the related variables in .env
+docker compose up -d
+```
+
+### Observability — HTTP + Prometheus / Grafana / Loki
+
+```bash
+cd examples/demo-app
+COMPOSE_PROFILES=observability docker compose up -d
+# Demo app: http://localhost:8080
+# Grafana:  http://localhost:3001  (admin / admin)
 ```
 
 Wait ~30 seconds for all services to become healthy.
 
-### Access URLs
-
 | Service | URL | Credentials |
 |---|---|---|
-| Demo app (via VibeWarden) | https://localhost:8443 | see Demo credentials below |
-| Grafana | http://localhost:3000 | admin / admin |
+| Demo app (via VibeWarden) | http://localhost:8080 | see Demo credentials below |
+| Grafana | http://localhost:3001 | admin / admin |
 | Prometheus | http://localhost:9090 | — |
 | Loki (ready check) | http://localhost:3100/ready | — |
 | Kratos public API | http://localhost:4433 | — |
 | Mailslurper (email UI) | http://localhost:4437 | — |
 
-### What the full stack demonstrates
-
-- **Self-signed TLS** — VibeWarden terminates HTTPS using a Caddy-generated
-  self-signed certificate.  No domain or ACME account required.
-- **Metrics** — Prometheus scrapes `/_vibewarden/metrics` every 15 s.  Open
-  Grafana and navigate to the VibeWarden dashboard to see request rates, latency
-  histograms, rate-limit hits, and auth decisions in real time.
-- **Log aggregation** — Promtail tails every container's stdout/stderr via the
-  Docker socket and ships structured JSON logs to Loki.  Grafana's Explore view
-  lets you query them with LogQL.
-- **Pre-provisioned dashboards** — Grafana starts with the Prometheus and Loki
-  datasources already configured and the VibeWarden dashboard pre-loaded.
-
-### Teardown
+### Full — TLS + observability
 
 ```bash
-docker compose -f docker-compose.local-demo.yml down        # stop containers
-docker compose -f docker-compose.local-demo.yml down -v     # also remove volumes
+cd examples/demo-app
+VIBEWARDEN_PROFILE=tls \
+VIBEWARDEN_HTTP_PORT=8443 \
+VIBEWARDEN_SERVER_PORT=8443 \
+VIBEWARDEN_TLS_ENABLED=true \
+VIBEWARDEN_TLS_PROVIDER=self-signed \
+KRATOS_PUBLIC_BASE_URL=https://localhost:8443/ \
+COMPOSE_PROFILES=full \
+docker compose up -d
+# Visit https://localhost:8443  (accept the self-signed certificate warning)
+# Grafana: http://localhost:3001
+```
+
+### Production — Let's Encrypt (public server)
+
+```bash
+cd examples/demo-app
+cp .env.example .env
+# Edit .env: set VIBEWARDEN_PROFILE=prod, DOMAIN, POSTGRES_PASSWORD, GRAFANA_ADMIN_PASSWORD, etc.
+COMPOSE_PROFILES=observability docker compose up -d
+```
+
+Required `.env` variables for prod:
+
+| Variable | Example |
+|---|---|
+| `VIBEWARDEN_PROFILE` | `prod` |
+| `VIBEWARDEN_HTTP_PORT` | `443` |
+| `VIBEWARDEN_SERVER_PORT` | `443` |
+| `VIBEWARDEN_TLS_ENABLED` | `true` |
+| `VIBEWARDEN_TLS_PROVIDER` | `letsencrypt` |
+| `VIBEWARDEN_TLS_DOMAIN` | `challenge.vibewarden.dev` |
+| `KRATOS_PUBLIC_BASE_URL` | `https://challenge.vibewarden.dev/` |
+| `POSTGRES_PASSWORD` | _(strong secret)_ |
+| `GRAFANA_ADMIN_PASSWORD` | _(strong secret)_ |
+
+## What each profile demonstrates
+
+| Profile | TLS | Observability | Rate limits |
+|---|---|---|---|
+| `dev` (default) | HTTP | none | 5 req/s per IP |
+| `tls` | self-signed HTTPS | none | 5 req/s per IP |
+| `observability` | HTTP | Prometheus + Grafana + Loki | 5 req/s per IP |
+| `full` | self-signed HTTPS | Prometheus + Grafana + Loki | 5 req/s per IP |
+| `prod` | Let's Encrypt | optional | configurable |
+
+The landing page at `/static/index.html` detects the active profile and
+shows or hides sections accordingly (TLS badge, observability links, etc.).
+
+## Teardown
+
+```bash
+docker compose down           # stop containers, keep volumes
+docker compose down -v        # stop containers and remove volumes
+
+# With a non-default profile:
+COMPOSE_PROFILES=observability docker compose down
+COMPOSE_PROFILES=observability docker compose down -v
 ```
 
 ## Demo UI
@@ -67,20 +140,20 @@ build step required).  Four pages showcase each VibeWarden feature visually:
 
 | Page | URL | What it shows |
 |---|---|---|
-| Home | `/static/index.html` | Auth status, VibeWarden health badge, login / register / logout |
+| Home | `/static/index.html` | Auth status, VibeWarden health badge, profile banner, login / register / logout |
 | My Profile | `/static/me.html` | User ID, email, and verification status from VibeWarden headers |
 | Headers Inspector | `/static/headers.html` | All response headers, security headers highlighted green / red |
 | Rate Limit Test | `/static/ratelimit.html` | Fire 20 rapid requests and watch 429s appear in real time |
 
-The UI uses [water.css](https://watercss.kognise.dev/) (MIT) loaded from
-jsDelivr CDN for a clean, classless style with zero build tooling.
+The UI uses [water.css](https://watercss.kognise.dev/) (MIT) loaded locally
+for a clean, classless style with zero build tooling.
 
 ## Architecture
 
 ```
 Browser / curl
     |
-    | :8080
+    | :8080 (dev) or :8443 (tls) or :443 (prod)
     v
 +-------------------+
 |    VibeWarden      |  <-- auth check (Kratos), rate limiting, security headers
@@ -106,10 +179,15 @@ from the validated Kratos session.
 # Unauthenticated
 curl http://localhost:8080/
 # {"authenticated":false,"message":"Welcome! Please log in."}
+```
 
-# After logging in (cookie set by Kratos)
-curl -b cookies.txt http://localhost:8080/
-# {"authenticated":true,"message":"Welcome, alice@example.com!"}
+### `GET /profile` — Active profile info (public)
+
+Returns the active demo profile and which feature sets are available.
+
+```bash
+curl http://localhost:8080/profile
+# {"observability_enabled":false,"profile":"dev","tls_enabled":false}
 ```
 
 ### `GET /public` — Public endpoint (no auth required)
@@ -127,8 +205,6 @@ curl http://localhost:8080/public
 
 Returns the authenticated user's ID, email, and email-verification status.
 Returns 401 if the request did not pass through VibeWarden (no session cookie).
-
-**Demonstrates:** Protected route — app trusts sidecar-injected identity headers.
 
 ```bash
 curl -b cookies.txt http://localhost:8080/me
@@ -150,10 +226,7 @@ curl http://localhost:8080/headers
 ### `POST /spam` — Rate-limit trigger
 
 Increments an in-memory counter.  Hitting this endpoint rapidly will trigger
-VibeWarden's rate limiter (configured at 5 req/s per IP, burst 10).
-
-**Demonstrates:** Rate limiting — the 11th back-to-back request gets a
-`429 Too Many Requests` response with a `Retry-After` header.
+VibeWarden's rate limiter.
 
 ```bash
 for i in $(seq 1 20); do
@@ -166,35 +239,10 @@ done
 
 Returns `{"status":"ok"}`.
 
-**Demonstrates:** Health endpoint excluded from auth and rate limiting.
-
 ```bash
 curl http://localhost:8080/health
 # {"status":"ok"}
 ```
-
-## Services
-
-### Basic stack (`docker-compose.yml`)
-
-| Service | URL | Description |
-|---|---|---|
-| VibeWarden | http://localhost:8080 | Security sidecar — the entry point |
-| Kratos public API | http://localhost:4433 | Self-service auth flows |
-| Kratos admin API | http://localhost:4434 | Internal admin (not for browsers) |
-| Mailslurper | http://localhost:4437 | Catches Kratos verification emails |
-
-### Full demo stack (`docker-compose.local-demo.yml`)
-
-| Service | URL | Description |
-|---|---|---|
-| VibeWarden (HTTPS) | https://localhost:8443 | Security sidecar with self-signed TLS |
-| Grafana | http://localhost:3000 | Pre-provisioned dashboards (admin / admin) |
-| Prometheus | http://localhost:9090 | Metrics storage and query UI |
-| Loki | http://localhost:3100 | Log aggregation backend |
-| Kratos public API | http://localhost:4433 | Self-service auth flows |
-| Kratos admin API | http://localhost:4434 | Internal admin (not for browsers) |
-| Mailslurper | http://localhost:4437 | Catches Kratos verification emails |
 
 ## Demo credentials
 
@@ -239,11 +287,4 @@ Inspect them with:
 
 ```bash
 curl -I http://localhost:8080/public
-```
-
-## Teardown
-
-```bash
-docker compose down        # stop containers
-docker compose down -v     # also remove the Postgres volume
 ```

--- a/examples/demo-app/docker-compose.yml
+++ b/examples/demo-app/docker-compose.yml
@@ -1,24 +1,49 @@
-# VibeWarden Demo App — Docker Compose
+# VibeWarden Demo App — Profile-based Docker Compose
 #
-# Brings up the full demo stack:
-#   postgres       — Kratos session / identity storage
-#   kratos-migrate — runs Kratos DB migrations once, then exits
-#   kratos         — Ory Kratos identity server (public :4433, admin :4434)
-#   mailslurper    — catches outbound Kratos emails (SMTP :4436, web UI :4437)
-#   seed           — seeds demo identities into Kratos once, then exits
-#   demo-app       — the Go API backend (internal only — not published to host)
-#   vibewarden     — the security sidecar exposed on :8080
+# Three profiles available via COMPOSE_PROFILES or --profile:
 #
-# Usage:
-#   docker compose up -d
-#   # Visit http://localhost:8080
+#   (default)       basic stack: demo-app, vibewarden, kratos, postgres, mailslurper, seed
+#   observability   adds Prometheus, Grafana, Loki, Promtail on top of the basic stack
+#   full            everything from observability + seed data (alias for observability)
+#
+# Profile selection:
+#
+#   docker compose up -d                                   # default: HTTP on :8080
+#   COMPOSE_PROFILES=observability docker compose up -d   # observability on top
+#   COMPOSE_PROFILES=full docker compose up -d            # same as observability
+#
+# Config profile (vibewarden behaviour):
+#
+#   VIBEWARDEN_PROFILE=dev  docker compose up -d   # HTTP, relaxed limits (default)
+#   VIBEWARDEN_PROFILE=tls  docker compose up -d   # HTTPS self-signed on :8443
+#   VIBEWARDEN_PROFILE=prod docker compose up -d   # HTTPS Let's Encrypt (requires DOMAIN)
+#
+# Required env vars for prod profile:
+#   DOMAIN                  public hostname (e.g. challenge.vibewarden.dev)
+#   POSTGRES_USER           postgres username
+#   POSTGRES_PASSWORD       postgres password
+#   POSTGRES_DB             postgres database name
+#   GRAFANA_ADMIN_PASSWORD  grafana admin password
 #
 # Demo credentials (seeded automatically):
 #   demo@vibewarden.dev  / demo1234
 #   alice@vibewarden.dev / alice1234
 #
-# Secrets: all credentials are hard-coded to simple demo values.
-# Never use these outside a local demo environment.
+# Secrets: hard-coded demo values are defaults. Override via env for prod.
+# Never use the default credentials outside a local demo environment.
+
+x-vibewarden-base: &vibewarden-base
+  container_name: demo-vibewarden
+  volumes:
+    - ./vibewarden.yaml:/vibewarden.yaml:ro
+    - caddy_data:/root/.local/share/caddy
+  depends_on:
+    kratos:
+      condition: service_healthy
+    demo-app:
+      condition: service_healthy
+  networks:
+    - demo
 
 services:
   # --------------------------------------------------------------------------
@@ -27,16 +52,17 @@ services:
   postgres:
     image: postgres:17-alpine
     container_name: demo-postgres
+    restart: unless-stopped
     environment:
-      POSTGRES_USER: demo
-      POSTGRES_PASSWORD: demo
-      POSTGRES_DB: demo
+      POSTGRES_USER:     ${POSTGRES_USER:-demo}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-demo}
+      POSTGRES_DB:       ${POSTGRES_DB:-demo}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:
       - demo
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U demo -d demo"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-demo} -d ${POSTGRES_DB:-demo}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -48,7 +74,7 @@ services:
     image: oryd/kratos:v1.3.1
     container_name: demo-kratos-migrate
     environment:
-      DSN: postgres://demo:demo@postgres:5432/demo?sslmode=disable
+      DSN: postgres://${POSTGRES_USER:-demo}:${POSTGRES_PASSWORD:-demo}@postgres:5432/${POSTGRES_DB:-demo}?sslmode=disable
     volumes:
       - ./kratos:/etc/config/kratos:ro
     command: migrate sql -e --yes
@@ -57,20 +83,24 @@ services:
         condition: service_healthy
     networks:
       - demo
+    restart: "no"
 
   # --------------------------------------------------------------------------
   # Kratos — identity / session management
   #
-  # Public API  (user-facing flows):  http://localhost:4433
-  # Admin API   (internal use only):  http://localhost:4434
+  # Public API  (user-facing flows):  internal only when VIBEWARDEN_PROFILE=prod
+  # Admin API   (internal use only):  never exposed to host
   # --------------------------------------------------------------------------
   kratos:
     image: oryd/kratos:v1.3.1
     container_name: demo-kratos
+    restart: unless-stopped
     environment:
-      DSN: postgres://demo:demo@postgres:5432/demo?sslmode=disable
-      # Browser-visible base URL is the VibeWarden address on the host.
-      SERVE_PUBLIC_BASE_URL: http://localhost:4433/
+      DSN: postgres://${POSTGRES_USER:-demo}:${POSTGRES_PASSWORD:-demo}@postgres:5432/${POSTGRES_DB:-demo}?sslmode=disable
+      # In dev/tls profiles the sidecar listens on localhost ports; in prod it
+      # uses the public domain.  The KRATOS_PUBLIC_BASE_URL variable lets
+      # operators override the browser-visible base URL without editing files.
+      SERVE_PUBLIC_BASE_URL: ${KRATOS_PUBLIC_BASE_URL:-http://localhost:4433/}
       SERVE_ADMIN_BASE_URL: http://kratos:4434/
     ports:
       - "4433:4433"
@@ -95,10 +125,13 @@ services:
   #
   # SMTP endpoint (used by Kratos): mailslurper:4436
   # Web UI to read captured emails:  http://localhost:4437
+  # In prod the ports are not published to the host; traffic stays on the
+  # internal Docker network.
   # --------------------------------------------------------------------------
   mailslurper:
     image: oryd/mailslurper:latest-smtps
     container_name: demo-mailslurper
+    restart: unless-stopped
     ports:
       - "4436:4436"   # SMTP
       - "4437:4437"   # Web UI
@@ -132,15 +165,18 @@ services:
   # --------------------------------------------------------------------------
   # Demo app — the Go API backend
   #
-  # Not published to the host — only reachable through VibeWarden on :8080.
+  # Not published to the host — only reachable through VibeWarden.
   # --------------------------------------------------------------------------
   demo-app:
     build:
       context: .
       dockerfile: Dockerfile
     container_name: demo-app
+    restart: unless-stopped
     environment:
       PORT: "3000"
+      # Expose the active profile to the app so the landing page can adapt.
+      VIBEWARDEN_PROFILE: ${VIBEWARDEN_PROFILE:-dev}
     networks:
       - demo
     healthcheck:
@@ -153,41 +189,169 @@ services:
   # --------------------------------------------------------------------------
   # VibeWarden — the security sidecar
   #
-  # Listens on :8080 and proxies to demo-app:3000.
-  # Enforces auth (Kratos), rate limiting, and security headers.
+  # Behaviour is controlled by VIBEWARDEN_PROFILE + env overrides:
+  #
+  #   dev  (default) — HTTP :8080, no TLS, relaxed limits
+  #   tls             — HTTPS :8443 self-signed (set VIBEWARDEN_HTTP_PORT=8443,
+  #                     VIBEWARDEN_SERVER_PORT=8443, VIBEWARDEN_TLS_ENABLED=true,
+  #                     VIBEWARDEN_TLS_PROVIDER=self-signed)
+  #   prod            — HTTPS :443 Let's Encrypt (set VIBEWARDEN_HTTP_PORT=443,
+  #                     VIBEWARDEN_SERVER_PORT=443, VIBEWARDEN_TLS_ENABLED=true,
+  #                     VIBEWARDEN_TLS_PROVIDER=letsencrypt, VIBEWARDEN_TLS_DOMAIN=<domain>)
+  #
+  # See .env.example for the full list of variables to set per profile.
   # --------------------------------------------------------------------------
   vibewarden:
+    <<: *vibewarden-base
     image: ghcr.io/vibewarden/vibewarden:latest
-    container_name: demo-vibewarden
     ports:
-      - "8080:8080"
-    volumes:
-      - ./vibewarden.yaml:/vibewarden.yaml:ro
+      - "${VIBEWARDEN_HTTP_PORT:-8080}:${VIBEWARDEN_HTTP_PORT:-8080}"
     environment:
       VIBEWARDEN_KRATOS_PUBLIC_URL: http://kratos:4433
       VIBEWARDEN_KRATOS_ADMIN_URL:  http://kratos:4434
       VIBEWARDEN_UPSTREAM_HOST: demo-app
       VIBEWARDEN_UPSTREAM_PORT: "3000"
       VIBEWARDEN_SERVER_HOST: "0.0.0.0"
-    depends_on:
-      kratos:
-        condition: service_healthy
-      demo-app:
-        condition: service_healthy
-    networks:
-      - demo
+      VIBEWARDEN_PROFILE: ${VIBEWARDEN_PROFILE:-dev}
+      # Profile-specific overrides — set in .env or shell environment.
+      # These are passed through only when the variable is set in the environment.
+      VIBEWARDEN_SERVER_PORT:                          ${VIBEWARDEN_SERVER_PORT:-}
+      VIBEWARDEN_TLS_ENABLED:                          ${VIBEWARDEN_TLS_ENABLED:-}
+      VIBEWARDEN_TLS_PROVIDER:                         ${VIBEWARDEN_TLS_PROVIDER:-}
+      VIBEWARDEN_TLS_DOMAIN:                           ${VIBEWARDEN_TLS_DOMAIN:-}
+      VIBEWARDEN_RATE_LIMIT_PER_IP_REQUESTS_PER_SECOND: ${VIBEWARDEN_RATE_LIMIT_PER_IP_REQUESTS_PER_SECOND:-}
+      VIBEWARDEN_RATE_LIMIT_PER_IP_BURST:              ${VIBEWARDEN_RATE_LIMIT_PER_IP_BURST:-}
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/_vibewarden/health || exit 1"]
+      test: ["CMD-SHELL", "wget -q --no-check-certificate --spider http://localhost:${VIBEWARDEN_HTTP_PORT:-8080}/_vibewarden/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 15s
+
+  # --------------------------------------------------------------------------
+  # Prometheus — scrapes VibeWarden metrics every 15 s  [observability profile]
+  #
+  # UI available at: http://localhost:9090
+  # --------------------------------------------------------------------------
+  prometheus:
+    image: prom/prometheus:v3.4.0
+    container_name: demo-prometheus
+    restart: unless-stopped
+    profiles:
+      - observability
+      - full
+    ports:
+      - "9090:9090"
+    volumes:
+      - ../../observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+    depends_on:
+      vibewarden:
+        condition: service_healthy
+    networks:
+      - demo
+
+  # --------------------------------------------------------------------------
+  # Grafana — pre-provisioned dashboards  [observability profile]
+  #
+  # UI available at: http://localhost:3001  (admin / admin by default)
+  # Datasources (Prometheus + Loki) and the VibeWarden dashboard are
+  # provisioned automatically from the observability/ directory.
+  # --------------------------------------------------------------------------
+  grafana:
+    image: grafana/grafana:12.0.1
+    container_name: demo-grafana
+    restart: unless-stopped
+    profiles:
+      - observability
+      - full
+    ports:
+      - "3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION: "false"
+    volumes:
+      - ../../observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../../observability/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+      - loki
+    networks:
+      - demo
+
+  # --------------------------------------------------------------------------
+  # Loki — log aggregation backend  [observability profile]
+  #
+  # Receives log streams from Promtail.
+  # Queried by Grafana for the log panels.
+  # API available at: http://localhost:3100
+  # --------------------------------------------------------------------------
+  loki:
+    image: grafana/loki:3.5.0
+    container_name: demo-loki
+    restart: unless-stopped
+    profiles:
+      - observability
+      - full
+    ports:
+      - "3100:3100"
+    volumes:
+      - ../../observability/loki/loki-config.yml:/etc/loki/local-config.yaml:ro
+      - loki_data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - demo
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3100/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
       start_period: 10s
+
+  # --------------------------------------------------------------------------
+  # Promtail — tails Docker container logs and ships them to Loki  [observability profile]
+  #
+  # Mounts the Docker socket so it can discover all running containers.
+  # Parses VibeWarden's structured JSON logs and promotes fields to Loki labels.
+  # --------------------------------------------------------------------------
+  promtail:
+    image: grafana/promtail:3.5.0
+    container_name: demo-promtail
+    restart: unless-stopped
+    profiles:
+      - observability
+      - full
+    volumes:
+      - ../../observability/promtail/promtail-config.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      loki:
+        condition: service_healthy
+    networks:
+      - demo
 
 # --------------------------------------------------------------------------
 # Named volumes
 # --------------------------------------------------------------------------
 volumes:
   postgres_data:
+    driver: local
+  caddy_data:
+    driver: local
+  prometheus_data:
+    driver: local
+  grafana_data:
+    driver: local
+  loki_data:
     driver: local
 
 # --------------------------------------------------------------------------

--- a/examples/demo-app/main.go
+++ b/examples/demo-app/main.go
@@ -112,6 +112,7 @@ func main() {
 	mux.HandleFunc("GET /headers", handleHeaders)
 	mux.HandleFunc("POST /spam", handleSpam)
 	mux.HandleFunc("GET /health", handleHealth)
+	mux.HandleFunc("GET /profile", handleProfile)
 	mux.HandleFunc("GET /auth/login", handleAuthPage(staticFS, "login.html"))
 	mux.HandleFunc("GET /auth/registration", handleAuthPage(staticFS, "register.html"))
 	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
@@ -182,6 +183,27 @@ func handleRoot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleProfile returns the active demo profile and which optional feature sets
+// are available.  The profile is read from the VIBEWARDEN_PROFILE environment
+// variable (set in docker-compose.yml).  The landing page JavaScript calls this
+// endpoint to decide which sections to show or hide.
+//
+// This endpoint is public (no auth required).
+func handleProfile(w http.ResponseWriter, r *http.Request) {
+	profile := os.Getenv("VIBEWARDEN_PROFILE")
+	if profile == "" {
+		profile = "dev"
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"profile": profile,
+		// Feature flags derived from the profile name so the landing page
+		// can conditionally show observability links.
+		"tls_enabled":           profile == "tls" || profile == "prod",
+		"observability_enabled": profile == "full" || profile == "observability",
+	})
 }
 
 // handlePublic always returns a public response regardless of auth status.

--- a/examples/demo-app/static/index.html
+++ b/examples/demo-app/static/index.html
@@ -62,6 +62,16 @@
     }
     .demo-creds span { color: #7C3AED; }
 
+    .profile-banner {
+      margin: 0 0 1.5em;
+      padding: 0.7em 1em;
+      border: 1px solid #e5e7eb;
+      border-radius: 6px;
+      background: #f9fafb;
+      font-size: 0.9em;
+    }
+    .profile-banner code { color: #7C3AED; font-weight: bold; }
+
     .vw-footer {
       margin-top: 3em;
       padding: 1em 1.2em;
@@ -84,6 +94,9 @@
     <a href="/static/ratelimit.html">Rate Limit Test</a>
     <a href="/static/vulnlab.html">Vulnerability Lab</a>
   </nav>
+
+  <!-- Active profile banner (filled in by JS) -->
+  <div id="profile-banner" class="profile-banner" style="display:none"></div>
 
   <!-- Hero -->
   <div class="hero">
@@ -125,11 +138,11 @@
   </p>
 
   <div class="protection-grid">
-    <div class="protection-card">
-      <h3>TLS — Let's Encrypt</h3>
-      <p>
-        HTTPS is automatic. VibeWarden obtains and renews certificates via ACME.
-        No configuration needed.
+    <div class="protection-card" id="card-tls">
+      <h3>TLS — <span id="tls-label">disabled</span></h3>
+      <p id="tls-desc">
+        HTTP mode. Start with <code>VIBEWARDEN_PROFILE=tls</code> for self-signed
+        HTTPS or <code>VIBEWARDEN_PROFILE=prod</code> for Let's Encrypt.
       </p>
     </div>
     <div class="protection-card">
@@ -149,7 +162,7 @@
       </p>
     </div>
     <div class="protection-card">
-      <h3>Rate Limiting — 20 req/s per IP</h3>
+      <h3>Rate Limiting — 5 req/s per IP</h3>
       <p>
         Requests over the threshold receive <code>429 Too Many Requests</code>
         with a <code>Retry-After</code> header. Try the
@@ -199,9 +212,12 @@
       <a href="/static/vulnlab.html">Vulnerability Lab</a> —
       intentional vulnerabilities with VibeWarden mitigation status for each.
     </li>
-    <li>
-      <a href="http://dashboard.vibewarden.dev" target="_blank" rel="noopener">Grafana Dashboard</a> —
+    <!-- Observability links — shown only when observability profile is active -->
+    <li id="observability-links" style="display:none">
+      <a id="grafana-link" href="http://localhost:3001" target="_blank" rel="noopener">Grafana Dashboard</a> —
       live metrics and structured logs from this sidecar instance.
+      Also: <a href="http://localhost:9090" target="_blank" rel="noopener">Prometheus</a>
+      and <a href="http://localhost:3100/ready" target="_blank" rel="noopener">Loki</a>.
     </li>
   </ul>
 
@@ -235,6 +251,55 @@
 
   <script>
     (async function () {
+      // Fetch active profile first so we can adapt the rest of the page.
+      let profileData = { profile: 'dev', tls_enabled: false, observability_enabled: false };
+      try {
+        const resp = await fetch('/profile');
+        if (resp.ok) {
+          profileData = await resp.json();
+        }
+      } catch (_) {
+        // profile endpoint unavailable — use defaults
+      }
+
+      // Profile banner
+      const profileBanner = document.getElementById('profile-banner');
+      const profileLabels = {
+        dev:  'dev — HTTP, relaxed limits',
+        tls:  'tls — HTTPS with self-signed certificate',
+        prod: 'prod — HTTPS with Let\'s Encrypt',
+        full: 'full — HTTPS + observability stack',
+        observability: 'observability — HTTP + Prometheus / Grafana / Loki',
+      };
+      const label = profileLabels[profileData.profile] || profileData.profile;
+      profileBanner.innerHTML =
+        'Active profile: <code>' + escapeHtml(label) + '</code> &nbsp;' +
+        '(<a href="https://github.com/vibewarden/vibewarden/tree/main/examples/demo-app#profiles" ' +
+        'target="_blank" rel="noopener">how to switch</a>)';
+      profileBanner.style.display = '';
+
+      // TLS card
+      const tlsLabel = document.getElementById('tls-label');
+      const tlsDesc  = document.getElementById('tls-desc');
+      if (profileData.tls_enabled) {
+        tlsLabel.textContent = 'Let\'s Encrypt';
+        if (profileData.profile === 'tls') {
+          tlsLabel.textContent = 'self-signed';
+          tlsDesc.textContent =
+            'VibeWarden terminates HTTPS using a Caddy-generated self-signed certificate. ' +
+            'Browsers show a security warning — accept it to proceed.';
+        } else {
+          tlsDesc.textContent =
+            'HTTPS is automatic. VibeWarden obtains and renews certificates via ACME. ' +
+            'No configuration needed.';
+        }
+      }
+
+      // Observability links
+      if (profileData.observability_enabled) {
+        document.getElementById('observability-links').style.display = '';
+      }
+
       // Auth status
       const authDiv = document.getElementById('auth-status');
       try {

--- a/examples/demo-app/vibewarden.yaml
+++ b/examples/demo-app/vibewarden.yaml
@@ -1,12 +1,23 @@
 # VibeWarden configuration for the demo app.
 #
-# VibeWarden listens on :8080 and proxies requests to the demo-app
-# container on demo-app:3000.
+# This file is the single source of truth for all demo profiles.
+# Behaviour is controlled by the VIBEWARDEN_PROFILE environment variable:
 #
-# Features demonstrated:
-#   - Auth (Ory Kratos) — protects all routes except the public_paths list
-#   - Rate limiting     — low limits so you can trigger them easily
-#   - Security headers  — added to every response
+#   dev   — HTTP :8080, relaxed limits, no TLS (default)
+#   tls   — HTTPS :8443, self-signed certificate
+#   prod  — HTTPS :80/:443, Let's Encrypt (requires DOMAIN env var)
+#
+# All other settings are identical across profiles.  Set the appropriate
+# VIBEWARDEN_* environment variables in docker compose (or your .env file)
+# to override individual values without editing this file.
+#
+# Env vars that change per profile (set in docker-compose.yml or .env):
+#   VIBEWARDEN_SERVER_PORT          — 8080 (dev), 8443 (tls), 443 (prod)
+#   VIBEWARDEN_TLS_ENABLED          — false (dev), true (tls/prod)
+#   VIBEWARDEN_TLS_PROVIDER         — "" (dev), "self-signed" (tls), "letsencrypt" (prod)
+#   VIBEWARDEN_TLS_DOMAIN           — "" (dev/tls), your domain (prod)
+#   VIBEWARDEN_RATE_LIMIT_PER_IP_REQUESTS_PER_SECOND — 5 (dev/tls), 20 (prod)
+#   VIBEWARDEN_RATE_LIMIT_PER_IP_BURST               — 10 (dev/tls), 40 (prod)
 
 server:
   host: "0.0.0.0"
@@ -30,6 +41,7 @@ auth:
     - "/"
     - "/public"
     - "/health"
+    - "/profile"
     - "/static"
     - "/auth"
     - "/vuln"


### PR DESCRIPTION
Closes #236
Closes #237
Closes #238
Closes #239

## Summary

- **#236 — Consolidated docker-compose**: replaced `docker-compose.yml`, `docker-compose.local-demo.yml`, and `docker-compose.prod.yml` with a single `docker-compose.yml` using Docker Compose profiles (`observability`, `full`). Default startup (no profile flag) gives the basic stack on HTTP :8080.

- **#237 — Profile-aware config**: replaced `vibewarden.yaml`, `vibewarden.local-demo.yaml`, and `vibewarden.prod.yaml` with a single `vibewarden.yaml`. Profile-specific behaviour (port, TLS provider, rate limits) is now controlled entirely by `VIBEWARDEN_*` environment variables. Added `.env.example` documenting every variable for each profile variant (dev / tls / prod).

- **#238 — Adaptive landing page**: added `GET /profile` endpoint (public, no auth) to `main.go` that returns `{ profile, tls_enabled, observability_enabled }`. The `static/index.html` fetches this endpoint on load and conditionally shows a profile banner, updates the TLS card text, and reveals Grafana / Prometheus / Loki links when the observability profile is active.

- **#239 — Documentation**: rewrote `examples/demo-app/README.md` with profile-based quickstart commands for all five variants (dev, tls, observability, full, prod), a profile comparison table, and updated service URL tables.

- Updated `Makefile` `demo` and `demo-down` targets to use the new profile-based compose invocation. Fixed `grafana-open` port (now 3001 to avoid conflict with demo-app internal port 3000).

## Test plan

- [ ] `make check` passes (all Go tests green, gofmt clean)
- [ ] `docker compose up -d` starts basic stack on http://localhost:8080
- [ ] `COMPOSE_PROFILES=observability docker compose up -d` adds Prometheus/Grafana/Loki; Grafana on :3001
- [ ] `VIBEWARDEN_PROFILE=tls ... docker compose up -d` starts HTTPS on :8443 with self-signed cert
- [ ] Landing page profile banner matches the active profile
- [ ] Observability links are hidden on the default profile and visible with `observability` profile
- [ ] `GET /profile` returns correct JSON for each profile setting