### PR TITLE
feat(#314): implement circuit breaker middleware

### DIFF
--- a/cmd/vibewarden/serve.go
+++ b/cmd/vibewarden/serve.go
@@ -483,23 +483,56 @@ func buildBodySizePortsConfig(cfg *config.Config) ports.BodySizeConfig {
 	return bodySizeCfg
 }
 
-// buildResiliencePortsConfig parses the resilience.timeout duration string and
-// returns a ports.ResilienceConfig. Unparseable values are replaced with the
-// 30-second default, consistent with how other duration fields are handled.
+// buildResiliencePortsConfig parses the resilience duration strings and returns
+// a ports.ResilienceConfig. Unparseable timeout values are replaced with the
+// 30-second default. Unparseable circuit breaker timeout values fall back to 60s.
 func buildResiliencePortsConfig(cfg *config.Config) ports.ResilienceConfig {
+	result := ports.ResilienceConfig{}
+
+	// Parse request timeout.
 	raw := cfg.Resilience.Timeout
-	if raw == "" || raw == "0" {
-		return ports.ResilienceConfig{}
+	if raw != "" && raw != "0" {
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			slog.Default().Warn("resilience.timeout parse error — using default 30s",
+				slog.String("error", err.Error()),
+				slog.String("value", raw),
+			)
+			result.Timeout = 30 * time.Second
+		} else {
+			result.Timeout = d
+		}
 	}
-	d, err := time.ParseDuration(raw)
-	if err != nil {
-		slog.Default().Warn("resilience.timeout parse error — using default 30s",
-			slog.String("error", err.Error()),
-			slog.String("value", raw),
-		)
-		return ports.ResilienceConfig{Timeout: 30 * time.Second}
+
+	// Parse circuit breaker config.
+	cbCfg := cfg.Resilience.CircuitBreaker
+	if cbCfg.Enabled {
+		threshold := cbCfg.Threshold
+		if threshold <= 0 {
+			threshold = 5
+		}
+
+		cbTimeout := 60 * time.Second
+		if cbCfg.Timeout != "" && cbCfg.Timeout != "0" {
+			d, err := time.ParseDuration(cbCfg.Timeout)
+			if err != nil {
+				slog.Default().Warn("resilience.circuit_breaker.timeout parse error — using default 60s",
+					slog.String("error", err.Error()),
+					slog.String("value", cbCfg.Timeout),
+				)
+			} else {
+				cbTimeout = d
+			}
+		}
+
+		result.CircuitBreaker = ports.CircuitBreakerConfig{
+			Enabled:   true,
+			Threshold: threshold,
+			Timeout:   cbTimeout,
+		}
 	}
-	return ports.ResilienceConfig{Timeout: d}
+
+	return result
 }
 
 // buildEventLogger constructs the event logger used by the caddy adapter and

--- a/internal/adapters/caddy/circuit_breaker_handler.go
+++ b/internal/adapters/caddy/circuit_breaker_handler.go
@@ -1,0 +1,175 @@
+// Package caddy implements the ProxyServer port using embedded Caddy.
+package caddy
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	gocaddy "github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+
+	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
+	resilienceadapter "github.com/vibewarden/vibewarden/internal/adapters/resilience"
+	"github.com/vibewarden/vibewarden/internal/middleware"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+func init() {
+	gocaddy.RegisterModule(CircuitBreakerHandler{})
+}
+
+// CircuitBreakerHandlerConfig is the JSON-serialisable configuration for the
+// CircuitBreakerHandler Caddy module.
+type CircuitBreakerHandlerConfig struct {
+	// Threshold is the number of consecutive failures required to trip the
+	// circuit from Closed to Open.
+	Threshold int `json:"threshold"`
+
+	// TimeoutSeconds is how long the circuit stays Open before transitioning
+	// to HalfOpen to allow a probe request.
+	TimeoutSeconds float64 `json:"timeout_seconds"`
+}
+
+// CircuitBreakerHandler is a Caddy HTTP middleware module that implements the
+// three-state circuit breaker pattern (Closed/Open/HalfOpen). When the circuit
+// is open it immediately returns 503 Service Unavailable without contacting the
+// upstream.
+//
+// The following upstream responses count as failures:
+//   - 502 Bad Gateway
+//   - 503 Service Unavailable
+//   - 504 Gateway Timeout
+//
+// The module is registered under the name "vibewarden_circuit_breaker" and
+// referenced from the Caddy JSON configuration as:
+//
+//	{"handler": "vibewarden_circuit_breaker", ...}
+type CircuitBreakerHandler struct {
+	// Config holds the circuit breaker configuration, populated by Caddy's JSON
+	// unmarshaller during the Provision lifecycle.
+	Config CircuitBreakerHandlerConfig `json:"config"`
+
+	// logger is used for internal error messages.
+	logger *slog.Logger
+
+	// eventLogger emits structured state-transition events.
+	eventLogger ports.EventLogger
+
+	// cb is the concurrency-safe circuit breaker adapter.
+	cb ports.CircuitBreaker
+}
+
+// CaddyModule returns the module metadata used to register it with Caddy.
+func (CircuitBreakerHandler) CaddyModule() gocaddy.ModuleInfo {
+	return gocaddy.ModuleInfo{
+		ID:  "http.handlers.vibewarden_circuit_breaker",
+		New: func() gocaddy.Module { return new(CircuitBreakerHandler) },
+	}
+}
+
+// Provision implements gocaddy.Provisioner. It initialises the circuit breaker,
+// logger and event logger.
+func (h *CircuitBreakerHandler) Provision(_ gocaddy.Context) error {
+	h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	h.eventLogger = logadapter.NewSlogEventLogger(os.Stdout)
+
+	cfg := ports.CircuitBreakerConfig{
+		Enabled:   true,
+		Threshold: h.Config.Threshold,
+		Timeout:   time.Duration(h.Config.TimeoutSeconds * float64(time.Second)),
+	}
+
+	cb, err := resilienceadapter.NewInMemoryCircuitBreaker(cfg, h.logger, h.eventLogger, nil)
+	if err != nil {
+		return fmt.Errorf("provisioning circuit breaker: %w", err)
+	}
+	h.cb = cb
+	return nil
+}
+
+// ServeHTTP implements caddyhttp.MiddlewareHandler. When the circuit is open it
+// writes a structured 503 response immediately. Otherwise it delegates to the
+// next handler and classifies the upstream response.
+func (h *CircuitBreakerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+	if h.cb.IsOpen() {
+		middleware.WriteErrorResponse(w, r, http.StatusServiceUnavailable,
+			"circuit_breaker_open",
+			"upstream is currently unavailable; try again later")
+		return nil
+	}
+
+	// Wrap the ResponseWriter to capture the status code written by downstream
+	// handlers so we can classify the response.
+	crw := &captureResponseWriter{ResponseWriter: w}
+
+	err := next.ServeHTTP(crw, r)
+
+	if err != nil || isUpstreamFailureStatus(crw.status) {
+		h.cb.RecordFailure()
+	} else {
+		h.cb.RecordSuccess()
+	}
+
+	return err
+}
+
+// isUpstreamFailureStatus returns true for HTTP status codes that indicate a
+// failure in the upstream service (502, 503, 504). Client errors (4xx) are not
+// counted as upstream failures.
+func isUpstreamFailureStatus(status int) bool {
+	switch status {
+	case http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	}
+	return false
+}
+
+// captureResponseWriter wraps http.ResponseWriter to capture the status code.
+type captureResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+// WriteHeader captures the status code and delegates to the underlying writer.
+func (c *captureResponseWriter) WriteHeader(status int) {
+	c.status = status
+	c.ResponseWriter.WriteHeader(status)
+}
+
+// buildCircuitBreakerHandlerJSON serialises a CircuitBreakerConfig to the Caddy
+// handler JSON fragment used in BuildCaddyConfig. Returns nil when the circuit
+// breaker is not enabled.
+func buildCircuitBreakerHandlerJSON(cfg ports.ResilienceConfig) (map[string]any, error) {
+	cbCfg := cfg.CircuitBreaker
+	if !cbCfg.Enabled {
+		return nil, nil
+	}
+
+	handlerCfg := CircuitBreakerHandlerConfig{
+		Threshold:      cbCfg.Threshold,
+		TimeoutSeconds: cbCfg.Timeout.Seconds(),
+	}
+
+	cfgBytes, err := json.Marshal(handlerCfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling circuit breaker handler config: %w", err)
+	}
+
+	return map[string]any{
+		"handler": "vibewarden_circuit_breaker",
+		"config":  json.RawMessage(cfgBytes),
+	}, nil
+}
+
+// Interface guards — ensure CircuitBreakerHandler satisfies required Caddy
+// interfaces at compile time.
+var (
+	_ gocaddy.Provisioner         = (*CircuitBreakerHandler)(nil)
+	_ caddyhttp.MiddlewareHandler = (*CircuitBreakerHandler)(nil)
+)

--- a/internal/adapters/caddy/circuit_breaker_handler_test.go
+++ b/internal/adapters/caddy/circuit_breaker_handler_test.go
@@ -1,0 +1,240 @@
+package caddy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	domainresilience "github.com/vibewarden/vibewarden/internal/domain/resilience"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+var _ ports.CircuitBreaker = (*fakeCB)(nil)
+
+// fakeCB is a simple ports.CircuitBreaker fake for handler tests.
+type fakeCB struct {
+	IsOpenResult bool
+	FailureCalls int
+	SuccessCalls int
+}
+
+func (f *fakeCB) IsOpen() bool                  { return f.IsOpenResult }
+func (f *fakeCB) RecordFailure()                { f.FailureCalls++ }
+func (f *fakeCB) RecordSuccess()                { f.SuccessCalls++ }
+func (f *fakeCB) State() domainresilience.State { return domainresilience.StateClosed }
+
+// fakeCaddyHandler is a minimal caddyhttp.Handler that writes a fixed status code.
+type fakeCaddyHandler struct {
+	statusCode int
+}
+
+func (f *fakeCaddyHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) error {
+	w.WriteHeader(f.statusCode)
+	return nil
+}
+
+func TestCircuitBreakerHandler_OpenCircuit_Returns503(t *testing.T) {
+	fake := &fakeCB{IsOpenResult: true}
+	h := &CircuitBreakerHandler{
+		cb: fake,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	err := h.ServeHTTP(rec, req, &fakeCaddyHandler{statusCode: http.StatusOK})
+	if err != nil {
+		t.Fatalf("ServeHTTP returned error: %v", err)
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rec.Code)
+	}
+	if fake.SuccessCalls != 0 || fake.FailureCalls != 0 {
+		t.Errorf("open circuit should not record anything; success=%d, failure=%d",
+			fake.SuccessCalls, fake.FailureCalls)
+	}
+}
+
+func TestCircuitBreakerHandler_ClosedCircuit_SuccessRecorded(t *testing.T) {
+	fake := &fakeCB{IsOpenResult: false}
+	h := &CircuitBreakerHandler{cb: fake}
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	err := h.ServeHTTP(rec, req, &fakeCaddyHandler{statusCode: http.StatusOK})
+	if err != nil {
+		t.Fatalf("ServeHTTP returned error: %v", err)
+	}
+	if fake.SuccessCalls != 1 {
+		t.Errorf("expected 1 RecordSuccess call, got %d", fake.SuccessCalls)
+	}
+	if fake.FailureCalls != 0 {
+		t.Errorf("expected 0 RecordFailure calls, got %d", fake.FailureCalls)
+	}
+}
+
+func TestCircuitBreakerHandler_UpstreamFailureStatuses(t *testing.T) {
+	tests := []struct {
+		name         string
+		upstreamCode int
+		wantFailure  bool
+	}{
+		{"502 bad gateway", http.StatusBadGateway, true},
+		{"503 service unavailable", http.StatusServiceUnavailable, true},
+		{"504 gateway timeout", http.StatusGatewayTimeout, true},
+		{"200 ok", http.StatusOK, false},
+		{"201 created", http.StatusCreated, false},
+		{"404 not found", http.StatusNotFound, false},
+		{"400 bad request", http.StatusBadRequest, false},
+		{"500 internal server error", http.StatusInternalServerError, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeCB{IsOpenResult: false}
+			h := &CircuitBreakerHandler{cb: fake}
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			rec := httptest.NewRecorder()
+
+			_ = h.ServeHTTP(rec, req, &fakeCaddyHandler{statusCode: tt.upstreamCode})
+
+			if tt.wantFailure && fake.FailureCalls != 1 {
+				t.Errorf("status %d: expected RecordFailure, got %d calls", tt.upstreamCode, fake.FailureCalls)
+			}
+			if !tt.wantFailure && fake.SuccessCalls != 1 {
+				t.Errorf("status %d: expected RecordSuccess, got %d calls", tt.upstreamCode, fake.SuccessCalls)
+			}
+		})
+	}
+}
+
+func TestBuildCircuitBreakerHandlerJSON_Disabled(t *testing.T) {
+	cfg := ports.ResilienceConfig{
+		CircuitBreaker: ports.CircuitBreakerConfig{Enabled: false},
+	}
+	result, err := buildCircuitBreakerHandlerJSON(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil when disabled, got %v", result)
+	}
+}
+
+func TestBuildCircuitBreakerHandlerJSON_Enabled(t *testing.T) {
+	cfg := ports.ResilienceConfig{
+		CircuitBreaker: ports.CircuitBreakerConfig{
+			Enabled:   true,
+			Threshold: 5,
+			Timeout:   60 * time.Second,
+		},
+	}
+	result, err := buildCircuitBreakerHandlerJSON(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result when enabled")
+	}
+	if result["handler"] != "vibewarden_circuit_breaker" {
+		t.Errorf("handler = %v, want vibewarden_circuit_breaker", result["handler"])
+	}
+	if result["config"] == nil {
+		t.Error("expected config key in result")
+	}
+}
+
+func TestBuildCaddyConfig_IncludesCircuitBreaker(t *testing.T) {
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "127.0.0.1:8080",
+		UpstreamAddr: "127.0.0.1:3000",
+		Resilience: ports.ResilienceConfig{
+			CircuitBreaker: ports.CircuitBreakerConfig{
+				Enabled:   true,
+				Threshold: 5,
+				Timeout:   60 * time.Second,
+			},
+		},
+	}
+
+	result, err := BuildCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("BuildCaddyConfig: %v", err)
+	}
+
+	// Walk the handler chain and find the circuit breaker.
+	handlers := extractHandlers(t, result)
+	found := false
+	for _, h := range handlers {
+		if h["handler"] == "vibewarden_circuit_breaker" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("circuit breaker handler not found in handler chain: %v", handlers)
+	}
+}
+
+func TestBuildCaddyConfig_CircuitBreakerBeforeTimeout(t *testing.T) {
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "127.0.0.1:8080",
+		UpstreamAddr: "127.0.0.1:3000",
+		Resilience: ports.ResilienceConfig{
+			Timeout: 30 * time.Second,
+			CircuitBreaker: ports.CircuitBreakerConfig{
+				Enabled:   true,
+				Threshold: 5,
+				Timeout:   60 * time.Second,
+			},
+		},
+	}
+
+	result, err := BuildCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("BuildCaddyConfig: %v", err)
+	}
+
+	handlers := extractHandlers(t, result)
+	cbIdx, toIdx := -1, -1
+	for i, h := range handlers {
+		switch h["handler"] {
+		case "vibewarden_circuit_breaker":
+			cbIdx = i
+		case "vibewarden_timeout":
+			toIdx = i
+		}
+	}
+
+	if cbIdx == -1 {
+		t.Fatal("circuit breaker handler not found")
+	}
+	if toIdx == -1 {
+		t.Fatal("timeout handler not found")
+	}
+	if cbIdx >= toIdx {
+		t.Errorf("circuit breaker (index %d) must come before timeout (index %d)", cbIdx, toIdx)
+	}
+}
+
+// extractHandlers walks the Caddy JSON config tree and returns the handler slice
+// from the catch-all route.
+func extractHandlers(t *testing.T, config map[string]any) []map[string]any {
+	t.Helper()
+	apps, _ := config["apps"].(map[string]any)
+	httpApp, _ := apps["http"].(map[string]any)
+	servers, _ := httpApp["servers"].(map[string]any)
+	vw, _ := servers["vibewarden"].(map[string]any)
+	routes, _ := vw["routes"].([]map[string]any)
+
+	// The catch-all route is the last one.
+	if len(routes) == 0 {
+		t.Fatal("no routes found")
+	}
+	last := routes[len(routes)-1]
+	handlers, _ := last["handle"].([]map[string]any)
+	return handlers
+}

