### PR TITLE
fix(#353): fix Kratos config version and add migration init container

### DIFF
--- a/internal/config/templates/docker-compose.yml.tmpl
+++ b/internal/config/templates/docker-compose.yml.tmpl
@@ -133,6 +133,22 @@ services:
       timeout: 5s
       retries: 10
 
+  kratos-migrate:
+    image: oryd/kratos:v1.3.1
+    restart: "no"
+    command: migrate sql -e --yes
+    env_file:
+      - ./.credentials
+    environment:
+      DSN: "postgres://kratos:${POSTGRES_PASSWORD}@kratos-db:5432/kratos?sslmode=disable"
+    volumes:
+      - ./kratos:/etc/kratos:ro
+    depends_on:
+      kratos-db:
+        condition: service_healthy
+    networks:
+      - vibewarden
+
   kratos:
     image: oryd/kratos:v1.3.1
     restart: unless-stopped
@@ -151,8 +167,8 @@ services:
     networks:
       - vibewarden
     depends_on:
-      kratos-db:
-        condition: service_healthy
+      kratos-migrate:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:4433/health/alive || exit 1"]
       interval: 10s

--- a/internal/config/templates/kratos.yml.tmpl
+++ b/internal/config/templates/kratos.yml.tmpl
@@ -2,9 +2,10 @@
 # Do not edit manually — re-run `vibewarden generate` to regenerate.
 # To customise, set overrides.kratos_config in vibewarden.yaml.
 
-version: v0.13.0
+version: v1.3.0
 
-dsn: {{ .Kratos.DSN }}
+# DSN is set via the DSN environment variable in docker-compose.yml.
+# Do not set it here — the env var takes precedence.
 
 serve:
   public:


### PR DESCRIPTION
## Summary
- Update `kratos.yml.tmpl` from `version: v0.13.0` to `version: v1.3.0`
- Remove empty `dsn:` field — Kratos reads DSN from the `DSN` environment variable
- Add `kratos-migrate` init container that runs `migrate sql -e --yes` before Kratos serve
- Kratos now depends on migration completing, not just DB healthcheck

Closes #353

## Test plan
- [x] `make check` passes
- [x] Full stack tested with 11 containers — all healthy
- [x] Health endpoint: `{"status":"ok","components":{"sidecar":"ok","upstream":"unknown"}}`
- [x] Rate limiting: 8 requests pass, then 429s
- [x] Security headers: CSP, X-Frame-Options, HSTS, Referrer-Policy, X-Content-Type-Options
- [x] Metrics: OTel target_info gauge present
- [x] Grafana: 200 on :3001
- [x] Jaeger: 200 on :16686
- [x] Prometheus: 302 on :9090
