### PR TITLE
docs(#229,#230,#231): production guide, hardening checklist, and framework examples

### DIFF
--- a/docs/examples/django.md
+++ b/docs/examples/django.md
@@ -1,0 +1,518 @@
+# VibeWarden + Django
+
+This guide shows how to put VibeWarden in front of a Django application running in
+Docker Compose. VibeWarden handles TLS, authentication (Ory Kratos), rate limiting,
+and security headers. Django receives only authenticated, validated requests with
+identity injected as HTTP headers.
+
+---
+
+## Architecture
+
+```
+Internet
+  │
+  ▼ :443 (HTTPS)
+VibeWarden (Caddy embedded)
+  │  validates session cookie → Kratos
+  │  injects X-User-* headers
+  ▼ :8000 (HTTP, internal, via Gunicorn)
+Django app
+```
+
+Your Django app listens on port 8000 on the internal Docker network via Gunicorn.
+It is never directly reachable from the internet — VibeWarden is the sole entry point.
+
+---
+
+## vibewarden.yaml
+
+```yaml
+server:
+  host: "0.0.0.0"
+  port: 443
+
+upstream:
+  host: "django"   # Docker Compose service name
+  port: 8000
+
+tls:
+  enabled: true
+  provider: letsencrypt
+  domain: "myapp.example.com"
+
+kratos:
+  public_url: "http://kratos:4433"
+  admin_url:  "http://kratos:4434"
+
+auth:
+  public_paths:
+    - "/login"
+    - "/register"
+    - "/recovery"
+    - "/verification"
+    - "/static/*"
+    - "/media/*"
+    - "/favicon.ico"
+    - "/robots.txt"
+    - "/api/public/*"
+  session_cookie_name: "ory_kratos_session"
+  login_url: "/login"
+
+body_size:
+  max: "10MB"
+  overrides:
+    - path: /api/upload
+      max: "50MB"
+
+rate_limit:
+  enabled: true
+  per_ip:
+    requests_per_second: 20
+    burst: 40
+  per_user:
+    requests_per_second: 200
+    burst: 400
+  trust_proxy_headers: false
+
+log:
+  level: "info"
+  format: "json"
+
+admin:
+  enabled: true
+  token: ""   # set via VIBEWARDEN_ADMIN_TOKEN env var
+
+metrics:
+  enabled: true
+  path_patterns:
+    - "/api/:resource"
+    - "/api/:resource/:id"
+    - "/api/v1/:resource"
+    - "/api/v1/:resource/:id"
+
+security_headers:
+  enabled: true
+  hsts_max_age: 31536000
+  hsts_include_subdomains: true
+  content_type_nosniff: true
+  frame_option: "DENY"
+  content_security_policy: "default-src 'self'"
+  referrer_policy: "strict-origin-when-cross-origin"
+  cross_origin_opener_policy: "same-origin"
+  cross_origin_resource_policy: "same-origin"
+  suppress_via_header: true
+```
+
+---
+
+## docker-compose.yml
+
+```yaml
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: myapp-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER:     ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB:       ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - myapp
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # App-level Postgres (separate DB for your Django app)
+  app-postgres:
+    image: postgres:17-alpine
+    container_name: myapp-app-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER:     ${APP_DB_USER}
+      POSTGRES_PASSWORD: ${APP_DB_PASSWORD}
+      POSTGRES_DB:       ${APP_DB_NAME}
+    volumes:
+      - app_postgres_data:/var/lib/postgresql/data
+    networks:
+      - myapp
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${APP_DB_USER} -d ${APP_DB_NAME}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  kratos-migrate:
+    image: oryd/kratos:v1.3.1
+    container_name: myapp-kratos-migrate
+    restart: on-failure
+    environment:
+      DSN: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+    volumes:
+      - ./config/kratos:/etc/config/kratos:ro
+    command: migrate sql -e --yes
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - myapp
+
+  kratos:
+    image: oryd/kratos:v1.3.1
+    container_name: myapp-kratos
+    restart: unless-stopped
+    environment:
+      DSN: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+      SERVE_PUBLIC_BASE_URL: https://${DOMAIN}/
+      SERVE_ADMIN_BASE_URL: http://kratos:4434/
+    volumes:
+      - ./config/kratos:/etc/config/kratos:ro
+    command: serve --config /etc/config/kratos/kratos.yml --watch-courier
+    depends_on:
+      kratos-migrate:
+        condition: service_completed_successfully
+    networks:
+      - myapp
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://kratos:4434/admin/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  vibewarden:
+    image: ghcr.io/vibewarden/vibewarden:latest
+    container_name: myapp-vibewarden
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./vibewarden.yaml:/vibewarden.yaml:ro
+      - caddy_data:/root/.local/share/caddy
+    environment:
+      VIBEWARDEN_KRATOS_PUBLIC_URL: http://kratos:4433
+      VIBEWARDEN_KRATOS_ADMIN_URL:  http://kratos:4434
+      VIBEWARDEN_UPSTREAM_HOST:     django
+      VIBEWARDEN_UPSTREAM_PORT:     "8000"
+      VIBEWARDEN_SERVER_HOST:       "0.0.0.0"
+      VIBEWARDEN_ADMIN_TOKEN:       ${VIBEWARDEN_ADMIN_TOKEN}
+    depends_on:
+      kratos:
+        condition: service_healthy
+      django:
+        condition: service_healthy
+    networks:
+      - myapp
+
+  django:
+    image: your-registry/your-django-app:latest
+    container_name: myapp-django
+    restart: unless-stopped
+    environment:
+      DJANGO_SETTINGS_MODULE: myapp.settings.production
+      DATABASE_URL: postgres://${APP_DB_USER}:${APP_DB_PASSWORD}@app-postgres:5432/${APP_DB_NAME}
+      SECRET_KEY: ${DJANGO_SECRET_KEY}
+    expose:
+      - "8000"
+    networks:
+      - myapp
+    depends_on:
+      app-postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8000/health/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+  app_postgres_data:
+  caddy_data:
+
+networks:
+  myapp:
+    driver: bridge
+```
+
+> Django has its own application database (`app-postgres`) separate from the Kratos
+> database (`postgres`). This separation keeps concerns clean.
+
+---
+
+## Reading X-User-* headers in Django
+
+VibeWarden injects identity headers on every authenticated request before forwarding
+to the upstream. Django receives them as HTTP headers; the WSGI/ASGI interface
+transforms header names to uppercase with an `HTTP_` prefix.
+
+### Available headers
+
+| HTTP Header | Django `request.META` key | Description |
+|---|---|---|
+| `X-User-ID` | `HTTP_X_USER_ID` | Kratos identity UUID |
+| `X-User-Email` | `HTTP_X_USER_EMAIL` | Primary email address |
+| `X-User-Verified` | `HTTP_X_USER_VERIFIED` | `"true"` if email is verified |
+| `X-Session-ID` | `HTTP_X_SESSION_ID` | Kratos session UUID |
+
+### Middleware
+
+Create a Django middleware that reads the VibeWarden headers and attaches a user
+object to `request.vw_user`:
+
+```python
+# myapp/middleware.py
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class VibeWardenUser:
+    """Represents the authenticated user as injected by VibeWarden."""
+
+    id: str
+    email: str
+    verified: bool
+    session_id: str
+
+
+class VibeWardenMiddleware:
+    """
+    Reads X-User-* headers injected by VibeWarden and attaches a
+    VibeWardenUser to request.vw_user.
+
+    Only trust these headers when all requests come through VibeWarden.
+    Never expose your Django app directly to the internet.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        user_id    = request.META.get("HTTP_X_USER_ID", "")
+        user_email = request.META.get("HTTP_X_USER_EMAIL", "")
+        verified   = request.META.get("HTTP_X_USER_VERIFIED", "false") == "true"
+        session_id = request.META.get("HTTP_X_SESSION_ID", "")
+
+        if user_id:
+            request.vw_user = VibeWardenUser(
+                id=user_id,
+                email=user_email,
+                verified=verified,
+                session_id=session_id,
+            )
+        else:
+            request.vw_user = None
+
+        return self.get_response(request)
+```
+
+Register the middleware in `settings.py`:
+
+```python
+# settings/production.py
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "myapp.middleware.VibeWardenMiddleware",   # add after standard middleware
+    # ...
+]
+```
+
+### Views
+
+```python
+# views.py
+from django.http import JsonResponse
+from django.views import View
+
+
+class MeView(View):
+    def get(self, request):
+        user = request.vw_user
+        if not user:
+            return JsonResponse({"error": "unauthorized"}, status=401)
+        return JsonResponse({
+            "id":       user.id,
+            "email":    user.email,
+            "verified": user.verified,
+        })
+
+
+class DashboardView(View):
+    def get(self, request):
+        user = request.vw_user
+        if not user:
+            return JsonResponse({"error": "unauthorized"}, status=401)
+        return JsonResponse({"message": f"Hello, {user.email}"})
+```
+
+### Decorator for protected views
+
+```python
+# myapp/decorators.py
+from functools import wraps
+from django.http import JsonResponse
+
+
+def vibewarden_required(view_func):
+    """
+    Decorator that rejects requests where VibeWarden did not inject
+    a user identity (i.e. the request is unauthenticated).
+    """
+    @wraps(view_func)
+    def wrapper(request, *args, **kwargs):
+        if not getattr(request, "vw_user", None):
+            return JsonResponse({"error": "unauthorized"}, status=401)
+        return view_func(request, *args, **kwargs)
+    return wrapper
+```
+
+Usage:
+
+```python
+from myapp.decorators import vibewarden_required
+
+@vibewarden_required
+def profile(request):
+    return JsonResponse({
+        "id":    request.vw_user.id,
+        "email": request.vw_user.email,
+    })
+```
+
+### Django REST Framework integration
+
+If you use DRF, create a custom authentication class:
+
+```python
+# myapp/authentication.py
+from rest_framework.authentication import BaseAuthentication
+from rest_framework.exceptions import AuthenticationFailed
+from dataclasses import dataclass
+
+
+@dataclass
+class VibeWardenIdentity:
+    """DRF-compatible user object populated from VibeWarden headers."""
+
+    pk: str      # required by DRF's is_authenticated logic
+    email: str
+    verified: bool
+    session_id: str
+
+    @property
+    def is_authenticated(self):
+        return True
+
+    @property
+    def is_anonymous(self):
+        return False
+
+
+class VibeWardenAuthentication(BaseAuthentication):
+    """
+    DRF authentication backend that reads X-User-* headers injected
+    by VibeWarden. Returns (user, None) on success.
+    """
+
+    def authenticate(self, request):
+        user_id = request.META.get("HTTP_X_USER_ID")
+        if not user_id:
+            return None   # unauthenticated; let DRF handle it
+
+        user = VibeWardenIdentity(
+            pk=user_id,
+            email=request.META.get("HTTP_X_USER_EMAIL", ""),
+            verified=request.META.get("HTTP_X_USER_VERIFIED", "false") == "true",
+            session_id=request.META.get("HTTP_X_SESSION_ID", ""),
+        )
+        return (user, None)
+```
+
+Register in `settings.py`:
+
+```python
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "myapp.authentication.VibeWardenAuthentication",
+    ],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
+    ],
+}
+```
+
+DRF views then use `request.user` as normal:
+
+```python
+from rest_framework.views import APIView
+from rest_framework.response import Response
+
+class ProfileView(APIView):
+    def get(self, request):
+        return Response({
+            "id":    request.user.pk,
+            "email": request.user.email,
+        })
+```
+
+---
+
+## Django settings for production behind a proxy
+
+Since VibeWarden terminates TLS and forwards HTTP to Django, configure Django to trust
+the forwarded headers:
+
+```python
+# settings/production.py
+
+# VibeWarden is the only trusted proxy; it runs on the same Docker network.
+# Set this to the VibeWarden container's IP or the Docker network CIDR.
+ALLOWED_HOSTS = ["myapp.example.com"]
+
+# Tell Django that HTTPS is being handled by VibeWarden upstream.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+# Django's own HSTS and security headers — disable these because VibeWarden
+# already adds them. Letting both add headers results in duplicates.
+SECURE_HSTS_SECONDS = 0
+SECURE_CONTENT_TYPE_NOSNIFF = False
+SECURE_BROWSER_XSS_FILTER = False
+X_FRAME_OPTIONS = ""   # VibeWarden sets X-Frame-Options
+
+# Do not redirect HTTP to HTTPS in Django — VibeWarden handles that.
+SECURE_SSL_REDIRECT = False
+
+# CSRF — Django still validates CSRF tokens for state-mutating requests.
+# VibeWarden does not bypass CSRF protection.
+CSRF_TRUSTED_ORIGINS = ["https://myapp.example.com"]
+```
+
+### Health check endpoint
+
+Add a lightweight health endpoint that does not touch the database:
+
+```python
+# urls.py
+from django.urls import path
+from django.http import JsonResponse
+
+def health(request):
+    return JsonResponse({"status": "ok"})
+
+urlpatterns = [
+    path("health/", health),
+    # ... your other URL patterns
+]
+```
+
+Register `/health/` in `auth.public_paths` in `vibewarden.yaml` so VibeWarden
+passes it through without a session check.

--- a/docs/examples/express.md
+++ b/docs/examples/express.md
@@ -1,0 +1,403 @@
+# VibeWarden + Express / Node.js
+
+This guide shows how to put VibeWarden in front of an Express (Node.js) application
+running in Docker Compose. VibeWarden handles TLS, authentication (Ory Kratos), rate
+limiting, and security headers. Express receives only authenticated, validated requests
+with identity injected as HTTP headers.
+
+---
+
+## Architecture
+
+```
+Internet
+  │
+  ▼ :443 (HTTPS)
+VibeWarden (Caddy embedded)
+  │  validates session cookie → Kratos
+  │  injects X-User-* headers
+  ▼ :3000 (HTTP, internal)
+Express app
+```
+
+Your Express app listens on port 3000 on the internal Docker network. It is never
+directly reachable from the internet — VibeWarden is the sole entry point.
+
+---
+
+## vibewarden.yaml
+
+```yaml
+server:
+  host: "0.0.0.0"
+  port: 443
+
+upstream:
+  host: "express"   # Docker Compose service name
+  port: 3000
+
+tls:
+  enabled: true
+  provider: letsencrypt
+  domain: "myapp.example.com"
+
+kratos:
+  public_url: "http://kratos:4433"
+  admin_url:  "http://kratos:4434"
+
+auth:
+  public_paths:
+    - "/login"
+    - "/register"
+    - "/recovery"
+    - "/verification"
+    - "/public/*"
+    - "/static/*"
+    - "/favicon.ico"
+    - "/robots.txt"
+  session_cookie_name: "ory_kratos_session"
+  login_url: "/login"
+
+body_size:
+  max: "10MB"
+  overrides:
+    - path: /api/upload
+      max: "50MB"
+
+rate_limit:
+  enabled: true
+  per_ip:
+    requests_per_second: 20
+    burst: 40
+  per_user:
+    requests_per_second: 200
+    burst: 400
+  trust_proxy_headers: false
+
+log:
+  level: "info"
+  format: "json"
+
+admin:
+  enabled: true
+  token: ""   # set via VIBEWARDEN_ADMIN_TOKEN env var
+
+metrics:
+  enabled: true
+  path_patterns:
+    - "/api/:resource"
+    - "/api/:resource/:id"
+    - "/api/v1/:resource"
+    - "/api/v1/:resource/:id"
+
+security_headers:
+  enabled: true
+  hsts_max_age: 31536000
+  hsts_include_subdomains: true
+  content_type_nosniff: true
+  frame_option: "DENY"
+  content_security_policy: "default-src 'self'"
+  referrer_policy: "strict-origin-when-cross-origin"
+  cross_origin_opener_policy: "same-origin"
+  cross_origin_resource_policy: "same-origin"
+  suppress_via_header: true
+```
+
+---
+
+## docker-compose.yml
+
+```yaml
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: myapp-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER:     ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB:       ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - myapp
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  kratos-migrate:
+    image: oryd/kratos:v1.3.1
+    container_name: myapp-kratos-migrate
+    restart: on-failure
+    environment:
+      DSN: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+    volumes:
+      - ./config/kratos:/etc/config/kratos:ro
+    command: migrate sql -e --yes
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - myapp
+
+  kratos:
+    image: oryd/kratos:v1.3.1
+    container_name: myapp-kratos
+    restart: unless-stopped
+    environment:
+      DSN: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+      SERVE_PUBLIC_BASE_URL: https://${DOMAIN}/
+      SERVE_ADMIN_BASE_URL: http://kratos:4434/
+    volumes:
+      - ./config/kratos:/etc/config/kratos:ro
+    command: serve --config /etc/config/kratos/kratos.yml --watch-courier
+    depends_on:
+      kratos-migrate:
+        condition: service_completed_successfully
+    networks:
+      - myapp
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://kratos:4434/admin/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  vibewarden:
+    image: ghcr.io/vibewarden/vibewarden:latest
+    container_name: myapp-vibewarden
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./vibewarden.yaml:/vibewarden.yaml:ro
+      - caddy_data:/root/.local/share/caddy
+    environment:
+      VIBEWARDEN_KRATOS_PUBLIC_URL: http://kratos:4433
+      VIBEWARDEN_KRATOS_ADMIN_URL:  http://kratos:4434
+      VIBEWARDEN_UPSTREAM_HOST:     express
+      VIBEWARDEN_UPSTREAM_PORT:     "3000"
+      VIBEWARDEN_SERVER_HOST:       "0.0.0.0"
+      VIBEWARDEN_ADMIN_TOKEN:       ${VIBEWARDEN_ADMIN_TOKEN}
+    depends_on:
+      kratos:
+        condition: service_healthy
+      express:
+        condition: service_healthy
+    networks:
+      - myapp
+
+  express:
+    image: your-registry/your-express-app:latest
+    container_name: myapp-express
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      PORT: "3000"
+    expose:
+      - "3000"
+    networks:
+      - myapp
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+  caddy_data:
+
+networks:
+  myapp:
+    driver: bridge
+```
+
+---
+
+## Reading X-User-* headers in Express
+
+VibeWarden injects identity headers on every authenticated request before forwarding
+to the upstream. Your Express app reads these headers to identify the current user
+without making any additional auth calls.
+
+### Available headers
+
+| Header | Description |
+|---|---|
+| `X-User-ID` | Kratos identity UUID |
+| `X-User-Email` | Primary email address from the identity traits |
+| `X-User-Verified` | `"true"` if the email address has been verified |
+| `X-Session-ID` | Kratos session UUID |
+
+### Middleware to extract user identity
+
+Create a middleware that reads the VibeWarden-injected headers and attaches the user
+to `req.user`:
+
+```javascript
+// middleware/vibewarden.js
+
+/**
+ * Reads the X-User-* headers injected by VibeWarden and attaches
+ * a user object to req.user. Must run after VibeWarden has validated
+ * the session — never trust these headers if the request did not come
+ * through VibeWarden.
+ */
+function vibewardenAuth(req, res, next) {
+  const userId    = req.headers["x-user-id"];
+  const userEmail = req.headers["x-user-email"];
+  const verified  = req.headers["x-user-verified"] === "true";
+  const sessionId = req.headers["x-session-id"];
+
+  if (!userId) {
+    // VibeWarden should have redirected unauthenticated requests.
+    // This is a defensive fallback for routes not covered by VibeWarden.
+    return res.status(401).json({ error: "unauthorized" });
+  }
+
+  req.user = { id: userId, email: userEmail, verified, sessionId };
+  next();
+}
+
+module.exports = { vibewardenAuth };
+```
+
+TypeScript version:
+
+```typescript
+// middleware/vibewarden.ts
+import { Request, Response, NextFunction } from "express";
+
+export interface VibeWardenUser {
+  id: string;
+  email: string;
+  verified: boolean;
+  sessionId: string;
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: VibeWardenUser;
+    }
+  }
+}
+
+export function vibewardenAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const id        = req.headers["x-user-id"] as string | undefined;
+  const email     = (req.headers["x-user-email"] as string) ?? "";
+  const verified  = req.headers["x-user-verified"] === "true";
+  const sessionId = (req.headers["x-session-id"] as string) ?? "";
+
+  if (!id) {
+    res.status(401).json({ error: "unauthorized" });
+    return;
+  }
+
+  req.user = { id, email, verified, sessionId };
+  next();
+}
+```
+
+### Applying the middleware
+
+Apply globally on all protected routes:
+
+```javascript
+// app.js
+const express = require("express");
+const { vibewardenAuth } = require("./middleware/vibewarden");
+
+const app = express();
+app.use(express.json());
+
+// Health check — public, no auth required.
+// Add this path to auth.public_paths in vibewarden.yaml.
+app.get("/health", (req, res) => res.json({ status: "ok" }));
+
+// All routes below require authentication via VibeWarden.
+app.use(vibewardenAuth);
+
+app.get("/api/me", (req, res) => {
+  res.json({
+    id:    req.user.id,
+    email: req.user.email,
+  });
+});
+
+app.get("/api/dashboard", (req, res) => {
+  res.json({ message: `Hello, ${req.user.email}` });
+});
+
+app.listen(3000);
+```
+
+Apply per-router for fine-grained control:
+
+```javascript
+const apiRouter = express.Router();
+apiRouter.use(vibewardenAuth);
+
+apiRouter.get("/profile", (req, res) => {
+  res.json({ userId: req.user.id });
+});
+
+app.use("/api", apiRouter);
+```
+
+### Health check route
+
+Add a `/health` endpoint that does not require authentication. Register it in
+`auth.public_paths` in `vibewarden.yaml` so VibeWarden passes it through without a
+session check:
+
+```javascript
+app.get("/health", (req, res) => {
+  res.json({ status: "ok" });
+});
+```
+
+```yaml
+# vibewarden.yaml
+auth:
+  public_paths:
+    - "/health"
+    - "/static/*"
+```
+
+---
+
+## Logging
+
+VibeWarden emits structured JSON logs. Configure Express to also emit JSON logs so
+your log aggregation pipeline receives a consistent format:
+
+```javascript
+// Using pino (recommended for production)
+const pino = require("pino");
+const pinoHttp = require("pino-http");
+
+const logger = pino({ level: "info" });
+
+app.use(
+  pinoHttp({
+    logger,
+    customProps: (req) => ({
+      userId:    req.headers["x-user-id"],
+      sessionId: req.headers["x-session-id"],
+    }),
+  })
+);
+```
+
+This enriches every HTTP log entry with the user and session IDs injected by
+VibeWarden, making it easy to correlate VibeWarden logs with Express logs in your log
+aggregation platform.

--- a/docs/examples/nextjs.md
+++ b/docs/examples/nextjs.md
@@ -1,0 +1,436 @@
+# VibeWarden + Next.js
+
+This guide shows how to put VibeWarden in front of a Next.js application running in
+Docker Compose. VibeWarden handles TLS, authentication (Ory Kratos), rate limiting,
+and security headers. Next.js receives only authenticated, validated requests.
+
+---
+
+## Architecture
+
+```
+Internet
+  │
+  ▼ :443 (HTTPS)
+VibeWarden (Caddy embedded)
+  │  validates session cookie → Kratos
+  │  injects X-User-* headers
+  ▼ :3000 (HTTP, internal)
+Next.js app
+```
+
+Your Next.js app listens on port 3000 on the internal Docker network. It is never
+directly reachable from the internet — VibeWarden is the sole entry point.
+
+---
+
+## vibewarden.yaml
+
+```yaml
+server:
+  host: "0.0.0.0"
+  port: 443
+
+upstream:
+  host: "nextjs"   # Docker Compose service name
+  port: 3000
+
+tls:
+  enabled: true
+  provider: letsencrypt
+  domain: "myapp.example.com"
+
+kratos:
+  public_url: "http://kratos:4433"
+  admin_url:  "http://kratos:4434"
+
+auth:
+  public_paths:
+    - "/login"
+    - "/register"
+    - "/recovery"
+    - "/verification"
+    - "/_next/static/*"
+    - "/_next/image"
+    - "/favicon.ico"
+    - "/robots.txt"
+    - "/api/public/*"
+  session_cookie_name: "ory_kratos_session"
+  login_url: "/login"
+
+body_size:
+  max: "10MB"
+  overrides:
+    - path: /api/upload
+      max: "50MB"
+
+rate_limit:
+  enabled: true
+  per_ip:
+    requests_per_second: 20
+    burst: 40
+  per_user:
+    requests_per_second: 200
+    burst: 400
+  trust_proxy_headers: false
+
+log:
+  level: "info"
+  format: "json"
+
+admin:
+  enabled: true
+  token: ""   # set via VIBEWARDEN_ADMIN_TOKEN env var
+
+metrics:
+  enabled: true
+  path_patterns:
+    - "/api/:resource"
+    - "/api/:resource/:id"
+
+security_headers:
+  enabled: true
+  hsts_max_age: 31536000
+  hsts_include_subdomains: true
+  content_type_nosniff: true
+  frame_option: "DENY"
+  # Next.js uses inline scripts for hydration — adjust CSP accordingly.
+  content_security_policy: >-
+    default-src 'self';
+    script-src 'self' 'unsafe-inline';
+    style-src 'self' 'unsafe-inline';
+    img-src 'self' data: https:;
+    font-src 'self' data:
+  referrer_policy: "strict-origin-when-cross-origin"
+  cross_origin_opener_policy: "same-origin"
+  cross_origin_resource_policy: "same-origin"
+  suppress_via_header: true
+```
+
+> Next.js requires `'unsafe-inline'` for its runtime hydration scripts unless you
+> implement per-request nonces. Tighten the CSP after testing with your specific pages.
+
+---
+
+## docker-compose.yml
+
+```yaml
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: myapp-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER:     ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB:       ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - myapp
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  kratos-migrate:
+    image: oryd/kratos:v1.3.1
+    container_name: myapp-kratos-migrate
+    restart: on-failure
+    environment:
+      DSN: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+    volumes:
+      - ./config/kratos:/etc/config/kratos:ro
+    command: migrate sql -e --yes
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - myapp
+
+  kratos:
+    image: oryd/kratos:v1.3.1
+    container_name: myapp-kratos
+    restart: unless-stopped
+    environment:
+      DSN: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+      SERVE_PUBLIC_BASE_URL: https://${DOMAIN}/
+      SERVE_ADMIN_BASE_URL: http://kratos:4434/
+    volumes:
+      - ./config/kratos:/etc/config/kratos:ro
+    command: serve --config /etc/config/kratos/kratos.yml --watch-courier
+    depends_on:
+      kratos-migrate:
+        condition: service_completed_successfully
+    networks:
+      - myapp
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://kratos:4434/admin/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  vibewarden:
+    image: ghcr.io/vibewarden/vibewarden:latest
+    container_name: myapp-vibewarden
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./vibewarden.yaml:/vibewarden.yaml:ro
+      - caddy_data:/root/.local/share/caddy
+    environment:
+      VIBEWARDEN_KRATOS_PUBLIC_URL: http://kratos:4433
+      VIBEWARDEN_KRATOS_ADMIN_URL:  http://kratos:4434
+      VIBEWARDEN_UPSTREAM_HOST:     nextjs
+      VIBEWARDEN_UPSTREAM_PORT:     "3000"
+      VIBEWARDEN_SERVER_HOST:       "0.0.0.0"
+      VIBEWARDEN_ADMIN_TOKEN:       ${VIBEWARDEN_ADMIN_TOKEN}
+    depends_on:
+      kratos:
+        condition: service_healthy
+      nextjs:
+        condition: service_healthy
+    networks:
+      - myapp
+
+  nextjs:
+    image: your-registry/your-nextjs-app:latest
+    container_name: myapp-nextjs
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      PORT: "3000"
+    expose:
+      - "3000"
+    networks:
+      - myapp
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+  caddy_data:
+
+networks:
+  myapp:
+    driver: bridge
+```
+
+---
+
+## Reading X-User-* headers in Next.js
+
+VibeWarden injects identity headers on every authenticated request before forwarding
+to the upstream. Your Next.js app reads these headers to identify the current user
+without making any additional auth calls.
+
+### Available headers
+
+| Header | Description |
+|---|---|
+| `X-User-ID` | Kratos identity UUID |
+| `X-User-Email` | Primary email address from the identity traits |
+| `X-User-Verified` | `"true"` if the email address has been verified |
+| `X-Session-ID` | Kratos session UUID |
+
+### App Router (Next.js 13+)
+
+In a Server Component or Route Handler, read headers via the `headers()` API:
+
+```typescript
+// app/dashboard/page.tsx
+import { headers } from "next/headers";
+
+export default async function DashboardPage() {
+  const headersList = await headers();
+  const userId    = headersList.get("x-user-id");
+  const userEmail = headersList.get("x-user-email");
+  const verified  = headersList.get("x-user-verified") === "true";
+
+  if (!userId) {
+    // VibeWarden should have redirected unauthenticated requests to /login.
+    // This branch is a defensive fallback.
+    return <p>Not authenticated</p>;
+  }
+
+  return (
+    <main>
+      <h1>Welcome, {userEmail}</h1>
+      {!verified && <p>Please verify your email address.</p>}
+    </main>
+  );
+}
+```
+
+In a Route Handler:
+
+```typescript
+// app/api/me/route.ts
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const headersList = await headers();
+  const userId    = headersList.get("x-user-id");
+  const userEmail = headersList.get("x-user-email");
+
+  if (!userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  return NextResponse.json({ userId, userEmail });
+}
+```
+
+### Pages Router (Next.js 12 and earlier)
+
+In `getServerSideProps`:
+
+```typescript
+// pages/dashboard.tsx
+import { GetServerSideProps } from "next";
+
+interface Props {
+  userId: string;
+  userEmail: string;
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({ req }) => {
+  const userId    = req.headers["x-user-id"] as string | undefined;
+  const userEmail = req.headers["x-user-email"] as string | undefined;
+
+  if (!userId) {
+    return {
+      redirect: { destination: "/login", permanent: false },
+    };
+  }
+
+  return {
+    props: { userId, userEmail: userEmail ?? "" },
+  };
+};
+
+export default function Dashboard({ userId, userEmail }: Props) {
+  return <h1>Welcome, {userEmail}</h1>;
+}
+```
+
+In an API route:
+
+```typescript
+// pages/api/me.ts
+import { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const userId    = req.headers["x-user-id"];
+  const userEmail = req.headers["x-user-email"];
+
+  if (!userId) {
+    return res.status(401).json({ error: "unauthorized" });
+  }
+
+  res.json({ userId, userEmail });
+}
+```
+
+### Middleware (edge runtime)
+
+If you use Next.js Middleware for additional routing logic, read the headers there too:
+
+```typescript
+// middleware.ts
+import { NextRequest, NextResponse } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const userId = request.headers.get("x-user-id");
+
+  // VibeWarden has already enforced auth; this is an extra guard.
+  if (!userId && !request.nextUrl.pathname.startsWith("/login")) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};
+```
+
+---
+
+## Login and registration pages
+
+The Kratos self-service UI flows are proxied by VibeWarden at `/self-service/*`. Your
+Next.js app renders the login and registration pages — they fetch the flow data from
+Kratos via the browser.
+
+Minimal login page (using the Kratos browser flow API):
+
+```typescript
+// app/login/page.tsx
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function LoginPage() {
+  const [flowId, setFlowId] = useState<string | null>(null);
+  const [csrfToken, setCsrfToken] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get("flow");
+    if (!id) {
+      // Initiate a new login flow via Kratos
+      window.location.href = "/self-service/login/browser";
+      return;
+    }
+    setFlowId(id);
+    fetch(`/self-service/login/flows?id=${id}`, { credentials: "include" })
+      .then((r) => r.json())
+      .then((flow) => {
+        const csrfNode = flow.ui?.nodes?.find(
+          (n: { attributes?: { name?: string; value?: string } }) =>
+            n.attributes?.name === "csrf_token"
+        );
+        setCsrfToken(csrfNode?.attributes?.value ?? "");
+      });
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch(`/self-service/login?flow=${flowId}`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        method: "password",
+        csrf_token: csrfToken,
+        identifier: email,
+        password,
+      }),
+    });
+    window.location.href = "/";
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
+      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" />
+      <button type="submit">Sign in</button>
+    </form>
+  );
+}
+```
+
+Refer to the [Ory Kratos documentation](https://www.ory.sh/docs/kratos/self-service)
+for complete flow implementations including CSRF handling and error display.

--- a/docs/examples/rails.md
+++ b/docs/examples/rails.md
@@ -1,0 +1,496 @@
+# VibeWarden + Rails
+
+This guide shows how to put VibeWarden in front of a Ruby on Rails application running
+in Docker Compose. VibeWarden handles TLS, authentication (Ory Kratos), rate limiting,
+and security headers. Rails receives only authenticated, validated requests with
+identity injected as HTTP headers.
+
+---
+
+## Architecture
+
+```
+Internet
+  │
+  ▼ :443 (HTTPS)
+VibeWarden (Caddy embedded)
+  │  validates session cookie → Kratos
+  │  injects X-User-* headers
+  ▼ :3000 (HTTP, internal, via Puma)
+Rails app
+```
+
+Your Rails app listens on port 3000 on the internal Docker network via Puma.
+It is never directly reachable from the internet — VibeWarden is the sole entry point.
+
+---
+
+## vibewarden.yaml
+
+```yaml
+server:
+  host: "0.0.0.0"
+  port: 443
+
+upstream:
+  host: "rails"   # Docker Compose service name
+  port: 3000
+
+tls:
+  enabled: true
+  provider: letsencrypt
+  domain: "myapp.example.com"
+
+kratos:
+  public_url: "http://kratos:4433"
+  admin_url:  "http://kratos:4434"
+
+auth:
+  public_paths:
+    - "/login"
+    - "/register"
+    - "/recovery"
+    - "/verification"
+    - "/assets/*"
+    - "/packs/*"
+    - "/favicon.ico"
+    - "/robots.txt"
+    - "/api/public/*"
+    - "/up"          # Rails 7.1+ health check
+  session_cookie_name: "ory_kratos_session"
+  login_url: "/login"
+
+body_size:
+  max: "10MB"
+  overrides:
+    - path: /uploads
+      max: "50MB"
+
+rate_limit:
+  enabled: true
+  per_ip:
+    requests_per_second: 20
+    burst: 40
+  per_user:
+    requests_per_second: 200
+    burst: 400
+  trust_proxy_headers: false
+
+log:
+  level: "info"
+  format: "json"
+
+admin:
+  enabled: true
+  token: ""   # set via VIBEWARDEN_ADMIN_TOKEN env var
+
+metrics:
+  enabled: true
+  path_patterns:
+    - "/api/:resource"
+    - "/api/:resource/:id"
+    - "/api/v1/:resource"
+    - "/api/v1/:resource/:id"
+
+security_headers:
+  enabled: true
+  hsts_max_age: 31536000
+  hsts_include_subdomains: true
+  content_type_nosniff: true
+  frame_option: "DENY"
+  # Rails uses inline scripts for UJS and Turbo — adjust CSP per your stack.
+  content_security_policy: "default-src 'self'"
+  referrer_policy: "strict-origin-when-cross-origin"
+  cross_origin_opener_policy: "same-origin"
+  cross_origin_resource_policy: "same-origin"
+  suppress_via_header: true
+```
+
+---
+
+## docker-compose.yml
+
+```yaml
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: myapp-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER:     ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB:       ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - myapp
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # App-level Postgres (separate DB for your Rails app)
+  app-postgres:
+    image: postgres:17-alpine
+    container_name: myapp-app-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER:     ${APP_DB_USER}
+      POSTGRES_PASSWORD: ${APP_DB_PASSWORD}
+      POSTGRES_DB:       ${APP_DB_NAME}
+    volumes:
+      - app_postgres_data:/var/lib/postgresql/data
+    networks:
+      - myapp
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${APP_DB_USER} -d ${APP_DB_NAME}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  kratos-migrate:
+    image: oryd/kratos:v1.3.1
+    container_name: myapp-kratos-migrate
+    restart: on-failure
+    environment:
+      DSN: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+    volumes:
+      - ./config/kratos:/etc/config/kratos:ro
+    command: migrate sql -e --yes
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - myapp
+
+  kratos:
+    image: oryd/kratos:v1.3.1
+    container_name: myapp-kratos
+    restart: unless-stopped
+    environment:
+      DSN: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+      SERVE_PUBLIC_BASE_URL: https://${DOMAIN}/
+      SERVE_ADMIN_BASE_URL: http://kratos:4434/
+    volumes:
+      - ./config/kratos:/etc/config/kratos:ro
+    command: serve --config /etc/config/kratos/kratos.yml --watch-courier
+    depends_on:
+      kratos-migrate:
+        condition: service_completed_successfully
+    networks:
+      - myapp
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://kratos:4434/admin/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  vibewarden:
+    image: ghcr.io/vibewarden/vibewarden:latest
+    container_name: myapp-vibewarden
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./vibewarden.yaml:/vibewarden.yaml:ro
+      - caddy_data:/root/.local/share/caddy
+    environment:
+      VIBEWARDEN_KRATOS_PUBLIC_URL: http://kratos:4433
+      VIBEWARDEN_KRATOS_ADMIN_URL:  http://kratos:4434
+      VIBEWARDEN_UPSTREAM_HOST:     rails
+      VIBEWARDEN_UPSTREAM_PORT:     "3000"
+      VIBEWARDEN_SERVER_HOST:       "0.0.0.0"
+      VIBEWARDEN_ADMIN_TOKEN:       ${VIBEWARDEN_ADMIN_TOKEN}
+    depends_on:
+      kratos:
+        condition: service_healthy
+      rails:
+        condition: service_healthy
+    networks:
+      - myapp
+
+  rails:
+    image: your-registry/your-rails-app:latest
+    container_name: myapp-rails
+    restart: unless-stopped
+    environment:
+      RAILS_ENV: production
+      RAILS_LOG_TO_STDOUT: "true"
+      DATABASE_URL: postgres://${APP_DB_USER}:${APP_DB_PASSWORD}@app-postgres:5432/${APP_DB_NAME}
+      SECRET_KEY_BASE: ${RAILS_SECRET_KEY_BASE}
+      RAILS_SERVE_STATIC_FILES: "true"
+    expose:
+      - "3000"
+    networks:
+      - myapp
+    depends_on:
+      app-postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/up"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+  app_postgres_data:
+  caddy_data:
+
+networks:
+  myapp:
+    driver: bridge
+```
+
+> Rails has its own application database (`app-postgres`) separate from the Kratos
+> database (`postgres`). This separation keeps concerns clean.
+
+---
+
+## Reading X-User-* headers in Rails
+
+VibeWarden injects identity headers on every authenticated request before forwarding
+to the upstream. Rack (the underlying interface for Rails) transforms HTTP header names
+to uppercase with an `HTTP_` prefix and hyphens replaced by underscores.
+
+### Available headers
+
+| HTTP Header | Rack env key | Description |
+|---|---|---|
+| `X-User-ID` | `HTTP_X_USER_ID` | Kratos identity UUID |
+| `X-User-Email` | `HTTP_X_USER_EMAIL` | Primary email address |
+| `X-User-Verified` | `HTTP_X_USER_VERIFIED` | `"true"` if email is verified |
+| `X-Session-ID` | `HTTP_X_SESSION_ID` | Kratos session UUID |
+
+### Middleware
+
+Create a Rack middleware that reads the VibeWarden headers and makes them available
+via `request.env`:
+
+```ruby
+# app/middleware/vibewarden_identity.rb
+
+# VibeWardenIdentity is a Rack middleware that reads the X-User-* headers
+# injected by VibeWarden and makes them available as request.env keys.
+#
+# Only trust these headers when all requests come through VibeWarden.
+# Never expose your Rails app directly to the internet.
+class VibeWardenIdentity
+  USER_ID_HEADER    = "HTTP_X_USER_ID".freeze
+  EMAIL_HEADER      = "HTTP_X_USER_EMAIL".freeze
+  VERIFIED_HEADER   = "HTTP_X_USER_VERIFIED".freeze
+  SESSION_ID_HEADER = "HTTP_X_SESSION_ID".freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    env[:vw_user_id]    = env[USER_ID_HEADER]
+    env[:vw_user_email] = env[EMAIL_HEADER]
+    env[:vw_verified]   = env[VERIFIED_HEADER] == "true"
+    env[:vw_session_id] = env[SESSION_ID_HEADER]
+
+    @app.call(env)
+  end
+end
+```
+
+Register the middleware in `config/application.rb`:
+
+```ruby
+# config/application.rb
+require_relative "../app/middleware/vibewarden_identity"
+
+module MyApp
+  class Application < Rails::Application
+    # Insert after the standard middleware stack so logging and
+    # exception handling middleware run first.
+    config.middleware.use VibeWardenIdentity
+  end
+end
+```
+
+### Concern for controllers
+
+Create an `ActionController` concern that provides a `current_user` helper and a
+`require_vibewarden_user` before action:
+
+```ruby
+# app/controllers/concerns/vibewarden_authenticated.rb
+module VibeWardenAuthenticated
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :current_vw_user
+  end
+
+  # current_vw_user returns a frozen hash with the authenticated user's
+  # attributes, or nil if the request is unauthenticated.
+  def current_vw_user
+    return nil unless request.env[:vw_user_id].present?
+
+    @current_vw_user ||= {
+      id:         request.env[:vw_user_id],
+      email:      request.env[:vw_user_email],
+      verified:   request.env[:vw_verified],
+      session_id: request.env[:vw_session_id],
+    }.freeze
+  end
+
+  # require_vibewarden_user halts the request with 401 if VibeWarden did
+  # not inject a user identity. Use as a before_action.
+  def require_vibewarden_user
+    return if current_vw_user
+
+    render json: { error: "unauthorized" }, status: :unauthorized
+  end
+end
+```
+
+Include the concern in `ApplicationController`:
+
+```ruby
+# app/controllers/application_controller.rb
+class ApplicationController < ActionController::Base
+  include VibeWardenAuthenticated
+
+  # Protect all actions by default. Override in specific controllers.
+  before_action :require_vibewarden_user
+end
+```
+
+### Controllers
+
+```ruby
+# app/controllers/api/me_controller.rb
+module Api
+  class MeController < ApplicationController
+    def show
+      render json: {
+        id:       current_vw_user[:id],
+        email:    current_vw_user[:email],
+        verified: current_vw_user[:verified],
+      }
+    end
+  end
+end
+```
+
+Skip authentication for public controllers:
+
+```ruby
+# app/controllers/pages_controller.rb
+class PagesController < ApplicationController
+  skip_before_action :require_vibewarden_user, only: %i[login register]
+
+  def login
+    # Render your login page. The form submits to /self-service/login
+    # which VibeWarden proxies to Kratos.
+  end
+
+  def register
+    # Render your registration page.
+  end
+end
+```
+
+### Views — accessing the current user
+
+Because `current_vw_user` is declared as a `helper_method`, it is available in views:
+
+```erb
+<%# app/views/dashboard/index.html.erb %>
+<h1>Welcome, <%= current_vw_user[:email] %></h1>
+
+<% unless current_vw_user[:verified] %>
+  <div class="alert">Please verify your email address.</div>
+<% end %>
+```
+
+---
+
+## Rails configuration for production behind a proxy
+
+Since VibeWarden terminates TLS and forwards HTTP to Rails, configure Rails to trust
+the forwarded headers:
+
+```ruby
+# config/environments/production.rb
+Rails.application.configure do
+  # Trust the X-Forwarded-Proto header set by VibeWarden.
+  # This makes request.ssl? return true for HTTPS requests.
+  config.force_ssl = false   # VibeWarden handles the redirect; do not double-redirect
+  config.assume_ssl = true   # tell Rails it is behind an SSL-terminating proxy
+
+  # VibeWarden sets security headers — disable Rails' own to avoid duplicates.
+  config.action_dispatch.default_headers = {
+    # Keep only headers that VibeWarden does not set.
+    # Remove entries that VibeWarden already handles.
+  }
+
+  # Log to stdout for Docker log collection.
+  config.logger = ActiveSupport::Logger.new($stdout)
+  config.log_level = :info
+end
+```
+
+### CSRF protection
+
+Rails' built-in CSRF protection applies to all state-mutating requests (POST, PUT,
+PATCH, DELETE) with `Content-Type: application/x-www-form-urlencoded` or
+`multipart/form-data`. VibeWarden does not bypass CSRF protection — Rails still
+validates the CSRF token.
+
+For JSON API endpoints that use VibeWarden for authentication, you may use:
+
+```ruby
+class ApiController < ApplicationController
+  protect_from_forgery with: :null_session   # or :exception for strict mode
+end
+```
+
+### Health check (Rails 7.1+)
+
+Rails 7.1 adds a built-in health check at `/up` that returns `200 OK` when the app
+is ready. Register `/up` in `auth.public_paths` in `vibewarden.yaml` so VibeWarden
+passes it through without a session check:
+
+```yaml
+# vibewarden.yaml
+auth:
+  public_paths:
+    - "/up"
+```
+
+For older Rails versions, add a minimal health route:
+
+```ruby
+# config/routes.rb
+Rails.application.routes.draw do
+  get "/health", to: proc { [200, {}, [{ status: "ok" }.to_json]] }
+  # ...
+end
+```
+
+---
+
+## Logging
+
+Rails logs to stdout in the Docker setup. VibeWarden enriches the request with user
+headers, which you can add to Rails' log tags for correlation:
+
+```ruby
+# config/environments/production.rb
+config.log_tags = [
+  :request_id,
+  ->(req) { req.env[:vw_user_id]   || "anonymous" },
+  ->(req) { req.env[:vw_session_id] || "no-session" },
+]
+```
+
+This prepends `[request_id] [user_id] [session_id]` to every Rails log line,
+making it easy to trace a user's requests across VibeWarden and Rails logs.

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -1,0 +1,648 @@
+# Production Deployment Guide
+
+This guide walks you through deploying VibeWarden in production using Docker Compose
+on a single Linux server. VibeWarden is a security sidecar — it always runs locally,
+next to your app, and is never hosted on a separate machine from the app it protects.
+
+---
+
+## Prerequisites
+
+### Server requirements
+
+- **OS**: Ubuntu 24.04 LTS or Debian 12 (recommended). Any Linux distribution with
+  Docker Engine 27+ and Docker Compose v2+ works.
+- **RAM**: 512 MB minimum. 1 GB+ recommended when running the full stack
+  (VibeWarden + Kratos + Postgres).
+- **CPU**: 1 vCPU minimum. 2 vCPU recommended.
+- **Disk**: 10 GB minimum for the OS, Docker images, and Postgres data.
+- **Open ports**: 80 (HTTP, used for ACME HTTP-01 challenge) and 443 (HTTPS).
+
+### Software
+
+Install Docker Engine and Docker Compose v2 on the server:
+
+```bash
+curl -fsSL https://get.docker.com | sh
+```
+
+Verify versions:
+
+```bash
+docker --version        # 27.0.0 or newer
+docker compose version  # v2.28.0 or newer
+```
+
+### Domain and DNS
+
+- A registered domain name (e.g. `myapp.example.com`).
+- An **A record** pointing your domain to the server's public IP address.
+  Let's Encrypt's ACME HTTP-01 challenge requires this before issuing a certificate.
+
+Verify DNS propagation before starting:
+
+```bash
+dig +short myapp.example.com
+# must return your server's IP
+```
+
+---
+
+## Directory layout
+
+Create a working directory on the server:
+
+```bash
+mkdir -p /opt/myapp && cd /opt/myapp
+mkdir -p config/kratos
+```
+
+You will end up with:
+
+```
+/opt/myapp/
+  docker-compose.yml
+  vibewarden.yaml
+  config/
+    kratos/
+      kratos.yml
+      identity.schema.json
+  .env              # secrets — never commit
+```
+
+---
+
+## Step 1: Write docker-compose.yml
+
+```yaml
+# /opt/myapp/docker-compose.yml
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: myapp-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER:     ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB:       ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - myapp
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  kratos-migrate:
+    image: oryd/kratos:v1.3.1
+    container_name: myapp-kratos-migrate
+    restart: on-failure
+    environment:
+      DSN: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+    volumes:
+      - ./config/kratos:/etc/config/kratos:ro
+    command: migrate sql -e --yes
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - myapp
+
+  kratos:
+    image: oryd/kratos:v1.3.1
+    container_name: myapp-kratos
+    restart: unless-stopped
+    environment:
+      DSN: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+      SERVE_PUBLIC_BASE_URL: https://${DOMAIN}/
+      SERVE_ADMIN_BASE_URL: http://kratos:4434/
+    volumes:
+      - ./config/kratos:/etc/config/kratos:ro
+    command: serve --config /etc/config/kratos/kratos.yml --watch-courier
+    depends_on:
+      kratos-migrate:
+        condition: service_completed_successfully
+    networks:
+      - myapp
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://kratos:4434/admin/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  vibewarden:
+    image: ghcr.io/vibewarden/vibewarden:latest
+    container_name: myapp-vibewarden
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./vibewarden.yaml:/vibewarden.yaml:ro
+      - caddy_data:/root/.local/share/caddy
+    environment:
+      VIBEWARDEN_KRATOS_PUBLIC_URL: http://kratos:4433
+      VIBEWARDEN_KRATOS_ADMIN_URL:  http://kratos:4434
+      VIBEWARDEN_UPSTREAM_HOST:     myapp        # your app's service name
+      VIBEWARDEN_UPSTREAM_PORT:     "3000"
+      VIBEWARDEN_SERVER_HOST:       "0.0.0.0"
+      VIBEWARDEN_ADMIN_TOKEN:       ${VIBEWARDEN_ADMIN_TOKEN}
+    depends_on:
+      kratos:
+        condition: service_healthy
+    networks:
+      - myapp
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:80/_vibewarden/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
+  myapp:
+    image: your-registry/your-app:latest
+    container_name: myapp
+    restart: unless-stopped
+    networks:
+      - myapp
+    # Expose only on the internal network, not on the host.
+    # VibeWarden is the only entry point.
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+  caddy_data:
+
+networks:
+  myapp:
+    driver: bridge
+```
+
+> Replace `myapp` and `your-registry/your-app:latest` with your application's
+> service name and image.
+
+---
+
+## Step 2: Write vibewarden.yaml
+
+```yaml
+# /opt/myapp/vibewarden.yaml
+server:
+  host: "0.0.0.0"
+  port: 443
+
+upstream:
+  host: "myapp"   # Docker Compose service name
+  port: 3000
+
+tls:
+  enabled: true
+  provider: letsencrypt
+  domain: "myapp.example.com"
+  storage_path: ""   # uses Caddy default: /root/.local/share/caddy
+
+kratos:
+  public_url: "http://kratos:4433"
+  admin_url:  "http://kratos:4434"
+
+auth:
+  public_paths:
+    - "/static/*"
+    - "/favicon.ico"
+    - "/robots.txt"
+  session_cookie_name: "ory_kratos_session"
+  login_url: ""
+
+body_size:
+  max: "10MB"
+
+rate_limit:
+  enabled: true
+  per_ip:
+    requests_per_second: 20
+    burst: 40
+  per_user:
+    requests_per_second: 200
+    burst: 400
+  trust_proxy_headers: false
+
+log:
+  level: "info"
+  format: "json"
+
+admin:
+  enabled: true
+  token: ""   # set via VIBEWARDEN_ADMIN_TOKEN env var
+
+metrics:
+  enabled: true
+  path_patterns:
+    - "/api/v1/:resource"
+    - "/api/v1/:resource/:id"
+
+security_headers:
+  enabled: true
+  hsts_max_age: 31536000
+  hsts_include_subdomains: true
+  hsts_preload: false
+  content_type_nosniff: true
+  frame_option: "DENY"
+  content_security_policy: "default-src 'self'"
+  referrer_policy: "strict-origin-when-cross-origin"
+  permissions_policy: ""
+  cross_origin_opener_policy: "same-origin"
+  cross_origin_resource_policy: "same-origin"
+  permitted_cross_domain_policies: "none"
+  suppress_via_header: true
+```
+
+---
+
+## Step 3: Configure Ory Kratos
+
+Create `config/kratos/identity.schema.json`:
+
+```json
+{
+  "$id": "https://schemas.ory.sh/presets/kratos/identity.email.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "traits": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "format": "email",
+          "title": "E-Mail",
+          "ory.sh/kratos": {
+            "credentials": {
+              "password": { "identifier": true }
+            },
+            "recovery": { "via": "email" },
+            "verification": { "via": "email" }
+          }
+        }
+      },
+      "required": ["email"],
+      "additionalProperties": false
+    }
+  }
+}
+```
+
+Create `config/kratos/kratos.yml`:
+
+```yaml
+version: v1.3.1
+
+dsn: memory   # overridden by DSN env var
+
+serve:
+  public:
+    base_url: https://myapp.example.com/
+    cors:
+      enabled: false
+  admin:
+    base_url: http://kratos:4434/
+
+selfservice:
+  default_browser_return_url: https://myapp.example.com/
+  allowed_return_urls:
+    - https://myapp.example.com/
+
+  methods:
+    password:
+      enabled: true
+
+  flows:
+    error:
+      ui_url: https://myapp.example.com/error
+    login:
+      ui_url: https://myapp.example.com/login
+      lifespan: 10m
+    logout:
+      default_browser_return_url: https://myapp.example.com/login
+    registration:
+      lifespan: 10m
+      ui_url: https://myapp.example.com/register
+    settings:
+      ui_url: https://myapp.example.com/settings
+    recovery:
+      enabled: true
+      ui_url: https://myapp.example.com/recovery
+    verification:
+      enabled: true
+      ui_url: https://myapp.example.com/verification
+      after:
+        default_browser_return_url: https://myapp.example.com/
+
+identity:
+  default_schema_id: default
+  schemas:
+    - id: default
+      url: file:///etc/config/kratos/identity.schema.json
+
+courier:
+  smtp:
+    connection_uri: smtps://user:password@smtp.example.com:465/
+    from_address: noreply@myapp.example.com
+    from_name: "My App"
+```
+
+Replace `smtp.example.com`, credentials, and all `myapp.example.com` references with
+your actual values.
+
+---
+
+## Step 4: Create the .env file
+
+```bash
+# /opt/myapp/.env
+# Never commit this file.
+
+DOMAIN=myapp.example.com
+
+POSTGRES_USER=vibewarden
+POSTGRES_PASSWORD=change-me-strong-password
+POSTGRES_DB=vibewarden
+
+VIBEWARDEN_ADMIN_TOKEN=change-me-random-64-char-token
+```
+
+Generate strong values:
+
+```bash
+openssl rand -hex 32   # for POSTGRES_PASSWORD
+openssl rand -hex 32   # for VIBEWARDEN_ADMIN_TOKEN
+```
+
+---
+
+## Step 5: TLS setup with Let's Encrypt
+
+VibeWarden embeds Caddy, which handles ACME certificate issuance automatically when
+`tls.provider` is set to `letsencrypt`.
+
+**Requirements**:
+- Port 80 must be reachable from the internet (ACME HTTP-01 challenge).
+- Port 443 must be reachable from the internet.
+- The domain must resolve to the server's public IP before you start the stack.
+
+**How it works**:
+1. On first startup, Caddy contacts Let's Encrypt and requests a certificate via
+   the HTTP-01 challenge on port 80.
+2. The certificate and private key are stored in the `caddy_data` Docker volume
+   (path: `/root/.local/share/caddy` inside the container).
+3. Caddy automatically renews the certificate before it expires (typically 30 days
+   before the 90-day expiry).
+
+**No manual action is required.** If certificate issuance fails, check:
+
+```bash
+docker compose logs vibewarden | grep -i "tls\|acme\|certificate"
+```
+
+Common causes of failure:
+- DNS not yet propagated (the A record does not point to the server).
+- Port 80 blocked by a firewall (see firewall section below).
+- Rate limiting by Let's Encrypt (5 failures per hour per domain).
+
+---
+
+## Step 6: Start the stack
+
+```bash
+cd /opt/myapp
+docker compose up -d
+```
+
+Check that all containers are healthy:
+
+```bash
+docker compose ps
+```
+
+Expected output (all `Status` columns showing `healthy` or `exited 0` for the
+migrate container):
+
+```
+NAME                   STATUS
+myapp-postgres         Up (healthy)
+myapp-kratos-migrate   Exited (0)
+myapp-kratos           Up (healthy)
+myapp-vibewarden       Up (healthy)
+myapp                  Up (healthy)
+```
+
+Verify the site is reachable:
+
+```bash
+curl -I https://myapp.example.com/_vibewarden/healthz
+# HTTP/2 200
+```
+
+---
+
+## Environment variables reference
+
+All `vibewarden.yaml` settings can be overridden via environment variables using the
+`VIBEWARDEN_` prefix and underscore-separated key path.
+
+| Environment variable | Config key | Description |
+|---|---|---|
+| `VIBEWARDEN_SERVER_HOST` | `server.host` | Bind address (use `0.0.0.0` in containers) |
+| `VIBEWARDEN_SERVER_PORT` | `server.port` | Listen port |
+| `VIBEWARDEN_UPSTREAM_HOST` | `upstream.host` | Upstream app hostname |
+| `VIBEWARDEN_UPSTREAM_PORT` | `upstream.port` | Upstream app port |
+| `VIBEWARDEN_TLS_ENABLED` | `tls.enabled` | Enable TLS termination |
+| `VIBEWARDEN_TLS_PROVIDER` | `tls.provider` | `letsencrypt`, `self-signed`, or `external` |
+| `VIBEWARDEN_TLS_DOMAIN` | `tls.domain` | Domain for ACME certificate |
+| `VIBEWARDEN_TLS_CERT_PATH` | `tls.cert_path` | Path to certificate file (external provider) |
+| `VIBEWARDEN_TLS_KEY_PATH` | `tls.key_path` | Path to private key file (external provider) |
+| `VIBEWARDEN_KRATOS_PUBLIC_URL` | `kratos.public_url` | Kratos public API URL |
+| `VIBEWARDEN_KRATOS_ADMIN_URL` | `kratos.admin_url` | Kratos admin API URL |
+| `VIBEWARDEN_ADMIN_TOKEN` | `admin.token` | Bearer token for the admin API |
+| `VIBEWARDEN_LOG_LEVEL` | `log.level` | `debug`, `info`, `warn`, `error` |
+| `VIBEWARDEN_LOG_FORMAT` | `log.format` | `json` or `text` |
+
+---
+
+## Database setup (Postgres)
+
+VibeWarden uses Postgres exclusively for Ory Kratos (identity and session storage).
+VibeWarden itself is stateless — no separate database is required for the sidecar.
+
+The `kratos-migrate` service in the Compose file runs Kratos database migrations
+automatically on every startup and exits with code 0 when done. `kratos` depends on
+`kratos-migrate` completing successfully before it starts.
+
+**Backup**: see the Backup and recovery section below.
+
+**Production Postgres hardening** (beyond Docker Compose):
+- Run Postgres on a separate host or use a managed service (e.g. Hetzner Managed
+  Databases, AWS RDS, Supabase) to get automated backups and failover.
+- Enforce SSL connections: add `?sslmode=require` to the DSN.
+- Create a least-privilege Postgres role for Kratos (only the `kratos` database,
+  no superuser).
+
+---
+
+## Reverse proxy considerations
+
+### Cloudflare in front of VibeWarden
+
+If you proxy traffic through Cloudflare (orange cloud):
+
+1. Set `tls.provider: external` in `vibewarden.yaml` and supply Cloudflare Origin
+   Certificates (`tls.cert_path` / `tls.key_path`), **or** set `tls.provider: self-signed`
+   if Cloudflare is configured with **Full (strict)** SSL mode and you trust Cloudflare
+   to handle public TLS.
+2. Enable `rate_limit.trust_proxy_headers: true` so VibeWarden reads the real client
+   IP from `CF-Connecting-IP` / `X-Forwarded-For` rather than the Cloudflare edge IP.
+3. Consider enabling Cloudflare's WAF rules as a complementary layer — VibeWarden's
+   own rate limiting and security headers still apply at the origin.
+
+### nginx in front of VibeWarden
+
+If you run nginx as an outer edge proxy (e.g. for multiple apps on one server):
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name myapp.example.com;
+
+    # nginx handles TLS; set tls.provider: external or tls.enabled: false in vibewarden.yaml
+    ssl_certificate     /etc/ssl/certs/myapp.crt;
+    ssl_certificate_key /etc/ssl/private/myapp.key;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto https;
+    }
+}
+```
+
+In this topology set `rate_limit.trust_proxy_headers: true` in `vibewarden.yaml`.
+
+---
+
+## Monitoring and logging
+
+### Structured logs
+
+VibeWarden emits structured JSON logs to stdout. In production, ship them with your
+existing log aggregation pipeline (Loki, Elasticsearch, CloudWatch, etc.).
+
+Each log event contains:
+
+| Field | Description |
+|---|---|
+| `schema_version` | Log schema version (e.g. `v1`) |
+| `event_type` | Event kind (e.g. `request.completed`) |
+| `ai_summary` | Human/AI-readable one-line description |
+| `level` | `DEBUG`, `INFO`, `WARN`, `ERROR` |
+| `time` | RFC 3339 timestamp |
+| `payload` | Event-specific JSON object |
+
+Follow logs:
+
+```bash
+docker compose logs -f vibewarden | jq .
+```
+
+### Prometheus metrics
+
+VibeWarden exposes Prometheus metrics at `/_vibewarden/metrics`. Scrape this endpoint
+from your Prometheus instance:
+
+```yaml
+# prometheus.yml (snippet)
+scrape_configs:
+  - job_name: vibewarden
+    static_configs:
+      - targets: ["myapp.example.com:443"]
+    scheme: https
+```
+
+Key metrics to alert on:
+
+| Metric | Condition | Severity |
+|---|---|---|
+| `vibewarden_upstream_errors_total` | Rate > 0 for 5 min | Critical |
+| `vibewarden_request_duration_seconds_p99` | > 2s for 5 min | Warning |
+| `vibewarden_rate_limit_hits_total` | Sudden spike | Warning |
+| `vibewarden_auth_decisions_total{decision="blocked"}` | High rate | Warning |
+
+See `docs/observability.md` for the full metrics reference and a local Grafana setup.
+
+### Health check endpoint
+
+```
+GET /_vibewarden/healthz
+```
+
+Returns `200 OK` with `{"status":"ok"}` when VibeWarden is running. Use this for
+load balancer and uptime monitor health checks.
+
+---
+
+## Backup and recovery
+
+### What to back up
+
+| Data | Location | Frequency |
+|---|---|---|
+| Postgres data (Kratos identities and sessions) | `postgres_data` Docker volume | Daily minimum |
+| Caddy TLS certificates | `caddy_data` Docker volume | Weekly or after cert renewal |
+| `vibewarden.yaml` | `/opt/myapp/vibewarden.yaml` | On every change, store in git |
+| Kratos config | `/opt/myapp/config/kratos/` | On every change, store in git |
+| `.env` | `/opt/myapp/.env` | On every change, store in a secrets manager |
+
+### Postgres backup
+
+```bash
+# Manual snapshot
+docker exec myapp-postgres pg_dump \
+  -U "$POSTGRES_USER" "$POSTGRES_DB" \
+  | gzip > /backups/vibewarden-$(date +%Y%m%d-%H%M%S).sql.gz
+
+# Restore
+gunzip -c /backups/vibewarden-20260101-120000.sql.gz \
+  | docker exec -i myapp-postgres psql -U "$POSTGRES_USER" "$POSTGRES_DB"
+```
+
+Schedule daily backups with a systemd timer or cron and ship the dumps to object
+storage (e.g. Hetzner Object Storage, S3-compatible).
+
+### TLS certificate backup
+
+```bash
+docker run --rm \
+  -v myapp_caddy_data:/data \
+  -v /backups:/backup \
+  alpine tar czf /backup/caddy-data-$(date +%Y%m%d).tar.gz -C /data .
+```
+
+Caddy automatically renews certificates before expiry, so you rarely need to restore
+the `caddy_data` volume. If you lose it, Caddy will request a new certificate on
+startup (subject to Let's Encrypt rate limits — 5 per hour per domain).
+
+### Full stack restore
+
+1. Restore `postgres_data` volume from the latest Postgres dump.
+2. Restore `vibewarden.yaml`, Kratos config, and `.env` from version control /
+   secrets manager.
+3. Start the stack: `docker compose up -d`.
+4. Verify: `docker compose ps` and `curl https://myapp.example.com/_vibewarden/healthz`.

