### PR TITLE
feat(#375): implement Redis-backed StateSync adapter

### DIFF
--- a/internal/adapters/statesync/redis.go
+++ b/internal/adapters/statesync/redis.go
@@ -1,0 +1,203 @@
+package statesync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// RedisConfig holds configuration for the Redis-backed StateSync adapter.
+type RedisConfig struct {
+	// URL is the Redis connection URL, e.g. "redis://:password@localhost:6379/0".
+	// Required.
+	URL string
+
+	// Password is the Redis AUTH password. Optional when already embedded in URL.
+	Password string
+
+	// DB is the Redis database index. Defaults to 0.
+	DB int
+
+	// PoolSize is the maximum number of socket connections held in the pool.
+	// Defaults to 10 when zero.
+	PoolSize int
+}
+
+// RedisStateSync is a Redis-backed implementation of ports.StateSync.
+// It uses atomic Redis commands (INCRBY, EXPIRE, SADD, SREM, SISMEMBER, GET)
+// to share state across multiple VibeWarden instances that point at the same
+// Redis instance. This makes it suitable for distributed rate limiting and
+// IP blocklist synchronisation.
+//
+// RedisStateSync is safe for concurrent use.
+type RedisStateSync struct {
+	client *redis.Client
+}
+
+// NewRedisStateSync creates a RedisStateSync, connects to Redis using cfg,
+// and verifies the connection with a PING health check.
+//
+// The caller must call Close when the adapter is no longer needed so the
+// underlying connection pool is released gracefully.
+func NewRedisStateSync(ctx context.Context, cfg RedisConfig) (*RedisStateSync, error) {
+	if cfg.URL == "" {
+		return nil, errors.New("redis statesync: URL must not be empty")
+	}
+
+	opts, err := redis.ParseURL(cfg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("redis statesync: parsing URL: %w", err)
+	}
+
+	// Allow explicit override of password and DB after URL parsing.
+	if cfg.Password != "" {
+		opts.Password = cfg.Password
+	}
+	if cfg.DB != 0 {
+		opts.DB = cfg.DB
+	}
+	if cfg.PoolSize > 0 {
+		opts.PoolSize = cfg.PoolSize
+	}
+
+	client := redis.NewClient(opts)
+
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("redis statesync: health check failed: %w", err)
+	}
+
+	return &RedisStateSync{client: client}, nil
+}
+
+// IncrementCounter implements ports.StateSync.
+//
+// It uses INCRBY to atomically add delta to the key and then conditionally
+// calls EXPIRE to set the TTL. The GET + EXPIRE combination is not atomic,
+// but INCRBY itself is, so the counter value is always consistent. The TTL
+// is refreshed on every increment which is the standard pattern for sliding
+// windows in Redis-backed rate limiters.
+//
+// delta must be positive; an error is returned otherwise.
+func (r *RedisStateSync) IncrementCounter(ctx context.Context, key string, delta int64, ttl time.Duration) (int64, error) {
+	if ctx.Err() != nil {
+		return 0, fmt.Errorf("incrementing counter %q: %w", key, ctx.Err())
+	}
+	if delta <= 0 {
+		return 0, errors.New("counter delta must be positive")
+	}
+
+	newVal, err := r.client.IncrBy(ctx, key, delta).Result()
+	if err != nil {
+		return 0, fmt.Errorf("redis statesync: INCRBY %q: %w", key, err)
+	}
+
+	if ttl > 0 {
+		if err := r.client.Expire(ctx, key, ttl).Err(); err != nil {
+			return 0, fmt.Errorf("redis statesync: EXPIRE %q: %w", key, err)
+		}
+	}
+
+	return newVal, nil
+}
+
+// GetCounter implements ports.StateSync.
+//
+// Returns 0 with a nil error when the key does not exist (Redis returns a
+// nil bulk string for missing keys, which go-redis surfaces as redis.Nil).
+func (r *RedisStateSync) GetCounter(ctx context.Context, key string) (int64, error) {
+	if ctx.Err() != nil {
+		return 0, fmt.Errorf("getting counter %q: %w", key, ctx.Err())
+	}
+
+	val, err := r.client.Get(ctx, key).Int64()
+	if errors.Is(err, redis.Nil) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("redis statesync: GET %q: %w", key, err)
+	}
+	return val, nil
+}
+
+// AddToSet implements ports.StateSync.
+//
+// Uses SADD to add member to the set. If ttl > 0, EXPIRE is called to
+// refresh the TTL on the whole set. Adding an already-present member is
+// idempotent (Redis returns 0 but no error).
+func (r *RedisStateSync) AddToSet(ctx context.Context, key string, member string, ttl time.Duration) error {
+	if ctx.Err() != nil {
+		return fmt.Errorf("adding to set %q: %w", key, ctx.Err())
+	}
+	if member == "" {
+		return errors.New("set member must not be empty")
+	}
+
+	if err := r.client.SAdd(ctx, key, member).Err(); err != nil {
+		return fmt.Errorf("redis statesync: SADD %q %q: %w", key, member, err)
+	}
+
+	if ttl > 0 {
+		if err := r.client.Expire(ctx, key, ttl).Err(); err != nil {
+			return fmt.Errorf("redis statesync: EXPIRE %q: %w", key, err)
+		}
+	}
+
+	return nil
+}
+
+// RemoveFromSet implements ports.StateSync.
+//
+// Uses SREM to remove member from the set. Removing a non-existent member is
+// a no-op (Redis returns 0 but no error).
+func (r *RedisStateSync) RemoveFromSet(ctx context.Context, key string, member string) error {
+	if ctx.Err() != nil {
+		return fmt.Errorf("removing from set %q: %w", key, ctx.Err())
+	}
+	if member == "" {
+		return errors.New("set member must not be empty")
+	}
+
+	if err := r.client.SRem(ctx, key, member).Err(); err != nil {
+		return fmt.Errorf("redis statesync: SREM %q %q: %w", key, member, err)
+	}
+	return nil
+}
+
+// SetContains implements ports.StateSync.
+//
+// Uses SISMEMBER. Returns false with a nil error when the key does not exist.
+func (r *RedisStateSync) SetContains(ctx context.Context, key string, member string) (bool, error) {
+	if ctx.Err() != nil {
+		return false, fmt.Errorf("checking set %q: %w", key, ctx.Err())
+	}
+
+	ok, err := r.client.SIsMember(ctx, key, member).Result()
+	if err != nil {
+		return false, fmt.Errorf("redis statesync: SISMEMBER %q %q: %w", key, member, err)
+	}
+	return ok, nil
+}
+
+// Close implements ports.StateSync.
+//
+// It closes the underlying Redis connection pool. Safe to call more than once;
+// subsequent calls return the same (nil) error that go-redis returns after
+// the pool has already been closed.
+func (r *RedisStateSync) Close() error {
+	if err := r.client.Close(); err != nil {
+		return fmt.Errorf("redis statesync: closing client: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Compile-time interface satisfaction check.
+// ---------------------------------------------------------------------------
+
+var _ ports.StateSync = (*RedisStateSync)(nil)

--- a/internal/adapters/statesync/redis_integration_test.go
+++ b/internal/adapters/statesync/redis_integration_test.go
@@ -1,0 +1,320 @@
+package statesync
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	tcredis "github.com/testcontainers/testcontainers-go/modules/redis"
+)
+
+// startRedisContainerForStateSync starts a Redis container and returns a
+// connection URL. The container is terminated when the test ends.
+func startRedisContainerForStateSync(t *testing.T) string {
+	t.Helper()
+	ctx := context.Background()
+
+	ctr, err := tcredis.Run(ctx, "redis:7-alpine")
+	if err != nil {
+		t.Fatalf("failed to start Redis container: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := ctr.Terminate(ctx); err != nil {
+			t.Logf("failed to terminate Redis container: %v", err)
+		}
+	})
+
+	connStr, err := ctr.ConnectionString(ctx)
+	if err != nil {
+		t.Fatalf("failed to get Redis connection string: %v", err)
+	}
+	return connStr
+}
+
+func TestRedisStateSync_Integration_IncrementCounter(t *testing.T) {
+	url := startRedisContainerForStateSync(t)
+	ctx := context.Background()
+
+	r, err := NewRedisStateSync(ctx, RedisConfig{URL: url})
+	if err != nil {
+		t.Fatalf("NewRedisStateSync: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	key := fmt.Sprintf("vw:ss:test:counter:%d", time.Now().UnixNano())
+
+	tests := []struct {
+		name      string
+		delta     int64
+		wantTotal int64
+		wantErr   bool
+	}{
+		{"first increment", 1, 1, false},
+		{"second increment", 4, 5, false},
+		{"zero delta", 0, 0, true},
+		{"negative delta", -1, 0, true},
+	}
+
+	total := int64(0)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := r.IncrementCounter(ctx, key, tt.delta, 0)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IncrementCounter(%d) error = %v, wantErr %v", tt.delta, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				total += tt.delta
+				if got != total {
+					t.Errorf("IncrementCounter(%d) = %d, want %d", tt.delta, got, total)
+				}
+			}
+		})
+	}
+}
+
+func TestRedisStateSync_Integration_GetCounter_Missing(t *testing.T) {
+	url := startRedisContainerForStateSync(t)
+	ctx := context.Background()
+
+	r, err := NewRedisStateSync(ctx, RedisConfig{URL: url})
+	if err != nil {
+		t.Fatalf("NewRedisStateSync: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	got, err := r.GetCounter(ctx, "does-not-exist")
+	if err != nil {
+		t.Fatalf("GetCounter on missing key: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("GetCounter(missing) = %d, want 0", got)
+	}
+}
+
+func TestRedisStateSync_Integration_IncrementCounter_TTL(t *testing.T) {
+	url := startRedisContainerForStateSync(t)
+	ctx := context.Background()
+
+	r, err := NewRedisStateSync(ctx, RedisConfig{URL: url})
+	if err != nil {
+		t.Fatalf("NewRedisStateSync: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	key := fmt.Sprintf("vw:ss:test:ttl-counter:%d", time.Now().UnixNano())
+	// Redis EXPIRE minimum granularity is 1 second; use 2s so the test is
+	// robust regardless of sub-second scheduling jitter.
+	ttl := 2 * time.Second
+
+	if _, err := r.IncrementCounter(ctx, key, 7, ttl); err != nil {
+		t.Fatalf("IncrementCounter: %v", err)
+	}
+
+	// Value must be present before TTL expires.
+	got, err := r.GetCounter(ctx, key)
+	if err != nil {
+		t.Fatalf("GetCounter before TTL: %v", err)
+	}
+	if got != 7 {
+		t.Errorf("before TTL: got %d, want 7", got)
+	}
+
+	time.Sleep(ttl + 500*time.Millisecond)
+
+	// After TTL the counter must look absent (0).
+	got, err = r.GetCounter(ctx, key)
+	if err != nil {
+		t.Fatalf("GetCounter after TTL: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("after TTL: got %d, want 0", got)
+	}
+}
+
+func TestRedisStateSync_Integration_Set_AddContainsRemove(t *testing.T) {
+	url := startRedisContainerForStateSync(t)
+	ctx := context.Background()
+
+	r, err := NewRedisStateSync(ctx, RedisConfig{URL: url})
+	if err != nil {
+		t.Fatalf("NewRedisStateSync: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	key := fmt.Sprintf("vw:ss:test:set:%d", time.Now().UnixNano())
+	member := "192.168.1.1"
+
+	// Initially absent.
+	ok, err := r.SetContains(ctx, key, member)
+	if err != nil || ok {
+		t.Fatalf("expected false/nil before Add, got %v/%v", ok, err)
+	}
+
+	// Add.
+	if err := r.AddToSet(ctx, key, member, 0); err != nil {
+		t.Fatalf("AddToSet: %v", err)
+	}
+	ok, err = r.SetContains(ctx, key, member)
+	if err != nil {
+		t.Fatalf("SetContains after Add: %v", err)
+	}
+	if !ok {
+		t.Error("expected Contains=true after Add")
+	}
+
+	// Idempotent re-add.
+	if err := r.AddToSet(ctx, key, member, 0); err != nil {
+		t.Fatalf("second AddToSet: %v", err)
+	}
+
+	// Remove.
+	if err := r.RemoveFromSet(ctx, key, member); err != nil {
+		t.Fatalf("RemoveFromSet: %v", err)
+	}
+	ok, err = r.SetContains(ctx, key, member)
+	if err != nil {
+		t.Fatalf("SetContains after Remove: %v", err)
+	}
+	if ok {
+		t.Error("expected Contains=false after Remove")
+	}
+}
+
+func TestRedisStateSync_Integration_Set_TTL(t *testing.T) {
+	url := startRedisContainerForStateSync(t)
+	ctx := context.Background()
+
+	r, err := NewRedisStateSync(ctx, RedisConfig{URL: url})
+	if err != nil {
+		t.Fatalf("NewRedisStateSync: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	key := fmt.Sprintf("vw:ss:test:set-ttl:%d", time.Now().UnixNano())
+	// Redis EXPIRE minimum granularity is 1 second; use 2s so the test is
+	// robust regardless of sub-second scheduling jitter.
+	ttl := 2 * time.Second
+
+	if err := r.AddToSet(ctx, key, "member", ttl); err != nil {
+		t.Fatalf("AddToSet: %v", err)
+	}
+
+	ok, err := r.SetContains(ctx, key, "member")
+	if err != nil || !ok {
+		t.Fatalf("before TTL: expected true/nil, got %v/%v", ok, err)
+	}
+
+	time.Sleep(ttl + 500*time.Millisecond)
+
+	ok, err = r.SetContains(ctx, key, "member")
+	if err != nil {
+		t.Fatalf("after TTL: %v", err)
+	}
+	if ok {
+		t.Error("expected Contains=false after TTL")
+	}
+}
+
+func TestRedisStateSync_Integration_RemoveFromSet_NonExistentKey(t *testing.T) {
+	url := startRedisContainerForStateSync(t)
+	ctx := context.Background()
+
+	r, err := NewRedisStateSync(ctx, RedisConfig{URL: url})
+	if err != nil {
+		t.Fatalf("NewRedisStateSync: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	// Removing from a key that does not exist must be a no-op.
+	if err := r.RemoveFromSet(ctx, "ghost-key", "member"); err != nil {
+		t.Errorf("RemoveFromSet on non-existent key: unexpected error: %v", err)
+	}
+}
+
+func TestRedisStateSync_Integration_MultipleInstances(t *testing.T) {
+	url := startRedisContainerForStateSync(t)
+	ctx := context.Background()
+
+	// Simulate two VibeWarden instances sharing the same Redis.
+	r1, err := NewRedisStateSync(ctx, RedisConfig{URL: url})
+	if err != nil {
+		t.Fatalf("instance 1 NewRedisStateSync: %v", err)
+	}
+	t.Cleanup(func() { _ = r1.Close() })
+
+	r2, err := NewRedisStateSync(ctx, RedisConfig{URL: url})
+	if err != nil {
+		t.Fatalf("instance 2 NewRedisStateSync: %v", err)
+	}
+	t.Cleanup(func() { _ = r2.Close() })
+
+	key := fmt.Sprintf("vw:ss:test:multi:%d", time.Now().UnixNano())
+
+	// r1 increments the counter.
+	v1, err := r1.IncrementCounter(ctx, key, 3, 0)
+	if err != nil {
+		t.Fatalf("r1 IncrementCounter: %v", err)
+	}
+	if v1 != 3 {
+		t.Errorf("r1 IncrementCounter = %d, want 3", v1)
+	}
+
+	// r2 must see the value incremented by r1.
+	got, err := r2.GetCounter(ctx, key)
+	if err != nil {
+		t.Fatalf("r2 GetCounter: %v", err)
+	}
+	if got != 3 {
+		t.Errorf("r2 GetCounter = %d, want 3", got)
+	}
+
+	// r2 increments further.
+	v2, err := r2.IncrementCounter(ctx, key, 2, 0)
+	if err != nil {
+		t.Fatalf("r2 IncrementCounter: %v", err)
+	}
+	if v2 != 5 {
+		t.Errorf("r2 IncrementCounter = %d, want 5", v2)
+	}
+
+	// r1 must see the combined total.
+	got, err = r1.GetCounter(ctx, key)
+	if err != nil {
+		t.Fatalf("r1 GetCounter after r2 increment: %v", err)
+	}
+	if got != 5 {
+		t.Errorf("r1 GetCounter = %d, want 5", got)
+	}
+
+	// Set cross-instance: r1 adds, r2 checks.
+	setKey := fmt.Sprintf("vw:ss:test:multi-set:%d", time.Now().UnixNano())
+	if err := r1.AddToSet(ctx, setKey, "blocked-ip", 0); err != nil {
+		t.Fatalf("r1 AddToSet: %v", err)
+	}
+	ok, err := r2.SetContains(ctx, setKey, "blocked-ip")
+	if err != nil {
+		t.Fatalf("r2 SetContains: %v", err)
+	}
+	if !ok {
+		t.Error("r2: expected Contains=true for member added by r1")
+	}
+}
+
+func TestRedisStateSync_Integration_PoolSize(t *testing.T) {
+	url := startRedisContainerForStateSync(t)
+	ctx := context.Background()
+
+	// Verify that a custom PoolSize is accepted without error.
+	r, err := NewRedisStateSync(ctx, RedisConfig{URL: url, PoolSize: 5})
+	if err != nil {
+		t.Fatalf("NewRedisStateSync with PoolSize=5: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	key := fmt.Sprintf("vw:ss:test:pool:%d", time.Now().UnixNano())
+	if _, err := r.IncrementCounter(ctx, key, 1, 0); err != nil {
+		t.Errorf("IncrementCounter with custom pool: %v", err)
+	}
+}

--- a/internal/adapters/statesync/redis_test.go
+++ b/internal/adapters/statesync/redis_test.go
@@ -1,0 +1,101 @@
+package statesync
+
+import (
+	"context"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// NewRedisStateSync — config validation (no Redis required)
+// ---------------------------------------------------------------------------
+
+func TestNewRedisStateSync_EmptyURL(t *testing.T) {
+	_, err := NewRedisStateSync(context.Background(), RedisConfig{})
+	if err == nil {
+		t.Fatal("expected error for empty URL, got nil")
+	}
+}
+
+func TestNewRedisStateSync_InvalidURL(t *testing.T) {
+	_, err := NewRedisStateSync(context.Background(), RedisConfig{URL: "not-a-url"})
+	if err == nil {
+		t.Fatal("expected error for invalid URL, got nil")
+	}
+}
+
+func TestNewRedisStateSync_UnreachableHost(t *testing.T) {
+	// Port 1 is reserved and should always refuse connections quickly.
+	_, err := NewRedisStateSync(context.Background(), RedisConfig{
+		URL: "redis://localhost:1/0",
+	})
+	if err == nil {
+		t.Fatal("expected error when Redis is unreachable, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Argument validation (no Redis required — errors must be returned before
+// any network call when the context is cancelled or arguments are invalid)
+// ---------------------------------------------------------------------------
+
+func TestRedisStateSync_IncrementCounter_InvalidDelta(t *testing.T) {
+	// We cannot construct a valid RedisStateSync without a live Redis, so we
+	// directly exercise the argument-validation path by checking the error that
+	// is returned before any Redis I/O.
+	tests := []struct {
+		name  string
+		delta int64
+	}{
+		{"zero delta", 0},
+		{"negative delta", -5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Use a nil-client adapter: argument validation fires before any
+			// client call, so we can safely use a zero-value struct here.
+			r := &RedisStateSync{}
+			_, err := r.IncrementCounter(context.Background(), "k", tt.delta, 0)
+			if err == nil {
+				t.Errorf("IncrementCounter(%d): expected error, got nil", tt.delta)
+			}
+		})
+	}
+}
+
+func TestRedisStateSync_AddToSet_EmptyMember(t *testing.T) {
+	r := &RedisStateSync{}
+	err := r.AddToSet(context.Background(), "k", "", 0)
+	if err == nil {
+		t.Error("expected error for empty member, got nil")
+	}
+}
+
+func TestRedisStateSync_RemoveFromSet_EmptyMember(t *testing.T) {
+	r := &RedisStateSync{}
+	err := r.RemoveFromSet(context.Background(), "k", "")
+	if err == nil {
+		t.Error("expected error for empty member, got nil")
+	}
+}
+
+func TestRedisStateSync_CancelledContext(t *testing.T) {
+	r := &RedisStateSync{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := r.IncrementCounter(ctx, "k", 1, 0); err == nil {
+		t.Error("IncrementCounter: expected error for cancelled context")
+	}
+	if _, err := r.GetCounter(ctx, "k"); err == nil {
+		t.Error("GetCounter: expected error for cancelled context")
+	}
+	if err := r.AddToSet(ctx, "k", "v", 0); err == nil {
+		t.Error("AddToSet: expected error for cancelled context")
+	}
+	if err := r.RemoveFromSet(ctx, "k", "v"); err == nil {
+		t.Error("RemoveFromSet: expected error for cancelled context")
+	}
+	if _, err := r.SetContains(ctx, "k", "v"); err == nil {
+		t.Error("SetContains: expected error for cancelled context")
+	}
+}


### PR DESCRIPTION
Closes #375

## Summary

- New `RedisStateSync` type in `internal/adapters/statesync/redis.go` implementing `ports.StateSync`
- Uses `go-redis/v9` (BSD-2-Clause, already in `go.mod` via the rate limiting adapter)
- `IncrementCounter`: atomic `INCRBY` followed by conditional `EXPIRE` for TTL
- `GetCounter`: `GET` with transparent `redis.Nil` -> 0 translation
- `AddToSet` / `RemoveFromSet` / `SetContains`: `SADD` / `SREM` / `SISMEMBER` with optional `EXPIRE`
- `RedisConfig` struct: `URL`, `Password`, `DB`, `PoolSize` fields — URL is required, rest have sane defaults
- PING health check on `NewRedisStateSync`; returns a wrapped error if Redis is unreachable
- Compile-time interface guard: `var _ ports.StateSync = (*RedisStateSync)(nil)`

## Test plan

- `redis_test.go` — pure unit tests (no Redis): empty/invalid URL, unreachable host, delta <= 0, empty member, cancelled context across all five operations
- `redis_integration_test.go` — testcontainers-go/redis tests:
  - `IncrementCounter` accumulates correctly across multiple calls
  - `GetCounter` returns 0 for missing key
  - TTL expiry for both counter and set (using 2s TTL to satisfy Redis 1s minimum)
  - `AddToSet` / `RemoveFromSet` / `SetContains` round-trip including idempotent re-add
  - `RemoveFromSet` is a no-op on a non-existent key
  - Two simulated instances sharing one Redis see each other's writes
  - Custom `PoolSize` is accepted and works
- `make check` passes (format + vet + build + all tests including integration)