--- a/internal/adapters/caddy/config.go
+++ b/internal/adapters/caddy/config.go
@@ -62,7 +62,7 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 	}
 
 	// Build route handlers (middleware chain + reverse proxy).
-	// Middleware order: StripUserHeaders → SecurityHeaders → AdminAuth → BodySize → RateLimit → ReverseProxy
+	// Middleware order: StripUserHeaders → SecurityHeaders → AdminAuth → BodySize → RateLimit → CircuitBreaker → Timeout → ReverseProxy
 	//
 	// The header strip handler MUST be first so that spoofed X-User-* headers sent
 	// by clients are removed before any other handler (including auth) runs.
@@ -101,6 +101,19 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 			return nil, fmt.Errorf("building rate limit handler config: %w", err)
 		}
 		handlers = append(handlers, rlHandler)
+	}
+
+	// Add circuit breaker handler before the timeout handler. The circuit breaker
+	// must run first so that open-circuit requests are rejected immediately,
+	// before the timeout budget is even started.
+	if cfg.Resilience.CircuitBreaker.Enabled {
+		cbHandler, err := buildCircuitBreakerHandlerJSON(cfg.Resilience)
+		if err != nil {
+			return nil, fmt.Errorf("building circuit breaker handler config: %w", err)
+		}
+		if cbHandler != nil {
+			handlers = append(handlers, cbHandler)
+		}
 	}
 
 	// Add timeout handler wrapping the reverse proxy when a timeout is configured.

