### PR TITLE
feat(#291): update Grafana dashboards for OTel-sourced metrics

### DIFF
--- a/internal/config/templates/observability/otel-collector-config.yml.tmpl
+++ b/internal/config/templates/observability/otel-collector-config.yml.tmpl
@@ -18,7 +18,6 @@ exporters:
   # Prometheus exporter: exposes /metrics for Prometheus to scrape
   prometheus:
     endpoint: 0.0.0.0:8889
-    namespace: vibewarden
     const_labels:
       source: otel_collector
 

--- a/internal/config/templates/observability/vibewarden-dashboard.json
+++ b/internal/config/templates/observability/vibewarden-dashboard.json
@@ -373,7 +373,7 @@
         {
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "{container=\"vibewarden\"} | json",
+          "expr": "{service=\"vibewarden\"} | json",
           "legendFormat": ""
         }
       ]
@@ -399,7 +399,7 @@
         {
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "{container=\"vibewarden\"} | json | event_type =~ \"auth.*\"",
+          "expr": "{service=\"vibewarden\"} | json | event_type =~ \"auth.*\"",
           "legendFormat": ""
         }
       ]
@@ -425,7 +425,7 @@
         {
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "{container=\"vibewarden\"} | json | event_type =~ \"rate_limit.*\"",
+          "expr": "{service=\"vibewarden\"} | json | event_type =~ \"rate_limit.*\"",
           "legendFormat": ""
         }
       ]
@@ -451,7 +451,7 @@
         {
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "{container=\"vibewarden\"} | json | event_type =~ \"security.*\" or event_type =~ \"blocked.*\" or event_type =~ \"suspicious.*\"",
+          "expr": "{service=\"vibewarden\"} | json | event_type =~ \"security.*\" or event_type =~ \"blocked.*\" or event_type =~ \"suspicious.*\"",
           "legendFormat": ""
         }
       ]

--- a/internal/config/templates/observability_test.go
+++ b/internal/config/templates/observability_test.go
@@ -1,0 +1,96 @@
+package templates_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/config/templates"
+)
+
+// TestOtelCollectorConfig_NoDoubleNamespace verifies that the OTel Collector
+// Prometheus exporter config does not include a "namespace: vibewarden" line.
+// The OTel adapter already names metrics with the vibewarden_ prefix, so adding
+// namespace would produce double-prefixed names like vibewarden_vibewarden_*.
+func TestOtelCollectorConfig_NoDoubleNamespace(t *testing.T) {
+	data, err := templates.FS.ReadFile("observability/otel-collector-config.yml.tmpl")
+	if err != nil {
+		t.Fatalf("reading otel-collector-config.yml.tmpl: %v", err)
+	}
+	content := string(data)
+
+	if strings.Contains(content, "namespace: vibewarden") {
+		t.Error("otel-collector-config.yml.tmpl must not contain 'namespace: vibewarden': " +
+			"the OTel adapter already prefixes metric names with vibewarden_, adding the " +
+			"Prometheus exporter namespace would produce double-prefixed names like " +
+			"vibewarden_vibewarden_requests_total")
+	}
+}
+
+// TestOtelCollectorConfig_PrometheusExporterPresent verifies that the Prometheus
+// exporter stanza is still present in the OTel Collector config after removing
+// the namespace field.
+func TestOtelCollectorConfig_PrometheusExporterPresent(t *testing.T) {
+	data, err := templates.FS.ReadFile("observability/otel-collector-config.yml.tmpl")
+	if err != nil {
+		t.Fatalf("reading otel-collector-config.yml.tmpl: %v", err)
+	}
+	content := string(data)
+
+	checks := []struct {
+		name    string
+		present string
+	}{
+		{"prometheus exporter section", "prometheus:"},
+		{"prometheus endpoint", "endpoint: 0.0.0.0:8889"},
+		{"const_labels", "const_labels:"},
+		{"source label", "source: otel_collector"},
+	}
+
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(content, tc.present) {
+				t.Errorf("otel-collector-config.yml.tmpl must contain %q", tc.present)
+			}
+		})
+	}
+}
+
+// TestDashboard_LokiQueriesUseServiceLabel verifies that all four Loki log panel
+// queries in the Grafana dashboard use the OTel-sourced {service="vibewarden"}
+// label selector instead of the Promtail-sourced {container="vibewarden"} selector.
+// The OTel Collector's Loki exporter maps the service.name resource attribute to the
+// "service" label, not the Docker "container" label.
+func TestDashboard_LokiQueriesUseServiceLabel(t *testing.T) {
+	data, err := templates.FS.ReadFile("observability/vibewarden-dashboard.json")
+	if err != nil {
+		t.Fatalf("reading vibewarden-dashboard.json: %v", err)
+	}
+	content := string(data)
+
+	if strings.Contains(content, `container=\"vibewarden\"`) || strings.Contains(content, `container="vibewarden"`) {
+		t.Error(`vibewarden-dashboard.json must not contain container="vibewarden" in Loki queries: ` +
+			`OTel Collector's Loki exporter uses service.name mapped to the "service" label, ` +
+			`not Docker's "container" label`)
+	}
+}
+
+// TestDashboard_LokiPanelsCovered verifies that all four expected Loki log panels
+// use the correct {service="vibewarden"} label selector.
+func TestDashboard_LokiPanelsCovered(t *testing.T) {
+	data, err := templates.FS.ReadFile("observability/vibewarden-dashboard.json")
+	if err != nil {
+		t.Fatalf("reading vibewarden-dashboard.json: %v", err)
+	}
+	content := string(data)
+
+	// The dashboard has 4 Loki log panels (IDs 20, 21, 22, 23). Each should
+	// reference the OTel-sourced label. Count occurrences of the correct selector.
+	const wantSelector = `service=\"vibewarden\"`
+	count := strings.Count(content, wantSelector)
+	const wantCount = 4
+	if count != wantCount {
+		t.Errorf("vibewarden-dashboard.json contains %d occurrence(s) of %q, want %d: "+
+			"all 4 Loki log panels (Log Stream, Auth Events, Rate Limit Events, Security Events) "+
+			"must use the OTel service label", count, wantSelector, wantCount)
+	}
+}


### PR DESCRIPTION
Closes #291

## Summary

- Removed `namespace: vibewarden` from the OTel Collector Prometheus exporter in `otel-collector-config.yml.tmpl`. The OTel adapter already names metrics with the `vibewarden_` prefix; the exporter namespace was prepending another prefix, producing `vibewarden_vibewarden_requests_total` and breaking all dashboard PromQL queries.
- Updated all four Loki log panel queries in `vibewarden-dashboard.json` from `{container="vibewarden"}` to `{service="vibewarden"}`. The OTel Collector's Loki exporter maps the `service.name` resource attribute to the `service` label (per ADR-016), not Docker's `container` label.
- Added four unit tests in `internal/config/templates/observability_test.go` that read the embedded FS and assert: no double namespace in the collector config, required exporter fields still present, no `container` label in dashboard queries, and all four Loki panels use the correct `service` label.

## Test plan

- `make check` passes (all 50+ packages, including the new `internal/config/templates` tests)
- Manual verification: `docker compose --profile observability up -d`, send traffic, confirm `vibewarden_requests_total` appears in Prometheus (not `vibewarden_vibewarden_requests_total`), and all four Grafana log panels show entries with `{service="vibewarden"}`