### PR TITLE
feat(#376): add Postgres connection resilience (TLS, pooling, timeouts)

### DIFF
--- a/internal/app/generate/service_integration_test.go
+++ b/internal/app/generate/service_integration_test.go
@@ -15,12 +15,16 @@ import (
 
 // TestGenerate_Integration_ExternalPostgres verifies that the docker-compose
 // template omits the local kratos-db container and kratos-migrate init container
-// when database.external_url is set, and uses the external URL as the Kratos DSN.
+// when database.external_url is set, and uses the enriched Kratos DSN (with
+// sslmode, connect_timeout, and pool_max_conns appended by BuildDSN).
 func TestGenerate_Integration_ExternalPostgres(t *testing.T) {
 	renderer := template.NewRenderer(templates.FS)
 	svc := generate.NewService(renderer)
 
 	const externalURL = "postgres://user:pass@db.example.com:5432/kratos?sslmode=require"
+	// BuildDSN preserves the existing sslmode and appends connect_timeout and
+	// pool_max_conns. url.Values.Encode() sorts keys alphabetically.
+	const enrichedDSN = "postgres://user:pass@db.example.com:5432/kratos?connect_timeout=10&pool_max_conns=10&sslmode=require"
 
 	tests := []struct {
 		name           string
@@ -40,14 +44,15 @@ func TestGenerate_Integration_ExternalPostgres(t *testing.T) {
 			},
 			wantAbsent: []string{
 				externalURL,
+				enrichedDSN,
 			},
 		},
 		{
-			name:        "external_url set — kratos-db and kratos-migrate omitted",
+			name:        "external_url set — kratos-db and kratos-migrate omitted, DSN enriched",
 			externalURL: externalURL,
 			wantSubstrings: []string{
 				"kratos:",
-				externalURL,
+				enrichedDSN,
 			},
 			wantAbsent: []string{
 				"kratos-db:",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,6 +99,17 @@ type Config struct {
 	WAF WAFConfig `mapstructure:"waf"`
 }
 
+// DatabasePoolConfig holds connection pool settings for PostgreSQL.
+type DatabasePoolConfig struct {
+	// MaxConns is the maximum number of open connections in the pool.
+	// Default: 10.
+	MaxConns int `mapstructure:"max_conns"`
+
+	// MinConns is the minimum number of idle connections kept open.
+	// Default: 2.
+	MinConns int `mapstructure:"min_conns"`
+}
+
 // DatabaseConfig holds PostgreSQL connection settings used for audit logging
 // and other persistence features.
 type DatabaseConfig struct {
@@ -114,6 +125,68 @@ type DatabaseConfig struct {
 	// Example: "postgres://user:pass@db.example.com:5432/kratos?sslmode=require"
 	// Can be set via VIBEWARDEN_DATABASE_EXTERNAL_URL env var.
 	ExternalURL string `mapstructure:"external_url"`
+
+	// TLSMode controls the PostgreSQL SSL/TLS negotiation mode when building
+	// a DSN. Accepted values: "disable", "require", "verify-ca", "verify-full".
+	// Default: "require".
+	// This value is appended as sslmode=<value> when building the DSN unless
+	// the URL already contains an sslmode query parameter.
+	TLSMode string `mapstructure:"tls_mode"`
+
+	// Pool holds connection pool settings.
+	Pool DatabasePoolConfig `mapstructure:"pool"`
+
+	// ConnectTimeout is the maximum time to wait when establishing a new
+	// Postgres connection, expressed as a Go duration string (e.g. "10s", "30s").
+	// Default: "10s".
+	ConnectTimeout string `mapstructure:"connect_timeout"`
+}
+
+// BuildDSN returns the external URL with connection resilience parameters
+// (sslmode, connect_timeout, pool_max_conns) appended as query parameters.
+// Parameters already present in ExternalURL are not overwritten.
+// Returns an empty string when ExternalURL is empty.
+func (d DatabaseConfig) BuildDSN() string {
+	if d.ExternalURL == "" {
+		return ""
+	}
+
+	u, err := url.Parse(d.ExternalURL)
+	if err != nil {
+		// ExternalURL has already been validated; this path should not be reached.
+		return d.ExternalURL
+	}
+
+	q := u.Query()
+
+	if _, ok := q["sslmode"]; !ok {
+		mode := d.TLSMode
+		if mode == "" {
+			mode = "require"
+		}
+		q.Set("sslmode", mode)
+	}
+
+	if _, ok := q["connect_timeout"]; !ok {
+		timeout := d.ConnectTimeout
+		if timeout == "" {
+			timeout = "10s"
+		}
+		// Postgres connect_timeout is in seconds (integer). Strip the "s" suffix if present.
+		secs := strings.TrimSuffix(timeout, "s")
+		q.Set("connect_timeout", secs)
+	}
+
+	if _, ok := q["pool_max_conns"]; !ok {
+		maxConns := d.Pool.MaxConns
+		if maxConns <= 0 {
+			maxConns = 10
+		}
+		q.Set("pool_max_conns", fmt.Sprintf("%d", maxConns))
+	}
+
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 // ServerConfig holds server-related settings.
@@ -1326,6 +1399,51 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// database.tls_mode validation.
+	validTLSModes := map[string]bool{
+		"":            true, // empty means use default ("require")
+		"disable":     true,
+		"require":     true,
+		"verify-ca":   true,
+		"verify-full": true,
+	}
+	if !validTLSModes[c.Database.TLSMode] {
+		errs = append(errs, fmt.Sprintf(
+			"database.tls_mode %q is invalid; accepted values: \"disable\", \"require\", \"verify-ca\", \"verify-full\"",
+			c.Database.TLSMode,
+		))
+	}
+
+	// database.pool validation.
+	if c.Database.Pool.MaxConns < 0 {
+		errs = append(errs, fmt.Sprintf(
+			"database.pool.max_conns %d is invalid; must be >= 0",
+			c.Database.Pool.MaxConns,
+		))
+	}
+	if c.Database.Pool.MinConns < 0 {
+		errs = append(errs, fmt.Sprintf(
+			"database.pool.min_conns %d is invalid; must be >= 0",
+			c.Database.Pool.MinConns,
+		))
+	}
+	if c.Database.Pool.MaxConns > 0 && c.Database.Pool.MinConns > c.Database.Pool.MaxConns {
+		errs = append(errs, fmt.Sprintf(
+			"database.pool.min_conns (%d) must be <= database.pool.max_conns (%d)",
+			c.Database.Pool.MinConns, c.Database.Pool.MaxConns,
+		))
+	}
+
+	// database.connect_timeout validation.
+	if c.Database.ConnectTimeout != "" {
+		if _, err := time.ParseDuration(c.Database.ConnectTimeout); err != nil {
+			errs = append(errs, fmt.Sprintf(
+				"database.connect_timeout %q is not a valid duration: %s",
+				c.Database.ConnectTimeout, err.Error(),
+			))
+		}
+	}
+
 	if len(errs) > 0 {
 		return fmt.Errorf("%s", strings.Join(errs, "; "))
 	}
@@ -1438,6 +1556,10 @@ func Load(configPath string) (*Config, error) {
 	v.SetDefault("ip_filter.trust_proxy_headers", false)
 	v.SetDefault("database.url", "")
 	v.SetDefault("database.external_url", "")
+	v.SetDefault("database.tls_mode", "require")
+	v.SetDefault("database.pool.max_conns", 10)
+	v.SetDefault("database.pool.min_conns", 2)
+	v.SetDefault("database.connect_timeout", "10s")
 	v.SetDefault("webhooks.endpoints", []WebhookEndpointConfig{})
 	v.SetDefault("secrets.enabled", false)
 	v.SetDefault("secrets.provider", "openbao")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2041,3 +2041,310 @@ func TestValidate_KratosExternal(t *testing.T) {
 		})
 	}
 }
+
+// TestValidate_DatabaseTLSMode verifies validation of database.tls_mode.
+func TestValidate_DatabaseTLSMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		tlsMode     string
+		wantErr     bool
+		wantContain string
+	}{
+		{name: "empty (default require)", tlsMode: "", wantErr: false},
+		{name: "disable", tlsMode: "disable", wantErr: false},
+		{name: "require", tlsMode: "require", wantErr: false},
+		{name: "verify-ca", tlsMode: "verify-ca", wantErr: false},
+		{name: "verify-full", tlsMode: "verify-full", wantErr: false},
+		{
+			name:        "invalid value",
+			tlsMode:     "allow",
+			wantErr:     true,
+			wantContain: "database.tls_mode",
+		},
+		{
+			name:        "invalid value uppercase",
+			tlsMode:     "REQUIRE",
+			wantErr:     true,
+			wantContain: "database.tls_mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Database: config.DatabaseConfig{TLSMode: tt.tlsMode},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.wantContain != "" && err != nil {
+				if !strings.Contains(err.Error(), tt.wantContain) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantContain)
+				}
+			}
+		})
+	}
+}
+
+// TestValidate_DatabasePool verifies validation of database.pool settings.
+func TestValidate_DatabasePool(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxConns    int
+		minConns    int
+		wantErr     bool
+		wantContain string
+	}{
+		{name: "zero values (use defaults)", maxConns: 0, minConns: 0, wantErr: false},
+		{name: "typical production", maxConns: 10, minConns: 2, wantErr: false},
+		{name: "min equals max", maxConns: 5, minConns: 5, wantErr: false},
+		{
+			name:        "negative max_conns",
+			maxConns:    -1,
+			minConns:    0,
+			wantErr:     true,
+			wantContain: "database.pool.max_conns",
+		},
+		{
+			name:        "negative min_conns",
+			maxConns:    10,
+			minConns:    -1,
+			wantErr:     true,
+			wantContain: "database.pool.min_conns",
+		},
+		{
+			name:        "min greater than max",
+			maxConns:    5,
+			minConns:    10,
+			wantErr:     true,
+			wantContain: "database.pool.min_conns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Database: config.DatabaseConfig{
+					Pool: config.DatabasePoolConfig{
+						MaxConns: tt.maxConns,
+						MinConns: tt.minConns,
+					},
+				},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.wantContain != "" && err != nil {
+				if !strings.Contains(err.Error(), tt.wantContain) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantContain)
+				}
+			}
+		})
+	}
+}
+
+// TestValidate_DatabaseConnectTimeout verifies validation of database.connect_timeout.
+func TestValidate_DatabaseConnectTimeout(t *testing.T) {
+	tests := []struct {
+		name           string
+		connectTimeout string
+		wantErr        bool
+		wantContain    string
+	}{
+		{name: "empty (use default 10s)", connectTimeout: "", wantErr: false},
+		{name: "10s", connectTimeout: "10s", wantErr: false},
+		{name: "30s", connectTimeout: "30s", wantErr: false},
+		{name: "1m", connectTimeout: "1m", wantErr: false},
+		{
+			name:           "invalid duration",
+			connectTimeout: "notaduration",
+			wantErr:        true,
+			wantContain:    "database.connect_timeout",
+		},
+		{
+			name:           "integer without unit",
+			connectTimeout: "10",
+			wantErr:        true,
+			wantContain:    "database.connect_timeout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Database: config.DatabaseConfig{ConnectTimeout: tt.connectTimeout},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.wantContain != "" && err != nil {
+				if !strings.Contains(err.Error(), tt.wantContain) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantContain)
+				}
+			}
+		})
+	}
+}
+
+// TestDatabaseConfig_BuildDSN verifies that BuildDSN produces the expected DSN
+// with connection resilience parameters appended, respecting existing query params.
+func TestDatabaseConfig_BuildDSN(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config.DatabaseConfig
+		wantDSN string
+	}{
+		{
+			name:    "empty external URL returns empty string",
+			cfg:     config.DatabaseConfig{},
+			wantDSN: "",
+		},
+		{
+			name: "external URL without params gets all defaults",
+			cfg: config.DatabaseConfig{
+				ExternalURL: "postgres://user:pass@db.example.com:5432/kratos",
+			},
+			wantDSN: "postgres://user:pass@db.example.com:5432/kratos?connect_timeout=10&pool_max_conns=10&sslmode=require",
+		},
+		{
+			name: "existing sslmode is not overwritten",
+			cfg: config.DatabaseConfig{
+				ExternalURL: "postgres://user:pass@db.example.com:5432/kratos?sslmode=verify-full",
+			},
+			wantDSN: "postgres://user:pass@db.example.com:5432/kratos?connect_timeout=10&pool_max_conns=10&sslmode=verify-full",
+		},
+		{
+			name: "existing connect_timeout is not overwritten",
+			cfg: config.DatabaseConfig{
+				ExternalURL: "postgres://user:pass@db.example.com:5432/kratos?connect_timeout=30",
+			},
+			wantDSN: "postgres://user:pass@db.example.com:5432/kratos?connect_timeout=30&pool_max_conns=10&sslmode=require",
+		},
+		{
+			name: "explicit tls_mode is applied when not present in URL",
+			cfg: config.DatabaseConfig{
+				ExternalURL: "postgres://user:pass@db.example.com:5432/kratos",
+				TLSMode:     "verify-full",
+			},
+			wantDSN: "postgres://user:pass@db.example.com:5432/kratos?connect_timeout=10&pool_max_conns=10&sslmode=verify-full",
+		},
+		{
+			name: "custom pool max_conns is applied",
+			cfg: config.DatabaseConfig{
+				ExternalURL: "postgres://user:pass@db.example.com:5432/kratos",
+				Pool:        config.DatabasePoolConfig{MaxConns: 25, MinConns: 5},
+			},
+			wantDSN: "postgres://user:pass@db.example.com:5432/kratos?connect_timeout=10&pool_max_conns=25&sslmode=require",
+		},
+		{
+			name: "custom connect_timeout strips s suffix",
+			cfg: config.DatabaseConfig{
+				ExternalURL:    "postgres://user:pass@db.example.com:5432/kratos",
+				ConnectTimeout: "30s",
+			},
+			wantDSN: "postgres://user:pass@db.example.com:5432/kratos?connect_timeout=30&pool_max_conns=10&sslmode=require",
+		},
+		{
+			name: "connect_timeout without s suffix is used as-is",
+			cfg: config.DatabaseConfig{
+				ExternalURL:    "postgres://user:pass@db.example.com:5432/kratos",
+				ConnectTimeout: "15",
+			},
+			wantDSN: "postgres://user:pass@db.example.com:5432/kratos?connect_timeout=15&pool_max_conns=10&sslmode=require",
+		},
+		{
+			name: "sslmode=disable is propagated without error",
+			cfg: config.DatabaseConfig{
+				ExternalURL: "postgres://user:pass@db.example.com:5432/kratos",
+				TLSMode:     "disable",
+			},
+			wantDSN: "postgres://user:pass@db.example.com:5432/kratos?connect_timeout=10&pool_max_conns=10&sslmode=disable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.BuildDSN()
+			if got != tt.wantDSN {
+				t.Errorf("BuildDSN() = %q, want %q", got, tt.wantDSN)
+			}
+		})
+	}
+}
+
+// TestLoad_DatabaseDefaults verifies that database resilience defaults are set
+// correctly when no database config is present in the YAML file.
+func TestLoad_DatabaseDefaults(t *testing.T) {
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"database.tls_mode", cfg.Database.TLSMode, "require"},
+		{"database.pool.max_conns", cfg.Database.Pool.MaxConns, 10},
+		{"database.pool.min_conns", cfg.Database.Pool.MinConns, 2},
+		{"database.connect_timeout", cfg.Database.ConnectTimeout, "10s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("default %s = %v, want %v", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoad_DatabaseResilienceFromFile verifies that database resilience settings
+// are loaded correctly from a YAML config file.
+func TestLoad_DatabaseResilienceFromFile(t *testing.T) {
+	content := `
+database:
+  external_url: "postgres://user:pass@db.example.com:5432/kratos?sslmode=require"
+  tls_mode: "verify-full"
+  connect_timeout: "30s"
+  pool:
+    max_conns: 20
+    min_conns: 5
+`
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "vibewarden.yaml")
+	if err := os.WriteFile(cfgFile, []byte(content), 0600); err != nil {
+		t.Fatalf("writing temp config file: %v", err)
+	}
+
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"database.tls_mode", cfg.Database.TLSMode, "verify-full"},
+		{"database.pool.max_conns", cfg.Database.Pool.MaxConns, 20},
+		{"database.pool.min_conns", cfg.Database.Pool.MinConns, 5},
+		{"database.connect_timeout", cfg.Database.ConnectTimeout, "30s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s = %v, want %v", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -1,6 +1,10 @@
 package config
 
-import "log/slog"
+import (
+	"log/slog"
+	"net/url"
+	"strings"
+)
 
 // MigrateLegacyMetrics converts a legacy metrics: config section to the new
 // telemetry: section. If the user has customised the metrics: block (either by
@@ -26,4 +30,30 @@ func MigrateLegacyMetrics(cfg *Config, logger *slog.Logger) {
 		slog.Bool("metrics_enabled", cfg.Metrics.Enabled),
 		slog.Int("path_patterns", len(cfg.Metrics.PathPatterns)),
 	)
+}
+
+// WarnInsecureDatabase logs advisory warnings when the database configuration
+// contains settings that are insecure for production use.
+//
+// It warns when:
+//   - database.tls_mode is "disable"
+//   - database.external_url contains sslmode=disable as a query parameter
+//
+// This function does not modify cfg and does not return an error; the warnings
+// are advisory only.
+func WarnInsecureDatabase(cfg *Config, logger *slog.Logger) {
+	if cfg.Database.TLSMode == "disable" {
+		logger.Warn("database.tls_mode is set to \"disable\"; TLS is strongly recommended for external Postgres connections")
+	}
+
+	if cfg.Database.ExternalURL != "" {
+		u, err := url.Parse(cfg.Database.ExternalURL)
+		if err == nil {
+			if strings.EqualFold(u.Query().Get("sslmode"), "disable") {
+				logger.Warn("database.external_url contains sslmode=disable; TLS is strongly recommended for external Postgres connections",
+					slog.String("external_url_host", u.Host),
+				)
+			}
+		}
+	}
 }

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -198,3 +198,86 @@ func TestMigrateLegacyMetrics_TableDriven(t *testing.T) {
 		})
 	}
 }