--- a/internal/adapters/metrics/noop.go
+++ b/internal/adapters/metrics/noop.go
@@ -1,6 +1,11 @@
 package metrics
 
-import "time"
+import (
+	"context"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/resilience"
+)
 
 // NoOpMetricsCollector is a MetricsCollector implementation that discards all
 // observations. Use it when metrics collection is disabled to satisfy the
@@ -27,3 +32,6 @@ func (NoOpMetricsCollector) IncUpstreamTimeout() {}
 
 // SetActiveConnections implements ports.MetricsCollector and does nothing.
 func (NoOpMetricsCollector) SetActiveConnections(_ int) {}
+
+// SetCircuitBreakerState implements ports.MetricsCollector and does nothing.
+func (NoOpMetricsCollector) SetCircuitBreakerState(_ context.Context, _ resilience.State) {}

--- a/internal/adapters/metrics/noop_test.go
+++ b/internal/adapters/metrics/noop_test.go
@@ -1,10 +1,12 @@
 package metrics_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/vibewarden/vibewarden/internal/adapters/metrics"
+	"github.com/vibewarden/vibewarden/internal/domain/resilience"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
@@ -29,4 +31,7 @@ func TestNoOpMetricsCollector_AllMethodsAreNoOps(t *testing.T) {
 	mc.IncUpstreamTimeout()
 	mc.SetActiveConnections(0)
 	mc.SetActiveConnections(42)
+	mc.SetCircuitBreakerState(context.Background(), resilience.StateClosed)
+	mc.SetCircuitBreakerState(context.Background(), resilience.StateOpen)
+	mc.SetCircuitBreakerState(context.Background(), resilience.StateHalfOpen)
 }

