### PR TITLE
feat(#321): implement OpenBao-backed API key validator with TTL cache

### DIFF
--- a/internal/adapters/apikey/openbao_validator.go
+++ b/internal/adapters/apikey/openbao_validator.go
@@ -1,0 +1,157 @@
+// Package apikey provides implementations of the ports.APIKeyValidator interface.
+// This file contains the OpenBaoValidator, which reads API key hashes from an
+// OpenBao KV path and caches them with a configurable TTL.
+package apikey
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/auth"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// KeyStore is the outbound dependency used by OpenBaoValidator to fetch
+// key data from a secret store. The map returned by Get must contain entries
+// where each key is the API key name and each value is its SHA-256 hex hash.
+//
+// This interface is satisfied by *openbao.Adapter.Get but is defined locally
+// so the adapter package does not import the openbao package directly.
+type KeyStore interface {
+	// Get returns all fields stored at the given KV path.
+	Get(ctx context.Context, path string) (map[string]string, error)
+}
+
+// OpenBaoValidator is an implementation of ports.APIKeyValidator that reads
+// API key hashes from an OpenBao KV path. Results are cached in memory and
+// refreshed after the configured TTL expires.
+//
+// The KV secret at the configured path must have string fields where each
+// field key is the human-readable key name and each field value is the
+// hex-encoded SHA-256 hash of the corresponding plaintext API key.
+//
+// Example KV data at "auth/api-keys":
+//
+//	{
+//	  "ci-deploy": "a4f2...",
+//	  "mobile-app": "9b1c..."
+//	}
+type OpenBaoValidator struct {
+	store    KeyStore
+	path     string
+	cacheTTL time.Duration
+	logger   *slog.Logger
+
+	mu          sync.RWMutex
+	cachedKeys  []*auth.APIKey
+	cacheLoadAt time.Time
+}
+
+// NewOpenBaoValidator creates an OpenBaoValidator that reads API key hashes
+// from the given OpenBao KV path and caches them for cacheTTL.
+// A zero cacheTTL defaults to 5 minutes.
+func NewOpenBaoValidator(store KeyStore, path string, cacheTTL time.Duration, logger *slog.Logger) (*OpenBaoValidator, error) {
+	if store == nil {
+		return nil, fmt.Errorf("openbao api key validator: store cannot be nil")
+	}
+	if path == "" {
+		return nil, fmt.Errorf("openbao api key validator: path cannot be empty")
+	}
+	if cacheTTL <= 0 {
+		cacheTTL = 5 * time.Minute
+	}
+	return &OpenBaoValidator{
+		store:    store,
+		path:     path,
+		cacheTTL: cacheTTL,
+		logger:   logger,
+	}, nil
+}
+
+// Validate looks up the plaintext key in the cached set of keys fetched from
+// OpenBao. The cache is refreshed lazily when it has expired.
+// Returns ports.ErrAPIKeyInvalid when the key is not found or the matching
+// key is inactive.
+func (v *OpenBaoValidator) Validate(ctx context.Context, plaintextKey string) (*auth.APIKey, error) {
+	keys, err := v.loadKeys(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("openbao api key validator: loading keys: %w", err)
+	}
+
+	for _, k := range keys {
+		if k.Matches(plaintextKey) {
+			if !k.Active {
+				return nil, ports.ErrAPIKeyInvalid
+			}
+			return k, nil
+		}
+	}
+	return nil, ports.ErrAPIKeyInvalid
+}
+
+// loadKeys returns the cached key list, refreshing it from OpenBao when the
+// cache has expired. The refresh is performed under a write lock; concurrent
+// callers that find a stale cache will block until the refresh completes.
+func (v *OpenBaoValidator) loadKeys(ctx context.Context) ([]*auth.APIKey, error) {
+	// Fast path: cache is valid.
+	v.mu.RLock()
+	if !v.cacheLoadAt.IsZero() && time.Since(v.cacheLoadAt) < v.cacheTTL {
+		keys := v.cachedKeys
+		v.mu.RUnlock()
+		return keys, nil
+	}
+	v.mu.RUnlock()
+
+	// Slow path: refresh under write lock.
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	// Double-check after acquiring the write lock — another goroutine may have
+	// already refreshed the cache while we were waiting.
+	if !v.cacheLoadAt.IsZero() && time.Since(v.cacheLoadAt) < v.cacheTTL {
+		return v.cachedKeys, nil
+	}
+
+	data, err := v.store.Get(ctx, v.path)
+	if err != nil {
+		// If we have a stale cache, serve it rather than returning an error.
+		if len(v.cachedKeys) > 0 {
+			v.logger.WarnContext(ctx, "openbao api key validator: refresh failed, serving stale cache",
+				slog.String("path", v.path),
+				slog.String("error", err.Error()),
+			)
+			return v.cachedKeys, nil
+		}
+		return nil, fmt.Errorf("fetching keys from path %q: %w", v.path, err)
+	}
+
+	keys := make([]*auth.APIKey, 0, len(data))
+	for name, hash := range data {
+		k := &auth.APIKey{
+			Name:    name,
+			KeyHash: hash,
+			Active:  true,
+		}
+		if validateErr := k.Validate(); validateErr != nil {
+			v.logger.WarnContext(ctx, "openbao api key validator: skipping invalid entry",
+				slog.String("name", name),
+				slog.String("error", validateErr.Error()),
+			)
+			continue
+		}
+		keys = append(keys, k)
+	}
+
+	v.cachedKeys = keys
+	v.cacheLoadAt = time.Now()
+
+	v.logger.InfoContext(ctx, "openbao api key validator: cache refreshed",
+		slog.String("path", v.path),
+		slog.Int("key_count", len(keys)),
+	)
+
+	return keys, nil
+}

--- a/internal/adapters/apikey/openbao_validator_test.go
+++ b/internal/adapters/apikey/openbao_validator_test.go
@@ -1,0 +1,318 @@
+package apikey
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/auth"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// fakeKeyStore is a test double for KeyStore.
+type fakeKeyStore struct {
+	data      map[string]string
+	err       error
+	callCount atomic.Int32
+}
+
+func (f *fakeKeyStore) Get(_ context.Context, _ string) (map[string]string, error) {
+	f.callCount.Add(1)
+	if f.err != nil {
+		return nil, f.err
+	}
+	// Return a copy to prevent mutation.
+	out := make(map[string]string, len(f.data))
+	for k, v := range f.data {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func TestNewOpenBaoValidator_Errors(t *testing.T) {
+	tests := []struct {
+		name     string
+		store    KeyStore
+		path     string
+		cacheTTL time.Duration
+		wantErr  bool
+	}{
+		{
+			name:    "nil store",
+			store:   nil,
+			path:    "auth/api-keys",
+			wantErr: true,
+		},
+		{
+			name:    "empty path",
+			store:   &fakeKeyStore{},
+			path:    "",
+			wantErr: true,
+		},
+		{
+			name:    "valid",
+			store:   &fakeKeyStore{},
+			path:    "auth/api-keys",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewOpenBaoValidator(tt.store, tt.path, tt.cacheTTL, slog.Default())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewOpenBaoValidator() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewOpenBaoValidator_DefaultTTL(t *testing.T) {
+	v, err := NewOpenBaoValidator(&fakeKeyStore{}, "auth/keys", 0, slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.cacheTTL != 5*time.Minute {
+		t.Errorf("cacheTTL = %v, want 5m", v.cacheTTL)
+	}
+}
+
+func TestOpenBaoValidator_Validate_Success(t *testing.T) {
+	store := &fakeKeyStore{
+		data: map[string]string{
+			"ci-deploy":  auth.HashKey("key-ci"),
+			"mobile-app": auth.HashKey("key-mobile"),
+		},
+	}
+
+	v, err := NewOpenBaoValidator(store, "auth/api-keys", time.Minute, slog.Default())
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		plaintextKey string
+		wantKeyName  string
+	}{
+		{"ci key", "key-ci", "ci-deploy"},
+		{"mobile key", "key-mobile", "mobile-app"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := v.Validate(context.Background(), tt.plaintextKey)
+			if err != nil {
+				t.Fatalf("Validate(%q) unexpected error: %v", tt.plaintextKey, err)
+			}
+			if got == nil {
+				t.Fatal("Validate returned nil key")
+			}
+			if got.Name != tt.wantKeyName {
+				t.Errorf("Name = %q, want %q", got.Name, tt.wantKeyName)
+			}
+			if !got.Active {
+				t.Error("key should be active")
+			}
+		})
+	}
+}
+
+func TestOpenBaoValidator_Validate_InvalidKey(t *testing.T) {
+	store := &fakeKeyStore{
+		data: map[string]string{
+			"ci-deploy": auth.HashKey("key-ci"),
+		},
+	}
+
+	v, err := NewOpenBaoValidator(store, "auth/api-keys", time.Minute, slog.Default())
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{"unknown key", "wrong-key"},
+		{"empty key", ""},
+		{"partial match", "key-c"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := v.Validate(context.Background(), tt.key)
+			if err == nil {
+				t.Errorf("Validate(%q) expected error, got nil", tt.key)
+			}
+			if !errors.Is(err, ports.ErrAPIKeyInvalid) {
+				t.Errorf("Validate(%q) error = %v, want %v", tt.key, err, ports.ErrAPIKeyInvalid)
+			}
+		})
+	}
+}
+
+func TestOpenBaoValidator_Validate_EmptyStore(t *testing.T) {
+	store := &fakeKeyStore{data: map[string]string{}}
+
+	v, err := NewOpenBaoValidator(store, "auth/api-keys", time.Minute, slog.Default())
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	_, err = v.Validate(context.Background(), "any-key")
+	if err == nil {
+		t.Error("expected ErrAPIKeyInvalid when store is empty, got nil")
+	}
+	if !errors.Is(err, ports.ErrAPIKeyInvalid) {
+		t.Errorf("error = %v, want %v", err, ports.ErrAPIKeyInvalid)
+	}
+}
+
+func TestOpenBaoValidator_Validate_StoreError_NoCache(t *testing.T) {
+	store := &fakeKeyStore{err: errors.New("openbao unavailable")}
+
+	v, err := NewOpenBaoValidator(store, "auth/api-keys", time.Minute, slog.Default())
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	_, err = v.Validate(context.Background(), "some-key")
+	if err == nil {
+		t.Error("expected error when store fails and cache is empty, got nil")
+	}
+	// Should not be ErrAPIKeyInvalid — it's a store error.
+	if errors.Is(err, ports.ErrAPIKeyInvalid) {
+		t.Error("error should not be ErrAPIKeyInvalid for a store failure")
+	}
+}
+
+func TestOpenBaoValidator_Validate_StoreError_ServeStaleCache(t *testing.T) {
+	store := &fakeKeyStore{
+		data: map[string]string{
+			"ci-deploy": auth.HashKey("key-ci"),
+		},
+	}
+
+	// Use a very short TTL so the cache expires quickly.
+	v, err := NewOpenBaoValidator(store, "auth/api-keys", 10*time.Millisecond, slog.Default())
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// Warm the cache with a successful call.
+	_, err = v.Validate(context.Background(), "key-ci")
+	if err != nil {
+		t.Fatalf("first Validate failed: %v", err)
+	}
+
+	// Now make the store fail.
+	store.err = errors.New("openbao unavailable")
+
+	// Wait for TTL to expire.
+	time.Sleep(20 * time.Millisecond)
+
+	// Validation should still succeed using stale cache.
+	got, err := v.Validate(context.Background(), "key-ci")
+	if err != nil {
+		t.Fatalf("Validate with stale cache returned error: %v", err)
+	}
+	if got.Name != "ci-deploy" {
+		t.Errorf("Name = %q, want %q", got.Name, "ci-deploy")
+	}
+}
+
+func TestOpenBaoValidator_CachingReducesStoreCalls(t *testing.T) {
+	store := &fakeKeyStore{
+		data: map[string]string{
+			"ci-deploy": auth.HashKey("key-ci"),
+		},
+	}
+
+	// Long TTL — cache should not expire during the test.
+	v, err := NewOpenBaoValidator(store, "auth/api-keys", time.Minute, slog.Default())
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// First call loads the cache.
+	if _, err := v.Validate(ctx, "key-ci"); err != nil {
+		t.Fatalf("first Validate: %v", err)
+	}
+
+	// Subsequent calls must reuse the cache.
+	for i := 0; i < 5; i++ {
+		if _, err := v.Validate(ctx, "key-ci"); err != nil {
+			t.Fatalf("Validate call %d: %v", i+2, err)
+		}
+	}
+
+	// Store should have been called exactly once.
+	if got := store.callCount.Load(); got != 1 {
+		t.Errorf("store.Get called %d times, want 1", got)
+	}
+}
+
+func TestOpenBaoValidator_CacheRefreshOnTTLExpiry(t *testing.T) {
+	store := &fakeKeyStore{
+		data: map[string]string{
+			"ci-deploy": auth.HashKey("key-ci"),
+		},
+	}
+
+	v, err := NewOpenBaoValidator(store, "auth/api-keys", 10*time.Millisecond, slog.Default())
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// First call — loads cache.
+	if _, err := v.Validate(ctx, "key-ci"); err != nil {
+		t.Fatalf("first Validate: %v", err)
+	}
+
+	// Wait for TTL to expire.
+	time.Sleep(20 * time.Millisecond)
+
+	// Second call — must trigger a refresh.
+	if _, err := v.Validate(ctx, "key-ci"); err != nil {
+		t.Fatalf("second Validate: %v", err)
+	}
+
+	if got := store.callCount.Load(); got < 2 {
+		t.Errorf("store.Get called %d times after TTL expiry, want >= 2", got)
+	}
+}
+
+func TestOpenBaoValidator_SkipsInvalidEntries(t *testing.T) {
+	// An entry with an empty hash is invalid and should be skipped gracefully.
+	store := &fakeKeyStore{
+		data: map[string]string{
+			"good-key": auth.HashKey("real-key"),
+			"":         auth.HashKey("some-key"), // empty name — will be skipped
+		},
+	}
+
+	v, err := NewOpenBaoValidator(store, "auth/api-keys", time.Minute, slog.Default())
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// The good key must still work.
+	got, err := v.Validate(context.Background(), "real-key")
+	if err != nil {
+		t.Fatalf("Validate(good-key) error = %v", err)
+	}
+	if got.Name != "good-key" {
+		t.Errorf("Name = %q, want %q", got.Name, "good-key")
+	}
+}
+
+// Compile-time assertion that OpenBaoValidator implements ports.APIKeyValidator.
+var _ ports.APIKeyValidator = (*OpenBaoValidator)(nil)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -321,6 +321,18 @@ type AuthAPIKeyConfig struct {
 	// Each entry must supply a name, a SHA-256 hex hash of the plaintext key,
 	// and an optional list of scopes.
 	Keys []APIKeyEntry `mapstructure:"keys"`
+
+	// OpenBaoPath is the KV path inside OpenBao where API keys are stored.
+	// When set, the OpenBao adapter is used instead of the static config adapter.
+	// The KV secret at this path must contain string fields whose keys are the
+	// key names and whose values are the SHA-256 hex hashes of the plaintext keys.
+	// Example: openbao_path: "auth/api-keys"
+	OpenBaoPath string `mapstructure:"openbao_path"`
+
+	// CacheTTL is how long the keys fetched from OpenBao are held in memory
+	// before the next refresh. Accepts Go duration strings (e.g. "5m", "1h").
+	// Defaults to "5m". Ignored when OpenBaoPath is empty.
+	CacheTTL string `mapstructure:"cache_ttl"`
 }
 
 // APIKeyEntry represents a single registered API key in the configuration.
@@ -1161,6 +1173,8 @@ func Load(configPath string) (*Config, error) {
 	v.SetDefault("kratos.smtp.host", "localhost")
 	v.SetDefault("kratos.smtp.port", 1025)
 	v.SetDefault("kratos.smtp.from", "no-reply@vibewarden.local")
+	v.SetDefault("auth.api_key.openbao_path", "")
+	v.SetDefault("auth.api_key.cache_ttl", "5m")
 	v.SetDefault("auth.enabled", false)
 	v.SetDefault("auth.identity_schema", "email_password")
 	v.SetDefault("auth.public_paths", []string{})


### PR DESCRIPTION
Closes #321

## Summary

- Adds `OpenBaoValidator` in `internal/adapters/apikey/openbao_validator.go` that implements `ports.APIKeyValidator` by reading API key hashes from an OpenBao KV path
- The KV secret at the configured path must contain fields where each key is the API key name and each value is the SHA-256 hex hash of the plaintext key
- The validator caches loaded keys in memory for a configurable TTL (default: 5 minutes) and refreshes lazily on expiry
- On refresh failure the validator serves the stale cache rather than failing open or closed — avoids a temporary OpenBao hiccup blocking all requests
- Extends `config.AuthAPIKeyConfig` with two new fields: `openbao_path` and `cache_ttl`
- Defines a narrow local `KeyStore` interface in the apikey package so the adapter has no import cycle with the openbao package; `*openbao.Adapter` satisfies it automatically

## Configuration

```yaml
auth:
  mode: api-key
  api_key:
    openbao_path: "auth/api-keys"   # takes precedence; uses OpenBao adapter
    cache_ttl: "5m"
    keys:                           # fallback when openbao_path is empty
      - name: "ci-deploy"
        hash: "a4f2..."
```

## Test plan

- `TestNewOpenBaoValidator_Errors` — nil store and empty path are rejected
- `TestNewOpenBaoValidator_DefaultTTL` — zero cacheTTL defaults to 5 minutes
- `TestOpenBaoValidator_Validate_Success` — known plaintext keys are matched by name
- `TestOpenBaoValidator_Validate_InvalidKey` — unknown/empty/partial keys return `ErrAPIKeyInvalid`
- `TestOpenBaoValidator_Validate_EmptyStore` — empty KV data returns `ErrAPIKeyInvalid`
- `TestOpenBaoValidator_Validate_StoreError_NoCache` — store failure with no warm cache propagates error
- `TestOpenBaoValidator_Validate_StoreError_ServeStaleCache` — store failure after warm cache serves stale data
- `TestOpenBaoValidator_CachingReducesStoreCalls` — 6 consecutive validations trigger exactly 1 store call
- `TestOpenBaoValidator_CacheRefreshOnTTLExpiry` — cache refresh is triggered after TTL expires
- `TestOpenBaoValidator_SkipsInvalidEntries` — entries with empty names are skipped, valid entries still work
- Compile-time guard: `var _ ports.APIKeyValidator = (*OpenBaoValidator)(nil)`

All tests pass; `make check` green.