### PR TITLE
fix(#273): use HTTPS in demo healthcheck when TLS is enabled

### DIFF
--- a/examples/demo-app/docker-compose.yml
+++ b/examples/demo-app/docker-compose.yml
@@ -222,7 +222,7 @@ services:
       VIBEWARDEN_RATE_LIMIT_PER_IP_REQUESTS_PER_SECOND: ${VIBEWARDEN_RATE_LIMIT_PER_IP_REQUESTS_PER_SECOND:-}
       VIBEWARDEN_RATE_LIMIT_PER_IP_BURST:              ${VIBEWARDEN_RATE_LIMIT_PER_IP_BURST:-}
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --no-check-certificate --spider http://localhost:${VIBEWARDEN_HTTP_PORT:-8080}/_vibewarden/health || exit 1"]
+      test: ["CMD-SHELL", "if [ \"$VIBEWARDEN_TLS_ENABLED\" = 'true' ]; then wget -q --no-check-certificate --spider https://localhost:${VIBEWARDEN_HTTP_PORT:-8080}/_vibewarden/health; else wget -q --spider http://localhost:${VIBEWARDEN_HTTP_PORT:-8080}/_vibewarden/health; fi"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- Healthcheck was hardcoded to `http://` which fails when the TLS profile serves HTTPS-only on port 8443
- Now conditionally uses `https://` when `VIBEWARDEN_TLS_ENABLED=true`, keeping `http://` for dev profile
- Verified: `make demo` with TLS profile now shows all containers healthy

Closes #273

## Test plan
- [x] `make demo` (TLS profile) — vibewarden container reaches healthy status
- [x] All dependent containers (prometheus, grafana) start successfully
- [x] `make check` passes
