### PR TITLE
feat(#383): implement external Kratos configuration

### DIFF
--- a/internal/app/generate/service.go
+++ b/internal/app/generate/service.go
@@ -77,11 +77,12 @@ func (s *Service) Generate(ctx context.Context, cfg *config.Config, outputDir st
 		return fmt.Errorf("prod profile requires secrets.enabled: true (OpenBao is mandatory for production)")
 	}
 
-	// kratosMode is true only when auth is enabled and mode is "kratos".
+	// kratosMode is true only when auth is enabled and mode is "kratos" and
+	// the Kratos instance is not managed externally.
 	// An empty mode string is also treated as Kratos for defensive backwards
-	// compatibility with code that constructs config.Config structs directly
+	// compatibility with code that constructs config.Config structs directly.
 	// When kratosMode is false, Kratos-specific files are not generated.
-	kratosMode := cfg.Auth.Enabled && cfg.Auth.Mode == config.AuthModeKratos
+	kratosMode := cfg.Auth.Enabled && cfg.Auth.Mode == config.AuthModeKratos && !cfg.Kratos.External
 
 	if kratosMode {
 		if err := os.MkdirAll(filepath.Join(outputDir, "kratos"), permDir); err != nil {

--- a/internal/app/generate/service_test.go
+++ b/internal/app/generate/service_test.go
@@ -1802,3 +1802,83 @@ func TestGenerate_Compose_KratosServicesAbsent(t *testing.T) {
 		})
 	}
 }
+
+// TestGenerate_Compose_ExternalKratosOmitsLocalContainers verifies that when
+// kratos.external is true the generated docker-compose.yml does not include the
+// local Kratos, kratos-migrate, kratos-db, or seed-users containers, but the
+// vibewarden service is still present.
+func TestGenerate_Compose_ExternalKratosOmitsLocalContainers(t *testing.T) {
+	cfg := &config.Config{
+		Server:   config.ServerConfig{Host: "127.0.0.1", Port: 8080},
+		Upstream: config.UpstreamConfig{Host: "127.0.0.1", Port: 3000},
+		Kratos: config.KratosConfig{
+			External:  true,
+			PublicURL: "https://kratos.example.com",
+			AdminURL:  "https://kratos-admin.example.com",
+		},
+		Auth: config.AuthConfig{
+			Enabled:        true,
+			Mode:           config.AuthModeKratos,
+			IdentitySchema: "email_password",
+		},
+	}
+
+	compose := renderCompose(t, cfg)
+
+	// Local Kratos infrastructure must be absent.
+	for _, absent := range []string{
+		"kratos:",
+		"kratos-db:",
+		"kratos-migrate:",
+		"seed-users:",
+		"oryd/kratos",
+		"kratos-db-data:",
+	} {
+		if bytes.Contains(compose, []byte(absent)) {
+			t.Errorf("docker-compose.yml contains %q but it should be absent when kratos.external is true", absent)
+		}
+	}
+
+	// vibewarden service must still be present.
+	if !bytes.Contains(compose, []byte("vibewarden:")) {
+		t.Error("expected 'vibewarden:' service to be present in docker-compose.yml")
+	}
+}
+
+// TestGenerate_Compose_ExternalKratosSkipsKratosFiles verifies that when
+// kratos.external is true the generate service does not write Kratos config
+// files (kratos.yml, identity.schema.json) under the output directory.
+func TestGenerate_Compose_ExternalKratosSkipsKratosFiles(t *testing.T) {
+	outputDir := t.TempDir()
+	cfg := &config.Config{
+		Server:   config.ServerConfig{Host: "127.0.0.1", Port: 8080},
+		Upstream: config.UpstreamConfig{Host: "127.0.0.1", Port: 3000},
+		Kratos: config.KratosConfig{
+			External:  true,
+			PublicURL: "https://kratos.example.com",
+			AdminURL:  "https://kratos-admin.example.com",
+		},
+		Auth: config.AuthConfig{
+			Enabled:        true,
+			Mode:           config.AuthModeKratos,
+			IdentitySchema: "email_password",
+		},
+	}
+
+	svc := generate.NewService(realRenderer())
+	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+		t.Fatalf("Generate() unexpected error: %v", err)
+	}
+
+	// kratos/ subdirectory must not exist.
+	kratosDir := filepath.Join(outputDir, "kratos")
+	if _, err := os.Stat(kratosDir); err == nil {
+		t.Errorf("kratos/ directory %q should not be created when kratos.external is true", kratosDir)
+	}
+
+	// docker-compose.yml must exist.
+	composePath := filepath.Join(outputDir, "docker-compose.yml")
+	if _, err := os.Stat(composePath); err != nil {
+		t.Errorf("docker-compose.yml should exist: %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,6 +211,13 @@ type KratosConfig struct {
 	DSN string `mapstructure:"dsn"`
 	// SMTP holds email delivery settings for Kratos.
 	SMTP KratosSMTPConfig `mapstructure:"smtp"`
+	// External indicates that VibeWarden should connect to a user-managed Kratos
+	// instance instead of spinning up a local one.
+	// When true, the generated Docker Compose file omits the kratos,
+	// kratos-migrate, kratos-db, and seed-users containers.
+	// Requires PublicURL and AdminURL to be set to the external instance URLs.
+	// Default: false.
+	External bool `mapstructure:"external"`
 }
 
 // SupportedSocialProviders is the set of accepted provider names for social login.
@@ -1126,6 +1133,17 @@ func (c *Config) Validate() error {
 		}
 		if jwt.Audience == "" {
 			errs = append(errs, "auth.jwt.audience is required when auth.mode is \"jwt\"")
+		}
+	}
+
+	// kratos.external validation: when external is true, public_url and admin_url
+	// must point to the external instance (they cannot be empty).
+	if c.Auth.Mode == AuthModeKratos && c.Kratos.External {
+		if c.Kratos.PublicURL == "" {
+			errs = append(errs, "kratos.public_url is required when kratos.external is true")
+		}
+		if c.Kratos.AdminURL == "" {
+			errs = append(errs, "kratos.admin_url is required when kratos.external is true")
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1878,3 +1878,98 @@ func TestValidate_JWTConfig(t *testing.T) {
 		})
 	}
 }
