### PR TITLE
feat(#324): audit event domain model and AuditEventLogger port

### DIFF
--- a/internal/domain/audit/audit.go
+++ b/internal/domain/audit/audit.go
@@ -1,0 +1,196 @@
+// Package audit defines the domain model for security audit events.
+// This package has zero external dependencies — only the Go standard library.
+//
+// An AuditEvent is a structured, immutable record of a security-relevant action
+// that occurred within VibeWarden. Every intercepted request that results in an
+// authentication decision, rate-limit enforcement, IP filter decision, circuit
+// breaker state change, or admin operation produces exactly one AuditEvent.
+//
+// Audit events are always emitted — they are not subject to log-level filtering.
+// The domain layer produces events; I/O is handled by the ports.AuditLogger port.
+package audit
+
+import (
+	"errors"
+	"time"
+)
+
+// EventType identifies the kind of security event being recorded.
+// Values are stable strings that form part of the public schema contract.
+// Changing or removing a constant is a breaking change.
+type EventType string
+
+// Audit event type constants — grouped by subsystem.
+// All values use the prefix "audit." followed by the subsystem and action.
+const (
+	// --- auth ---
+
+	// EventTypeAuthSuccess is recorded when a request is authenticated
+	// successfully (session cookie or API key).
+	EventTypeAuthSuccess EventType = "audit.auth.success"
+
+	// EventTypeAuthFailure is recorded when a request is rejected because the
+	// presented credentials are missing, invalid, or expired.
+	EventTypeAuthFailure EventType = "audit.auth.failure"
+
+	// EventTypeAuthAPIKeySuccess is recorded when a request is authenticated
+	// successfully via an API key.
+	EventTypeAuthAPIKeySuccess EventType = "audit.auth.api_key.success"
+
+	// EventTypeAuthAPIKeyFailure is recorded when a request is rejected because
+	// the presented API key is missing, invalid, or belongs to an inactive key.
+	EventTypeAuthAPIKeyFailure EventType = "audit.auth.api_key.failure"
+
+	// EventTypeAuthAPIKeyForbidden is recorded when a valid API key is presented
+	// but lacks the required scopes to access the requested path + method.
+	EventTypeAuthAPIKeyForbidden EventType = "audit.auth.api_key.forbidden"
+
+	// --- rate_limit ---
+
+	// EventTypeRateLimitHit is recorded when a request is rejected because the
+	// caller exceeded its per-IP or per-user rate limit.
+	EventTypeRateLimitHit EventType = "audit.rate_limit.hit"
+
+	// EventTypeRateLimitUnidentified is recorded when a request is rejected
+	// because the client IP address could not be determined.
+	EventTypeRateLimitUnidentified EventType = "audit.rate_limit.unidentified_client"
+
+	// --- ip_filter ---
+
+	// EventTypeIPFilterBlocked is recorded when a request is rejected by the IP
+	// filter plugin because the client IP is not in the allowlist or is in the
+	// blocklist.
+	EventTypeIPFilterBlocked EventType = "audit.ip_filter.blocked"
+
+	// --- circuit_breaker ---
+
+	// EventTypeCircuitBreakerOpened is recorded when the circuit breaker trips
+	// from Closed to Open because consecutive failures reached the threshold.
+	EventTypeCircuitBreakerOpened EventType = "audit.circuit_breaker.opened"
+
+	// EventTypeCircuitBreakerHalfOpen is recorded when the circuit breaker
+	// transitions from Open to HalfOpen because the open timeout expired.
+	EventTypeCircuitBreakerHalfOpen EventType = "audit.circuit_breaker.half_open"
+
+	// EventTypeCircuitBreakerClosed is recorded when the circuit breaker returns
+	// to Closed because the upstream probe succeeded.
+	EventTypeCircuitBreakerClosed EventType = "audit.circuit_breaker.closed"
+
+	// --- admin ---
+
+	// EventTypeAdminUserCreated is recorded when an admin creates a new user
+	// identity in the identity provider.
+	EventTypeAdminUserCreated EventType = "audit.admin.user_created"
+
+	// EventTypeAdminUserDeactivated is recorded when an admin deactivates a user
+	// identity, preventing further authentication.
+	EventTypeAdminUserDeactivated EventType = "audit.admin.user_deactivated"
+
+	// EventTypeAdminUserDeleted is recorded when an admin permanently deletes a
+	// user identity from the identity provider.
+	EventTypeAdminUserDeleted EventType = "audit.admin.user_deleted"
+
+	// EventTypeAdminAPIKeyCreated is recorded when an admin registers a new API
+	// key.
+	EventTypeAdminAPIKeyCreated EventType = "audit.admin.api_key_created"
+
+	// EventTypeAdminAPIKeyRevoked is recorded when an admin revokes (deactivates)
+	// an API key.
+	EventTypeAdminAPIKeyRevoked EventType = "audit.admin.api_key_revoked"
+)
+
+// Outcome describes whether the audited action succeeded or failed.
+type Outcome string
+
+const (
+	// OutcomeSuccess indicates the action completed successfully.
+	OutcomeSuccess Outcome = "success"
+
+	// OutcomeFailure indicates the action was rejected or failed.
+	OutcomeFailure Outcome = "failure"
+)
+
+// Actor identifies who (or what) triggered the audited action.
+// All fields are optional — set only the ones available for the given event.
+type Actor struct {
+	// IP is the client IP address, if available.
+	IP string
+
+	// UserID is the identity provider UUID of the authenticated user, if any.
+	UserID string
+
+	// APIKeyName is the human-readable name of the API key used to authenticate,
+	// if any.
+	APIKeyName string
+}
+
+// Target describes the resource or endpoint that was the subject of the action.
+type Target struct {
+	// Path is the HTTP URL path of the request (e.g. "/api/orders").
+	Path string
+
+	// Resource is an optional higher-level resource identifier
+	// (e.g. "user:id-abc123", "api_key:ci-deploy").
+	Resource string
+}
+
+// AuditEvent is an immutable value object that records a single
+// security-relevant action within VibeWarden.
+//
+// AuditEvent equality is by value: two events are equal if all fields are equal.
+// Callers must not mutate the Details map after construction.
+type AuditEvent struct {
+	// Timestamp is when the event occurred, always in UTC.
+	Timestamp time.Time
+
+	// EventType identifies the kind of security event (e.g. "audit.auth.success").
+	EventType EventType
+
+	// Actor identifies who triggered the action.
+	Actor Actor
+
+	// Target describes the resource or endpoint acted upon.
+	Target Target
+
+	// Outcome indicates whether the action succeeded or failed.
+	Outcome Outcome
+
+	// TraceID is the distributed trace ID for correlating the event with the
+	// originating request across systems. May be empty if tracing is not enabled.
+	TraceID string
+
+	// Details holds event-specific structured data. Values must be JSON-serialisable.
+	// Callers must not mutate the map after passing it to NewAuditEvent.
+	Details map[string]any
+}
+
+// NewAuditEvent constructs a validated AuditEvent.
+// Timestamp is always set to the current UTC time.
+// Returns an error if eventType is empty or outcome is empty.
+func NewAuditEvent(
+	eventType EventType,
+	actor Actor,
+	target Target,
+	outcome Outcome,
+	traceID string,
+	details map[string]any,
+) (AuditEvent, error) {
+	if eventType == "" {
+		return AuditEvent{}, errors.New("audit event type cannot be empty")
+	}
+	if outcome == "" {
+		return AuditEvent{}, errors.New("audit event outcome cannot be empty")
+	}
+	if details == nil {
+		details = map[string]any{}
+	}
+	return AuditEvent{
+		Timestamp: time.Now().UTC(),
+		EventType: eventType,
+		Actor:     actor,
+		Target:    target,
+		Outcome:   outcome,
+		TraceID:   traceID,
+		Details:   details,
+	}, nil
+}

--- a/internal/domain/audit/audit_test.go
+++ b/internal/domain/audit/audit_test.go
@@ -1,0 +1,228 @@
+package audit_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/audit"
+)
+
+func TestNewAuditEvent_Valid(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType audit.EventType
+		actor     audit.Actor
+		target    audit.Target
+		outcome   audit.Outcome
+		traceID   string
+		details   map[string]any
+	}{
+		{
+			name:      "auth success with all fields",
+			eventType: audit.EventTypeAuthSuccess,
+			actor: audit.Actor{
+				IP:     "192.168.1.1",
+				UserID: "user-abc123",
+			},
+			target: audit.Target{
+				Path:     "/api/orders",
+				Resource: "orders",
+			},
+			outcome: audit.OutcomeSuccess,
+			traceID: "trace-xyz",
+			details: map[string]any{"session_id": "sess-001"},
+		},
+		{
+			name:      "rate limit hit with nil details becomes empty map",
+			eventType: audit.EventTypeRateLimitHit,
+			actor:     audit.Actor{IP: "10.0.0.5"},
+			target:    audit.Target{Path: "/api/data"},
+			outcome:   audit.OutcomeFailure,
+			traceID:   "",
+			details:   nil,
+		},
+		{
+			name:      "ip filter blocked with api key actor",
+			eventType: audit.EventTypeIPFilterBlocked,
+			actor: audit.Actor{
+				IP:         "203.0.113.42",
+				APIKeyName: "ci-deploy",
+			},
+			target:  audit.Target{Path: "/deploy"},
+			outcome: audit.OutcomeFailure,
+			traceID: "trace-999",
+			details: map[string]any{"mode": "blocklist"},
+		},
+		{
+			name:      "admin user created with empty trace id",
+			eventType: audit.EventTypeAdminUserCreated,
+			actor:     audit.Actor{UserID: "admin-001"},
+			target:    audit.Target{Resource: "user:new-user-001"},
+			outcome:   audit.OutcomeSuccess,
+			traceID:   "",
+			details:   map[string]any{"email": "newuser@example.com"},
+		},
+		{
+			name:      "circuit breaker opened",
+			eventType: audit.EventTypeCircuitBreakerOpened,
+			actor:     audit.Actor{},
+			target:    audit.Target{},
+			outcome:   audit.OutcomeFailure,
+			traceID:   "",
+			details:   map[string]any{"threshold": 5},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := time.Now().UTC()
+			ev, err := audit.NewAuditEvent(tt.eventType, tt.actor, tt.target, tt.outcome, tt.traceID, tt.details)
+			after := time.Now().UTC()
+
+			if err != nil {
+				t.Fatalf("NewAuditEvent() unexpected error: %v", err)
+			}
+
+			if ev.EventType != tt.eventType {
+				t.Errorf("EventType = %q, want %q", ev.EventType, tt.eventType)
+			}
+			if ev.Actor != tt.actor {
+				t.Errorf("Actor = %+v, want %+v", ev.Actor, tt.actor)
+			}
+			if ev.Target != tt.target {
+				t.Errorf("Target = %+v, want %+v", ev.Target, tt.target)
+			}
+			if ev.Outcome != tt.outcome {
+				t.Errorf("Outcome = %q, want %q", ev.Outcome, tt.outcome)
+			}
+			if ev.TraceID != tt.traceID {
+				t.Errorf("TraceID = %q, want %q", ev.TraceID, tt.traceID)
+			}
+
+			if ev.Timestamp.IsZero() {
+				t.Error("Timestamp is zero")
+			}
+			if ev.Timestamp.Location() != time.UTC {
+				t.Errorf("Timestamp location = %v, want UTC", ev.Timestamp.Location())
+			}
+			if ev.Timestamp.Before(before) || ev.Timestamp.After(after) {
+				t.Errorf("Timestamp %v is outside [%v, %v]", ev.Timestamp, before, after)
+			}
+
+			if ev.Details == nil {
+				t.Error("Details must not be nil")
+			}
+		})
+	}
+}
+
+func TestNewAuditEvent_Invalid(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType audit.EventType
+		outcome   audit.Outcome
+		wantErr   string
+	}{
+		{
+			name:      "empty event type",
+			eventType: "",
+			outcome:   audit.OutcomeSuccess,
+			wantErr:   "audit event type cannot be empty",
+		},
+		{
+			name:      "empty outcome",
+			eventType: audit.EventTypeAuthSuccess,
+			outcome:   "",
+			wantErr:   "audit event outcome cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := audit.NewAuditEvent(tt.eventType, audit.Actor{}, audit.Target{}, tt.outcome, "", nil)
+			if err == nil {
+				t.Fatal("NewAuditEvent() expected error, got nil")
+			}
+			if err.Error() != tt.wantErr {
+				t.Errorf("error = %q, want %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestOutcomeConstants(t *testing.T) {
+	tests := []struct {
+		outcome audit.Outcome
+		want    string
+	}{
+		{audit.OutcomeSuccess, "success"},
+		{audit.OutcomeFailure, "failure"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.outcome), func(t *testing.T) {
+			if string(tt.outcome) != tt.want {
+				t.Errorf("Outcome = %q, want %q", tt.outcome, tt.want)
+			}
+		})
+	}
+}
+
+func TestEventTypeConstants(t *testing.T) {
+	// Verify that every event type constant has the "audit." prefix and is non-empty.
+	// This guards against accidental blank values or missing prefixes.
+	types := []audit.EventType{
+		audit.EventTypeAuthSuccess,
+		audit.EventTypeAuthFailure,
+		audit.EventTypeAuthAPIKeySuccess,
+		audit.EventTypeAuthAPIKeyFailure,
+		audit.EventTypeAuthAPIKeyForbidden,
+		audit.EventTypeRateLimitHit,
+		audit.EventTypeRateLimitUnidentified,
+		audit.EventTypeIPFilterBlocked,
+		audit.EventTypeCircuitBreakerOpened,
+		audit.EventTypeCircuitBreakerHalfOpen,
+		audit.EventTypeCircuitBreakerClosed,
+		audit.EventTypeAdminUserCreated,
+		audit.EventTypeAdminUserDeactivated,
+		audit.EventTypeAdminUserDeleted,
+		audit.EventTypeAdminAPIKeyCreated,
+		audit.EventTypeAdminAPIKeyRevoked,
+	}
+
+	seen := make(map[audit.EventType]bool)
+	for _, et := range types {
+		t.Run(string(et), func(t *testing.T) {
+			if et == "" {
+				t.Error("EventType is empty")
+			}
+			if len(string(et)) < len("audit.") || string(et)[:len("audit.")] != "audit." {
+				t.Errorf("EventType %q does not start with \"audit.\"", et)
+			}
+			if seen[et] {
+				t.Errorf("EventType %q is duplicated", et)
+			}
+			seen[et] = true
+		})
+	}
+}
+
+func TestNilDetailsBecomesEmptyMap(t *testing.T) {
+	ev, err := audit.NewAuditEvent(
+		audit.EventTypeAuthFailure,
+		audit.Actor{},
+		audit.Target{},
+		audit.OutcomeFailure,
+		"",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev.Details == nil {
+		t.Error("Details must not be nil when nil was passed")
+	}
+	if len(ev.Details) != 0 {
+		t.Errorf("Details len = %d, want 0", len(ev.Details))
+	}
+}

--- a/internal/ports/audit_event_logger.go
+++ b/internal/ports/audit_event_logger.go
@@ -1,0 +1,22 @@
+// Package ports defines the interfaces (ports) for VibeWarden's hexagonal architecture.
+package ports
+
+import (
+	"context"
+
+	"github.com/vibewarden/vibewarden/internal/domain/audit"
+)
+
+// AuditEventLogger is the outbound port for recording security audit events.
+// Implementations write events to a durable sink (e.g. PostgreSQL, stdout JSON).
+//
+// Audit events are always emitted — they are not subject to log-level filtering.
+// The port intentionally mirrors the shape of EventLogger to keep the consumer
+// API consistent, but targets the domain/audit model rather than domain/events.
+type AuditEventLogger interface {
+	// Log persists a single audit event. Implementations must not modify the event.
+	// Returns a non-nil error if the event could not be persisted or emitted.
+	// Callers should not halt request processing on error; they should surface the
+	// failure through a secondary channel (e.g. a structured log entry) instead.
+	Log(ctx context.Context, event audit.AuditEvent) error
+}


### PR DESCRIPTION
Closes #324

## Summary

- **`internal/domain/audit/audit.go`** — `AuditEvent` value object with `Timestamp`, `EventType`, `Actor` (IP, UserID, APIKeyName), `Target` (Path, Resource), `Outcome`, `TraceID`, and `Details` map. `NewAuditEvent` validates that `EventType` and `Outcome` are non-empty and normalises `nil` Details to an empty map. Zero external dependencies.
- **16 `EventType` constants** across five namespaces: `audit.auth.*`, `audit.rate_limit.*`, `audit.ip_filter.*`, `audit.circuit_breaker.*`, `audit.admin.*`.
- **`Outcome` constants** — `success` and `failure`.
- **`internal/ports/audit_event_logger.go`** — `AuditEventLogger` interface with `Log(ctx context.Context, event audit.AuditEvent) error`. Named `AuditEventLogger` (not `AuditLogger`) to be distinct from the existing user-management `AuditLogger` port in `ports/audit.go`.
- **`internal/domain/audit/audit_test.go`** — table-driven tests covering valid construction, both validation errors, `Outcome` string values, event-type constant shape (non-empty, `audit.` prefix, no duplicates), and nil-Details normalisation.

## Test plan

- [ ] `make check` passes (build, vet, format, race tests) — verified locally before pushing
- [ ] `internal/domain/audit` package appears in test output with no failures
- [ ] `internal/ports` package appears in test output with no failures