--- a/docs/production-hardening.md
+++ b/docs/production-hardening.md
@@ -1,0 +1,392 @@
+# Production Hardening Checklist
+
+Use this checklist before going live and after each significant infrastructure change.
+Each item is a concrete action, not a vague recommendation.
+
+---
+
+## Security checklist
+
+### TLS
+
+- [ ] `tls.enabled: true` in `vibewarden.yaml`.
+- [ ] `tls.provider: letsencrypt` (or `external` if TLS is terminated upstream by
+  Cloudflare / nginx). Never use `self-signed` in production.
+- [ ] `tls.domain` set to the exact public hostname (e.g. `myapp.example.com`).
+- [ ] Caddy `caddy_data` volume is persisted across restarts so certificates survive
+  container recreation.
+- [ ] Port 80 is open to the internet for Let's Encrypt ACME HTTP-01 challenges.
+- [ ] Port 443 is open to the internet.
+- [ ] `hsts_max_age` is at least `31536000` (1 year).
+- [ ] `hsts_include_subdomains: true` if all subdomains are also served over HTTPS.
+- [ ] `hsts_preload: false` unless you have submitted the domain to the HSTS preload
+  list and understand the implications (cannot revert without browser update cycles).
+
+### Admin token rotation
+
+- [ ] `admin.enabled: true` only if you actively use the admin API. Disable it if
+  you do not need it.
+- [ ] `admin.token` is set exclusively via the `VIBEWARDEN_ADMIN_TOKEN` environment
+  variable — never hard-coded in `vibewarden.yaml` or committed to version control.
+- [ ] Admin token is at least 32 bytes of random data:
+  ```bash
+  openssl rand -hex 32
+  ```
+- [ ] Admin token is stored in a secrets manager (e.g. HashiCorp Vault, AWS Secrets
+  Manager, Hetzner Robot secrets) or at minimum in an `.env` file with `chmod 600`.
+- [ ] Rotate the admin token every 90 days or after any team member with access leaves.
+  Update the environment variable and restart the VibeWarden container.
+- [ ] The admin API endpoint (`/_vibewarden/admin/*`) is not directly reachable from
+  the internet. If you use a firewall allow-list, restrict this path to your internal
+  management network.
+
+### Rate limits
+
+- [ ] `rate_limit.enabled: true`.
+- [ ] `per_ip.requests_per_second` is tuned to your expected legitimate traffic.
+  A good starting point: 20 req/s per IP, burst 40. Tighten if you observe abuse.
+- [ ] `per_user.requests_per_second` is higher than `per_ip` (authenticated users
+  are known). Starting point: 200 req/s per user, burst 400.
+- [ ] `trust_proxy_headers: true` only when VibeWarden sits behind a trusted proxy
+  (Cloudflare, nginx). When `false` (the default), the TCP source IP is used —
+  this prevents IP spoofing via forged `X-Forwarded-For` headers.
+- [ ] `exempt_paths` contains only truly public, non-abusable paths.
+  Do not exempt API endpoints that mutate state.
+
+### Security headers
+
+- [ ] `security_headers.enabled: true`.
+- [ ] `content_security_policy` is set to the strictest policy your app supports.
+  At minimum use `"default-src 'self'"`. Tighten per-app after testing:
+  ```yaml
+  content_security_policy: >-
+    default-src 'self';
+    script-src 'self' 'nonce-{nonce}';
+    style-src 'self' 'unsafe-inline';
+    img-src 'self' data: https:;
+    connect-src 'self' https://api.myapp.example.com
+  ```
+- [ ] `frame_option: "DENY"` unless your app intentionally embeds other origins in
+  frames. Use `"SAMEORIGIN"` if you embed pages from the same origin.
+- [ ] `referrer_policy: "strict-origin-when-cross-origin"` or stricter
+  (`"no-referrer"`) if your app does not depend on referrer information.
+- [ ] `permissions_policy` is set to restrict browser features your app does not use.
+  Example:
+  ```yaml
+  permissions_policy: "camera=(), microphone=(), geolocation=(), payment=()"
+  ```
+- [ ] `cross_origin_opener_policy: "same-origin"`.
+- [ ] `cross_origin_resource_policy: "same-origin"`.
+- [ ] `suppress_via_header: true` (reduces information disclosure about the proxy).
+
+---
+
+## Docker hardening
+
+### Non-root user
+
+The official VibeWarden image runs as a non-root user by default. Verify:
+
+```bash
+docker inspect ghcr.io/vibewarden/vibewarden:latest \
+  --format '{{.Config.User}}'
+# expected: vibewarden (or a non-zero UID)
+```
+
+If building a custom image, add to your `Dockerfile`:
+
+```dockerfile
+RUN addgroup -S vibewarden && adduser -S vibewarden -G vibewarden
+USER vibewarden
+```
+
+### Read-only filesystem
+
+Add `read_only: true` to the VibeWarden service in `docker-compose.yml` and mount
+writable directories explicitly:
+
+```yaml
+vibewarden:
+  image: ghcr.io/vibewarden/vibewarden:latest
+  read_only: true
+  tmpfs:
+    - /tmp
+  volumes:
+    - ./vibewarden.yaml:/vibewarden.yaml:ro
+    - caddy_data:/root/.local/share/caddy   # writable: Caddy stores certs here
+```
+
+### Resource limits
+
+Prevent runaway containers from exhausting the host:
+
+```yaml
+vibewarden:
+  deploy:
+    resources:
+      limits:
+        cpus: "1.0"
+        memory: "256M"
+      reservations:
+        cpus: "0.25"
+        memory: "64M"
+
+kratos:
+  deploy:
+    resources:
+      limits:
+        cpus: "1.0"
+        memory: "256M"
+
+postgres:
+  deploy:
+    resources:
+      limits:
+        cpus: "2.0"
+        memory: "512M"
+```
+
+> `deploy.resources` in Docker Compose requires the `docker compose` CLI (v2) and
+> has no effect with the standalone `docker-compose` v1 binary.
+
+### No privileged containers
+
+- [ ] No container uses `privileged: true`.
+- [ ] No container uses `--cap-add` beyond what is strictly required. VibeWarden
+  requires no extra capabilities.
+- [ ] Drop all capabilities explicitly:
+  ```yaml
+  vibewarden:
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE   # required to bind ports 80 and 443
+  ```
+
+### Image provenance
+
+- [ ] Pin the VibeWarden image to a specific digest or tag (not `latest`) in production:
+  ```yaml
+  image: ghcr.io/vibewarden/vibewarden:v0.3.0
+  ```
+- [ ] Verify the image signature before deploying (when Cosign signing is available).
+- [ ] Scan the image for vulnerabilities before deploying:
+  ```bash
+  docker scout cves ghcr.io/vibewarden/vibewarden:v0.3.0
+  # or:
+  trivy image ghcr.io/vibewarden/vibewarden:v0.3.0
+  ```
+
+---
+
+## Network hardening
+
+### Firewall rules
+
+Allow only the ports your server must expose publicly. Example using `ufw`:
+
+```bash
+# Default: deny all incoming
+ufw default deny incoming
+ufw default allow outgoing
+
+# Allow SSH (change port if you moved it)
+ufw allow 22/tcp
+
+# Allow HTTP and HTTPS (required for ACME challenge and app traffic)
+ufw allow 80/tcp
+ufw allow 443/tcp
+
+# Enable the firewall
+ufw enable
+
+# Verify
+ufw status verbose
+```
+
+### Expose only 80 and 443
+
+- [ ] Postgres is not exposed on any host port. Remove or omit the `ports:` directive
+  for the `postgres` service in `docker-compose.yml`. Kratos connects to Postgres
+  over the internal Docker network.
+- [ ] Kratos admin API (port 4434) is not exposed on any host port. VibeWarden
+  connects to it over the internal Docker network via `VIBEWARDEN_KRATOS_ADMIN_URL`.
+- [ ] Kratos public API (port 4433) is not exposed on any host port when VibeWarden
+  proxies all Kratos traffic. VibeWarden forwards `/self-service/*` to Kratos
+  internally.
+- [ ] Your application container exposes no host ports. VibeWarden connects to it
+  over the internal Docker network.
+- [ ] The Prometheus metrics endpoint (`/_vibewarden/metrics`) is accessible over
+  HTTPS. Restrict access to your Prometheus scraper's IP using Cloudflare Access,
+  nginx `allow`/`deny`, or a VPN if you do not want metrics publicly readable.
+
+### Internal-only services
+
+Add explicit `expose` declarations (not `ports`) for services that should only be
+reachable on the internal Docker network:
+
+```yaml
+postgres:
+  expose:
+    - "5432"  # internal only
+
+kratos:
+  expose:
+    - "4433"
+    - "4434"  # internal only
+
+myapp:
+  expose:
+    - "3000"  # internal only
+```
+
+---
+
+## Kratos hardening
+
+### SMTP
+
+- [ ] Configure a real SMTP relay for Kratos email delivery. Do not use `mailslurper`
+  (the dev mail sink) in production.
+- [ ] Use TLS-secured SMTP (`smtps://` or STARTTLS). Connection URI format:
+  ```
+  smtps://user:password@smtp.example.com:465/
+  ```
+- [ ] Store SMTP credentials in environment variables, not in `kratos.yml` directly.
+  Kratos supports environment variable substitution in its config:
+  ```yaml
+  courier:
+    smtp:
+      connection_uri: ${SMTP_URI}
+  ```
+- [ ] Set a recognisable `from_address` and `from_name` so users trust verification
+  and recovery emails.
+
+### Session configuration
+
+- [ ] `selfservice.flows.login.lifespan` is set to a short but usable value (e.g. `10m`
+  for the login flow itself, not the session).
+- [ ] Configure session lifespan in `kratos.yml`:
+  ```yaml
+  session:
+    lifespan: 720h   # 30 days — adjust to your security requirements
+    cookie:
+      same_site: Lax
+  ```
+- [ ] `selfservice.allowed_return_urls` contains only your own domain. Never allow
+  arbitrary return URLs (open redirect).
+- [ ] `selfservice.default_browser_return_url` points to your app's authenticated
+  landing page.
+- [ ] Account verification (`flows.verification.enabled: true`) is enabled so users
+  must confirm their email address.
+- [ ] Account recovery (`flows.recovery.enabled: true`) is enabled so users can
+  regain access via email.
+
+### Kratos admin API exposure
+
+- [ ] The Kratos admin API (`kratos:4434`) is reachable only from within the Docker
+  network. It is not exposed to the host or the internet.
+- [ ] VibeWarden communicates with the Kratos admin API via `VIBEWARDEN_KRATOS_ADMIN_URL`
+  using the internal Docker network hostname (e.g. `http://kratos:4434`).
+
+---
+
+## Monitoring checklist
+
+### Alerting
+
+Configure alerts in Prometheus (or your alerting platform) for:
+
+- [ ] **Upstream errors**: `rate(vibewarden_upstream_errors_total[5m]) > 0`
+  — your app is unreachable or crashing.
+- [ ] **High latency**: `histogram_quantile(0.99, rate(vibewarden_request_duration_seconds_bucket[5m])) > 2`
+  — p99 latency exceeds 2 seconds.
+- [ ] **Rate limit spike**: `rate(vibewarden_rate_limit_hits_total[5m]) > 10`
+  — possible brute-force or abuse.
+- [ ] **High auth block rate**: `rate(vibewarden_auth_decisions_total{decision="blocked"}[5m]) > 5`
+  — many unauthenticated requests to protected routes.
+- [ ] **Container restarts**: Docker / host-level alert when any container in the
+  stack has restart count > 2 in 10 minutes.
+- [ ] **Disk usage**: alert when the volume hosting `postgres_data` exceeds 80%
+  capacity.
+- [ ] **Certificate expiry**: Caddy logs a warning 30 days before expiry. Configure
+  a log-based alert on `"certificate will expire"` in your log aggregation platform.
+
+### Log retention
+
+- [ ] Set a log retention policy in your aggregation platform.
+  Recommended minimum: 30 days. Compliance requirements may mandate 90 days or more.
+- [ ] If using Loki locally, configure retention in `loki-config.yml`:
+  ```yaml
+  limits_config:
+    retention_period: 30d
+  compactor:
+    retention_enabled: true
+  ```
+- [ ] VibeWarden logs are structured JSON — ensure your log aggregation pipeline
+  parses them as JSON rather than treating them as plain text strings.
+- [ ] Set `log.level: "info"` in production. Use `"debug"` only temporarily when
+  diagnosing a specific issue, as debug logs are verbose and may contain sensitive data.
+
+---
+
+## Regular maintenance
+
+### Updates
+
+- [ ] Subscribe to VibeWarden releases: watch the GitHub repository
+  (`vibewarden/vibewarden`) for new tags.
+- [ ] Update the VibeWarden image tag in `docker-compose.yml` after each release.
+  Pull and restart:
+  ```bash
+  docker compose pull vibewarden
+  docker compose up -d vibewarden
+  ```
+- [ ] Update the Kratos image tag in `docker-compose.yml` after each Kratos release.
+  Run `kratos-migrate` before starting the new Kratos container:
+  ```bash
+  docker compose run --rm kratos-migrate
+  docker compose up -d kratos
+  ```
+- [ ] Update the Postgres image tag once a year (or when a new major version ships
+  with a supported upgrade path).
+- [ ] Apply OS security patches monthly:
+  ```bash
+  apt-get update && apt-get dist-upgrade -y
+  ```
+- [ ] Reboot the server after kernel updates to apply them.
+
+### Certificate renewal
+
+Caddy handles certificate renewal automatically. Verify renewal is working:
+
+```bash
+docker compose logs vibewarden | grep -i "renewed\|renew\|certificate"
+```
+
+If renewal fails (e.g. port 80 was temporarily blocked), Caddy retries automatically.
+Let's Encrypt certificates are valid for 90 days; Caddy renews 30 days before expiry,
+giving a 30-day window to resolve any issues before the site goes down.
+
+### Secret rotation schedule
+
+| Secret | Rotation frequency | Action |
+|---|---|---|
+| `VIBEWARDEN_ADMIN_TOKEN` | 90 days | Update env var, restart VibeWarden container |
+| `POSTGRES_PASSWORD` | 180 days | Update DSN in all services, rolling restart |
+| SMTP credentials | On provider request or annually | Update `SMTP_URI`, restart Kratos |
+| TLS certificates | Automatic (Caddy) | Monitor Caddy logs for renewal errors |
+
+### Database maintenance
+
+- [ ] Run `VACUUM ANALYZE` on Postgres monthly to keep query plans fresh:
+  ```bash
+  docker exec myapp-postgres psql -U "$POSTGRES_USER" "$POSTGRES_DB" \
+    -c "VACUUM ANALYZE;"
+  ```
+- [ ] Review Postgres slow query log quarterly. Enable it in `postgresql.conf`:
+  ```
+  log_min_duration_statement = 1000   # log queries slower than 1s
+  ```
+- [ ] Verify that daily backup jobs are completing successfully and that backup files
+  are landing in the expected destination. Test restores quarterly.


