### PR TITLE
feat(#311): implement W3C traceparent propagation to upstream

### DIFF
--- a/internal/adapters/otel/provider.go
+++ b/internal/adapters/otel/provider.go
@@ -32,6 +32,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
 	otelmetric "go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -48,6 +49,7 @@ type Provider struct {
 	tracerProvider *sdktrace.TracerProvider
 	meter          otelmetric.Meter
 	tracer         trace.Tracer
+	propagator     *propagatorAdapter
 	handler        http.Handler
 	registry       *prometheusclient.Registry
 
@@ -176,6 +178,13 @@ func (p *Provider) Init(ctx context.Context, serviceName, serviceVersion string,
 		// Set as global tracer provider.
 		otel.SetTracerProvider(p.tracerProvider)
 
+		// Register W3C Trace Context as the global text map propagator so that
+		// incoming traceparent headers are extracted and outgoing requests carry
+		// the propagated span context automatically.
+		tc := propagation.TraceContext{}
+		otel.SetTextMapPropagator(tc)
+		p.propagator = &propagatorAdapter{p: tc}
+
 		// Create the application tracer.
 		p.tracer = p.tracerProvider.Tracer("github.com/vibewarden/vibewarden")
 		p.traceEnabled = true
@@ -234,6 +243,18 @@ func (p *Provider) Tracer() ports.Tracer {
 		return nil
 	}
 	return &tracerAdapter{t: p.tracer}
+}
+
+// Propagator returns a ports.TextMapPropagator that implements W3C Trace Context
+// extraction and injection. Returns nil if tracing is disabled or Init has not
+// been called.
+func (p *Provider) Propagator() ports.TextMapPropagator {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.propagator == nil {
+		return nil
+	}
+	return p.propagator
 }
 
 // PrometheusEnabled returns true if the Prometheus exporter is active.

--- a/internal/adapters/otel/tracer.go
+++ b/internal/adapters/otel/tracer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -85,3 +86,32 @@ func convertStatusCode(code ports.SpanStatusCode) codes.Code {
 		return codes.Unset
 	}
 }
+
+// propagatorAdapter wraps propagation.TraceContext to implement ports.TextMapPropagator.
+// It bridges the OTel SDK propagation API to VibeWarden's port layer.
+type propagatorAdapter struct {
+	p propagation.TraceContext
+}
+
+// Extract reads the W3C traceparent (and tracestate) headers from the carrier
+// into the returned context, enabling the span started from that context to
+// become a child of the upstream trace.
+func (a *propagatorAdapter) Extract(ctx context.Context, carrier ports.TextMapCarrier) context.Context {
+	return a.p.Extract(ctx, headerCarrierBridge{c: carrier})
+}
+
+// Inject writes the current span context from ctx into the carrier as W3C
+// traceparent and tracestate headers, enabling downstream services to
+// continue the trace.
+func (a *propagatorAdapter) Inject(ctx context.Context, carrier ports.TextMapCarrier) {
+	a.p.Inject(ctx, headerCarrierBridge{c: carrier})
+}
+
+// headerCarrierBridge adapts ports.TextMapCarrier to propagation.TextMapCarrier.
+type headerCarrierBridge struct {
+	c ports.TextMapCarrier
+}
+
+func (b headerCarrierBridge) Get(key string) string { return b.c.Get(key) }
+func (b headerCarrierBridge) Set(key, value string) { b.c.Set(key, value) }
+func (b headerCarrierBridge) Keys() []string        { return b.c.Keys() }

