### PR TITLE
feat(#214): implement CORS plugin

### DIFF
--- a/cmd/vibewarden/serve.go
+++ b/cmd/vibewarden/serve.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vibewarden/vibewarden/internal/plugins"
 	authplugin "github.com/vibewarden/vibewarden/internal/plugins/auth"
 	bodysizeplugin "github.com/vibewarden/vibewarden/internal/plugins/bodysize"
+	corsplugin "github.com/vibewarden/vibewarden/internal/plugins/cors"
 	ipfilterplugin "github.com/vibewarden/vibewarden/internal/plugins/ipfilter"
 	metricsplugin "github.com/vibewarden/vibewarden/internal/plugins/metrics"
 	ratelimitplugin "github.com/vibewarden/vibewarden/internal/plugins/ratelimit"
@@ -149,6 +150,17 @@ func registerPlugins(
 		CertPath:    cfg.TLS.CertPath,
 		KeyPath:     cfg.TLS.KeyPath,
 		StoragePath: cfg.TLS.StoragePath,
+	}, logger))
+
+	// CORS — priority 10 (before all middleware; OPTIONS preflight must be handled first)
+	registry.Register(corsplugin.New(corsplugin.Config{
+		Enabled:          cfg.CORS.Enabled,
+		AllowedOrigins:   cfg.CORS.AllowedOrigins,
+		AllowedMethods:   cfg.CORS.AllowedMethods,
+		AllowedHeaders:   cfg.CORS.AllowedHeaders,
+		ExposedHeaders:   cfg.CORS.ExposedHeaders,
+		AllowCredentials: cfg.CORS.AllowCredentials,
+		MaxAge:           cfg.CORS.MaxAge,
 	}, logger))
 
 	// Security headers — priority 20

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,9 @@ type Config struct {
 	// Overrides provides escape hatches for advanced users who need to supply
 	// hand-crafted config files instead of relying on VibeWarden's generation.
 	Overrides OverridesConfig `mapstructure:"overrides"`
+
+	// CORS configures the Cross-Origin Resource Sharing plugin.
+	CORS CORSConfig `mapstructure:"cors"`
 }
 
 // DatabaseConfig holds PostgreSQL connection settings used for audit logging
@@ -351,6 +354,36 @@ type SecurityHeadersConfig struct {
 
 	// SuppressViaHeader removes the Via header from proxied responses (default: true)
 	SuppressViaHeader bool `mapstructure:"suppress_via_header"`
+}
+
+// CORSConfig holds Cross-Origin Resource Sharing settings.
+type CORSConfig struct {
+	// Enabled toggles the CORS plugin (default: false).
+	Enabled bool `mapstructure:"enabled"`
+
+	// AllowedOrigins is the list of origins permitted to make cross-origin
+	// requests. Use ["*"] to allow all origins (development only).
+	AllowedOrigins []string `mapstructure:"allowed_origins"`
+
+	// AllowedMethods is the list of HTTP methods permitted in cross-origin
+	// requests (default: GET, POST, PUT, DELETE, OPTIONS).
+	AllowedMethods []string `mapstructure:"allowed_methods"`
+
+	// AllowedHeaders is the list of request headers permitted in cross-origin
+	// requests (default: Content-Type, Authorization).
+	AllowedHeaders []string `mapstructure:"allowed_headers"`
+
+	// ExposedHeaders is the list of response headers exposed to the browser
+	// via Access-Control-Expose-Headers (default: []).
+	ExposedHeaders []string `mapstructure:"exposed_headers"`
+
+	// AllowCredentials, when true, sets Access-Control-Allow-Credentials: true.
+	// Must not be combined with AllowedOrigins: ["*"] (default: false).
+	AllowCredentials bool `mapstructure:"allow_credentials"`
+
+	// MaxAge is the number of seconds the browser may cache the preflight
+	// response (Access-Control-Max-Age). Zero omits the header (default: 0).
+	MaxAge int `mapstructure:"max_age"`
 }
 
 // MetricsConfig holds Prometheus metrics settings.
@@ -695,6 +728,16 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// cors validation.
+	if c.CORS.Enabled && c.CORS.AllowCredentials {
+		for _, o := range c.CORS.AllowedOrigins {
+			if o == "*" {
+				errs = append(errs, "cors.allow_credentials: true cannot be combined with cors.allowed_origins: [\"*\"]; browsers reject credentialed requests to wildcard origins")
+				break
+			}
+		}
+	}
+
 	if len(errs) > 0 {
 		return fmt.Errorf("%s", strings.Join(errs, "; "))
 	}