### PR DESCRIPTION
Closes #229, #230, #231

## Summary

- **docs/production-deployment.md** (#229): end-to-end production deployment guide covering prerequisites (Docker, domain, DNS), Docker Compose stack layout, vibewarden.yaml for production, Kratos configuration, .env secrets, Let's Encrypt TLS setup, environment variables reference, Postgres database setup, Cloudflare and nginx reverse proxy guidance, Prometheus monitoring and structured log reference, and Postgres/Caddy backup and recovery procedures.

- **docs/production-hardening.md** (#230): actionable hardening checklist with concrete items across six categories: TLS (provider, HSTS, cert storage), admin token rotation (generation, storage, 90-day schedule), rate limits (per-IP/per-user tuning, trust_proxy_headers guidance), security headers (CSP, Permissions-Policy, COOP/CORP), Docker hardening (non-root user, read-only fs, resource limits, no privileged containers, image pinning/scanning), network hardening (ufw rules, expose only 80/443, internal-only Postgres/Kratos), Kratos hardening (SMTP, session config, allowed return URLs), monitoring alerts (upstream errors, p99 latency, rate limit spikes, auth blocks, disk, cert expiry), log retention guidance, and a regular maintenance schedule (updates, cert renewal, secret rotation, DB maintenance).

- **docs/examples/nextjs.md** (#231): VibeWarden + Next.js with vibewarden.yaml snippet (CSP note for hydration scripts), Docker Compose snippet, and X-User-* header reading examples for App Router Server Components, App Router Route Handlers, Pages Router getServerSideProps, Pages Router API routes, and Next.js Middleware. Includes a minimal Kratos self-service login page example.

- **docs/examples/express.md** (#231): VibeWarden + Express/Node.js with vibewarden.yaml snippet, Docker Compose snippet, and TypeScript/JavaScript middleware to extract X-User-* headers into req.user, with examples for global middleware, per-router application, health check configuration, and pino structured logging integration.

- **docs/examples/django.md** (#231): VibeWarden + Django with vibewarden.yaml snippet, Docker Compose snippet (separate Kratos DB and app DB), Rack-key reference table for X-User-* headers, Django middleware class, view examples, view decorator, Django REST Framework authentication backend, production settings (SECURE_PROXY_SSL_HEADER, CSRF_TRUSTED_ORIGINS, disabling duplicate security headers), and health endpoint.

- **docs/examples/rails.md** (#231): VibeWarden + Rails with vibewarden.yaml snippet, Docker Compose snippet (separate Kratos DB and app DB), Rack env key reference table, Rack middleware, ActionController concern with current_vw_user helper and require_vibewarden_user before_action, controller and view examples, production config (assume_ssl, log tags for user/session correlation), CSRF notes, and Rails 7.1+ /up health check integration.

## Test plan

- [x] `make check` passes (gofmt, go vet, go build, go test -race, demo-app checks)
- [ ] Read through each document and verify all code snippets are syntactically correct
- [ ] Verify Docker Compose snippets reference correct image names and service names matching the rest of the codebase
- [ ] Verify vibewarden.yaml snippets use valid config keys (cross-reference vibewarden.example.yaml)