+
+// TestValidate_KratosExternal verifies that kratos.external requires public_url and admin_url.
+func TestValidate_KratosExternal(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(cfg *config.Config)
+		wantErr     bool
+		wantContain string
+	}{
+		{
+			name: "external with both URLs",
+			mutate: func(cfg *config.Config) {
+				cfg.Auth.Mode = config.AuthModeKratos
+				cfg.Kratos.External = true
+				cfg.Kratos.PublicURL = "https://kratos.example.com"
+				cfg.Kratos.AdminURL = "https://kratos-admin.example.com"
+			},
+			wantErr: false,
+		},
+		{
+			name: "external missing public_url",
+			mutate: func(cfg *config.Config) {
+				cfg.Auth.Mode = config.AuthModeKratos
+				cfg.Kratos.External = true
+				cfg.Kratos.PublicURL = ""
+				cfg.Kratos.AdminURL = "https://kratos-admin.example.com"
+			},
+			wantErr:     true,
+			wantContain: "kratos.public_url is required when kratos.external is true",
+		},
+		{
+			name: "external missing admin_url",
+			mutate: func(cfg *config.Config) {
+				cfg.Auth.Mode = config.AuthModeKratos
+				cfg.Kratos.External = true
+				cfg.Kratos.PublicURL = "https://kratos.example.com"
+				cfg.Kratos.AdminURL = ""
+			},
+			wantErr:     true,
+			wantContain: "kratos.admin_url is required when kratos.external is true",
+		},
+		{
+			name: "external missing both URLs",
+			mutate: func(cfg *config.Config) {
+				cfg.Auth.Mode = config.AuthModeKratos
+				cfg.Kratos.External = true
+				cfg.Kratos.PublicURL = ""
+				cfg.Kratos.AdminURL = ""
+			},
+			wantErr:     true,
+			wantContain: "kratos.public_url is required when kratos.external is true",
+		},
+		{
+			name: "external false does not trigger URL validation",
+			mutate: func(cfg *config.Config) {
+				cfg.Auth.Mode = config.AuthModeKratos
+				cfg.Kratos.External = false
+				cfg.Kratos.PublicURL = ""
+				cfg.Kratos.AdminURL = ""
+			},
+			wantErr: false,
+		},
+		{
+			name: "external true but mode is not kratos — no URL validation",
+			mutate: func(cfg *config.Config) {
+				cfg.Auth.Mode = config.AuthModeNone
+				cfg.Kratos.External = true
+				cfg.Kratos.PublicURL = ""
+				cfg.Kratos.AdminURL = ""
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := config.Load("")
+			if err != nil {
+				t.Fatalf("Load(): %v", err)
+			}
+			tt.mutate(cfg)
+
+			err = cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.wantContain != "" {
+				if !strings.Contains(err.Error(), tt.wantContain) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantContain)
+				}
+			}
+		})
+	}
+}

