### PR TITLE
docs(#277): clarify that docker-compose.yml is generated and gitignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,10 @@ curl -fsSL https://vibewarden.dev/vibew > vibew && chmod +x vibew
 That's it. Your app on port 3000 is now behind VibeWarden with TLS, auth,
 rate limiting, and security headers.
 
-### What `init` generates
+### What `init` creates
 
 ```
-vibewarden.yaml          # VibeWarden configuration
-docker-compose.yml       # Full stack: VibeWarden + Kratos + Postgres
+vibewarden.yaml          # VibeWarden configuration (commit this)
 vibew                    # Wrapper script (macOS/Linux)
 vibew.ps1                # Wrapper script (Windows)
 vibew.cmd                # Wrapper script (Windows)
@@ -49,6 +48,19 @@ vibew.cmd                # Wrapper script (Windows)
 .cursor/rules            # AI agent context (Cursor)
 AGENTS.md                # AI agent context (generic)
 ```
+
+Running `vibew dev` or `vibew generate` creates runtime files under
+`.vibewarden/generated/` (gitignored by default):
+
+```
+.vibewarden/generated/
+  docker-compose.yml                # Full stack: VibeWarden + Kratos + Postgres
+  kratos/kratos.yml                 # Ory Kratos configuration
+  kratos/identity.schema.json       # Identity schema
+```
+
+Do not edit the generated files — re-run `vibew generate` after changing
+`vibewarden.yaml` instead.
 
 ### Windows
 

--- a/examples/demo-app/docker-compose.yml
+++ b/examples/demo-app/docker-compose.yml
@@ -1,5 +1,9 @@
 # VibeWarden Demo App — Profile-based Docker Compose
 #
+# NOTE: This file is manually maintained for the demo app. Normal user projects
+# should NOT commit a docker-compose.yml — instead run `vibewarden generate`
+# which writes a gitignored file to .vibewarden/generated/docker-compose.yml.
+#
 # Three profiles available via COMPOSE_PROFILES or --profile:
 #
 #   (default)       basic stack: demo-app, vibewarden, kratos, postgres, mailslurper, seed


### PR DESCRIPTION
## Summary
- Fix README: `init` does not create `docker-compose.yml` — `generate` does, under `.vibewarden/generated/` (gitignored by default)
- Add note to demo app's compose file that it is a manually-maintained exception
- All acceptance criteria from #277 were already implemented in code; this PR adds the missing documentation

Closes #277

## Test plan
- [x] `make check` passes
- [x] README accurately reflects the init/generate workflow