+
+// TestWarnInsecureDatabase verifies that WarnInsecureDatabase emits the expected
+// advisory log messages and stays silent when the configuration is secure.
+func TestWarnInsecureDatabase(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         config.DatabaseConfig
+		wantWarning bool
+		wantContain string
+	}{
+		{
+			name:        "no external URL, no tls_mode — silent",
+			cfg:         config.DatabaseConfig{},
+			wantWarning: false,
+		},
+		{
+			name: "tls_mode=require — silent",
+			cfg: config.DatabaseConfig{
+				TLSMode: "require",
+			},
+			wantWarning: false,
+		},
+		{
+			name: "tls_mode=disable — warns",
+			cfg: config.DatabaseConfig{
+				TLSMode: "disable",
+			},
+			wantWarning: true,
+			wantContain: "database.tls_mode",
+		},
+		{
+			name: "external_url with sslmode=require — silent",
+			cfg: config.DatabaseConfig{
+				ExternalURL: "postgres://user:pass@db.example.com:5432/kratos?sslmode=require",
+			},
+			wantWarning: false,
+		},
+		{
+			name: "external_url with sslmode=disable — warns",
+			cfg: config.DatabaseConfig{
+				ExternalURL: "postgres://user:pass@db.example.com:5432/kratos?sslmode=disable",
+			},
+			wantWarning: true,
+			wantContain: "sslmode=disable",
+		},
+		{
+			name: "external_url without sslmode param — silent",
+			cfg: config.DatabaseConfig{
+				ExternalURL: "postgres://user:pass@db.example.com:5432/kratos",
+			},
+			wantWarning: false,
+		},
+		{
+			name: "tls_mode=disable AND external_url sslmode=disable — warns once per condition",
+			cfg: config.DatabaseConfig{
+				TLSMode:     "disable",
+				ExternalURL: "postgres://user:pass@db.example.com:5432/kratos?sslmode=disable",
+			},
+			wantWarning: true,
+			wantContain: "disable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			logger := captureLogger(&logBuf)
+
+			cfg := &config.Config{Database: tt.cfg}
+			config.WarnInsecureDatabase(cfg, logger)
+
+			hasWarning := logBuf.Len() > 0
+			if hasWarning != tt.wantWarning {
+				t.Errorf("warning emitted = %v, want %v (log: %q)", hasWarning, tt.wantWarning, logBuf.String())
+			}
+			if tt.wantWarning && tt.wantContain != "" {
+				if !strings.Contains(logBuf.String(), tt.wantContain) {
+					t.Errorf("log output %q does not contain %q", logBuf.String(), tt.wantContain)
+				}
+			}
+		})
+	}
+}