--- a/internal/adapters/otel/tracer_test.go
+++ b/internal/adapters/otel/tracer_test.go
@@ -206,3 +206,109 @@ func TestMockSpan_RecordsState(t *testing.T) {
 		t.Errorf("Errors = %v, want 1 error", span.Errors)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Propagator
+// ---------------------------------------------------------------------------
+
+func TestProvider_PropagatorBeforeInit_ReturnsNil(t *testing.T) {
+	p := oteladapter.NewProvider()
+	if prop := p.Propagator(); prop != nil {
+		t.Error("Propagator() before Init should return nil")
+	}
+}
+
+func TestProvider_PropagatorWithoutTracing_ReturnsNil(t *testing.T) {
+	p := oteladapter.NewProvider()
+	cfg := ports.TelemetryConfig{
+		Prometheus: ports.PrometheusExporterConfig{Enabled: true},
+	}
+	if err := p.Init(context.Background(), "test", "0.0.1", cfg); err != nil {
+		t.Fatalf("Init() failed: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(context.Background()) })
+
+	if prop := p.Propagator(); prop != nil {
+		t.Error("Propagator() should return nil when tracing is disabled")
+	}
+}
+
+func TestProvider_PropagatorWithTracing_ReturnsNonNil(t *testing.T) {
+	p, cleanup := newTracerProvider(t)
+	defer cleanup()
+
+	prop := p.Propagator()
+	if prop == nil {
+		t.Fatal("Propagator() should return non-nil when tracing is enabled")
+	}
+}
+
+func TestProvider_Propagator_ImplementsPort(t *testing.T) {
+	p, cleanup := newTracerProvider(t)
+	defer cleanup()
+
+	var _ ports.TextMapPropagator = p.Propagator()
+}
+
+func TestProvider_Propagator_Extract_ReturnsContext(t *testing.T) {
+	p, cleanup := newTracerProvider(t)
+	defer cleanup()
+
+	prop := p.Propagator()
+	carrier := &mapCarrier{m: map[string]string{
+		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+	}}
+	ctx := prop.Extract(context.Background(), carrier)
+	if ctx == nil {
+		t.Error("Extract() should return a non-nil context")
+	}
+}
+
+func TestProvider_Propagator_Inject_WritesHeader(t *testing.T) {
+	p, cleanup := newTracerProvider(t)
+	defer cleanup()
+
+	prop := p.Propagator()
+	// First extract to get a valid span context in ctx.
+	carrier := &mapCarrier{m: map[string]string{
+		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+	}}
+	ctx := prop.Extract(context.Background(), carrier)
+
+	// Inject into a new carrier.
+	out := &mapCarrier{m: map[string]string{}}
+	prop.Inject(ctx, out)
+
+	if tp := out.m["traceparent"]; tp == "" {
+		t.Error("Inject() should write a traceparent header")
+	}
+}
+
+func TestProvider_Propagator_Extract_InvalidTraceparent_NoError(t *testing.T) {
+	p, cleanup := newTracerProvider(t)
+	defer cleanup()
+
+	prop := p.Propagator()
+	// An invalid traceparent should not cause a panic; it simply results in
+	// no parent context being set.
+	carrier := &mapCarrier{m: map[string]string{
+		"traceparent": "not-a-valid-traceparent",
+	}}
+	ctx := prop.Extract(context.Background(), carrier)
+	if ctx == nil {
+		t.Error("Extract() with invalid traceparent should still return a non-nil context")
+	}
+}
+
+// mapCarrier is a simple ports.TextMapCarrier backed by a map, used in tests.
+type mapCarrier struct{ m map[string]string }
+
+func (c *mapCarrier) Get(key string) string { return c.m[key] }
+func (c *mapCarrier) Set(key, value string) { c.m[key] = value }
+func (c *mapCarrier) Keys() []string {
+	keys := make([]string, 0, len(c.m))
+	for k := range c.m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/middleware/tracing.go
+++ b/internal/middleware/tracing.go
@@ -32,9 +32,26 @@ func (rw *tracingResponseWriter) Write(b []byte) (int, error) {
 	return rw.ResponseWriter.Write(b)
 }
 
+// httpHeaderCarrier adapts http.Header to implement ports.TextMapCarrier.
+type httpHeaderCarrier http.Header
+
+func (c httpHeaderCarrier) Get(key string) string { return http.Header(c).Get(key) }
+func (c httpHeaderCarrier) Set(key, value string) { http.Header(c).Set(key, value) }
+func (c httpHeaderCarrier) Keys() []string {
+	keys := make([]string, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 // TracingMiddleware returns HTTP middleware that creates an OTel span for each request.
 // It must be the outermost middleware (first in, last out) to capture the full
 // request lifecycle including auth, rate limiting, and proxy latency.
+//
+// When a non-nil propagator is provided, it extracts the W3C traceparent header
+// from the incoming request, making the new span a child of any upstream trace.
+// Pass nil for propagator to disable context extraction (no-op, root span only).
 //
 // The middleware sets standard HTTP span attributes:
 //   - http.request.method
@@ -49,6 +66,7 @@ func (rw *tracingResponseWriter) Write(b []byte) (int, error) {
 func TracingMiddleware(
 	tracer ports.Tracer,
 	normalizePathFn func(string) string,
+	propagator ports.TextMapPropagator,
 ) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -58,8 +76,15 @@ func TracingMiddleware(
 				return
 			}
 
+			// Extract incoming trace context (W3C traceparent) when a propagator
+			// is configured. This makes the new span a child of any upstream trace.
+			ctx := r.Context()
+			if propagator != nil {
+				ctx = propagator.Extract(ctx, httpHeaderCarrier(r.Header))
+			}
+
 			// Create span with server kind.
-			ctx, span := tracer.Start(r.Context(), "HTTP "+r.Method,
+			ctx, span := tracer.Start(ctx, "HTTP "+r.Method,
 				ports.WithSpanKind(ports.SpanKindServer))
 			defer span.End()
 

--- a/internal/middleware/tracing_test.go
+++ b/internal/middleware/tracing_test.go
@@ -1,6 +1,7 @@
 package middleware_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,9 +14,45 @@ import (
 // identityPath is a normalizer that returns the path unchanged.
 func identityPath(p string) string { return p }
 
+// mockPropagator implements ports.TextMapPropagator for testing.
+// It records Extract and Inject calls and optionally stores a context key/value
+// to simulate extracting a parent trace context.
+type mockPropagator struct {
+	ExtractCalls []http.Header
+	InjectCalls  []http.Header
+	// ContextKey and ContextValue are injected into the extracted context when set.
+	ContextKey   interface{}
+	ContextValue interface{}
+}
+
+func (m *mockPropagator) Extract(ctx context.Context, carrier ports.TextMapCarrier) context.Context {
+	// Record which headers were seen.
+	if hc, ok := carrier.(interface{ Keys() []string }); ok {
+		_ = hc.Keys()
+	}
+	// Build a header snapshot for assertions.
+	h := http.Header{}
+	for _, k := range carrier.Keys() {
+		h.Set(k, carrier.Get(k))
+	}
+	m.ExtractCalls = append(m.ExtractCalls, h)
+	if m.ContextKey != nil {
+		ctx = context.WithValue(ctx, m.ContextKey, m.ContextValue)
+	}
+	return ctx
+}
+
+func (m *mockPropagator) Inject(ctx context.Context, carrier ports.TextMapCarrier) {
+	h := http.Header{}
+	for _, k := range carrier.Keys() {
+		h.Set(k, carrier.Get(k))
+	}
+	m.InjectCalls = append(m.InjectCalls, h)
+}
+
 func TestTracingMiddleware_CreatesSpan(t *testing.T) {
 	mock := &oteladapter.MockTracer{}
-	handler := middleware.TracingMiddleware(mock, identityPath)(
+	handler := middleware.TracingMiddleware(mock, identityPath, nil)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),
@@ -36,7 +73,7 @@ func TestTracingMiddleware_CreatesSpan(t *testing.T) {
 func TestTracingMiddleware_SetsAttributes(t *testing.T) {
 	span := &oteladapter.MockSpan{}
 	mock := &oteladapter.MockTracer{SpanToReturn: span}
-	handler := middleware.TracingMiddleware(mock, identityPath)(
+	handler := middleware.TracingMiddleware(mock, identityPath, nil)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),
@@ -80,7 +117,7 @@ func TestTracingMiddleware_SetsNormalizedRoute(t *testing.T) {
 		return p
 	}
 
-	handler := middleware.TracingMiddleware(mock, normalize)(
+	handler := middleware.TracingMiddleware(mock, normalize, nil)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),
@@ -112,7 +149,7 @@ func TestTracingMiddleware_SkipsInternalPaths(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &oteladapter.MockTracer{}
-			handler := middleware.TracingMiddleware(mock, identityPath)(
+			handler := middleware.TracingMiddleware(mock, identityPath, nil)(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusOK)
 				}),
@@ -146,7 +183,7 @@ func TestTracingMiddleware_CapturesStatusCode(t *testing.T) {
 			span := &oteladapter.MockSpan{}
 			mock := &oteladapter.MockTracer{SpanToReturn: span}
 
-			handler := middleware.TracingMiddleware(mock, identityPath)(
+			handler := middleware.TracingMiddleware(mock, identityPath, nil)(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(tt.writeCode)
 				}),
@@ -184,7 +221,7 @@ func TestTracingMiddleware_SetsErrorStatus(t *testing.T) {
 			span := &oteladapter.MockSpan{}
 			mock := &oteladapter.MockTracer{SpanToReturn: span}
 
-			handler := middleware.TracingMiddleware(mock, identityPath)(
+			handler := middleware.TracingMiddleware(mock, identityPath, nil)(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(tt.statusCode)
 				}),
@@ -205,7 +242,7 @@ func TestTracingMiddleware_SpanEndedAfterRequest(t *testing.T) {
 	span := &oteladapter.MockSpan{}
 	mock := &oteladapter.MockTracer{SpanToReturn: span}
 
-	handler := middleware.TracingMiddleware(mock, identityPath)(
+	handler := middleware.TracingMiddleware(mock, identityPath, nil)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if span.Ended {
 				t.Error("span should not be ended during request handling")
@@ -225,7 +262,7 @@ func TestTracingMiddleware_SpanEndedAfterRequest(t *testing.T) {
 
 func TestTracingMiddleware_UsesSpanKindServer(t *testing.T) {
 	mock := &oteladapter.MockTracer{}
-	handler := middleware.TracingMiddleware(mock, identityPath)(
+	handler := middleware.TracingMiddleware(mock, identityPath, nil)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),
@@ -249,7 +286,7 @@ func TestTracingMiddleware_DefaultStatusCode200(t *testing.T) {
 	span := &oteladapter.MockSpan{}
 	mock := &oteladapter.MockTracer{SpanToReturn: span}
 
-	handler := middleware.TracingMiddleware(mock, identityPath)(
+	handler := middleware.TracingMiddleware(mock, identityPath, nil)(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Write body without calling WriteHeader — should default to 200.
 			_, _ = w.Write([]byte("hello"))
@@ -266,5 +303,128 @@ func TestTracingMiddleware_DefaultStatusCode200(t *testing.T) {
 	}
 	if got := attrMap["http.response.status_code"]; got != "200" {
 		t.Errorf("http.response.status_code = %q, want %q", got, "200")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Propagation tests
+// ---------------------------------------------------------------------------
+
+func TestTracingMiddleware_NilPropagator_DoesNotPanic(t *testing.T) {
+	mock := &oteladapter.MockTracer{}
+	handler := middleware.TracingMiddleware(mock, identityPath, nil)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/hello", nil)
+	req.Header.Set("Traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	rr := httptest.NewRecorder()
+	// Must not panic even when propagator is nil.
+	handler.ServeHTTP(rr, req)
+
+	if len(mock.StartCalls) != 1 {
+		t.Fatalf("expected 1 span start, got %d", len(mock.StartCalls))
+	}
+}
+
+func TestTracingMiddleware_WithPropagator_CallsExtract(t *testing.T) {
+	mock := &oteladapter.MockTracer{}
+	prop := &mockPropagator{}
+
+	handler := middleware.TracingMiddleware(mock, identityPath, prop)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/hello", nil)
+	req.Header.Set("Traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if len(prop.ExtractCalls) != 1 {
+		t.Fatalf("expected 1 Extract call, got %d", len(prop.ExtractCalls))
+	}
+}
+
+func TestTracingMiddleware_WithPropagator_SkipsExtractForInternalPaths(t *testing.T) {
+	mock := &oteladapter.MockTracer{}
+	prop := &mockPropagator{}
+
+	handler := middleware.TracingMiddleware(mock, identityPath, prop)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/metrics", nil)
+	req.Header.Set("Traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if len(prop.ExtractCalls) != 0 {
+		t.Errorf("expected 0 Extract calls for internal path, got %d", len(prop.ExtractCalls))
+	}
+	if len(mock.StartCalls) != 0 {
+		t.Errorf("expected 0 span starts for internal path, got %d", len(mock.StartCalls))
+	}
+}
+
+type contextKey string
+
+func TestTracingMiddleware_WithPropagator_ExtractedContextPassedToSpan(t *testing.T) {
+	type ctxKey = contextKey
+	const key ctxKey = "parent-trace-id"
+	const wantVal = "test-parent"
+
+	// The mock propagator will inject a value into the context during Extract.
+	prop := &mockPropagator{ContextKey: key, ContextValue: wantVal}
+
+	var gotVal interface{}
+	mock := &oteladapter.MockTracer{}
+
+	handler := middleware.TracingMiddleware(mock, identityPath, prop)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// The context passed to ServeHTTP should contain the extracted value.
+			gotVal = r.Context().Value(key)
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/hello", nil)
+	req.Header.Set("Traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if gotVal != wantVal {
+		t.Errorf("extracted context value = %v, want %v", gotVal, wantVal)
+	}
+}
+
+func TestTracingMiddleware_WithPropagator_SpanStartedAfterExtract(t *testing.T) {
+	// Verify that tracer.Start is called once even with a propagator present.
+	prop := &mockPropagator{}
+	mock := &oteladapter.MockTracer{}
+
+	handler := middleware.TracingMiddleware(mock, identityPath, prop)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodPut, "/resource/1", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if len(mock.StartCalls) != 1 {
+		t.Fatalf("expected 1 span start, got %d", len(mock.StartCalls))
+	}
+	if mock.StartCalls[0].Name != "HTTP PUT" {
+		t.Errorf("span name = %q, want %q", mock.StartCalls[0].Name, "HTTP PUT")
+	}
+	if len(prop.ExtractCalls) != 1 {
+		t.Errorf("expected 1 Extract call, got %d", len(prop.ExtractCalls))
 	}
 }

--- a/internal/plugins/metrics/plugin.go
+++ b/internal/plugins/metrics/plugin.go
@@ -208,6 +208,16 @@ func (p *Plugin) Tracer() ports.Tracer {
 	return p.otelProvider.Tracer()
 }
 
+// Propagator returns a ports.TextMapPropagator for W3C traceparent extraction and
+// injection. Returns nil if the plugin is disabled, tracing is not configured, or
+// Init has not been called. Callers should check for nil before using.
+func (p *Plugin) Propagator() ports.TextMapPropagator {
+	if p.otelProvider == nil {
+		return nil
+	}
+	return p.otelProvider.Propagator()
+}
+
 // InternalAddr returns the host:port of the internal metrics HTTP server.
 // The address is only valid after a successful Start with Prometheus enabled.
 func (p *Plugin) InternalAddr() string { return p.internalAddr }

--- a/internal/ports/otel.go
+++ b/internal/ports/otel.go
@@ -97,6 +97,11 @@ type OTelProvider interface {
 	// Returns nil if tracing is disabled or Init has not been called.
 	Tracer() Tracer
 
+	// Propagator returns a TextMapPropagator that extracts and injects W3C
+	// traceparent headers. Returns nil if tracing is disabled or Init has not
+	// been called.
+	Propagator() TextMapPropagator
+
 	// PrometheusEnabled returns true if the Prometheus exporter is active.
 	PrometheusEnabled() bool
 
@@ -114,6 +119,26 @@ type Tracer interface {
 	// Start creates a span and a context containing the newly-created span.
 	// The span must be ended by calling span.End() when the operation completes.
 	Start(ctx context.Context, spanName string, opts ...SpanStartOption) (context.Context, Span)
+}
+
+// TextMapCarrier is a key-value store used by a TextMapPropagator.
+// It maps to the W3C Trace Context HTTP header model.
+type TextMapCarrier interface {
+	// Get returns the value for the given key. The key is case-insensitive.
+	Get(key string) string
+	// Set stores the key-value pair.
+	Set(key, value string)
+	// Keys lists all keys stored in this carrier.
+	Keys() []string
+}
+
+// TextMapPropagator injects and extracts trace context across process boundaries
+// using a carrier (e.g., HTTP headers). It implements W3C Trace Context propagation.
+type TextMapPropagator interface {
+	// Extract reads trace context from the carrier into the returned context.
+	Extract(ctx context.Context, carrier TextMapCarrier) context.Context
+	// Inject writes trace context from ctx into the carrier.
+	Inject(ctx context.Context, carrier TextMapCarrier)
 }
 
 // Span represents a single operation within a trace.


### PR DESCRIPTION
Closes #311

## Summary

- Added `ports.TextMapCarrier` and `ports.TextMapPropagator` interfaces to the port layer, keeping application code decoupled from the OTel SDK propagation API
- Set `otel.SetTextMapPropagator(propagation.TraceContext{})` in `Provider.Init` when tracing is enabled, registering W3C Trace Context as the global propagator
- Added `propagatorAdapter` (wraps `propagation.TraceContext`) and `headerCarrierBridge` in the otel adapter to bridge OTel's SDK types to the port interfaces
- Updated `TracingMiddleware` to accept an optional `ports.TextMapPropagator`; when non-nil, `Extract` is called on each incoming request so the span becomes a child of the upstream trace carried in the `traceparent` header; nil propagator is a safe no-op (root span)
- Added `Propagator()` to `ports.OTelProvider`, `*otel.Provider`, and `metrics.Plugin` so callers can retrieve and pass the propagator when wiring the middleware
- Caddy reverse proxy forwards headers by default, so the `traceparent` injected upstream is propagated without additional configuration

## Test plan

- `TestProvider_PropagatorBeforeInit_ReturnsNil` — nil before Init
- `TestProvider_PropagatorWithoutTracing_ReturnsNil` — nil when tracing disabled
- `TestProvider_PropagatorWithTracing_ReturnsNonNil` — non-nil when tracing enabled
- `TestProvider_Propagator_Extract_ReturnsContext` — Extract with valid traceparent returns non-nil ctx
- `TestProvider_Propagator_Inject_WritesHeader` — Inject writes traceparent into carrier
- `TestProvider_Propagator_Extract_InvalidTraceparent_NoError` — no panic on bad input
- `TestTracingMiddleware_NilPropagator_DoesNotPanic` — nil propagator is safe
- `TestTracingMiddleware_WithPropagator_CallsExtract` — Extract called once per request
- `TestTracingMiddleware_WithPropagator_SkipsExtractForInternalPaths` — internal paths bypass both span creation and extraction
- `TestTracingMiddleware_WithPropagator_ExtractedContextPassedToSpan` — extracted context values flow into downstream handler
- `TestTracingMiddleware_WithPropagator_SpanStartedAfterExtract` — span started after context extraction
- `make check` — all 50 packages pass with `-race`