--- a/internal/adapters/metrics/otel.go
+++ b/internal/adapters/metrics/otel.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/vibewarden/vibewarden/internal/domain/resilience"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
@@ -13,16 +14,18 @@ import (
 // It creates counters and histograms via ports.Meter and records observations.
 // All methods are safe for concurrent use.
 type OTelAdapter struct {
-	requestsTotal     ports.Int64Counter
-	requestDuration   ports.Float64Histogram
-	rateLimitHits     ports.Int64Counter
-	authDecisions     ports.Int64Counter
-	upstreamErrors    ports.Int64Counter
-	upstreamTimeouts  ports.Int64Counter
-	activeConnections ports.Int64UpDownCounter
-	currentConns      atomic.Int64
-	pathMatcher       *PathMatcher
-	handler           http.Handler
+	requestsTotal       ports.Int64Counter
+	requestDuration     ports.Float64Histogram
+	rateLimitHits       ports.Int64Counter
+	authDecisions       ports.Int64Counter
+	upstreamErrors      ports.Int64Counter
+	upstreamTimeouts    ports.Int64Counter
+	activeConnections   ports.Int64UpDownCounter
+	circuitBreakerState ports.Int64UpDownCounter
+	currentConns        atomic.Int64
+	currentCBState      atomic.Int64
+	pathMatcher         *PathMatcher
+	handler             http.Handler
 }
 
 // NewOTelAdapter creates a new OTel-backed MetricsCollector.
@@ -83,16 +86,24 @@ func NewOTelAdapter(provider ports.OTelProvider, pathPatterns []string) (*OTelAd
 		return nil, err
 	}
 
+	circuitBreakerState, err := meter.Int64UpDownCounter("vibewarden_circuit_breaker_state",
+		ports.WithDescription("Current circuit breaker state: 0=closed, 1=open, 2=half_open."),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &OTelAdapter{
-		requestsTotal:     requestsTotal,
-		requestDuration:   requestDuration,
-		rateLimitHits:     rateLimitHits,
-		authDecisions:     authDecisions,
-		upstreamErrors:    upstreamErrors,
-		upstreamTimeouts:  upstreamTimeouts,
-		activeConnections: activeConnections,
-		pathMatcher:       NewPathMatcher(pathPatterns),
-		handler:           provider.Handler(),
+		requestsTotal:       requestsTotal,
+		requestDuration:     requestDuration,
+		rateLimitHits:       rateLimitHits,
+		authDecisions:       authDecisions,
+		upstreamErrors:      upstreamErrors,
+		upstreamTimeouts:    upstreamTimeouts,
+		activeConnections:   activeConnections,
+		circuitBreakerState: circuitBreakerState,
+		pathMatcher:         NewPathMatcher(pathPatterns),
+		handler:             provider.Handler(),
 	}, nil
 }
 
@@ -154,5 +165,19 @@ func (a *OTelAdapter) SetActiveConnections(n int) {
 	delta := next - prev
 	if delta != 0 {
 		a.activeConnections.Add(context.Background(), delta)
+	}
+}
+
+// SetCircuitBreakerState implements ports.MetricsCollector.
+// Records the current circuit breaker state as a gauge value:
+// 0=closed, 1=open, 2=half_open.
+// OTel's UpDownCounter only supports Add; this implementation tracks the
+// previous value atomically and emits only the delta.
+func (a *OTelAdapter) SetCircuitBreakerState(ctx context.Context, state resilience.State) {
+	next := int64(state)
+	prev := a.currentCBState.Swap(next)
+	delta := next - prev
+	if delta != 0 {
+		a.circuitBreakerState.Add(ctx, delta)
 	}
 }

--- a/internal/adapters/resilience/circuit_breaker.go
+++ b/internal/adapters/resilience/circuit_breaker.go
@@ -1,0 +1,140 @@
+// Package resilience provides adapters for upstream resilience features.
+package resilience
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	domainresilience "github.com/vibewarden/vibewarden/internal/domain/resilience"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// InMemoryCircuitBreaker is a ports.CircuitBreaker implementation backed by the
+// domain CircuitBreaker entity. All state transitions are protected by a mutex
+// so concurrent requests are safe.
+//
+// On state transition the adapter emits a structured event via ports.EventLogger
+// and, when available, updates the vibewarden_circuit_breaker_state gauge via
+// ports.MetricsCollectorWithCircuitBreaker.
+type InMemoryCircuitBreaker struct {
+	mu     sync.Mutex
+	cb     *domainresilience.CircuitBreaker
+	logger *slog.Logger
+	events ports.EventLogger
+	// metrics is optional; may be nil when metrics are disabled.
+	metrics ports.MetricsCollectorWithCircuitBreaker
+}
+
+// NewInMemoryCircuitBreaker creates an InMemoryCircuitBreaker from a ports config.
+// Returns an error when the configuration is invalid (threshold ≤ 0 or timeout ≤ 0).
+func NewInMemoryCircuitBreaker(
+	cfg ports.CircuitBreakerConfig,
+	logger *slog.Logger,
+	eventLogger ports.EventLogger,
+	metrics ports.MetricsCollectorWithCircuitBreaker,
+) (*InMemoryCircuitBreaker, error) {
+	domainCfg := domainresilience.CircuitBreakerConfig{
+		Threshold: cfg.Threshold,
+		Timeout:   cfg.Timeout,
+	}
+	cb, err := domainresilience.NewCircuitBreaker(domainCfg)
+	if err != nil {
+		return nil, err
+	}
+	return &InMemoryCircuitBreaker{
+		cb:      cb,
+		logger:  logger,
+		events:  eventLogger,
+		metrics: metrics,
+	}, nil
+}
+
+// IsOpen implements ports.CircuitBreaker. It is safe for concurrent use.
+// When the circuit transitions from Open to HalfOpen (because the timeout
+// expired) a circuit_breaker.half_open event is emitted.
+func (a *InMemoryCircuitBreaker) IsOpen() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	prevState := a.cb.State()
+	open := a.cb.IsOpen(time.Now())
+
+	// Detect Open → HalfOpen transition.
+	if prevState == domainresilience.StateOpen && a.cb.State() == domainresilience.StateHalfOpen {
+		a.emitEvent(events.NewCircuitBreakerHalfOpen(events.CircuitBreakerHalfOpenParams{
+			TimeoutSeconds: a.cb.Config().Timeout.Seconds(),
+		}))
+		a.recordStateMetric(context.Background())
+	}
+
+	return open
+}
+
+// RecordSuccess implements ports.CircuitBreaker. It is safe for concurrent use.
+// When the circuit was HalfOpen and transitions back to Closed a
+// circuit_breaker.closed event is emitted.
+func (a *InMemoryCircuitBreaker) RecordSuccess() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	previous := a.cb.RecordSuccess()
+	if previous == domainresilience.StateHalfOpen {
+		// Transition: HalfOpen → Closed.
+		a.emitEvent(events.NewCircuitBreakerClosed())
+		a.recordStateMetric(context.Background())
+	}
+}
+
+// RecordFailure implements ports.CircuitBreaker. It is safe for concurrent use.
+// When the failure threshold is reached (Closed → Open) or a probe fails
+// (HalfOpen → Open) a circuit_breaker.opened event is emitted.
+func (a *InMemoryCircuitBreaker) RecordFailure() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	_, transitioned := a.cb.RecordFailure(time.Now())
+	if transitioned && a.cb.State() == domainresilience.StateOpen {
+		a.emitEvent(events.NewCircuitBreakerOpened(events.CircuitBreakerOpenedParams{
+			Threshold:      a.cb.Config().Threshold,
+			TimeoutSeconds: a.cb.Config().Timeout.Seconds(),
+		}))
+		a.recordStateMetric(context.Background())
+	}
+}
+
+// State implements ports.CircuitBreaker. It is safe for concurrent use.
+func (a *InMemoryCircuitBreaker) State() domainresilience.State {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.cb.State()
+}
+
+// emitEvent sends a structured event. Failures are logged but do not interrupt
+// request handling. Must be called with a.mu held.
+func (a *InMemoryCircuitBreaker) emitEvent(ev events.Event) {
+	if a.events == nil {
+		return
+	}
+	if err := a.events.Log(context.Background(), ev); err != nil {
+		if a.logger != nil {
+			a.logger.Error("circuit_breaker: failed to emit event",
+				slog.String("event_type", ev.EventType),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+}
+
+// recordStateMetric updates the circuit breaker state gauge. Must be called with a.mu held.
+func (a *InMemoryCircuitBreaker) recordStateMetric(ctx context.Context) {
+	if a.metrics == nil {
+		return
+	}
+	a.metrics.SetCircuitBreakerState(ctx, a.cb.State())
+}
+
+// Compile-time assertion that InMemoryCircuitBreaker satisfies ports.CircuitBreaker.
+var _ ports.CircuitBreaker = (*InMemoryCircuitBreaker)(nil)

--- a/internal/adapters/resilience/circuit_breaker_test.go
+++ b/internal/adapters/resilience/circuit_breaker_test.go
@@ -1,0 +1,260 @@
+package resilience_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/adapters/resilience"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	domainresilience "github.com/vibewarden/vibewarden/internal/domain/resilience"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// fakeEventLogger records emitted events for test assertions.
+type fakeEventLogger struct {
+	mu     sync.Mutex
+	events []events.Event
+}
+
+func (f *fakeEventLogger) Log(_ context.Context, ev events.Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, ev)
+	return nil
+}
+
+func (f *fakeEventLogger) EventTypes() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	types := make([]string, len(f.events))
+	for i, e := range f.events {
+		types[i] = e.EventType
+	}
+	return types
+}
+
+func (f *fakeEventLogger) Count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.events)
+}
+
+// fakeMetrics records circuit breaker state updates.
+type fakeMetrics struct {
+	mu     sync.Mutex
+	states []domainresilience.State
+}
+
+func (f *fakeMetrics) SetCircuitBreakerState(_ context.Context, s domainresilience.State) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.states = append(f.states, s)
+}
+
+func (f *fakeMetrics) LastState() (domainresilience.State, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.states) == 0 {
+		return 0, false
+	}
+	return f.states[len(f.states)-1], true
+}
+
+// fakeMetrics also needs to implement ports.MetricsCollectorWithCircuitBreaker
+// (which embeds ports.MetricsCollector). Provide no-ops for all other methods.
+func (f *fakeMetrics) IncRequestTotal(_, _, _ string)                      {}
+func (f *fakeMetrics) ObserveRequestDuration(_, _ string, _ time.Duration) {}
+func (f *fakeMetrics) IncRateLimitHit(_ string)                            {}
+func (f *fakeMetrics) IncAuthDecision(_ string)                            {}
+func (f *fakeMetrics) IncUpstreamError()                                   {}
+func (f *fakeMetrics) IncUpstreamTimeout()                                 {}
+func (f *fakeMetrics) SetActiveConnections(_ int)                          {}
+
+var _ ports.MetricsCollectorWithCircuitBreaker = (*fakeMetrics)(nil)
+
+func newCB(t *testing.T, threshold int, timeout time.Duration) (*resilience.InMemoryCircuitBreaker, *fakeEventLogger, *fakeMetrics) {
+	t.Helper()
+	el := &fakeEventLogger{}
+	m := &fakeMetrics{}
+	cfg := ports.CircuitBreakerConfig{
+		Enabled:   true,
+		Threshold: threshold,
+		Timeout:   timeout,
+	}
+	cb, err := resilience.NewInMemoryCircuitBreaker(cfg, slog.Default(), el, m)
+	if err != nil {
+		t.Fatalf("NewInMemoryCircuitBreaker: %v", err)
+	}
+	return cb, el, m
+}
+
+func TestInMemoryCircuitBreaker_InvalidConfig(t *testing.T) {
+	cfg := ports.CircuitBreakerConfig{
+		Enabled:   true,
+		Threshold: 0, // invalid
+		Timeout:   time.Minute,
+	}
+	_, err := resilience.NewInMemoryCircuitBreaker(cfg, nil, nil, nil)
+	if err == nil {
+		t.Error("expected error for zero threshold")
+	}
+}
+
+func TestInMemoryCircuitBreaker_InitiallyClosed(t *testing.T) {
+	cb, _, _ := newCB(t, 3, time.Minute)
+	if cb.IsOpen() {
+		t.Error("expected circuit to be closed initially")
+	}
+	if cb.State() != domainresilience.StateClosed {
+		t.Errorf("initial state = %v, want Closed", cb.State())
+	}
+}
+
+func TestInMemoryCircuitBreaker_TripsAfterThreshold(t *testing.T) {
+	cb, el, m := newCB(t, 3, time.Minute)
+
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if cb.IsOpen() {
+		t.Error("should not be open after 2 failures (threshold=3)")
+	}
+
+	cb.RecordFailure() // third failure trips the circuit
+	if !cb.IsOpen() {
+		t.Error("expected circuit open after threshold")
+	}
+	if cb.State() != domainresilience.StateOpen {
+		t.Errorf("state = %v, want Open", cb.State())
+	}
+
+	// circuit_breaker.opened event must have been emitted.
+	types := el.EventTypes()
+	if len(types) == 0 || types[len(types)-1] != events.EventTypeCircuitBreakerOpened {
+		t.Errorf("event types = %v, want last = circuit_breaker.opened", types)
+	}
+
+	// Gauge must have been updated.
+	if s, ok := m.LastState(); !ok || s != domainresilience.StateOpen {
+		t.Errorf("metrics last state = %v, want Open", s)
+	}
+}
+
+func TestInMemoryCircuitBreaker_OpenTransitionsToHalfOpen(t *testing.T) {
+	// Use a very short timeout so we can test the transition without sleeping.
+	// The transition is driven by time.Now() inside IsOpen; we cannot inject a
+	// clock into the adapter directly, so we sleep briefly.
+	cb, el, _ := newCB(t, 1, 50*time.Millisecond)
+
+	cb.RecordFailure() // trips
+	if !cb.IsOpen() {
+		t.Fatal("expected circuit open")
+	}
+
+	// Wait for the open timeout to expire.
+	time.Sleep(100 * time.Millisecond)
+
+	// First IsOpen call after timeout should return false (probe allowed).
+	if cb.IsOpen() {
+		t.Error("expected circuit to allow probe after timeout (HalfOpen)")
+	}
+	if cb.State() != domainresilience.StateHalfOpen {
+		t.Errorf("state = %v, want HalfOpen", cb.State())
+	}
+
+	// circuit_breaker.half_open event must have been emitted.
+	types := el.EventTypes()
+	found := false
+	for _, et := range types {
+		if et == events.EventTypeCircuitBreakerHalfOpen {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("event types = %v, expected circuit_breaker.half_open", types)
+	}
+}
+
+func TestInMemoryCircuitBreaker_HalfOpenSuccessCloses(t *testing.T) {
+	cb, el, m := newCB(t, 1, 50*time.Millisecond)
+
+	cb.RecordFailure()
+	time.Sleep(100 * time.Millisecond)
+	cb.IsOpen() // transitions to HalfOpen
+
+	cb.RecordSuccess()
+	if cb.State() != domainresilience.StateClosed {
+		t.Errorf("state = %v, want Closed after probe success", cb.State())
+	}
+	if cb.IsOpen() {
+		t.Error("expected circuit closed after probe success")
+	}
+
+	types := el.EventTypes()
+	found := false
+	for _, et := range types {
+		if et == events.EventTypeCircuitBreakerClosed {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("event types = %v, expected circuit_breaker.closed", types)
+	}
+
+	if s, ok := m.LastState(); !ok || s != domainresilience.StateClosed {
+		t.Errorf("metrics last state = %v, want Closed", s)
+	}
+}
+
+func TestInMemoryCircuitBreaker_HalfOpenFailureReopens(t *testing.T) {
+	cb, el, _ := newCB(t, 1, 50*time.Millisecond)
+
+	cb.RecordFailure()
+	time.Sleep(100 * time.Millisecond)
+	cb.IsOpen() // transitions to HalfOpen
+
+	cb.RecordFailure() // probe fails → back to Open
+	if cb.State() != domainresilience.StateOpen {
+		t.Errorf("state = %v, want Open after probe failure", cb.State())
+	}
+	if !cb.IsOpen() {
+		t.Error("expected circuit open after probe failure")
+	}
+
+	// Should have two circuit_breaker.opened events (initial trip + re-open).
+	count := 0
+	for _, et := range el.EventTypes() {
+		if et == events.EventTypeCircuitBreakerOpened {
+			count++
+		}
+	}
+	if count < 2 {
+		t.Errorf("expected at least 2 circuit_breaker.opened events, got %d", count)
+	}
+}
+
+func TestInMemoryCircuitBreaker_Concurrent(t *testing.T) {
+	cb, _, _ := newCB(t, 10, time.Minute)
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				cb.RecordFailure()
+			} else {
+				cb.RecordSuccess()
+			}
+			_ = cb.IsOpen()
+			_ = cb.State()
+		}(i)
+	}
+	wg.Wait()
+	// No assertion on the final state — just verifying no race / panic.
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -565,6 +565,26 @@ type ResilienceConfig struct {
 	// A value of "0" or "" disables the timeout (no limit).
 	// Default: "30s".
 	Timeout string `mapstructure:"timeout"`
+
+	// CircuitBreaker configures the circuit breaker middleware.
+	CircuitBreaker CircuitBreakerConfig `mapstructure:"circuit_breaker"`
+}
+
+// CircuitBreakerConfig holds circuit breaker settings.
+type CircuitBreakerConfig struct {
+	// Enabled toggles the circuit breaker middleware.
+	Enabled bool `mapstructure:"enabled"`
+
+	// Threshold is the number of consecutive failures required to trip the
+	// circuit from Closed to Open. Must be > 0 when Enabled is true.
+	// Default: 5.
+	Threshold int `mapstructure:"threshold"`
+
+	// Timeout is how long the circuit stays Open before transitioning to
+	// HalfOpen to allow a probe request, expressed as a duration string
+	// (e.g. "60s", "1m"). Must be > 0 when Enabled is true.
+	// Default: "60s".
+	Timeout string `mapstructure:"timeout"`
 }
 
 // BodySizeConfig holds request body size limit settings.