--- a/internal/config/templates/docker-compose.yml.tmpl
+++ b/internal/config/templates/docker-compose.yml.tmpl
@@ -7,7 +7,7 @@
 #   app         — Your application
 {{- end }}
 #   vibewarden  — Security sidecar (listens on :{{ .Server.Port }}, forwards to app on :{{ .Upstream.Port }})
-{{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") }}
+{{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) }}
 #   kratos      — Ory Kratos identity server
 #   kratos-db   — PostgreSQL for Kratos
 {{- end }}
@@ -90,13 +90,13 @@ services:
 {{- end }}
     networks:
       - vibewarden
-{{- if or (and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos")) .App.Build .App.Image .Secrets.Enabled (eq .RateLimit.Store "redis") }}
+{{- if or (and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External)) .App.Build .App.Image .Secrets.Enabled (eq .RateLimit.Store "redis") }}
     depends_on:
 {{- if or .App.Build .App.Image }}
       app:
         condition: service_healthy
 {{- end }}
-{{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") }}
+{{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) }}
       kratos:
         condition: service_healthy
 {{- end }}
@@ -112,7 +112,7 @@ services:
         condition: service_healthy
 {{- end }}
 {{- end }}
-{{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") }}
+{{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) }}
 
   kratos-db:
     image: postgres:17-alpine
@@ -220,7 +220,7 @@ services:
       - vibewarden
     restart: "no"
 {{- end }}
-{{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") }}
+{{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) }}
 
   seed-users:
     image: curlimages/curl:8.12.1
@@ -386,10 +386,10 @@ services:
 networks:
   vibewarden:
     driver: bridge
-{{- if or (and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos")) .TLS.Enabled (eq .RateLimit.Store "redis") .Observability.Enabled }}
+{{- if or (and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External)) .TLS.Enabled (eq .RateLimit.Store "redis") .Observability.Enabled }}
 
 volumes:
-{{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") }}
+{{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) }}
   kratos-db-data:
 {{- end }}
 {{- if .TLS.Enabled }}


### PR DESCRIPTION
Closes #383

## Summary

- Added `kratos.external` (bool, default `false`) field to `KratosConfig` in `internal/config/config.go`
- When `auth.mode == "kratos"` and `kratos.external == true`, the generated `docker-compose.yml` omits the `kratos`, `kratos-migrate`, `kratos-db`, and `seed-users` containers and the `kratos-db-data` volume
- The generate service skips writing Kratos config files (`kratos.yml`, `identity.schema.json`, mapper files) when `kratos.external == true`
- Validation: when `kratos.external == true` and `auth.mode == "kratos"`, both `kratos.public_url` and `kratos.admin_url` are required

## Test plan

- `TestValidate_KratosExternal` — 6 table-driven cases covering valid external config, missing `public_url`, missing `admin_url`, missing both URLs, `external: false` passthrough, and non-kratos mode with `external: true`
- `TestGenerate_Compose_ExternalKratosOmitsLocalContainers` — verifies that `kratos:`, `kratos-db:`, `kratos-migrate:`, `seed-users:`, `oryd/kratos`, and `kratos-db-data:` are absent from the rendered compose when `kratos.external: true`
- `TestGenerate_Compose_ExternalKratosSkipsKratosFiles` — verifies that the `kratos/` subdirectory is not created when `kratos.external: true`
- All existing tests continue to pass; `make check` green