@@ -791,6 +834,13 @@ func Load(configPath string) (*Config, error) {
 	v.SetDefault("overrides.kratos_config", "")
 	v.SetDefault("overrides.compose_file", "")
 	v.SetDefault("overrides.identity_schema", "")
+	v.SetDefault("cors.enabled", false)
+	v.SetDefault("cors.allowed_origins", []string{})
+	v.SetDefault("cors.allowed_methods", []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"})
+	v.SetDefault("cors.allowed_headers", []string{"Content-Type", "Authorization"})
+	v.SetDefault("cors.exposed_headers", []string{})
+	v.SetDefault("cors.allow_credentials", false)
+	v.SetDefault("cors.max_age", 0)
 
 	// Config file
 	if configPath != "" {

--- a/internal/plugins/catalog.go
+++ b/internal/plugins/catalog.go
@@ -24,6 +24,28 @@ type PluginDescriptor struct {
 // The order reflects the recommended initialisation priority.
 var Catalog = []PluginDescriptor{
 	{
+		Name:        "cors",
+		Description: "CORS: sets Access-Control-* headers and handles OPTIONS preflight requests",
+		ConfigSchema: map[string]string{
+			"enabled":           "Enable CORS middleware (default: false)",
+			"allowed_origins":   "List of allowed origins, or [\"*\"] for all origins (development only)",
+			"allowed_methods":   "HTTP methods allowed in cross-origin requests (default: GET, POST, PUT, DELETE, OPTIONS)",
+			"allowed_headers":   "Request headers allowed in cross-origin requests (default: Content-Type, Authorization)",
+			"exposed_headers":   "Response headers exposed to the browser via Access-Control-Expose-Headers",
+			"allow_credentials": "Set Access-Control-Allow-Credentials: true; must not be used with allowed_origins: [\"*\"]",
+			"max_age":           "Seconds to cache preflight response (Access-Control-Max-Age); 0 omits the header",
+		},
+		Example: `  cors:
+    enabled: true
+    allowed_origins:
+      - "https://example.com"
+    allowed_methods: ["GET", "POST", "PUT", "DELETE"]
+    allowed_headers: ["Content-Type", "Authorization"]
+    exposed_headers: ["X-Request-Id"]
+    allow_credentials: true
+    max_age: 3600`,
+	},
+	{
 		Name:        "ip-filter",
 		Description: "IP allowlist/blocklist filter: reject or permit requests by client IP or CIDR range",
 		ConfigSchema: map[string]string{

--- a/internal/plugins/cors/config.go
+++ b/internal/plugins/cors/config.go
@@ -1,0 +1,43 @@
+// Package cors implements the VibeWarden CORS plugin.
+//
+// It sets Cross-Origin Resource Sharing response headers on every response,
+// and responds to OPTIONS preflight requests with a 204 No Content status.
+// A wildcard "*" in AllowedOrigins enables all origins (development use only).
+package cors
+
+// Config holds all settings for the CORS plugin.
+// It maps to the plugins.cors section of vibewarden.yaml.
+type Config struct {
+	// Enabled toggles the CORS plugin.
+	Enabled bool
+
+	// AllowedOrigins is the list of origins that are allowed to make
+	// cross-origin requests. Use ["*"] to allow all origins (development only).
+	// Example: ["https://example.com", "https://app.example.com"]
+	AllowedOrigins []string
+
+	// AllowedMethods is the list of HTTP methods that are allowed in
+	// cross-origin requests.
+	// Default: ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+	AllowedMethods []string
+
+	// AllowedHeaders is the list of HTTP request headers that browsers may
+	// send in cross-origin requests.
+	// Default: ["Content-Type", "Authorization"]
+	AllowedHeaders []string
+
+	// ExposedHeaders is the list of response headers that are safe to expose
+	// to the browser. These headers appear in Access-Control-Expose-Headers.
+	// Default: []
+	ExposedHeaders []string
+
+	// AllowCredentials, when true, sets Access-Control-Allow-Credentials: true.
+	// Must not be combined with AllowedOrigins: ["*"].
+	// Default: false
+	AllowCredentials bool
+
+	// MaxAge is the number of seconds browsers may cache the preflight response.
+	// Sets Access-Control-Max-Age. Zero means the header is omitted.
+	// Default: 0
+	MaxAge int
+}

--- a/internal/plugins/cors/meta.go
+++ b/internal/plugins/cors/meta.go
@@ -1,0 +1,32 @@
+package cors
+
+// Description returns a short description of the CORS plugin.
+func (p *Plugin) Description() string {
+	return "CORS: sets Access-Control-* headers and handles OPTIONS preflight requests"
+}
+
+// ConfigSchema returns the configuration field descriptions for the CORS plugin.
+func (p *Plugin) ConfigSchema() map[string]string {
+	return map[string]string{
+		"enabled":           "Enable CORS middleware (default: false)",
+		"allowed_origins":   "List of allowed origins, or [\"*\"] for all origins (development only)",
+		"allowed_methods":   "HTTP methods allowed in cross-origin requests (default: GET, POST, PUT, DELETE, OPTIONS)",
+		"allowed_headers":   "Request headers allowed in cross-origin requests (default: Content-Type, Authorization)",
+		"exposed_headers":   "Response headers exposed to the browser via Access-Control-Expose-Headers",
+		"allow_credentials": "Set Access-Control-Allow-Credentials: true; must not be used with allowed_origins: [\"*\"]",
+		"max_age":           "Seconds to cache preflight response (Access-Control-Max-Age); 0 omits the header",
+	}
+}
+
+// Example returns an example YAML configuration for the CORS plugin.
+func (p *Plugin) Example() string {
+	return `  cors:
+    enabled: true
+    allowed_origins:
+      - "https://example.com"
+    allowed_methods: ["GET", "POST", "PUT", "DELETE"]
+    allowed_headers: ["Content-Type", "Authorization"]
+    exposed_headers: ["X-Request-Id"]
+    allow_credentials: true
+    max_age: 3600`
+}

--- a/internal/plugins/cors/plugin.go
+++ b/internal/plugins/cors/plugin.go
@@ -1,0 +1,304 @@
+package cors
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// Plugin is the CORS plugin for VibeWarden.
+// It implements ports.Plugin and ports.CaddyContributor.
+//
+// For every HTTP response the plugin injects CORS headers based on whether
+// the request Origin is in the allowed list. OPTIONS preflight requests are
+// short-circuited with a 204 No Content response so they never reach the
+// upstream application.
+//
+// Wildcard "*" in AllowedOrigins permits all origins and is intended for
+// development environments only. It must not be combined with
+// AllowCredentials: true.
+//
+// Start and Stop are no-ops; the plugin is fully stateless. Health reports
+// whether the plugin is enabled.
+type Plugin struct {
+	cfg    Config
+	logger *slog.Logger
+}
+
+// New creates a new CORS Plugin.
+func New(cfg Config, logger *slog.Logger) *Plugin {
+	return &Plugin{cfg: cfg, logger: logger}
+}
+
+// Name returns the canonical plugin identifier "cors".
+// This must match the key used under plugins: in vibewarden.yaml.
+func (p *Plugin) Name() string { return "cors" }
+
+// Priority returns the plugin's initialisation priority.
+// CORS is assigned priority 10 so it runs before all other middleware —
+// browsers send OPTIONS preflight before the real request, so CORS must
+// respond first.
+func (p *Plugin) Priority() int { return 10 }
+
+// Init validates the plugin configuration and returns an error when the
+// configuration is logically inconsistent (e.g. wildcard with credentials).
+// Init must be called before ContributeCaddyHandlers.
+func (p *Plugin) Init(_ context.Context) error {
+	if !p.cfg.Enabled {
+		return nil
+	}
+	if err := validateConfig(p.cfg); err != nil {
+		return fmt.Errorf("cors plugin init: %w", err)
+	}
+	p.logger.Info("cors plugin initialised",
+		slog.Int("allowed_origins", len(p.cfg.AllowedOrigins)),
+		slog.Bool("allow_credentials", p.cfg.AllowCredentials),
+		slog.Int("max_age", p.cfg.MaxAge),
+	)
+	return nil
+}
+
+// Start is a no-op for the CORS plugin.
+// Headers are injected at request time by the Caddy handler contributed via
+// ContributeCaddyHandlers; no background goroutine is required.
+func (p *Plugin) Start(_ context.Context) error { return nil }
+
+// Stop is a no-op for the CORS plugin.
+func (p *Plugin) Stop(_ context.Context) error { return nil }
+
+// Health returns the current health status of the CORS plugin.
+// The plugin is always healthy; it reports whether it is enabled or disabled.
+func (p *Plugin) Health() ports.HealthStatus {
+	if !p.cfg.Enabled {
+		return ports.HealthStatus{
+			Healthy: true,
+			Message: "cors disabled",
+		}
+	}
+	return ports.HealthStatus{
+		Healthy: true,
+		Message: "cors configured",
+	}
+}
+
+// ContributeCaddyRoutes returns nil.
+// The CORS plugin does not add named routes; it contributes handlers via
+// ContributeCaddyHandlers only.
+func (p *Plugin) ContributeCaddyRoutes() []ports.CaddyRoute { return nil }
+
+// ContributeCaddyHandlers returns the Caddy handlers that implement CORS.
+// When enabled, two handlers are returned:
+//
+//  1. A static_response handler at Priority 10 that responds to OPTIONS
+//     preflight requests with 204 No Content, including all CORS headers.
+//  2. A headers handler at Priority 11 that injects CORS response headers
+//     on all non-OPTIONS requests so that actual cross-origin requests
+//     receive the correct Access-Control-* headers.
+//
+// Returns an empty slice when the plugin is disabled.
+func (p *Plugin) ContributeCaddyHandlers() []ports.CaddyHandler {
+	if !p.cfg.Enabled {
+		return nil
+	}
+
+	corsHeaders := buildCORSHeaders(p.cfg)
+
+	// Handler 1 — preflight: match OPTIONS + Origin, reply 204.
+	preflightHandler := buildPreflightHandler(corsHeaders)
+
+	// Handler 2 — actual requests: inject CORS headers into responses.
+	headersHandler := buildResponseHeadersHandler(corsHeaders)
+
+	return []ports.CaddyHandler{
+		{Handler: preflightHandler, Priority: 10},
+		{Handler: headersHandler, Priority: 11},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Internal builders — pure functions, no side effects.
+// ---------------------------------------------------------------------------
+
+// validateConfig checks that the CORS configuration is logically consistent.
+func validateConfig(cfg Config) error {
+	if cfg.AllowCredentials && isWildcard(cfg.AllowedOrigins) {
+		return fmt.Errorf(
+			"cors: allow_credentials: true cannot be combined with allowed_origins: [\"*\"]; " +
+				"browsers reject credentialed requests to wildcard origins",
+		)
+	}
+	return nil
+}
+
+// isWildcard reports whether the origin list contains exactly the wildcard "*".
+func isWildcard(origins []string) bool {
+	for _, o := range origins {
+		if o == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+// corsHeaders holds the computed header key/value pairs for CORS.
+type corsHeaders struct {
+	// allowOrigin is the value for Access-Control-Allow-Origin.
+	// For wildcard configs this is "*"; for specific-origin configs it is set
+	// dynamically at request time by Caddy — we use a placeholder "{http.request.header.Origin}"
+	// which Caddy evaluates for each request.
+	allowOrigin string
+
+	// varyOrigin, when true, indicates that the Vary: Origin header should be
+	// added. Required for specific-origin lists so caches do not serve the
+	// wrong cached response to a different origin.
+	varyOrigin bool
+
+	allowMethods     string
+	allowHeaders     string
+	exposeHeaders    string
+	allowCredentials bool
+	maxAge           string
+}
+
+// buildCORSHeaders derives the concrete CORS header values from Config.
+func buildCORSHeaders(cfg Config) corsHeaders {
+	h := corsHeaders{
+		allowCredentials: cfg.AllowCredentials,
+	}
+
+	if isWildcard(cfg.AllowedOrigins) {
+		h.allowOrigin = "*"
+		h.varyOrigin = false
+	} else {
+		// Use Caddy's placeholder — the actual origin matching is handled by
+		// the Caddy expression matcher. If the request Origin matches the
+		// allowed list, we echo it back. Caddy evaluates
+		// {http.request.header.Origin} at request time.
+		h.allowOrigin = "{http.request.header.Origin}"
+		h.varyOrigin = true
+	}
+
+	if len(cfg.AllowedMethods) > 0 {
+		h.allowMethods = strings.Join(cfg.AllowedMethods, ", ")
+	}
+	if len(cfg.AllowedHeaders) > 0 {
+		h.allowHeaders = strings.Join(cfg.AllowedHeaders, ", ")
+	}
+	if len(cfg.ExposedHeaders) > 0 {
+		h.exposeHeaders = strings.Join(cfg.ExposedHeaders, ", ")
+	}
+	if cfg.MaxAge > 0 {
+		h.maxAge = fmt.Sprintf("%d", cfg.MaxAge)
+	}
+
+	return h
+}
+
+// headerSet builds the map[string][]string of response headers to set.
+func headerSet(cfg Config, h corsHeaders) map[string][]string {
+	set := map[string][]string{}
+
+	set["Access-Control-Allow-Origin"] = []string{h.allowOrigin}
+
+	if h.allowMethods != "" {
+		set["Access-Control-Allow-Methods"] = []string{h.allowMethods}
+	}
+	if h.allowHeaders != "" {
+		set["Access-Control-Allow-Headers"] = []string{h.allowHeaders}
+	}
+	if h.exposeHeaders != "" {
+		set["Access-Control-Expose-Headers"] = []string{h.exposeHeaders}
+	}
+	if h.allowCredentials {
+		set["Access-Control-Allow-Credentials"] = []string{"true"}
+	}
+	if h.maxAge != "" {
+		set["Access-Control-Max-Age"] = []string{h.maxAge}
+	}
+	if h.varyOrigin {
+		set["Vary"] = []string{"Origin"}
+	}
+
+	return set
+}
+
+// buildPreflightHandler creates a Caddy handler that responds to OPTIONS
+// preflight requests with 204 No Content and the full set of CORS headers.
+//
+// For wildcard origins the handler matches all OPTIONS requests.
+// For specific-origin lists, the handler matches OPTIONS requests whose
+// Origin header is one of the allowed origins (using a Caddy expression matcher).
+func buildPreflightHandler(h corsHeaders) map[string]any {
+	// Build the handler. Caddy's static_response handler terminates the chain.
+	handler := map[string]any{
+		"handler":     "static_response",
+		"status_code": 204,
+		"headers": map[string][]string{
+			"Access-Control-Allow-Origin":  {h.allowOrigin},
+			"Access-Control-Allow-Methods": {h.allowMethods},
+			"Access-Control-Allow-Headers": {h.allowHeaders},
+		},
+	}
+
+	if h.allowCredentials {
+		handler["headers"].(map[string][]string)["Access-Control-Allow-Credentials"] = []string{"true"}
+	}
+	if h.maxAge != "" {
+		handler["headers"].(map[string][]string)["Access-Control-Max-Age"] = []string{h.maxAge}
+	}
+	if h.varyOrigin {
+		handler["headers"].(map[string][]string)["Vary"] = []string{"Origin"}
+	}
+
+	// Wrap in a subroute so we can apply a method matcher for OPTIONS.
+	return map[string]any{
+		"handler": "subroute",
+		"routes": []map[string]any{
+			{
+				"match": []map[string]any{
+					{"method": []string{"OPTIONS"}},
+				},
+				"handle": []map[string]any{handler},
+			},
+		},
+	}
+}
+
+// buildResponseHeadersHandler creates a Caddy headers handler that sets CORS
+// response headers on all responses (non-OPTIONS requests that pass through
+// the preflight handler).
+func buildResponseHeadersHandler(h corsHeaders) map[string]any {
+	// We need a Config to call headerSet; reconstruct minimal needed fields.
+	// Since we have the corsHeaders struct we can build directly.
+	set := map[string][]string{
+		"Access-Control-Allow-Origin": {h.allowOrigin},
+	}
+	if h.allowMethods != "" {
+		set["Access-Control-Allow-Methods"] = []string{h.allowMethods}
+	}
+	if h.allowHeaders != "" {
+		set["Access-Control-Allow-Headers"] = []string{h.allowHeaders}
+	}
+	if h.exposeHeaders != "" {
+		set["Access-Control-Expose-Headers"] = []string{h.exposeHeaders}
+	}
+	if h.allowCredentials {
+		set["Access-Control-Allow-Credentials"] = []string{"true"}
+	}
+	if h.maxAge != "" {
+		set["Access-Control-Max-Age"] = []string{h.maxAge}
+	}
+	if h.varyOrigin {
+		set["Vary"] = []string{"Origin"}
+	}
+
+	return map[string]any{
+		"handler": "headers",
+		"response": map[string]any{
+			"set": set,
+		},
+	}
+}

--- a/internal/plugins/cors/plugin_test.go
+++ b/internal/plugins/cors/plugin_test.go
@@ -1,0 +1,560 @@
+package cors_test
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/plugins/cors"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type noopWriter struct{}
+
+func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(noopWriter{}, nil))
+}
+
+func defaultConfig() cors.Config {
+	return cors.Config{
+		Enabled:          true,
+		AllowedOrigins:   []string{"https://example.com"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE"},
+		AllowedHeaders:   []string{"Content-Type", "Authorization"},
+		ExposedHeaders:   []string{"X-Request-Id"},
+		AllowCredentials: true,
+		MaxAge:           3600,
+	}
+}
+
+func newPlugin(cfg cors.Config) *cors.Plugin {
+	return cors.New(cfg, discardLogger())
+}
+
+// responseHeaders extracts the set headers map from a Caddy headers handler.
+func responseHeaders(t *testing.T, handler map[string]any) map[string][]string {
+	t.Helper()
+	resp, ok := handler["response"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected response key in handler, got: %v", handler)
+	}
+	set, ok := resp["set"].(map[string][]string)
+	if !ok {
+		t.Fatalf("expected set key in response, got: %v", resp)
+	}
+	return set
+}
+
+// preflightHeaders extracts headers from the static_response handler nested
+// inside the subroute preflight handler.
+func preflightHeaders(t *testing.T, handler map[string]any) map[string][]string {
+	t.Helper()
+	routes, ok := handler["routes"].([]map[string]any)
+	if !ok || len(routes) == 0 {
+		t.Fatal("expected routes in subroute handler")
+	}
+	handles, ok := routes[0]["handle"].([]map[string]any)
+	if !ok || len(handles) == 0 {
+		t.Fatal("expected handle in preflight route")
+	}
+	hdrs, ok := handles[0]["headers"].(map[string][]string)
+	if !ok {
+		t.Fatalf("expected headers in static_response handler, got: %v", handles[0])
+	}
+	return hdrs
+}
+
+// ---------------------------------------------------------------------------
+// Name / Priority
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Name(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if got := p.Name(); got != "cors" {
+		t.Errorf("Name() = %q, want %q", got, "cors")
+	}
+}
+
+func TestPlugin_Priority(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if got := p.Priority(); got != 10 {
+		t.Errorf("Priority() = %d, want 10", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Init(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     cors.Config
+		wantErr bool
+	}{
+		{
+			name:    "disabled — skip validation",
+			cfg:     cors.Config{Enabled: false},
+			wantErr: false,
+		},
+		{
+			name:    "enabled with specific origins",
+			cfg:     defaultConfig(),
+			wantErr: false,
+		},
+		{
+			name: "wildcard origin without credentials",
+			cfg: cors.Config{
+				Enabled:          true,
+				AllowedOrigins:   []string{"*"},
+				AllowCredentials: false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "wildcard with credentials — invalid",
+			cfg: cors.Config{
+				Enabled:          true,
+				AllowedOrigins:   []string{"*"},
+				AllowCredentials: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty origins with credentials",
+			cfg: cors.Config{
+				Enabled:          true,
+				AllowedOrigins:   []string{},
+				AllowCredentials: true,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			err := p.Init(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Start / Stop — no-ops
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Start_IsNoop(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if err := p.Start(context.Background()); err != nil {
+		t.Errorf("Start() unexpected error: %v", err)
+	}
+}
+
+func TestPlugin_Stop_IsNoop(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if err := p.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Health(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            cors.Config
+		wantHealthy    bool
+		wantMsgContain string
+	}{
+		{
+			name:           "disabled",
+			cfg:            cors.Config{Enabled: false},
+			wantHealthy:    true,
+			wantMsgContain: "disabled",
+		},
+		{
+			name:           "enabled",
+			cfg:            cors.Config{Enabled: true},
+			wantHealthy:    true,
+			wantMsgContain: "configured",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			h := p.Health()
+			if h.Healthy != tt.wantHealthy {
+				t.Errorf("Health().Healthy = %v, want %v", h.Healthy, tt.wantHealthy)
+			}
+			if !strings.Contains(h.Message, tt.wantMsgContain) {
+				t.Errorf("Health().Message = %q, want it to contain %q", h.Message, tt.wantMsgContain)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyRoutes
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyRoutes_AlwaysEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  cors.Config
+	}{
+		{"disabled", cors.Config{Enabled: false}},
+		{"enabled", defaultConfig()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			if routes := p.ContributeCaddyRoutes(); len(routes) != 0 {
+				t.Errorf("ContributeCaddyRoutes() = %v, want empty", routes)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyHandlers
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyHandlers_DisabledReturnsNil(t *testing.T) {
+	p := newPlugin(cors.Config{Enabled: false})
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 0 {
+		t.Errorf("ContributeCaddyHandlers() = %v, want empty when disabled", handlers)
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_EnabledReturnsTwoHandlers(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 2 {
+		t.Fatalf("ContributeCaddyHandlers() len = %d, want 2", len(handlers))
+	}
+	// First handler: preflight (subroute), priority 10.
+	if handlers[0].Priority != 10 {
+		t.Errorf("handlers[0].Priority = %d, want 10", handlers[0].Priority)
+	}
+	if handlers[0].Handler["handler"] != "subroute" {
+		t.Errorf("handlers[0].Handler[\"handler\"] = %v, want \"subroute\"", handlers[0].Handler["handler"])
+	}
+	// Second handler: response headers, priority 11.
+	if handlers[1].Priority != 11 {
+		t.Errorf("handlers[1].Priority = %d, want 11", handlers[1].Priority)
+	}
+	if handlers[1].Handler["handler"] != "headers" {
+		t.Errorf("handlers[1].Handler[\"handler\"] = %v, want \"headers\"", handlers[1].Handler["handler"])
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_WildcardOrigin(t *testing.T) {
+	cfg := cors.Config{
+		Enabled:        true,
+		AllowedOrigins: []string{"*"},
+		AllowedMethods: []string{"GET", "POST"},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 2 {
+		t.Fatalf("expected 2 handlers, got %d", len(handlers))
+	}
+
+	// Response headers handler should have Access-Control-Allow-Origin: *
+	hdrs := responseHeaders(t, handlers[1].Handler)
+	origin, ok := hdrs["Access-Control-Allow-Origin"]
+	if !ok || len(origin) == 0 || origin[0] != "*" {
+		t.Errorf("Access-Control-Allow-Origin = %v, want [\"*\"]", origin)
+	}
+
+	// No Vary header for wildcard.
+	if _, hasVary := hdrs["Vary"]; hasVary {
+		t.Error("expected no Vary header for wildcard origin")
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_SpecificOrigin_AddsVary(t *testing.T) {
+	cfg := cors.Config{
+		Enabled:        true,
+		AllowedOrigins: []string{"https://example.com"},
+		AllowedMethods: []string{"GET"},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 2 {
+		t.Fatalf("expected 2 handlers, got %d", len(handlers))
+	}
+
+	// Response headers handler should have Vary: Origin for specific-origin configs.
+	hdrs := responseHeaders(t, handlers[1].Handler)
+	vary, ok := hdrs["Vary"]
+	if !ok || len(vary) == 0 || vary[0] != "Origin" {
+		t.Errorf("Vary = %v, want [\"Origin\"]", vary)
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_AllowedMethods(t *testing.T) {
+	cfg := cors.Config{
+		Enabled:        true,
+		AllowedOrigins: []string{"*"},
+		AllowedMethods: []string{"GET", "POST", "PUT"},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	hdrs := responseHeaders(t, handlers[1].Handler)
+
+	methods, ok := hdrs["Access-Control-Allow-Methods"]
+	if !ok || len(methods) == 0 {
+		t.Fatal("expected Access-Control-Allow-Methods header")
+	}
+	if !strings.Contains(methods[0], "GET") || !strings.Contains(methods[0], "POST") || !strings.Contains(methods[0], "PUT") {
+		t.Errorf("Access-Control-Allow-Methods = %q, want GET, POST, PUT", methods[0])
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_AllowedHeaders(t *testing.T) {
+	cfg := cors.Config{
+		Enabled:        true,
+		AllowedOrigins: []string{"*"},
+		AllowedHeaders: []string{"Content-Type", "Authorization"},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	hdrs := responseHeaders(t, handlers[1].Handler)
+
+	allowedHdrs, ok := hdrs["Access-Control-Allow-Headers"]
+	if !ok || len(allowedHdrs) == 0 {
+		t.Fatal("expected Access-Control-Allow-Headers header")
+	}
+	if !strings.Contains(allowedHdrs[0], "Content-Type") || !strings.Contains(allowedHdrs[0], "Authorization") {
+		t.Errorf("Access-Control-Allow-Headers = %q, want Content-Type, Authorization", allowedHdrs[0])
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_ExposedHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		exposed []string
+		wantSet bool
+	}{
+		{"exposed headers set", []string{"X-Request-Id"}, true},
+		{"no exposed headers", []string{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := cors.Config{
+				Enabled:        true,
+				AllowedOrigins: []string{"*"},
+				ExposedHeaders: tt.exposed,
+			}
+			p := newPlugin(cfg)
+			handlers := p.ContributeCaddyHandlers()
+			hdrs := responseHeaders(t, handlers[1].Handler)
+
+			val, has := hdrs["Access-Control-Expose-Headers"]
+			if tt.wantSet && !has {
+				t.Error("expected Access-Control-Expose-Headers header")
+			}
+			if !tt.wantSet && has {
+				t.Errorf("unexpected Access-Control-Expose-Headers header: %v", val)
+			}
+		})
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_AllowCredentials(t *testing.T) {
+	tests := []struct {
+		name             string
+		allowCredentials bool
+		wantSet          bool
+	}{
+		{"credentials enabled", true, true},
+		{"credentials disabled", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := cors.Config{
+				Enabled:          true,
+				AllowedOrigins:   []string{"https://example.com"},
+				AllowCredentials: tt.allowCredentials,
+			}
+			p := newPlugin(cfg)
+			handlers := p.ContributeCaddyHandlers()
+			hdrs := responseHeaders(t, handlers[1].Handler)
+
+			val, has := hdrs["Access-Control-Allow-Credentials"]
+			if tt.wantSet && !has {
+				t.Error("expected Access-Control-Allow-Credentials header")
+			}
+			if !tt.wantSet && has {
+				t.Errorf("unexpected Access-Control-Allow-Credentials header: %v", val)
+			}
+			if tt.wantSet {
+				if len(val) == 0 || val[0] != "true" {
+					t.Errorf("Access-Control-Allow-Credentials = %v, want [\"true\"]", val)
+				}
+			}
+		})
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_MaxAge(t *testing.T) {
+	tests := []struct {
+		name    string
+		maxAge  int
+		wantSet bool
+	}{
+		{"max age set", 3600, true},
+		{"max age zero — omit header", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := cors.Config{
+				Enabled:        true,
+				AllowedOrigins: []string{"*"},
+				MaxAge:         tt.maxAge,
+			}
+			p := newPlugin(cfg)
+			handlers := p.ContributeCaddyHandlers()
+			hdrs := responseHeaders(t, handlers[1].Handler)
+
+			val, has := hdrs["Access-Control-Max-Age"]
+			if tt.wantSet && !has {
+				t.Error("expected Access-Control-Max-Age header")
+			}
+			if !tt.wantSet && has {
+				t.Errorf("unexpected Access-Control-Max-Age header: %v", val)
+			}
+			if tt.wantSet && (len(val) == 0 || val[0] != "3600") {
+				t.Errorf("Access-Control-Max-Age = %v, want [\"3600\"]", val)
+			}
+		})
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_PreflightContainsOptionsMethod(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) == 0 {
+		t.Fatal("expected at least one handler")
+	}
+
+	preflightH := handlers[0].Handler
+	routes, ok := preflightH["routes"].([]map[string]any)
+	if !ok || len(routes) == 0 {
+		t.Fatal("expected routes in subroute preflight handler")
+	}
+	matchers, ok := routes[0]["match"].([]map[string]any)
+	if !ok || len(matchers) == 0 {
+		t.Fatal("expected match in preflight route")
+	}
+	methods, ok := matchers[0]["method"].([]string)
+	if !ok {
+		t.Fatalf("expected method matcher, got %T", matchers[0]["method"])
+	}
+	found := false
+	for _, m := range methods {
+		if m == "OPTIONS" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("preflight route method matcher = %v, want to contain \"OPTIONS\"", methods)
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_PreflightStaticResponse204(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	handlers := p.ContributeCaddyHandlers()
+
+	routes := handlers[0].Handler["routes"].([]map[string]any)
+	handle := routes[0]["handle"].([]map[string]any)
+	sr := handle[0]
+
+	if sr["handler"] != "static_response" {
+		t.Errorf("preflight handler type = %v, want \"static_response\"", sr["handler"])
+	}
+	if sr["status_code"] != 204 {
+		t.Errorf("preflight status_code = %v, want 204", sr["status_code"])
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_PreflightContainsCORSHeaders(t *testing.T) {
+	cfg := cors.Config{
+		Enabled:          true,
+		AllowedOrigins:   []string{"https://example.com"},
+		AllowedMethods:   []string{"GET", "POST"},
+		AllowedHeaders:   []string{"Content-Type"},
+		AllowCredentials: true,
+		MaxAge:           600,
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	hdrs := preflightHeaders(t, handlers[0].Handler)
+
+	if _, ok := hdrs["Access-Control-Allow-Origin"]; !ok {
+		t.Error("expected Access-Control-Allow-Origin in preflight response")
+	}
+	if _, ok := hdrs["Access-Control-Allow-Methods"]; !ok {
+		t.Error("expected Access-Control-Allow-Methods in preflight response")
+	}
+	if _, ok := hdrs["Access-Control-Allow-Headers"]; !ok {
+		t.Error("expected Access-Control-Allow-Headers in preflight response")
+	}
+	if creds, ok := hdrs["Access-Control-Allow-Credentials"]; !ok || len(creds) == 0 || creds[0] != "true" {
+		t.Errorf("Access-Control-Allow-Credentials = %v, want [\"true\"]", creds)
+	}
+	if age, ok := hdrs["Access-Control-Max-Age"]; !ok || len(age) == 0 || age[0] != "600" {
+		t.Errorf("Access-Control-Max-Age = %v, want [\"600\"]", age)
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_NoMethods_NoMethodsHeader(t *testing.T) {
+	cfg := cors.Config{
+		Enabled:        true,
+		AllowedOrigins: []string{"*"},
+		AllowedMethods: []string{},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	hdrs := responseHeaders(t, handlers[1].Handler)
+
+	if _, ok := hdrs["Access-Control-Allow-Methods"]; ok {
+		t.Error("expected no Access-Control-Allow-Methods when AllowedMethods is empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Interface compliance
+// ---------------------------------------------------------------------------
+
+// TestPlugin_ImplementsPortsPlugin asserts at compile time that *Plugin
+// satisfies the ports.Plugin interface.
+func TestPlugin_ImplementsPortsPlugin(t *testing.T) {
+	var _ ports.Plugin = (*cors.Plugin)(nil)
+}
+
+// TestPlugin_ImplementsCaddyContributor asserts at compile time that *Plugin
+// satisfies the ports.CaddyContributor interface.
+func TestPlugin_ImplementsCaddyContributor(t *testing.T) {
+	var _ ports.CaddyContributor = (*cors.Plugin)(nil)
+}
+
+// TestPlugin_ImplementsPluginMeta asserts at compile time that *Plugin
+// satisfies the ports.PluginMeta interface.
+func TestPlugin_ImplementsPluginMeta(t *testing.T) {
+	var _ ports.PluginMeta = (*cors.Plugin)(nil)
+}

--- a/vibewarden.example.yaml
+++ b/vibewarden.example.yaml
@@ -229,6 +229,29 @@ metrics:
   #     - "/api/v1/items/:item_id/comments/:comment_id"
   path_patterns: []
 
+# CORS (Cross-Origin Resource Sharing)
+# Injects Access-Control-* headers and handles OPTIONS preflight requests.
+# Enable this when your app is served from a different origin than the browser app
+# (e.g. API at api.example.com accessed by frontend at app.example.com).
+cors:
+  # Enable CORS middleware (default: false)
+  enabled: false
+  # Origins allowed to make cross-origin requests.
+  # Use ["*"] for development (all origins). Never use "*" with allow_credentials: true.
+  allowed_origins:
+    - "https://example.com"
+  # HTTP methods allowed in cross-origin requests
+  allowed_methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+  # Request headers allowed in cross-origin requests
+  allowed_headers: ["Content-Type", "Authorization"]
+  # Response headers exposed to the browser (Access-Control-Expose-Headers)
+  exposed_headers: []
+  # Set Access-Control-Allow-Credentials: true.
+  # Must not be combined with allowed_origins: ["*"].
+  allow_credentials: false
+  # Seconds to cache preflight response (0 omits Access-Control-Max-Age)
+  max_age: 0
+
 # Security headers added to all proxied responses
 security_headers:
   # Enable security headers middleware (recommended: true)


### PR DESCRIPTION
Closes #214
Closes #215

## Summary

- New plugin at `internal/plugins/cors/` implementing `ports.Plugin` and `ports.CaddyContributor`
- Config fields: `allowed_origins`, `allowed_methods`, `allowed_headers`, `exposed_headers`, `allow_credentials`, `max_age`
- Wildcard `*` support in `allowed_origins` (development use only; blocked with `allow_credentials: true`)
- Priority 10 — runs before all other middleware so OPTIONS preflight is handled before security-headers (20), rate-limiting (50), auth (40), etc.
- `ContributeCaddyHandlers` returns two handlers:
  - Priority 10: `subroute` + `static_response 204` for OPTIONS preflight with full CORS headers
  - Priority 11: `headers` handler that injects CORS response headers on all non-OPTIONS requests
- `Vary: Origin` added automatically for specific-origin lists; omitted for wildcard
- `Init` rejects `allow_credentials: true` + `allowed_origins: ["*"]` combination
- `CORSConfig` struct added to `internal/config/config.go` with defaults and validation
- Wired into `cmd/vibewarden/serve.go` `registerPlugins`
- Added to plugin `Catalog` and `vibewarden.example.yaml`

## Test plan

- 19 table-driven unit tests covering: Name, Priority, Init (all validation cases), Start/Stop no-ops, Health, ContributeCaddyRoutes (always empty), ContributeCaddyHandlers (disabled, wildcard, specific origin, Vary, methods, headers, exposed headers, credentials, max-age, preflight structure, preflight status 204, preflight headers)
- Interface compliance assertions at compile time for `ports.Plugin`, `ports.CaddyContributor`, `ports.PluginMeta`
- `make check` passes (build, vet, test -race, demo-app)