--- a/internal/config/templates/docker-compose.yml.tmpl
+++ b/internal/config/templates/docker-compose.yml.tmpl
@@ -163,7 +163,7 @@ services:
 {{- if eq .Database.ExternalURL "" }}
       DSN: "postgres://kratos:${POSTGRES_PASSWORD}@kratos-db:5432/kratos?sslmode=disable"
 {{- else }}
-      DSN: "{{ .Database.ExternalURL }}"
+      DSN: "{{ .Database.BuildDSN }}"
 {{- end }}
       SECRETS_COOKIE: "${KRATOS_SECRETS_COOKIE}"
       SECRETS_CIPHER: "${KRATOS_SECRETS_CIPHER}"


### PR DESCRIPTION
Closes #376

## Summary

- Added `database.tls_mode` config field (accepted: `disable`, `require`, `verify-ca`, `verify-full`; default: `require`)
- Added `database.pool.max_conns` (default: 10) and `database.pool.min_conns` (default: 2)
- Added `database.connect_timeout` duration string (default: `10s`)
- Added `DatabaseConfig.BuildDSN()` method that appends `sslmode`, `connect_timeout`, and `pool_max_conns` to `ExternalURL` without overwriting params already present in the URL
- Updated the docker-compose template to use `{{ .Database.BuildDSN }}` so the Kratos DSN carries the resilience params when an external URL is set
- Added `WarnInsecureDatabase()` advisory logger (same pattern as `MigrateLegacyMetrics`) that warns when `tls_mode=disable` or `external_url` contains `sslmode=disable`
- Validation rejects invalid `tls_mode` values, negative pool bounds, min > max, and malformed `connect_timeout` durations

## Test plan

- `TestValidate_DatabaseTLSMode` — valid and invalid tls_mode values
- `TestValidate_DatabasePool` — pool bounds including negative and min>max
- `TestValidate_DatabaseConnectTimeout` — valid durations and invalid strings
- `TestDatabaseConfig_BuildDSN` — 9 table-driven cases covering defaults, existing params preserved, custom values, suffix stripping
- `TestLoad_DatabaseDefaults` — defaults via `Load("")`
- `TestLoad_DatabaseResilienceFromFile` — values loaded from YAML
- `TestWarnInsecureDatabase` — 7 table-driven cases in migrate_test.go
- Updated `TestGenerate_Integration_ExternalPostgres` to assert the enriched DSN (with `connect_timeout` and `pool_max_conns`) appears in the generated docker-compose.yml
