### PR TITLE
feat(#308): inject trace_id and span_id into slog context

### DIFF
--- a/internal/adapters/log/slog_adapter.go
+++ b/internal/adapters/log/slog_adapter.go
@@ -11,6 +11,8 @@ import (
 	"log/slog"
 	"os"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/vibewarden/vibewarden/internal/domain/events"
 )
 
@@ -74,8 +76,15 @@ func NewSlogEventLogger(w io.Writer, additionalHandlers ...slog.Handler) *SlogEv
 //	  "event_type":     "auth.success",
 //	  "timestamp":      "2026-03-26T12:00:00Z",
 //	  "ai_summary":     "...",
-//	  "payload": { ... }
+//	  "payload":        { ... },
+//	  "trace_id":       "4bf92f3577b34da6a3ce929d0e0e4736",  // present only when tracing is active
+//	  "span_id":        "00f067aa0ba902b7"                   // present only when tracing is active
 //	}
+//
+// When the context contains a valid OTel span context (injected by TracingMiddleware),
+// trace_id and span_id are appended as top-level fields for request correlation.
+// When tracing is disabled or no span is present, those fields are completely absent
+// (never emitted as empty strings).
 func (l *SlogEventLogger) Log(ctx context.Context, event events.Event) error {
 	// Serialize the payload map to a json.RawMessage so that:
 	//  - An empty payload emits {} rather than being omitted (slog.Group with
@@ -90,15 +99,29 @@ func (l *SlogEventLogger) Log(ctx context.Context, event events.Event) error {
 		return fmt.Errorf("marshalling event payload: %w", err)
 	}
 
-	l.logger.LogAttrs(
-		ctx,
-		slog.LevelInfo,
-		"", // message field is suppressed by ReplaceAttr above
+	attrs := []slog.Attr{
 		slog.String("schema_version", event.SchemaVersion),
 		slog.String("event_type", event.EventType),
 		slog.Time("timestamp", event.Timestamp),
 		slog.String("ai_summary", event.AISummary),
 		slog.Any("payload", json.RawMessage(payloadBytes)),
+	}
+
+	// Extract trace context if the request context carries a valid OTel span.
+	// SpanContextFromContext is a cheap map lookup and returns an invalid
+	// SpanContext when no span has been stored — no allocation occurs.
+	if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+		attrs = append(attrs,
+			slog.String("trace_id", sc.TraceID().String()),
+			slog.String("span_id", sc.SpanID().String()),
+		)
+	}
+
+	l.logger.LogAttrs(
+		ctx,
+		slog.LevelInfo,
+		"", // message field is suppressed by ReplaceAttr above
+		attrs...,
 	)
 
 	// slog.JSONHandler does not surface write errors through the API.

--- a/internal/adapters/log/slog_adapter_test.go
+++ b/internal/adapters/log/slog_adapter_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
 	"github.com/vibewarden/vibewarden/internal/adapters/log"
 	"github.com/vibewarden/vibewarden/internal/domain/events"
 )
@@ -455,5 +459,98 @@ func TestSlogEventLogger_NoAdditionalHandlers(t *testing.T) {
 	}
 	if buf.Len() == 0 {
 		t.Error("JSON writer produced no output")
+	}
+}
+
+// traceEvent returns a minimal Event suitable for trace context tests.
+func traceEvent() events.Event {
+	return events.Event{
+		SchemaVersion: events.SchemaVersion,
+		EventType:     events.EventTypeAuthSuccess,
+		Timestamp:     time.Now(),
+		AISummary:     "Test event for trace context",
+		Payload:       map[string]any{},
+	}
+}
+
+// logAndDecodeWithCtx writes a single event using the given context and decodes
+// the JSON output. It fails the test if the output is not valid JSON.
+func logAndDecodeWithCtx(t *testing.T, ctx context.Context, event events.Event) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	logger := log.NewSlogEventLogger(&buf)
+	if err := logger.Log(ctx, event); err != nil {
+		t.Fatalf("Log() returned unexpected error: %v", err)
+	}
+	out := buf.Bytes()
+	if len(out) == 0 {
+		t.Fatal("Log() produced no output")
+	}
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+	}
+	return result
+}
+
+// TestSlogEventLogger_Log_WithTraceContext verifies that when the context carries
+// a valid OTel span, the emitted JSON includes trace_id (32 hex chars) and
+// span_id (16 hex chars) as top-level fields.
+func TestSlogEventLogger_Log_WithTraceContext(t *testing.T) {
+	// Use an in-memory exporter so the span is recorded without a live backend.
+	exp := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(trace.WithSyncer(exp))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	ctx, span := tp.Tracer("test").Start(context.Background(), "test-span")
+	defer span.End()
+
+	result := logAndDecodeWithCtx(t, ctx, traceEvent())
+
+	traceID, ok := result["trace_id"].(string)
+	if !ok || len(traceID) != 32 {
+		t.Errorf("trace_id = %q, want 32-char hex string", traceID)
+	}
+
+	spanID, ok := result["span_id"].(string)
+	if !ok || len(spanID) != 16 {
+		t.Errorf("span_id = %q, want 16-char hex string", spanID)
+	}
+}
+
+// TestSlogEventLogger_Log_WithoutTraceContext verifies that when the context has
+// no span, trace_id and span_id are completely absent from the emitted JSON
+// (not present as empty strings).
+func TestSlogEventLogger_Log_WithoutTraceContext(t *testing.T) {
+	result := logAndDecodeWithCtx(t, context.Background(), traceEvent())
+
+	if _, ok := result["trace_id"]; ok {
+		t.Error("trace_id should be absent when no span context, but it was present")
+	}
+	if _, ok := result["span_id"]; ok {
+		t.Error("span_id should be absent when no span context, but it was present")
+	}
+}
+
+// TestSlogEventLogger_Log_WithInvalidSpanContext verifies that a context carrying
+// an invalid span context (zero trace ID / zero span ID) produces no trace fields.
+func TestSlogEventLogger_Log_WithInvalidSpanContext(t *testing.T) {
+	// Construct a span context where IsValid() returns false.
+	// A zero-value SpanContext has an all-zero TraceID and SpanID, which IsValid()
+	// treats as invalid.
+	invalidSC := oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    oteltrace.TraceID{},
+		SpanID:     oteltrace.SpanID{},
+		TraceFlags: oteltrace.FlagsSampled,
+	})
+	ctx := oteltrace.ContextWithSpanContext(context.Background(), invalidSC)
+
+	result := logAndDecodeWithCtx(t, ctx, traceEvent())
+
+	if _, ok := result["trace_id"]; ok {
+		t.Error("trace_id should be absent for invalid span context, but it was present")
+	}
+	if _, ok := result["span_id"]; ok {
+		t.Error("span_id should be absent for invalid span context, but it was present")
 	}
 }


### PR DESCRIPTION
Closes #308

## Summary

- Modified `SlogEventLogger.Log()` to call `trace.SpanContextFromContext(ctx)` and check `sc.IsValid()` before appending `trace_id` and `span_id` slog attributes.
- `trace_id` (32-char hex) and `span_id` (16-char hex) appear as top-level JSON fields after `payload`, but only when the request context carries a valid OTel span context injected by TracingMiddleware.
- When tracing is disabled or no span is present, the fields are completely absent — never emitted as empty strings.
- No new dependencies: `go.opentelemetry.io/otel/trace` was already in the module graph.

## Test plan

- `TestSlogEventLogger_Log_WithTraceContext` — starts a real OTel span using an in-memory exporter; asserts `trace_id` is a 32-char hex string and `span_id` is a 16-char hex string in the emitted JSON.
- `TestSlogEventLogger_Log_WithoutTraceContext` — uses `context.Background()` (no span); asserts both fields are absent.
- `TestSlogEventLogger_Log_WithInvalidSpanContext` — injects a zero-value `SpanContext` (IsValid() == false); asserts both fields are absent.
- All existing tests continue to pass; `make check` green including `-race`.