--- a/internal/domain/events/circuit_breaker.go
+++ b/internal/domain/events/circuit_breaker.go
@@ -1,0 +1,89 @@
+package events
+
+import (
+	"fmt"
+	"time"
+)
+
+// Event type constants for circuit breaker state transitions.
+const (
+	// EventTypeCircuitBreakerOpened is emitted when the circuit breaker trips
+	// from Closed to Open because consecutive failures reached the threshold.
+	EventTypeCircuitBreakerOpened = "circuit_breaker.opened"
+
+	// EventTypeCircuitBreakerHalfOpen is emitted when the circuit breaker
+	// transitions from Open to HalfOpen because the open timeout expired and a
+	// probe request is allowed through.
+	EventTypeCircuitBreakerHalfOpen = "circuit_breaker.half_open"
+
+	// EventTypeCircuitBreakerClosed is emitted when the circuit breaker returns
+	// to Closed because the upstream probe succeeded.
+	EventTypeCircuitBreakerClosed = "circuit_breaker.closed"
+)
+
+// CircuitBreakerOpenedParams contains the parameters needed to construct a
+// circuit_breaker.opened event.
+type CircuitBreakerOpenedParams struct {
+	// Threshold is the consecutive failure count that tripped the circuit.
+	Threshold int
+
+	// TimeoutSeconds is the duration the circuit will remain open before
+	// allowing a probe, in seconds.
+	TimeoutSeconds float64
+}
+
+// NewCircuitBreakerOpened creates a circuit_breaker.opened event indicating
+// that the circuit breaker has tripped and is now blocking upstream traffic.
+func NewCircuitBreakerOpened(params CircuitBreakerOpenedParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeCircuitBreakerOpened,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"Circuit breaker opened after %d consecutive failures; upstream blocked for %.0fs",
+			params.Threshold, params.TimeoutSeconds,
+		),
+		Payload: map[string]any{
+			"threshold":       params.Threshold,
+			"timeout_seconds": params.TimeoutSeconds,
+		},
+	}
+}
+
+// CircuitBreakerHalfOpenParams contains the parameters needed to construct a
+// circuit_breaker.half_open event.
+type CircuitBreakerHalfOpenParams struct {
+	// TimeoutSeconds is the open timeout that elapsed before the probe, in seconds.
+	TimeoutSeconds float64
+}
+
+// NewCircuitBreakerHalfOpen creates a circuit_breaker.half_open event
+// indicating that the open timeout expired and a probe request is allowed
+// through to test whether the upstream has recovered.
+func NewCircuitBreakerHalfOpen(params CircuitBreakerHalfOpenParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeCircuitBreakerHalfOpen,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"Circuit breaker entered half-open state after %.0fs timeout; probe request allowed",
+			params.TimeoutSeconds,
+		),
+		Payload: map[string]any{
+			"timeout_seconds": params.TimeoutSeconds,
+		},
+	}
+}
+
+// NewCircuitBreakerClosed creates a circuit_breaker.closed event indicating
+// that the upstream probe succeeded and the circuit breaker has returned to
+// normal operation.
+func NewCircuitBreakerClosed() Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeCircuitBreakerClosed,
+		Timestamp:     time.Now().UTC(),
+		AISummary:     "Circuit breaker closed; upstream recovered and traffic is flowing normally",
+		Payload:       map[string]any{},
+	}
+}

