### PR TITLE
feat(#378): add StateSync port abstraction with in-memory adapter

### DIFF
--- a/internal/adapters/statesync/memory.go
+++ b/internal/adapters/statesync/memory.go
@@ -1,0 +1,171 @@
+// Package statesync provides implementations of the ports.StateSync interface.
+package statesync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// counterEntry holds an int64 counter together with an optional expiry time.
+type counterEntry struct {
+	value     int64
+	expiresAt time.Time // zero means no expiry
+}
+
+// expired reports whether this entry has passed its TTL.
+func (e *counterEntry) expired(now time.Time) bool {
+	return !e.expiresAt.IsZero() && now.After(e.expiresAt)
+}
+
+// setEntry holds a string set together with an optional expiry time.
+type setEntry struct {
+	members   map[string]struct{}
+	expiresAt time.Time // zero means no expiry
+}
+
+// expired reports whether this entry has passed its TTL.
+func (e *setEntry) expired(now time.Time) bool {
+	return !e.expiresAt.IsZero() && now.After(e.expiresAt)
+}
+
+// MemoryStateSync is an in-process implementation of ports.StateSync. It is
+// designed for single-instance deployments where cross-instance synchronisation
+// is not required. All operations are local and in-memory; nothing is persisted
+// or sent over the network.
+//
+// MemoryStateSync is safe for concurrent use.
+type MemoryStateSync struct {
+	mu       sync.Mutex
+	counters map[string]*counterEntry
+	sets     map[string]*setEntry
+}
+
+// NewMemoryStateSync creates a new MemoryStateSync ready for use.
+// The caller must call Close when the store is no longer needed.
+func NewMemoryStateSync() *MemoryStateSync {
+	return &MemoryStateSync{
+		counters: make(map[string]*counterEntry),
+		sets:     make(map[string]*setEntry),
+	}
+}
+
+// IncrementCounter implements ports.StateSync.
+func (m *MemoryStateSync) IncrementCounter(ctx context.Context, key string, delta int64, ttl time.Duration) (int64, error) {
+	if ctx.Err() != nil {
+		return 0, fmt.Errorf("incrementing counter %q: %w", key, ctx.Err())
+	}
+	if delta <= 0 {
+		return 0, errors.New("counter delta must be positive")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	entry, ok := m.counters[key]
+	if !ok || entry.expired(now) {
+		entry = &counterEntry{}
+		m.counters[key] = entry
+	}
+
+	entry.value += delta
+	if ttl > 0 {
+		entry.expiresAt = now.Add(ttl)
+	}
+
+	return entry.value, nil
+}
+
+// GetCounter implements ports.StateSync.
+func (m *MemoryStateSync) GetCounter(ctx context.Context, key string) (int64, error) {
+	if ctx.Err() != nil {
+		return 0, fmt.Errorf("getting counter %q: %w", key, ctx.Err())
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.counters[key]
+	if !ok || entry.expired(time.Now()) {
+		return 0, nil
+	}
+	return entry.value, nil
+}
+
+// AddToSet implements ports.StateSync.
+func (m *MemoryStateSync) AddToSet(ctx context.Context, key string, member string, ttl time.Duration) error {
+	if ctx.Err() != nil {
+		return fmt.Errorf("adding to set %q: %w", key, ctx.Err())
+	}
+	if member == "" {
+		return errors.New("set member must not be empty")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	entry, ok := m.sets[key]
+	if !ok || entry.expired(now) {
+		entry = &setEntry{members: make(map[string]struct{})}
+		m.sets[key] = entry
+	}
+
+	entry.members[member] = struct{}{}
+	if ttl > 0 {
+		entry.expiresAt = now.Add(ttl)
+	}
+
+	return nil
+}
+
+// RemoveFromSet implements ports.StateSync.
+func (m *MemoryStateSync) RemoveFromSet(ctx context.Context, key string, member string) error {
+	if ctx.Err() != nil {
+		return fmt.Errorf("removing from set %q: %w", key, ctx.Err())
+	}
+	if member == "" {
+		return errors.New("set member must not be empty")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.sets[key]
+	if !ok || entry.expired(time.Now()) {
+		return nil
+	}
+	delete(entry.members, member)
+	return nil
+}
+
+// SetContains implements ports.StateSync.
+func (m *MemoryStateSync) SetContains(ctx context.Context, key string, member string) (bool, error) {
+	if ctx.Err() != nil {
+		return false, fmt.Errorf("checking set %q: %w", key, ctx.Err())
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.sets[key]
+	if !ok || entry.expired(time.Now()) {
+		return false, nil
+	}
+	_, found := entry.members[member]
+	return found, nil
+}
+
+// Close implements ports.StateSync.
+// For the in-memory implementation this is a no-op that always returns nil.
+func (m *MemoryStateSync) Close() error {
+	return nil
+}
+
+// Compile-time interface satisfaction check.
+var _ ports.StateSync = (*MemoryStateSync)(nil)

--- a/internal/adapters/statesync/memory_test.go
+++ b/internal/adapters/statesync/memory_test.go
@@ -1,0 +1,309 @@
+package statesync
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ---------------------------------------------------------------------------
+// IncrementCounter
+// ---------------------------------------------------------------------------
+
+func TestMemoryStateSync_IncrementCounter(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		delta     int64
+		wantValue int64
+		wantErr   bool
+	}{
+		{"increment by one", "key1", 1, 1, false},
+		{"increment by ten", "key2", 10, 10, false},
+		{"zero delta", "key3", 0, 0, true},
+		{"negative delta", "key4", -1, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewMemoryStateSync()
+			got, err := m.IncrementCounter(context.Background(), tt.key, tt.delta, 0)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IncrementCounter() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil && got != tt.wantValue {
+				t.Errorf("IncrementCounter() = %d, want %d", got, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestMemoryStateSync_IncrementCounter_Accumulates(t *testing.T) {
+	m := NewMemoryStateSync()
+	ctx := context.Background()
+	key := "acc"
+
+	for i := int64(1); i <= 3; i++ {
+		got, err := m.IncrementCounter(ctx, key, i, 0)
+		if err != nil {
+			t.Fatalf("step %d: unexpected error: %v", i, err)
+		}
+		want := i * (i + 1) / 2
+		if got != want {
+			t.Errorf("step %d: got %d, want %d", i, got, want)
+		}
+	}
+}
+
+func TestMemoryStateSync_IncrementCounter_TTL(t *testing.T) {
+	m := NewMemoryStateSync()
+	ctx := context.Background()
+	key := "ttl-counter"
+	ttl := 50 * time.Millisecond
+
+	_, err := m.IncrementCounter(ctx, key, 5, ttl)
+	if err != nil {
+		t.Fatalf("IncrementCounter: %v", err)
+	}
+
+	// Value should be present before TTL.
+	got, err := m.GetCounter(ctx, key)
+	if err != nil {
+		t.Fatalf("GetCounter before TTL: %v", err)
+	}
+	if got != 5 {
+		t.Errorf("before TTL: got %d, want 5", got)
+	}
+
+	time.Sleep(ttl + 20*time.Millisecond)
+
+	// After TTL the counter should look absent (0).
+	got, err = m.GetCounter(ctx, key)
+	if err != nil {
+		t.Fatalf("GetCounter after TTL: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("after TTL: got %d, want 0", got)
+	}
+}
+
+func TestMemoryStateSync_IncrementCounter_CancelledContext(t *testing.T) {
+	m := NewMemoryStateSync()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := m.IncrementCounter(ctx, "key", 1, 0)
+	if err == nil {
+		t.Error("expected error for cancelled context, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetCounter
+// ---------------------------------------------------------------------------
+
+func TestMemoryStateSync_GetCounter_NonExistent(t *testing.T) {
+	m := NewMemoryStateSync()
+	got, err := m.GetCounter(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("GetCounter: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("GetCounter(missing) = %d, want 0", got)
+	}
+}
+
+func TestMemoryStateSync_GetCounter_CancelledContext(t *testing.T) {
+	m := NewMemoryStateSync()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := m.GetCounter(ctx, "key")
+	if err == nil {
+		t.Error("expected error for cancelled context, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AddToSet / RemoveFromSet / SetContains
+// ---------------------------------------------------------------------------
+
+func TestMemoryStateSync_Set_AddContainsRemove(t *testing.T) {
+	m := NewMemoryStateSync()
+	ctx := context.Background()
+	key := "blocklist"
+
+	// Initially empty.
+	ok, err := m.SetContains(ctx, key, "1.2.3.4")
+	if err != nil || ok {
+		t.Fatalf("expected false/nil, got %v/%v", ok, err)
+	}
+
+	// Add a member.
+	if err := m.AddToSet(ctx, key, "1.2.3.4", 0); err != nil {
+		t.Fatalf("AddToSet: %v", err)
+	}
+	ok, err = m.SetContains(ctx, key, "1.2.3.4")
+	if err != nil {
+		t.Fatalf("SetContains: %v", err)
+	}
+	if !ok {
+		t.Error("expected Contains=true after Add")
+	}
+
+	// Remove the member.
+	if err := m.RemoveFromSet(ctx, key, "1.2.3.4"); err != nil {
+		t.Fatalf("RemoveFromSet: %v", err)
+	}
+	ok, err = m.SetContains(ctx, key, "1.2.3.4")
+	if err != nil {
+		t.Fatalf("SetContains after Remove: %v", err)
+	}
+	if ok {
+		t.Error("expected Contains=false after Remove")
+	}
+}
+
+func TestMemoryStateSync_AddToSet_EmptyMember(t *testing.T) {
+	m := NewMemoryStateSync()
+	err := m.AddToSet(context.Background(), "key", "", 0)
+	if err == nil {
+		t.Error("expected error for empty member, got nil")
+	}
+}
+
+func TestMemoryStateSync_RemoveFromSet_EmptyMember(t *testing.T) {
+	m := NewMemoryStateSync()
+	err := m.RemoveFromSet(context.Background(), "key", "")
+	if err == nil {
+		t.Error("expected error for empty member, got nil")
+	}
+}
+
+func TestMemoryStateSync_RemoveFromSet_NonExistentKey(t *testing.T) {
+	m := NewMemoryStateSync()
+	err := m.RemoveFromSet(context.Background(), "ghost", "member")
+	if err != nil {
+		t.Errorf("RemoveFromSet on non-existent key: unexpected error: %v", err)
+	}
+}
+
+func TestMemoryStateSync_AddToSet_Idempotent(t *testing.T) {
+	m := NewMemoryStateSync()
+	ctx := context.Background()
+	key := "idem"
+
+	_ = m.AddToSet(ctx, key, "a", 0)
+	_ = m.AddToSet(ctx, key, "a", 0)
+
+	// Entry should exist exactly once — no duplicates possible.
+	m.mu.Lock()
+	size := len(m.sets[key].members)
+	m.mu.Unlock()
+	if size != 1 {
+		t.Errorf("after duplicate Add: member count = %d, want 1", size)
+	}
+}
+
+func TestMemoryStateSync_Set_TTL(t *testing.T) {
+	m := NewMemoryStateSync()
+	ctx := context.Background()
+	key := "ttl-set"
+	ttl := 50 * time.Millisecond
+
+	_ = m.AddToSet(ctx, key, "member", ttl)
+
+	ok, err := m.SetContains(ctx, key, "member")
+	if err != nil || !ok {
+		t.Fatalf("before TTL: expected true/nil, got %v/%v", ok, err)
+	}
+
+	time.Sleep(ttl + 20*time.Millisecond)
+
+	ok, err = m.SetContains(ctx, key, "member")
+	if err != nil {
+		t.Fatalf("after TTL: unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("after TTL: expected Contains=false, got true")
+	}
+}
+
+func TestMemoryStateSync_Set_CancelledContext(t *testing.T) {
+	m := NewMemoryStateSync()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := m.AddToSet(ctx, "k", "v", 0); err == nil {
+		t.Error("AddToSet: expected error for cancelled context")
+	}
+	if err := m.RemoveFromSet(ctx, "k", "v"); err == nil {
+		t.Error("RemoveFromSet: expected error for cancelled context")
+	}
+	if _, err := m.SetContains(ctx, "k", "v"); err == nil {
+		t.Error("SetContains: expected error for cancelled context")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Close
+// ---------------------------------------------------------------------------
+
+func TestMemoryStateSync_Close(t *testing.T) {
+	m := NewMemoryStateSync()
+	if err := m.Close(); err != nil {
+		t.Errorf("Close() unexpected error: %v", err)
+	}
+	// Second call must also return nil.
+	if err := m.Close(); err != nil {
+		t.Errorf("second Close() unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+func TestMemoryStateSync_ConcurrentAccess(t *testing.T) {
+	m := NewMemoryStateSync()
+	ctx := context.Background()
+
+	const goroutines = 50
+	const ops = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	// Concurrent counter increments.
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range ops {
+				_, _ = m.IncrementCounter(ctx, "shared-counter", 1, 0)
+			}
+		}()
+	}
+
+	// Concurrent set operations.
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			member := "member"
+			for range ops {
+				_ = m.AddToSet(ctx, "shared-set", member, 0)
+				_, _ = m.SetContains(ctx, "shared-set", member)
+				_ = m.RemoveFromSet(ctx, "shared-set", member)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// Compile-time interface satisfaction
+// ---------------------------------------------------------------------------
+
+var _ ports.StateSync = (*MemoryStateSync)(nil)

--- a/internal/domain/sync/sync.go
+++ b/internal/domain/sync/sync.go
@@ -1,0 +1,188 @@
+// Package sync contains the domain model for cross-instance state synchronisation.
+// All types in this package are pure domain objects with zero external dependencies.
+package sync
+
+import (
+	"errors"
+	"time"
+)
+
+// StateType is a discriminator that identifies the kind of state being synchronised.
+// It is used as a type discriminator in SyncMessage so that consumers can route
+// payloads to the correct handler without type-switching on interface values.
+type StateType string
+
+const (
+	// StateTypeRateLimit identifies counter state used by the rate-limiting plugin.
+	StateTypeRateLimit StateType = "rate_limit"
+
+	// StateTypeIPBlocklist identifies set state used by the IP blocklist plugin.
+	StateTypeIPBlocklist StateType = "ip_blocklist"
+
+	// StateTypeCircuitBreaker identifies counter/flag state used by the circuit
+	// breaker plugin.
+	StateTypeCircuitBreaker StateType = "circuit_breaker"
+)
+
+// ErrUnknownStateType is returned when a StateType value is not recognised.
+var ErrUnknownStateType = errors.New("unknown state type")
+
+// Validate returns ErrUnknownStateType when s is not one of the declared constants.
+func (s StateType) Validate() error {
+	switch s {
+	case StateTypeRateLimit, StateTypeIPBlocklist, StateTypeCircuitBreaker:
+		return nil
+	default:
+		return ErrUnknownStateType
+	}
+}
+
+// String returns the string form of the StateType.
+func (s StateType) String() string { return string(s) }
+
+// Counter is a syncable integer counter that supports increment and read operations.
+// It is the domain model for per-key rate-limit counters, failure counts in circuit
+// breakers, and any other integer accumulator that needs to be shared across instances.
+//
+// Counter is not safe for concurrent use on its own. Adapters must serialise access.
+type Counter struct {
+	value int64
+}
+
+// NewCounter creates a Counter with an initial value of zero.
+func NewCounter() Counter {
+	return Counter{}
+}
+
+// NewCounterWithValue creates a Counter seeded with the supplied initial value.
+// Returns an error when value is negative.
+func NewCounterWithValue(value int64) (Counter, error) {
+	if value < 0 {
+		return Counter{}, errors.New("counter initial value must be non-negative")
+	}
+	return Counter{value: value}, nil
+}
+
+// Increment adds delta to the counter and returns the resulting value.
+// delta must be positive; passing zero or a negative delta returns an error.
+func (c *Counter) Increment(delta int64) (int64, error) {
+	if delta <= 0 {
+		return c.value, errors.New("counter delta must be positive")
+	}
+	c.value += delta
+	return c.value, nil
+}
+
+// Get returns the current counter value.
+func (c *Counter) Get() int64 {
+	return c.value
+}
+
+// Reset sets the counter back to zero and returns the value it held before reset.
+func (c *Counter) Reset() int64 {
+	prev := c.value
+	c.value = 0
+	return prev
+}
+
+// Set is a syncable collection of string members. It supports add, remove, and
+// membership-test operations and is the domain model for IP blocklists and
+// similar allow/deny collections.
+//
+// Set is not safe for concurrent use on its own. Adapters must serialise access.
+type Set struct {
+	members map[string]struct{}
+}
+
+// NewSet creates an empty Set.
+func NewSet() Set {
+	return Set{members: make(map[string]struct{})}
+}
+
+// Add inserts member into the set. Adding an already-present member is a no-op.
+// Returns an error when member is empty.
+func (s *Set) Add(member string) error {
+	if member == "" {
+		return errors.New("set member must not be empty")
+	}
+	s.members[member] = struct{}{}
+	return nil
+}
+
+// Remove deletes member from the set. Removing a non-existent member is a no-op.
+// Returns an error when member is empty.
+func (s *Set) Remove(member string) error {
+	if member == "" {
+		return errors.New("set member must not be empty")
+	}
+	delete(s.members, member)
+	return nil
+}
+
+// Contains reports whether member is present in the set.
+func (s *Set) Contains(member string) bool {
+	_, ok := s.members[member]
+	return ok
+}
+
+// Size returns the number of members currently in the set.
+func (s *Set) Size() int {
+	return len(s.members)
+}
+
+// StateUpdate carries a delta change to a single named state entry.
+// It is the unit of information passed to StateSync.Publish so that
+// consumers can apply incremental updates rather than full snapshots.
+type StateUpdate struct {
+	// Type identifies which state subsystem owns this update.
+	Type StateType
+
+	// Key is the per-entry identifier, for example a client IP address or a
+	// circuit breaker name.
+	Key string
+
+	// Delta is the signed integer change for counter-type state.
+	// For set-type state it is not used; use Members instead.
+	Delta int64
+
+	// Members carries the full member list for set-type state updates.
+	// Nil means this is a counter-type update.
+	Members []string
+
+	// TTL is the suggested expiry for this state entry. Zero means no expiry.
+	TTL time.Duration
+}
+
+// Validate returns an error when the StateUpdate is structurally invalid.
+func (u StateUpdate) Validate() error {
+	if err := u.Type.Validate(); err != nil {
+		return err
+	}
+	if u.Key == "" {
+		return errors.New("state update key must not be empty")
+	}
+	return nil
+}
+
+// SyncMessage wraps a StateUpdate with routing metadata so that subscribers
+// can quickly filter messages without deserialising the full payload.
+type SyncMessage struct {
+	// Type mirrors Update.Type for fast routing without unpacking Update.
+	Type StateType
+
+	// InstanceID identifies the VibeWarden instance that produced this message.
+	// Consumers must ignore messages whose InstanceID matches their own to
+	// avoid feedback loops.
+	InstanceID string
+
+	// Update is the actual state change being communicated.
+	Update StateUpdate
+}
+
+// Validate returns an error when the SyncMessage is structurally invalid.
+func (m SyncMessage) Validate() error {
+	if m.InstanceID == "" {
+		return errors.New("sync message instance ID must not be empty")
+	}
+	return m.Update.Validate()
+}

--- a/internal/domain/sync/sync_test.go
+++ b/internal/domain/sync/sync_test.go
@@ -1,0 +1,364 @@
+package sync
+
+import (
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// StateType
+// ---------------------------------------------------------------------------
+
+func TestStateType_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   StateType
+		wantErr bool
+	}{
+		{"rate_limit", StateTypeRateLimit, false},
+		{"ip_blocklist", StateTypeIPBlocklist, false},
+		{"circuit_breaker", StateTypeCircuitBreaker, false},
+		{"unknown", StateType("unknown"), true},
+		{"empty", StateType(""), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.input.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestStateType_String(t *testing.T) {
+	tests := []struct {
+		input StateType
+		want  string
+	}{
+		{StateTypeRateLimit, "rate_limit"},
+		{StateTypeIPBlocklist, "ip_blocklist"},
+		{StateTypeCircuitBreaker, "circuit_breaker"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.input.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Counter
+// ---------------------------------------------------------------------------
+
+func TestNewCounter(t *testing.T) {
+	c := NewCounter()
+	if c.Get() != 0 {
+		t.Errorf("NewCounter().Get() = %d, want 0", c.Get())
+	}
+}
+
+func TestNewCounterWithValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   int64
+		wantErr bool
+	}{
+		{"zero", 0, false},
+		{"positive", 42, false},
+		{"negative", -1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewCounterWithValue(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewCounterWithValue(%d) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+			if err == nil && c.Get() != tt.value {
+				t.Errorf("Get() = %d, want %d", c.Get(), tt.value)
+			}
+		})
+	}
+}
+
+func TestCounter_Increment(t *testing.T) {
+	tests := []struct {
+		name      string
+		initial   int64
+		delta     int64
+		wantValue int64
+		wantErr   bool
+	}{
+		{"increment by one", 0, 1, 1, false},
+		{"increment by ten", 5, 10, 15, false},
+		{"zero delta", 0, 0, 0, true},
+		{"negative delta", 0, -1, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := NewCounterWithValue(tt.initial)
+			got, err := c.Increment(tt.delta)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Increment(%d) error = %v, wantErr %v", tt.delta, err, tt.wantErr)
+			}
+			if err == nil && got != tt.wantValue {
+				t.Errorf("Increment(%d) = %d, want %d", tt.delta, got, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestCounter_Increment_Accumulates(t *testing.T) {
+	c := NewCounter()
+
+	for i := int64(1); i <= 5; i++ {
+		got, err := c.Increment(i)
+		if err != nil {
+			t.Fatalf("Increment(%d): unexpected error: %v", i, err)
+		}
+		// sum of 1+2+3+4+5 incrementally: 1, 3, 6, 10, 15
+		want := i * (i + 1) / 2
+		if got != want {
+			t.Errorf("after Increment(%d): got %d, want %d", i, got, want)
+		}
+	}
+}
+
+func TestCounter_Reset(t *testing.T) {
+	c, _ := NewCounterWithValue(10)
+	prev := c.Reset()
+	if prev != 10 {
+		t.Errorf("Reset() previous = %d, want 10", prev)
+	}
+	if c.Get() != 0 {
+		t.Errorf("after Reset(), Get() = %d, want 0", c.Get())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Set
+// ---------------------------------------------------------------------------
+
+func TestNewSet(t *testing.T) {
+	s := NewSet()
+	if s.Size() != 0 {
+		t.Errorf("NewSet().Size() = %d, want 0", s.Size())
+	}
+}
+
+func TestSet_Add(t *testing.T) {
+	tests := []struct {
+		name    string
+		member  string
+		wantErr bool
+	}{
+		{"valid member", "192.168.1.1", false},
+		{"empty member", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewSet()
+			err := s.Add(tt.member)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Add(%q) error = %v, wantErr %v", tt.member, err, tt.wantErr)
+			}
+			if err == nil && !s.Contains(tt.member) {
+				t.Errorf("after Add(%q), Contains() = false, want true", tt.member)
+			}
+		})
+	}
+}
+
+func TestSet_Add_Idempotent(t *testing.T) {
+	s := NewSet()
+	_ = s.Add("10.0.0.1")
+	_ = s.Add("10.0.0.1")
+	if s.Size() != 1 {
+		t.Errorf("adding duplicate: Size() = %d, want 1", s.Size())
+	}
+}
+
+func TestSet_Remove(t *testing.T) {
+	tests := []struct {
+		name       string
+		member     string
+		addFirst   bool
+		wantErr    bool
+		wantExists bool
+	}{
+		{"remove existing", "10.0.0.1", true, false, false},
+		{"remove non-existent is no-op", "10.0.0.2", false, false, false},
+		{"empty member", "", false, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewSet()
+			if tt.addFirst {
+				_ = s.Add(tt.member)
+			}
+			err := s.Remove(tt.member)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Remove(%q) error = %v, wantErr %v", tt.member, err, tt.wantErr)
+			}
+			if err == nil && s.Contains(tt.member) != tt.wantExists {
+				t.Errorf("Contains(%q) = %v, want %v", tt.member, s.Contains(tt.member), tt.wantExists)
+			}
+		})
+	}
+}
+
+func TestSet_Contains(t *testing.T) {
+	s := NewSet()
+	_ = s.Add("present")
+
+	tests := []struct {
+		member string
+		want   bool
+	}{
+		{"present", true},
+		{"absent", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.member, func(t *testing.T) {
+			if got := s.Contains(tt.member); got != tt.want {
+				t.Errorf("Contains(%q) = %v, want %v", tt.member, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSet_Size(t *testing.T) {
+	s := NewSet()
+	if s.Size() != 0 {
+		t.Errorf("empty set: Size() = %d, want 0", s.Size())
+	}
+	_ = s.Add("a")
+	_ = s.Add("b")
+	if s.Size() != 2 {
+		t.Errorf("after 2 adds: Size() = %d, want 2", s.Size())
+	}
+	_ = s.Remove("a")
+	if s.Size() != 1 {
+		t.Errorf("after remove: Size() = %d, want 1", s.Size())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// StateUpdate
+// ---------------------------------------------------------------------------
+
+func TestStateUpdate_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		update  StateUpdate
+		wantErr bool
+	}{
+		{
+			name: "valid counter update",
+			update: StateUpdate{
+				Type:  StateTypeRateLimit,
+				Key:   "192.168.1.1",
+				Delta: 1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid set update",
+			update: StateUpdate{
+				Type:    StateTypeIPBlocklist,
+				Key:     "blocklist-main",
+				Members: []string{"1.2.3.4"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid update with TTL",
+			update: StateUpdate{
+				Type:  StateTypeRateLimit,
+				Key:   "user:42",
+				Delta: 5,
+				TTL:   time.Minute,
+			},
+			wantErr: false,
+		},
+		{
+			name: "unknown type",
+			update: StateUpdate{
+				Type:  StateType("bogus"),
+				Key:   "key",
+				Delta: 1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty key",
+			update: StateUpdate{
+				Type:  StateTypeRateLimit,
+				Key:   "",
+				Delta: 1,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.update.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SyncMessage
+// ---------------------------------------------------------------------------
+
+func TestSyncMessage_Validate(t *testing.T) {
+	validUpdate := StateUpdate{
+		Type:  StateTypeRateLimit,
+		Key:   "key",
+		Delta: 1,
+	}
+
+	tests := []struct {
+		name    string
+		msg     SyncMessage
+		wantErr bool
+	}{
+		{
+			name:    "valid message",
+			msg:     SyncMessage{Type: StateTypeRateLimit, InstanceID: "instance-1", Update: validUpdate},
+			wantErr: false,
+		},
+		{
+			name:    "empty instance ID",
+			msg:     SyncMessage{Type: StateTypeRateLimit, InstanceID: "", Update: validUpdate},
+			wantErr: true,
+		},
+		{
+			name: "invalid update",
+			msg: SyncMessage{
+				Type:       StateTypeRateLimit,
+				InstanceID: "instance-1",
+				Update: StateUpdate{
+					Type:  StateType("bad"),
+					Key:   "key",
+					Delta: 1,
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/ports/statesync.go
+++ b/internal/ports/statesync.go
@@ -1,0 +1,54 @@
+package ports
+
+import (
+	"context"
+	"time"
+)
+
+// StateSync is the outbound port for distributed state synchronisation.
+// Implementations provide atomic counter and set operations whose state is
+// visible to all VibeWarden instances that share the same backend (e.g. Redis).
+//
+// In single-instance deployments the no-op implementation is used, so all
+// operations fall back to the local in-process store without any network I/O.
+//
+// The interface is intentionally narrow: it expresses the operations needed by
+// the current set of plugins (rate limiting, IP blocklists, circuit breakers).
+// Future state types (e.g. distributed session flags) are added by extending
+// the interface in a backwards-compatible way.
+type StateSync interface {
+	// IncrementCounter atomically adds delta to the counter identified by key
+	// and returns the new value. If the counter does not yet exist it is created
+	// starting at zero before applying the delta.
+	//
+	// ttl is the suggested expiry for the counter entry. Passing a zero duration
+	// means no expiry. The implementation may round the TTL to its internal
+	// precision (e.g. Redis integer seconds).
+	//
+	// delta must be positive; implementations must return an error when delta ≤ 0.
+	IncrementCounter(ctx context.Context, key string, delta int64, ttl time.Duration) (int64, error)
+
+	// GetCounter returns the current value of the counter identified by key.
+	// If the counter does not exist the returned value is 0 with a nil error.
+	GetCounter(ctx context.Context, key string) (int64, error)
+
+	// AddToSet adds member to the set identified by key.
+	// If the set does not yet exist it is created. Adding a member that is
+	// already present is a no-op (returns nil).
+	//
+	// ttl is the suggested expiry for the set entry. Zero means no expiry.
+	AddToSet(ctx context.Context, key string, member string, ttl time.Duration) error
+
+	// RemoveFromSet removes member from the set identified by key.
+	// Removing a member that is not present is a no-op (returns nil).
+	RemoveFromSet(ctx context.Context, key string, member string) error
+
+	// SetContains reports whether member is present in the set identified by key.
+	// If the set does not exist the result is false with a nil error.
+	SetContains(ctx context.Context, key string, member string) (bool, error)
+
+	// Close releases any resources held by the implementation, such as
+	// connection pools or background goroutines. Should be called on graceful
+	// shutdown. Safe to call more than once.
+	Close() error
+}


### PR DESCRIPTION
Closes #378

## Summary

- **`internal/domain/sync/sync.go`** — pure domain types (zero external deps):
  - `StateType` string discriminator with three constants (`rate_limit`, `ip_blocklist`, `circuit_breaker`) and a `Validate()` method
  - `Counter` value object with `Increment(delta)`, `Get()`, and `Reset()`
  - `Set` value object with `Add(member)`, `Remove(member)`, `Contains(member)`, and `Size()`
  - `StateUpdate` — carries a single delta change (counter or set); extensible via `Members []string`
  - `SyncMessage` — wraps `StateUpdate` with `InstanceID` routing metadata

- **`internal/ports/statesync.go`** — `StateSync` outbound port interface:
  - Counter operations: `IncrementCounter(ctx, key, delta, ttl)`, `GetCounter(ctx, key)`
  - Set operations: `AddToSet(ctx, key, member, ttl)`, `RemoveFromSet(ctx, key, member)`, `SetContains(ctx, key, member)`
  - `Close()` for graceful shutdown
  - Designed for future extension (IP blocklists, circuit breaker state) without breaking existing callers

- **`internal/adapters/statesync/memory.go`** — `MemoryStateSync`, the in-process implementation for single-instance mode:
  - TTL-aware counter and set entries (expired entries treated as absent)
  - `context.Context` cancellation checked on every operation
  - Mutex-protected; compile-time `var _ ports.StateSync = (*MemoryStateSync)(nil)` guard

## Test plan

- `internal/domain/sync/sync_test.go` — table-driven tests for all domain types including `StateType.Validate`, `Counter` increment/accumulate/reset, `Set` add/remove/contains/idempotency, `StateUpdate.Validate`, `SyncMessage.Validate`
- `internal/adapters/statesync/memory_test.go` — full coverage of `MemoryStateSync` including TTL expiry, cancelled context handling, concurrent access (verified with `-race`), and double-`Close` safety
- All checks pass: `make check` (format, vet, build, test -race, demo-app)