--- a/internal/domain/events/circuit_breaker_test.go
+++ b/internal/domain/events/circuit_breaker_test.go
@@ -1,0 +1,65 @@
+package events_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+)
+
+func TestNewCircuitBreakerOpened(t *testing.T) {
+	params := events.CircuitBreakerOpenedParams{
+		Threshold:      5,
+		TimeoutSeconds: 60,
+	}
+	before := time.Now()
+	ev := events.NewCircuitBreakerOpened(params)
+	after := time.Now()
+
+	if ev.EventType != events.EventTypeCircuitBreakerOpened {
+		t.Errorf("EventType = %q, want %q", ev.EventType, events.EventTypeCircuitBreakerOpened)
+	}
+	if ev.SchemaVersion != events.SchemaVersion {
+		t.Errorf("SchemaVersion = %q, want %q", ev.SchemaVersion, events.SchemaVersion)
+	}
+	if ev.Timestamp.Before(before) || ev.Timestamp.After(after) {
+		t.Errorf("Timestamp %v not in expected range [%v, %v]", ev.Timestamp, before, after)
+	}
+	if ev.AISummary == "" {
+		t.Error("AISummary must not be empty")
+	}
+	if ev.Payload["threshold"] != 5 {
+		t.Errorf("Payload[threshold] = %v, want 5", ev.Payload["threshold"])
+	}
+	if ev.Payload["timeout_seconds"] != float64(60) {
+		t.Errorf("Payload[timeout_seconds] = %v, want 60", ev.Payload["timeout_seconds"])
+	}
+}
+
+func TestNewCircuitBreakerHalfOpen(t *testing.T) {
+	params := events.CircuitBreakerHalfOpenParams{
+		TimeoutSeconds: 30,
+	}
+	ev := events.NewCircuitBreakerHalfOpen(params)
+
+	if ev.EventType != events.EventTypeCircuitBreakerHalfOpen {
+		t.Errorf("EventType = %q, want %q", ev.EventType, events.EventTypeCircuitBreakerHalfOpen)
+	}
+	if ev.AISummary == "" {
+		t.Error("AISummary must not be empty")
+	}
+	if ev.Payload["timeout_seconds"] != float64(30) {
+		t.Errorf("Payload[timeout_seconds] = %v, want 30", ev.Payload["timeout_seconds"])
+	}
+}
+
+func TestNewCircuitBreakerClosed(t *testing.T) {
+	ev := events.NewCircuitBreakerClosed()
+
+	if ev.EventType != events.EventTypeCircuitBreakerClosed {
+		t.Errorf("EventType = %q, want %q", ev.EventType, events.EventTypeCircuitBreakerClosed)
+	}
+	if ev.AISummary == "" {
+		t.Error("AISummary must not be empty")
+	}
+}

--- a/internal/domain/resilience/circuit_breaker.go
+++ b/internal/domain/resilience/circuit_breaker.go
@@ -1,0 +1,168 @@
+// Package resilience contains the domain model for upstream resilience features.
+// This package has zero external dependencies — only Go stdlib.
+package resilience
+
+import (
+	"errors"
+	"time"
+)
+
+// State represents the state of a circuit breaker.
+type State int
+
+const (
+	// StateClosed is the normal operating state. Requests pass through and
+	// failures are counted. Once the failure threshold is reached the circuit
+	// transitions to StateOpen.
+	StateClosed State = iota
+
+	// StateOpen means the circuit has tripped. All requests are short-circuited
+	// immediately with an error — no upstream contact is made. After the
+	// configured timeout the circuit transitions to StateHalfOpen.
+	StateOpen
+
+	// StateHalfOpen is the probing state. A single trial request is allowed
+	// through to test whether the upstream has recovered. If the trial
+	// succeeds the circuit returns to StateClosed; if it fails, it goes back
+	// to StateOpen.
+	StateHalfOpen
+)
+
+// String returns a human-readable name for the state.
+func (s State) String() string {
+	switch s {
+	case StateClosed:
+		return "closed"
+	case StateOpen:
+		return "open"
+	case StateHalfOpen:
+		return "half_open"
+	default:
+		return "unknown"
+	}
+}
+
+// ErrCircuitOpen is returned when a request is rejected because the circuit
+// breaker is in the open state.
+var ErrCircuitOpen = errors.New("circuit breaker is open")
+
+// CircuitBreakerConfig holds the parameters that drive a CircuitBreaker.
+type CircuitBreakerConfig struct {
+	// Threshold is the number of consecutive failures required to trip the
+	// circuit from Closed to Open.
+	// Must be > 0.
+	Threshold int
+
+	// Timeout is how long the circuit stays Open before transitioning to
+	// HalfOpen to allow a probe request.
+	// Must be > 0.
+	Timeout time.Duration
+}
+
+// Validate returns an error when the configuration is invalid.
+func (c CircuitBreakerConfig) Validate() error {
+	if c.Threshold <= 0 {
+		return errors.New("circuit breaker threshold must be greater than zero")
+	}
+	if c.Timeout <= 0 {
+		return errors.New("circuit breaker timeout must be greater than zero")
+	}
+	return nil
+}
+
+// CircuitBreaker is a domain entity that implements the three-state circuit
+// breaker pattern (Closed → Open → HalfOpen → Closed).
+//
+// CircuitBreaker is not safe for concurrent use on its own — callers must
+// synchronise access externally (e.g. via the in-memory adapter which wraps
+// it in a mutex). The methods are intentionally pure to keep domain logic
+// free of concurrency primitives.
+type CircuitBreaker struct {
+	cfg CircuitBreakerConfig
+
+	state    State
+	failures int
+	openedAt time.Time
+}
+
+// NewCircuitBreaker creates a new CircuitBreaker in the Closed state with the
+// given configuration. Returns an error when the configuration is invalid.
+func NewCircuitBreaker(cfg CircuitBreakerConfig) (*CircuitBreaker, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &CircuitBreaker{cfg: cfg, state: StateClosed}, nil
+}
+
+// State returns the current circuit state.
+func (cb *CircuitBreaker) State() State {
+	return cb.state
+}
+
+// Config returns the configuration used by this circuit breaker.
+func (cb *CircuitBreaker) Config() CircuitBreakerConfig {
+	return cb.cfg
+}
+
+// IsOpen returns true when requests should be rejected without contacting the
+// upstream. It evaluates the timeout and advances state from Open to HalfOpen
+// when enough time has passed. The provided now value should be time.Now() from
+// the caller, allowing deterministic testing without real clocks.
+func (cb *CircuitBreaker) IsOpen(now time.Time) bool {
+	if cb.state == StateClosed {
+		return false
+	}
+	if cb.state == StateHalfOpen {
+		// HalfOpen: the probe slot is already consumed — block further requests.
+		return true
+	}
+	// StateOpen: check whether the timeout has expired.
+	if now.After(cb.openedAt.Add(cb.cfg.Timeout)) {
+		cb.state = StateHalfOpen
+		return false // allow the probe through
+	}
+	return true
+}
+
+// RecordSuccess records a successful upstream response. When in HalfOpen state
+// the circuit closes and the failure counter is reset. Returns the previous
+// state so callers can detect transitions.
+func (cb *CircuitBreaker) RecordSuccess() (previous State) {
+	previous = cb.state
+	cb.failures = 0
+	cb.state = StateClosed
+	return previous
+}
+
+// RecordFailure records a failed upstream response. In Closed state it
+// increments the failure counter and trips the circuit when the threshold is
+// reached. In HalfOpen state a single failure re-opens the circuit immediately.
+// Returns the previous state and whether a state transition occurred.
+func (cb *CircuitBreaker) RecordFailure(now time.Time) (previous State, transitioned bool) {
+	previous = cb.state
+	switch cb.state {
+	case StateClosed:
+		cb.failures++
+		if cb.failures >= cb.cfg.Threshold {
+			cb.state = StateOpen
+			cb.openedAt = now
+			return previous, true
+		}
+	case StateHalfOpen:
+		cb.state = StateOpen
+		cb.openedAt = now
+		return previous, true
+	}
+	return previous, false
+}
+
+// Failures returns the current consecutive failure count.
+func (cb *CircuitBreaker) Failures() int {
+	return cb.failures
+}
+
+// OpenedAt returns the time the circuit was last opened. The zero value is
+// returned when the circuit has never been opened.
+func (cb *CircuitBreaker) OpenedAt() time.Time {
+	return cb.openedAt
+}

--- a/internal/domain/resilience/circuit_breaker_test.go
+++ b/internal/domain/resilience/circuit_breaker_test.go
@@ -1,0 +1,253 @@
+package resilience_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/resilience"
+)
+
+func validConfig() resilience.CircuitBreakerConfig {
+	return resilience.CircuitBreakerConfig{
+		Threshold: 3,
+		Timeout:   10 * time.Second,
+	}
+}
+
+func TestCircuitBreakerConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     resilience.CircuitBreakerConfig
+		wantErr bool
+	}{
+		{
+			name:    "valid config",
+			cfg:     resilience.CircuitBreakerConfig{Threshold: 1, Timeout: time.Second},
+			wantErr: false,
+		},
+		{
+			name:    "zero threshold",
+			cfg:     resilience.CircuitBreakerConfig{Threshold: 0, Timeout: time.Second},
+			wantErr: true,
+		},
+		{
+			name:    "negative threshold",
+			cfg:     resilience.CircuitBreakerConfig{Threshold: -1, Timeout: time.Second},
+			wantErr: true,
+		},
+		{
+			name:    "zero timeout",
+			cfg:     resilience.CircuitBreakerConfig{Threshold: 1, Timeout: 0},
+			wantErr: true,
+		},
+		{
+			name:    "negative timeout",
+			cfg:     resilience.CircuitBreakerConfig{Threshold: 1, Timeout: -time.Second},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewCircuitBreaker_InvalidConfig(t *testing.T) {
+	_, err := resilience.NewCircuitBreaker(resilience.CircuitBreakerConfig{Threshold: 0, Timeout: time.Second})
+	if err == nil {
+		t.Error("expected error for zero threshold, got nil")
+	}
+}
+
+func TestCircuitBreaker_InitialState(t *testing.T) {
+	cb, err := resilience.NewCircuitBreaker(validConfig())
+	if err != nil {
+		t.Fatalf("NewCircuitBreaker: %v", err)
+	}
+	if got := cb.State(); got != resilience.StateClosed {
+		t.Errorf("initial state = %v, want Closed", got)
+	}
+	if cb.IsOpen(time.Now()) {
+		t.Error("expected IsOpen = false in initial closed state")
+	}
+}
+
+func TestCircuitBreaker_Closed_FailuresAccumulate(t *testing.T) {
+	cfg := resilience.CircuitBreakerConfig{Threshold: 3, Timeout: time.Minute}
+	cb, _ := resilience.NewCircuitBreaker(cfg)
+	now := time.Now()
+
+	// First two failures should not trip.
+	cb.RecordFailure(now)
+	cb.RecordFailure(now)
+	if cb.State() != resilience.StateClosed {
+		t.Errorf("expected Closed after 2 failures, got %v", cb.State())
+	}
+	if cb.Failures() != 2 {
+		t.Errorf("expected 2 failures, got %d", cb.Failures())
+	}
+
+	// Third failure reaches threshold → Open.
+	_, transitioned := cb.RecordFailure(now)
+	if !transitioned {
+		t.Error("expected transition on threshold failure")
+	}
+	if cb.State() != resilience.StateOpen {
+		t.Errorf("expected Open after threshold, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreaker_Open_BlocksRequests(t *testing.T) {
+	cfg := resilience.CircuitBreakerConfig{Threshold: 1, Timeout: time.Minute}
+	cb, _ := resilience.NewCircuitBreaker(cfg)
+	now := time.Now()
+
+	cb.RecordFailure(now)
+
+	if !cb.IsOpen(now) {
+		t.Error("expected IsOpen = true when Open and timeout not elapsed")
+	}
+}
+
+func TestCircuitBreaker_Open_TransitionsToHalfOpenAfterTimeout(t *testing.T) {
+	cfg := resilience.CircuitBreakerConfig{Threshold: 1, Timeout: time.Second}
+	cb, _ := resilience.NewCircuitBreaker(cfg)
+	opened := time.Now()
+
+	cb.RecordFailure(opened)
+
+	// Before timeout: still open.
+	if !cb.IsOpen(opened.Add(500 * time.Millisecond)) {
+		t.Error("expected still open before timeout")
+	}
+
+	// After timeout: transitions to HalfOpen and allows probe.
+	if cb.IsOpen(opened.Add(2 * time.Second)) {
+		t.Error("expected IsOpen = false after timeout (HalfOpen probe allowed)")
+	}
+	if cb.State() != resilience.StateHalfOpen {
+		t.Errorf("expected HalfOpen after timeout, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreaker_HalfOpen_SuccessCloses(t *testing.T) {
+	cfg := resilience.CircuitBreakerConfig{Threshold: 1, Timeout: time.Second}
+	cb, _ := resilience.NewCircuitBreaker(cfg)
+	opened := time.Now()
+
+	cb.RecordFailure(opened)
+	// Advance to HalfOpen.
+	cb.IsOpen(opened.Add(2 * time.Second))
+
+	// HalfOpen: first request after IsOpen advances state. Now record success.
+	previous := cb.RecordSuccess()
+	if previous != resilience.StateHalfOpen {
+		t.Errorf("RecordSuccess previous state = %v, want HalfOpen", previous)
+	}
+	if cb.State() != resilience.StateClosed {
+		t.Errorf("expected Closed after probe success, got %v", cb.State())
+	}
+	if cb.Failures() != 0 {
+		t.Errorf("expected 0 failures after close, got %d", cb.Failures())
+	}
+}
+
+func TestCircuitBreaker_HalfOpen_FailureReopens(t *testing.T) {
+	cfg := resilience.CircuitBreakerConfig{Threshold: 1, Timeout: time.Second}
+	cb, _ := resilience.NewCircuitBreaker(cfg)
+	opened := time.Now()
+
+	cb.RecordFailure(opened)
+	// Advance to HalfOpen.
+	cb.IsOpen(opened.Add(2 * time.Second))
+
+	// HalfOpen: probe fails → back to Open.
+	probeTime := opened.Add(2 * time.Second)
+	_, transitioned := cb.RecordFailure(probeTime)
+	if !transitioned {
+		t.Error("expected transition on HalfOpen failure")
+	}
+	if cb.State() != resilience.StateOpen {
+		t.Errorf("expected Open after probe failure, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreaker_HalfOpen_BlocksFurtherRequests(t *testing.T) {
+	cfg := resilience.CircuitBreakerConfig{Threshold: 1, Timeout: time.Second}
+	cb, _ := resilience.NewCircuitBreaker(cfg)
+	opened := time.Now()
+
+	cb.RecordFailure(opened)
+	// Advance to HalfOpen — first IsOpen call allows probe through.
+	cb.IsOpen(opened.Add(2 * time.Second))
+
+	// A second IsOpen call while in HalfOpen should block further requests.
+	if !cb.IsOpen(opened.Add(2 * time.Second)) {
+		t.Error("expected HalfOpen to block concurrent requests (probe slot consumed)")
+	}
+}
+
+func TestCircuitBreaker_SuccessResetFailures(t *testing.T) {
+	cfg := resilience.CircuitBreakerConfig{Threshold: 5, Timeout: time.Minute}
+	cb, _ := resilience.NewCircuitBreaker(cfg)
+	now := time.Now()
+
+	cb.RecordFailure(now)
+	cb.RecordFailure(now)
+	cb.RecordSuccess()
+
+	if cb.Failures() != 0 {
+		t.Errorf("expected failures reset to 0 after success, got %d", cb.Failures())
+	}
+	if cb.State() != resilience.StateClosed {
+		t.Errorf("expected Closed after success, got %v", cb.State())
+	}
+}
+
+func TestState_String(t *testing.T) {
+	tests := []struct {
+		state resilience.State
+		want  string
+	}{
+		{resilience.StateClosed, "closed"},
+		{resilience.StateOpen, "open"},
+		{resilience.StateHalfOpen, "half_open"},
+		{resilience.State(99), "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.state.String(); got != tt.want {
+				t.Errorf("State.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCircuitBreaker_OpenedAt(t *testing.T) {
+	cfg := resilience.CircuitBreakerConfig{Threshold: 1, Timeout: time.Minute}
+	cb, _ := resilience.NewCircuitBreaker(cfg)
+
+	// Before any failures, OpenedAt should be zero.
+	if !cb.OpenedAt().IsZero() {
+		t.Error("expected zero OpenedAt before any failure")
+	}
+
+	now := time.Now()
+	cb.RecordFailure(now)
+	if cb.OpenedAt().IsZero() {
+		t.Error("expected non-zero OpenedAt after tripping")
+	}
+}
+
+func TestCircuitBreaker_Config(t *testing.T) {
+	cfg := validConfig()
+	cb, _ := resilience.NewCircuitBreaker(cfg)
+	got := cb.Config()
+	if got.Threshold != cfg.Threshold || got.Timeout != cfg.Timeout {
+		t.Errorf("Config() = %+v, want %+v", got, cfg)
+	}
+}

--- a/internal/middleware/metrics_test.go
+++ b/internal/middleware/metrics_test.go
@@ -1,12 +1,14 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	vibemetrics "github.com/vibewarden/vibewarden/internal/adapters/metrics"
+	"github.com/vibewarden/vibewarden/internal/domain/resilience"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
@@ -58,6 +60,9 @@ func (f *fakeMetricsCollector) IncUpstreamTimeout() {}
 func (f *fakeMetricsCollector) SetActiveConnections(n int) {
 	f.activeConnections = n
 }
+
+// SetCircuitBreakerState implements ports.MetricsCollector and does nothing.
+func (f *fakeMetricsCollector) SetCircuitBreakerState(_ context.Context, _ resilience.State) {}
 
 // Compile-time check: fakeMetricsCollector satisfies ports.MetricsCollector.
 var _ ports.MetricsCollector = (*fakeMetricsCollector)(nil)

--- a/internal/ports/circuit_breaker.go
+++ b/internal/ports/circuit_breaker.go
@@ -1,0 +1,61 @@
+// Package ports defines the interfaces (ports) for VibeWarden's hexagonal architecture.
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/resilience"
+)
+
+// CircuitBreaker is the outbound port for the circuit breaker pattern.
+// Implementations wrap the domain entity in a concurrency-safe adapter.
+// All methods must be safe for concurrent use.
+type CircuitBreaker interface {
+	// IsOpen returns true when the circuit is open and the request should be
+	// rejected immediately without contacting the upstream. Implementations
+	// must evaluate the open timeout internally and advance to HalfOpen when
+	// it expires.
+	IsOpen() bool
+
+	// RecordSuccess records a successful upstream response. When the circuit
+	// is in HalfOpen state this transitions it back to Closed.
+	RecordSuccess()
+
+	// RecordFailure records a failed upstream response. When the consecutive
+	// failure count reaches the threshold the circuit trips to Open.
+	RecordFailure()
+
+	// State returns the current circuit state.
+	State() resilience.State
+}
+
+// CircuitBreakerConfig holds configuration for the circuit breaker in the
+// ports layer. It mirrors the domain config but lives in the ports package so
+// that config builders do not need to import the domain package.
+type CircuitBreakerConfig struct {
+	// Enabled toggles the circuit breaker middleware.
+	Enabled bool
+
+	// Threshold is the number of consecutive failures required to trip the
+	// circuit from Closed to Open.
+	Threshold int
+
+	// Timeout is how long the circuit stays Open before transitioning to
+	// HalfOpen to allow a probe request.
+	Timeout time.Duration
+}
+
+// SetCircuitBreakerState sets the vibewarden_circuit_breaker_state gauge.
+// The state values match the schema: 0=closed, 1=open, 2=half_open.
+//
+// This method is defined on MetricsCollector via an extension interface so that
+// existing implementations that do not expose this gauge can embed a no-op.
+// Adapters that support it implement MetricsCollectorWithCircuitBreaker.
+type MetricsCollectorWithCircuitBreaker interface {
+	MetricsCollector
+
+	// SetCircuitBreakerState records the current circuit breaker state as a gauge.
+	// state: 0=closed, 1=open, 2=half_open (matches resilience.State constants).
+	SetCircuitBreakerState(ctx context.Context, state resilience.State)
+}

--- a/internal/ports/metrics.go
+++ b/internal/ports/metrics.go
@@ -1,7 +1,12 @@
 // Package ports defines the interfaces (ports) for VibeWarden's hexagonal architecture.
 package ports
 
-import "time"
+import (
+	"context"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/resilience"
+)
 
 // MetricsCollector is the outbound port for recording application metrics.
 // Implementations emit metrics to a backend (e.g., Prometheus registry).
@@ -41,6 +46,11 @@ type MetricsCollector interface {
 
 	// SetActiveConnections sets the current number of active connections.
 	SetActiveConnections(n int)
+
+	// SetCircuitBreakerState records the current circuit breaker state as a
+	// gauge. The mapping is: 0=closed, 1=open, 2=half_open, matching the
+	// resilience.State constants.
+	SetCircuitBreakerState(ctx context.Context, state resilience.State)
 }
 
 // MetricsConfig holds configuration for the metrics subsystem.

--- a/internal/ports/proxy.go
+++ b/internal/ports/proxy.go
@@ -74,6 +74,9 @@ type ResilienceConfig struct {
 	// respond before returning 504 Gateway Timeout.
 	// A zero value disables the timeout (no limit).
 	Timeout time.Duration
+
+	// CircuitBreaker holds configuration for the circuit breaker middleware.
+	CircuitBreaker CircuitBreakerConfig
 }
 
 // IPFilterConfig holds configuration for IP-based access control.


### PR DESCRIPTION
Closes #314

## Summary

- **Domain** (`internal/domain/resilience/`): `CircuitBreaker` entity with three-state machine (Closed → Open → HalfOpen → Closed), configurable threshold and timeout, pure functions with no concurrency primitives — deterministically testable
- **Events** (`internal/domain/events/circuit_breaker.go`): `circuit_breaker.opened`, `circuit_breaker.half_open`, `circuit_breaker.closed` structured events following the v1 schema contract
- **Port** (`internal/ports/circuit_breaker.go`): `CircuitBreaker` interface + `CircuitBreakerConfig` struct + `MetricsCollectorWithCircuitBreaker` extension interface for the gauge
- **Adapter** (`internal/adapters/resilience/circuit_breaker.go`): `InMemoryCircuitBreaker` wraps the domain entity in a `sync.Mutex`, emits events on state transitions, updates the metrics gauge
- **Caddy handler** (`internal/adapters/caddy/circuit_breaker_handler.go`): `vibewarden_circuit_breaker` Caddy module; returns 503 when open, classifies 502/503/504 as upstream failures, all other responses as successes
- **Metric**: `vibewarden_circuit_breaker_state` OTel UpDownCounter gauge (0=closed, 1=open, 2=half_open) added to `OTelAdapter` and `NoOpMetricsCollector`
- **Config**: `resilience.circuit_breaker.{enabled,threshold,timeout}` in both `config.ResilienceConfig` and `ports.ResilienceConfig`; `buildResiliencePortsConfig` in `serve.go` parses and applies defaults (threshold=5, timeout=60s)
- **Wire-up**: circuit breaker inserted before the timeout handler in `BuildCaddyConfig` so open-circuit requests are rejected before the timeout budget starts

## Test plan

- `internal/domain/resilience/circuit_breaker_test.go` — 12 table-driven tests covering all state transitions, edge cases, `OpenedAt`, `Config`, `State.String`
- `internal/domain/events/circuit_breaker_test.go` — 3 event constructor tests
- `internal/adapters/resilience/circuit_breaker_test.go` — 7 adapter tests including a race-detector concurrent test with 50 goroutines
- `internal/adapters/caddy/circuit_breaker_handler_test.go` — 8 handler tests: open circuit returns 503, success/failure classification for all relevant status codes, JSON builder, middleware ordering assertion
- All existing tests pass with `make check` (includes race detector)
