### PR TITLE
feat(#381): external Redis configuration and shared rate limit counters

### DIFF
--- a/internal/app/generate/helpers.go
+++ b/internal/app/generate/helpers.go
@@ -10,11 +10,13 @@ func NeedsOpenBao(cfg *config.Config) bool {
 	return cfg.Secrets.Enabled
 }
 
-// NeedsRedis returns true if the config requires a Redis service in the
+// NeedsRedis returns true if the config requires a local Redis service in the
 // generated docker-compose.yml. This is the case when rate limiting uses the
-// Redis backing store.
+// Redis backing store AND no external Redis URL has been configured.
+// When rate_limit.redis.url points to an external instance, the local Redis
+// container is omitted from the generated Compose file.
 func NeedsRedis(cfg *config.Config) bool {
-	return cfg.RateLimit.Store == "redis"
+	return cfg.RateLimit.Store == "redis" && !cfg.RateLimit.Redis.HasExternalURL()
 }
 
 // NeedsObservability returns true if the config requires the observability

--- a/internal/app/generate/helpers_test.go
+++ b/internal/app/generate/helpers_test.go
@@ -85,6 +85,36 @@ func TestNeedsRedis(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "store redis with external URL returns false",
+			cfg: &config.Config{
+				RateLimit: config.RateLimitConfig{
+					Store: "redis",
+					Redis: config.RateLimitRedisConfig{URL: "redis://external.example.com:6379/0"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "store redis with rediss TLS URL returns false",
+			cfg: &config.Config{
+				RateLimit: config.RateLimitConfig{
+					Store: "redis",
+					Redis: config.RateLimitRedisConfig{URL: "rediss://user:pass@redis.example.com:6380/1"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "store redis with address only (no URL) returns true",
+			cfg: &config.Config{
+				RateLimit: config.RateLimitConfig{
+					Store: "redis",
+					Redis: config.RateLimitRedisConfig{Address: "localhost:6379"},
+				},
+			},
+			want: true,
+		},
+		{
 			name: "store memory returns false",
 			cfg:  &config.Config{RateLimit: config.RateLimitConfig{Store: "memory"}},
 			want: false,

--- a/internal/app/generate/service_integration_test.go
+++ b/internal/app/generate/service_integration_test.go
@@ -93,6 +93,82 @@ func TestGenerate_Integration_ExternalPostgres(t *testing.T) {
 	}
 }
 
+// TestGenerate_Integration_ExternalRedis verifies that the docker-compose
+// template omits the local redis container and redis-data volume when
+// rate_limit.redis.url is set to an external Redis URL. When no external URL
+// is set the local container is included as before.
+func TestGenerate_Integration_ExternalRedis(t *testing.T) {
+	renderer := template.NewRenderer(templates.FS)
+	svc := generate.NewService(renderer)
+
+	const externalRedisURL = "rediss://user:pass@redis.example.com:6380/1"
+
+	tests := []struct {
+		name           string
+		redisURL       string
+		wantSubstrings []string
+		wantAbsent     []string
+	}{
+		{
+			name:     "no external redis url — local redis container included",
+			redisURL: "",
+			wantSubstrings: []string{
+				"redis:",
+				"image: redis:7-alpine",
+				"redis-data:",
+				"VIBEWARDEN_RATE_LIMIT_REDIS_ADDRESS=redis:6379",
+				"condition: service_healthy",
+			},
+			wantAbsent: []string{
+				"VIBEWARDEN_RATE_LIMIT_REDIS_URL",
+			},
+		},
+		{
+			name:     "external redis url set — local redis container omitted",
+			redisURL: externalRedisURL,
+			wantSubstrings: []string{
+				"VIBEWARDEN_RATE_LIMIT_REDIS_URL=" + externalRedisURL,
+			},
+			wantAbsent: []string{
+				"image: redis:7-alpine",
+				"redis-data:",
+				"VIBEWARDEN_RATE_LIMIT_REDIS_ADDRESS=redis:6379",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+			cfg := minimalConfig()
+			cfg.RateLimit.Store = "redis"
+			cfg.RateLimit.Redis.Address = "localhost:6379" // required when URL is empty
+			cfg.RateLimit.Redis.URL = tt.redisURL
+
+			if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+				t.Fatalf("Generate() unexpected error: %v", err)
+			}
+
+			composePath := filepath.Join(outputDir, "docker-compose.yml")
+			data, err := os.ReadFile(composePath)
+			if err != nil {
+				t.Fatalf("reading docker-compose.yml: %v", err)
+			}
+
+			for _, want := range tt.wantSubstrings {
+				if !bytes.Contains(data, []byte(want)) {
+					t.Errorf("docker-compose.yml missing expected substring %q\n--- content ---\n%s", want, data)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if bytes.Contains(data, []byte(absent)) {
+					t.Errorf("docker-compose.yml contains unexpected substring %q\n--- content ---\n%s", absent, data)
+				}
+			}
+		})
+	}
+}
+
 // TestGenerate_Integration_KratosOIDCRendering verifies that the real template
 // renderer produces a kratos.yml that includes the OIDC method block when
 // social providers are configured and omits it when they are not.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -608,15 +608,29 @@ type RateLimitConfig struct {
 
 // RateLimitRedisConfig holds Redis connection settings for the rate limit store.
 type RateLimitRedisConfig struct {
+	// URL is the Redis connection URL (e.g. "redis://:password@localhost:6379/0"
+	// or "rediss://user:password@redis.example.com:6380/1" for TLS).
+	// When set, URL takes precedence over Address, Password, and DB.
+	// Use a redis:// URL for unencrypted connections and a rediss:// URL for TLS.
+	// Optional: if omitted, Address is used to build the connection.
+	URL string `mapstructure:"url"`
+
 	// Address is the Redis server address in host:port form (default: "localhost:6379").
-	// Required when rate_limit.store is "redis".
+	// Used when URL is empty. At least one of URL or Address is required when
+	// rate_limit.store is "redis".
 	Address string `mapstructure:"address"`
 
 	// Password is the Redis AUTH password (default: empty, no auth).
+	// Ignored when URL is set (embed credentials in the URL instead).
 	Password string `mapstructure:"password"`
 
 	// DB is the Redis logical database index (default: 0).
+	// Ignored when URL is set (embed the DB index in the URL path instead).
 	DB int `mapstructure:"db"`
+
+	// PoolSize is the maximum number of socket connections held in the pool
+	// (default: 0, which lets go-redis choose a sensible value based on CPU count).
+	PoolSize int `mapstructure:"pool_size"`
 
 	// KeyPrefix is the namespace prefix prepended to every Redis key
 	// (default: "vibewarden").
@@ -632,6 +646,13 @@ type RateLimitRedisConfig struct {
 	// for recovery after a failure, expressed as a duration string (e.g. "30s").
 	// Default: "30s".
 	HealthCheckInterval string `mapstructure:"health_check_interval"`
+}
+
+// HasExternalURL reports whether an explicit Redis URL has been configured.
+// When true, VibeWarden connects to that external Redis instance directly and
+// the generated Docker Compose file omits the local redis container.
+func (r RateLimitRedisConfig) HasExternalURL() bool {
+	return r.URL != ""
 }
 
 // RateLimitRuleConfig holds the sustained rate and burst size for a rate limit.
@@ -1310,8 +1331,13 @@ func (c *Config) Validate() error {
 	case "", "memory":
 		// valid — "memory" is the default
 	case "redis":
-		if c.RateLimit.Redis.Address == "" {
-			errs = append(errs, "rate_limit.redis.address is required when rate_limit.store is \"redis\"")
+		if c.RateLimit.Redis.URL == "" && c.RateLimit.Redis.Address == "" {
+			errs = append(errs, "rate_limit.redis.address is required when rate_limit.store is \"redis\" and rate_limit.redis.url is not set")
+		}
+		if c.RateLimit.Redis.URL != "" {
+			if err := validateRedisURL(c.RateLimit.Redis.URL); err != nil {
+				errs = append(errs, fmt.Sprintf("rate_limit.redis.url: %s", err.Error()))
+			}
 		}
 	default:
 		errs = append(errs, fmt.Sprintf(
@@ -1466,6 +1492,22 @@ func validatePostgresURL(s string) error {
 	return nil
 }
 
+// validateRedisURL returns an error if s is not a valid Redis connection URL.
+// It accepts "redis://" (plain) and "rediss://" (TLS) schemes.
+func validateRedisURL(s string) error {
+	u, err := url.Parse(s)
+	if err != nil {
+		return fmt.Errorf("must be a valid URL: %w", err)
+	}
+	if u.Scheme != "redis" && u.Scheme != "rediss" {
+		return fmt.Errorf("must use redis:// or rediss:// scheme, got %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("must include a host")
+	}
+	return nil
+}
+
 // Load reads configuration from file and environment variables.
 // Config file path can be specified; defaults to "./vibewarden.yaml".
 // Environment variables override file values using VIBEWARDEN_ prefix.
@@ -1508,9 +1550,11 @@ func Load(configPath string) (*Config, error) {
 	v.SetDefault("auth.ui.recovery_url", "")
 	v.SetDefault("rate_limit.enabled", true)
 	v.SetDefault("rate_limit.store", "memory")
+	v.SetDefault("rate_limit.redis.url", "")
 	v.SetDefault("rate_limit.redis.address", "")
 	v.SetDefault("rate_limit.redis.password", "")
 	v.SetDefault("rate_limit.redis.db", 0)
+	v.SetDefault("rate_limit.redis.pool_size", 0)
 	v.SetDefault("rate_limit.redis.key_prefix", "vibewarden")
 	v.SetDefault("rate_limit.redis.fallback", true)
 	v.SetDefault("rate_limit.redis.health_check_interval", "30s")

--- a/internal/config/ratelimit_config_test.go
+++ b/internal/config/ratelimit_config_test.go
@@ -38,15 +38,46 @@ func TestValidate_RateLimitStore(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "store redis without address is invalid",
+			name: "store redis without address or url is invalid",
 			cfg: config.Config{
 				RateLimit: config.RateLimitConfig{
 					Store: "redis",
-					Redis: config.RateLimitRedisConfig{Address: ""},
+					Redis: config.RateLimitRedisConfig{Address: "", URL: ""},
 				},
 			},
 			wantErr: true,
 			errMsg:  "rate_limit.redis.address is required",
+		},
+		{
+			name: "store redis with url only is valid",
+			cfg: config.Config{
+				RateLimit: config.RateLimitConfig{
+					Store: "redis",
+					Redis: config.RateLimitRedisConfig{URL: "redis://localhost:6379/0"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "store redis with rediss url (TLS) is valid",
+			cfg: config.Config{
+				RateLimit: config.RateLimitConfig{
+					Store: "redis",
+					Redis: config.RateLimitRedisConfig{URL: "rediss://user:pass@redis.example.com:6380/1"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "store redis with invalid url scheme is invalid",
+			cfg: config.Config{
+				RateLimit: config.RateLimitConfig{
+					Store: "redis",
+					Redis: config.RateLimitRedisConfig{URL: "http://localhost:6379"},
+				},
+			},
+			wantErr: true,
+			errMsg:  "rate_limit.redis.url",
 		},
 		{
 			name: "unknown store is invalid",
@@ -92,6 +123,12 @@ func TestLoad_RateLimitStoreDefaults(t *testing.T) {
 	if cfg.RateLimit.Store != "memory" {
 		t.Errorf("RateLimit.Store default = %q, want %q", cfg.RateLimit.Store, "memory")
 	}
+	if cfg.RateLimit.Redis.URL != "" {
+		t.Errorf("RateLimit.Redis.URL default = %q, want empty string", cfg.RateLimit.Redis.URL)
+	}
+	if cfg.RateLimit.Redis.PoolSize != 0 {
+		t.Errorf("RateLimit.Redis.PoolSize default = %d, want 0", cfg.RateLimit.Redis.PoolSize)
+	}
 	if cfg.RateLimit.Redis.KeyPrefix != "vibewarden" {
 		t.Errorf("RateLimit.Redis.KeyPrefix default = %q, want %q", cfg.RateLimit.Redis.KeyPrefix, "vibewarden")
 	}
@@ -130,5 +167,87 @@ func TestLoad_RateLimitRedisFromEnv(t *testing.T) {
 	}
 	if cfg.RateLimit.Redis.DB != 2 {
 		t.Errorf("DB = %d, want 2", cfg.RateLimit.Redis.DB)
+	}
+}
+
+// TestLoad_RateLimitRedisURLFromEnv verifies that VIBEWARDEN_RATE_LIMIT_REDIS_URL
+// overrides the config file and is the sole connection parameter when set.
+func TestLoad_RateLimitRedisURLFromEnv(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "vibewarden.yaml")
+	content := "rate_limit:\n  store: redis\n  redis:\n    address: localhost:6379\n"
+	if err := os.WriteFile(cfgFile, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	t.Setenv("VIBEWARDEN_RATE_LIMIT_REDIS_URL", "rediss://user:pass@redis.example.com:6380/2")
+
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.RateLimit.Redis.URL != "rediss://user:pass@redis.example.com:6380/2" {
+		t.Errorf("URL = %q, want rediss://user:pass@redis.example.com:6380/2", cfg.RateLimit.Redis.URL)
+	}
+}
+
+// TestLoad_RateLimitRedisPoolSizeFromEnv verifies that VIBEWARDEN_RATE_LIMIT_REDIS_POOL_SIZE
+// is loaded from environment variables.
+func TestLoad_RateLimitRedisPoolSizeFromEnv(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "vibewarden.yaml")
+	content := "rate_limit:\n  store: redis\n  redis:\n    address: localhost:6379\n"
+	if err := os.WriteFile(cfgFile, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	t.Setenv("VIBEWARDEN_RATE_LIMIT_REDIS_POOL_SIZE", "20")
+
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.RateLimit.Redis.PoolSize != 20 {
+		t.Errorf("PoolSize = %d, want 20", cfg.RateLimit.Redis.PoolSize)
+	}
+}
+
+// TestRateLimitRedisConfig_HasExternalURL verifies the HasExternalURL helper.
+func TestRateLimitRedisConfig_HasExternalURL(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.RateLimitRedisConfig
+		want bool
+	}{
+		{
+			name: "empty URL returns false",
+			cfg:  config.RateLimitRedisConfig{},
+			want: false,
+		},
+		{
+			name: "redis URL returns true",
+			cfg:  config.RateLimitRedisConfig{URL: "redis://localhost:6379/0"},
+			want: true,
+		},
+		{
+			name: "rediss TLS URL returns true",
+			cfg:  config.RateLimitRedisConfig{URL: "rediss://user:pass@redis.example.com:6380/1"},
+			want: true,
+		},
+		{
+			name: "address-only config returns false",
+			cfg:  config.RateLimitRedisConfig{Address: "localhost:6379"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.HasExternalURL()
+			if got != tt.want {
+				t.Errorf("HasExternalURL() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/config/templates/docker-compose.yml.tmpl
+++ b/internal/config/templates/docker-compose.yml.tmpl
@@ -19,7 +19,7 @@
 {{- if and .Secrets.Enabled (or (len .Secrets.Inject.Headers) (len .Secrets.Inject.Env)) }}
 #   seed-secrets — One-shot container that seeds demo secrets into OpenBao
 {{- end }}
-{{- if eq .RateLimit.Store "redis" }}
+{{- if and (eq .RateLimit.Store "redis") (not (.RateLimit.Redis.HasExternalURL)) }}
 #   redis       — Redis backing store for rate limiting
 {{- end }}
 {{- if .Observability.Enabled }}
@@ -79,7 +79,11 @@ services:
       - VIBEWARDEN_SECRETS_OPENBAO_AUTH_TOKEN=${OPENBAO_DEV_ROOT_TOKEN}
 {{- end }}
 {{- if eq .RateLimit.Store "redis" }}
+{{- if .RateLimit.Redis.HasExternalURL }}
+      - VIBEWARDEN_RATE_LIMIT_REDIS_URL={{ .RateLimit.Redis.URL }}
+{{- else }}
       - VIBEWARDEN_RATE_LIMIT_REDIS_ADDRESS=redis:6379
+{{- end }}
 {{- end }}
 {{- if .Observability.Enabled }}
       - VIBEWARDEN_TELEMETRY_OTLP_ENABLED=true
@@ -92,7 +96,7 @@ services:
 {{- end }}
     networks:
       - vibewarden
-{{- if or (and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External)) .App.Build .App.Image .Secrets.Enabled (eq .RateLimit.Store "redis") }}
+{{- if or (and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External)) .App.Build .App.Image .Secrets.Enabled (and (eq .RateLimit.Store "redis") (not (.RateLimit.Redis.HasExternalURL))) }}
     depends_on:
 {{- if or .App.Build .App.Image }}
       app:
@@ -109,7 +113,7 @@ services:
       openbao:
         condition: service_healthy
 {{- end }}
-{{- if eq .RateLimit.Store "redis" }}
+{{- if and (eq .RateLimit.Store "redis") (not (.RateLimit.Redis.HasExternalURL)) }}
       redis:
         condition: service_healthy
 {{- end }}
@@ -246,7 +250,7 @@ services:
       - vibewarden
     restart: "no"
 {{- end }}
-{{- if eq .RateLimit.Store "redis" }}
+{{- if and (eq .RateLimit.Store "redis") (not (.RateLimit.Redis.HasExternalURL)) }}
 
   redis:
     image: redis:7-alpine
@@ -396,7 +400,7 @@ services:
 networks:
   vibewarden:
     driver: bridge
-{{- if or (and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) (eq .Database.ExternalURL "")) .TLS.Enabled (eq .RateLimit.Store "redis") .Observability.Enabled }}
+{{- if or (and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) (eq .Database.ExternalURL "")) .TLS.Enabled (and (eq .RateLimit.Store "redis") (not (.RateLimit.Redis.HasExternalURL))) .Observability.Enabled }}
 
 volumes:
 {{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) (eq .Database.ExternalURL "") }}
@@ -405,7 +409,7 @@ volumes:
 {{- if .TLS.Enabled }}
   vibewarden-data:
 {{- end }}
-{{- if eq .RateLimit.Store "redis" }}
+{{- if and (eq .RateLimit.Store "redis") (not (.RateLimit.Redis.HasExternalURL)) }}
   redis-data:
 {{- end }}
 {{- if .Observability.Enabled }}

--- a/internal/plugins/ratelimit/config.go
+++ b/internal/plugins/ratelimit/config.go
@@ -42,15 +42,28 @@ type Config struct {
 
 // RedisConfig holds connection settings for the Redis rate limit store.
 type RedisConfig struct {
+	// URL is the Redis connection URL (e.g. "redis://:password@localhost:6379/0"
+	// or "rediss://user:pass@redis.example.com:6380/1" for TLS).
+	// When set, URL takes precedence over Address, Password, and DB.
+	// Supports both redis:// (plain) and rediss:// (TLS) schemes.
+	URL string
+
 	// Address is the Redis server address in host:port form.
-	// Required when Store is "redis".
+	// Used when URL is empty. At least one of URL or Address is required
+	// when Store is "redis".
 	Address string
 
 	// Password is the Redis AUTH password.
+	// Ignored when URL is set (embed credentials in the URL instead).
 	Password string
 
 	// DB is the Redis logical database index.
+	// Ignored when URL is set (embed the DB index in the URL path instead).
 	DB int
+
+	// PoolSize is the maximum number of socket connections held in the pool.
+	// Defaults to 0 (go-redis picks a sensible value based on CPU count).
+	PoolSize int
 
 	// KeyPrefix is the namespace prefix prepended to every Redis key.
 	KeyPrefix string

--- a/internal/plugins/ratelimit/plugin.go
+++ b/internal/plugins/ratelimit/plugin.go
@@ -104,6 +104,39 @@ func (p *Plugin) Init(ctx context.Context) error {
 	return nil
 }
 
+// buildRedisClient creates a *redis.Client from the plugin's RedisConfig.
+// When cfg.URL is set it is parsed with redis.ParseURL so that both redis://
+// and rediss:// (TLS) schemes are supported. Password, DB, and PoolSize fields
+// serve as explicit overrides applied on top of whatever the URL specifies.
+// When cfg.URL is empty, cfg.Address/Password/DB are used directly.
+func buildRedisClient(cfg RedisConfig) (*redis.Client, error) {
+	var opts *redis.Options
+	if cfg.URL != "" {
+		var err error
+		opts, err = redis.ParseURL(cfg.URL)
+		if err != nil {
+			return nil, fmt.Errorf("rate-limiting: parsing redis URL: %w", err)
+		}
+		// Allow explicit field overrides on top of the URL.
+		if cfg.Password != "" {
+			opts.Password = cfg.Password
+		}
+		if cfg.DB != 0 {
+			opts.DB = cfg.DB
+		}
+	} else {
+		opts = &redis.Options{
+			Addr:     cfg.Address,
+			Password: cfg.Password,
+			DB:       cfg.DB,
+		}
+	}
+	if cfg.PoolSize > 0 {
+		opts.PoolSize = cfg.PoolSize
+	}
+	return redis.NewClient(opts), nil
+}
+
 // buildFactory constructs a RateLimiterFactory based on p.cfg.Store.
 // It returns the factory, an optional Redis client (non-nil only for Redis
 // stores), and any error encountered during construction.
@@ -114,11 +147,10 @@ func (p *Plugin) buildFactory(_ context.Context) (ports.RateLimiterFactory, *red
 
 	case "redis":
 		rCfg := p.cfg.Redis
-		client := redis.NewClient(&redis.Options{
-			Addr:     rCfg.Address,
-			Password: rCfg.Password,
-			DB:       rCfg.DB,
-		})
+		client, err := buildRedisClient(rCfg)
+		if err != nil {
+			return nil, nil, err
+		}
 
 		keyPrefix := rCfg.KeyPrefix
 		if keyPrefix == "" {

--- a/internal/plugins/ratelimit/redis_client_test.go
+++ b/internal/plugins/ratelimit/redis_client_test.go
@@ -1,0 +1,83 @@
+package ratelimit_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/plugins/ratelimit"
+)
+
+// TestPlugin_Init_RedisURL_InvalidScheme verifies that buildRedisClient rejects
+// an http:// URL (not a valid Redis scheme) and surfaces the error through Init.
+func TestPlugin_Init_RedisURL_InvalidScheme(t *testing.T) {
+	cfg := ratelimit.Config{
+		Enabled: true,
+		Store:   "redis",
+		Redis: ratelimit.RedisConfig{
+			URL: "http://localhost:6379",
+		},
+	}
+	p := ratelimit.New(cfg, nil, discardLogger())
+
+	err := p.Init(context.Background())
+	if err == nil {
+		_ = p.Stop(context.Background())
+		t.Fatal("Init() expected error for invalid Redis URL scheme, got nil")
+	}
+	if !strings.Contains(err.Error(), "building rate limiter factory") {
+		t.Errorf("Init() error = %q, want it to contain %q", err.Error(), "building rate limiter factory")
+	}
+}
+
+// TestPlugin_Init_RedisURL_WithPoolSize verifies that a redis:// URL combined
+// with a PoolSize override does not panic or produce a construction error.
+// (Connectivity failures are expected and handled gracefully via fallback.)
+func TestPlugin_Init_RedisURL_WithPoolSize(t *testing.T) {
+	cfg := ratelimit.Config{
+		Enabled: true,
+		Store:   "redis",
+		Redis: ratelimit.RedisConfig{
+			// Port 1 always refuses — tests URL parsing without real Redis.
+			URL:      "redis://localhost:1/0",
+			PoolSize: 5,
+			// With Fallback=true the plugin falls back to memory on
+			// the health-check failure that happens when a limiter is
+			// first used, so Init itself succeeds.
+			Fallback: true,
+		},
+		PerIP:   ratelimit.RuleConfig{RequestsPerSecond: 10, Burst: 20},
+		PerUser: ratelimit.RuleConfig{RequestsPerSecond: 100, Burst: 200},
+	}
+	p := ratelimit.New(cfg, nil, discardLogger())
+
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() unexpected error: %v", err)
+	}
+	if err := p.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() unexpected error: %v", err)
+	}
+}
+
+// TestPlugin_Init_RedisURL_TLSScheme verifies that a rediss:// URL is accepted
+// by the URL parser (TLS scheme).
+func TestPlugin_Init_RedisURL_TLSScheme(t *testing.T) {
+	cfg := ratelimit.Config{
+		Enabled: true,
+		Store:   "redis",
+		Redis: ratelimit.RedisConfig{
+			// rediss:// is the TLS scheme; port 1 ensures the connection
+			// will fail fast but URL parsing must succeed.
+			URL:      "rediss://localhost:1/0",
+			Fallback: true,
+		},
+		PerIP:   ratelimit.RuleConfig{RequestsPerSecond: 10, Burst: 20},
+		PerUser: ratelimit.RuleConfig{RequestsPerSecond: 100, Burst: 200},
+	}
+	p := ratelimit.New(cfg, nil, discardLogger())
+
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() unexpected error for rediss:// URL: %v", err)
+	}
+	_ = p.Stop(context.Background())
+}


### PR DESCRIPTION
Closes #381

## Summary

- **Config** (`internal/config/config.go`): Add `URL` and `PoolSize` fields to `RateLimitRedisConfig`. `URL` accepts `redis://` (plain) and `rediss://` (TLS) schemes and takes precedence over `Address`/`Password`/`DB` when set. `HasExternalURL()` helper reports whether an explicit URL was provided. Validation now accepts either `URL` or `Address` (at least one required when `store: redis`). New `validateRedisURL()` helper. Defaults for `rate_limit.redis.url` and `rate_limit.redis.pool_size` added to `Load()`.

- **Plugin** (`internal/plugins/ratelimit/plugin.go`): Extract `buildRedisClient(cfg RedisConfig) (*redis.Client, error)` which calls `redis.ParseURL` when `URL` is set (enabling TLS and credentials embedded in the URL) and falls back to `Addr`/`Password`/`DB` fields when `URL` is empty. `PoolSize` override is applied in both paths. Existing fallback/health-check logic is preserved unchanged.

- **Helpers** (`internal/app/generate/helpers.go`): `NeedsRedis` now returns `false` when `rate_limit.redis.url` is set, so the generated Compose file omits the local `redis` container when pointing at an external instance.

- **Template** (`internal/config/templates/docker-compose.yml.tmpl`): All six `redis`-related blocks now check `(eq .RateLimit.Store "redis") AND (not .RateLimit.Redis.HasExternalURL)`. When an external URL is configured, `VIBEWARDEN_RATE_LIMIT_REDIS_URL` is injected into the vibewarden service env instead of `VIBEWARDEN_RATE_LIMIT_REDIS_ADDRESS`.

## Test plan

- `TestRateLimitRedisConfig_HasExternalURL` — unit tests for the `HasExternalURL()` method
- `TestValidate_RateLimitStore` — updated: accepts URL-only config, rejects `http://` scheme, rejects missing both URL and Address
- `TestLoad_RateLimitRedisURLFromEnv` — env var `VIBEWARDEN_RATE_LIMIT_REDIS_URL` loads correctly
- `TestLoad_RateLimitRedisPoolSizeFromEnv` — env var `VIBEWARDEN_RATE_LIMIT_REDIS_POOL_SIZE` loads correctly
- `TestLoad_RateLimitStoreDefaults` — verifies `URL` and `PoolSize` default to zero values
- `TestNeedsRedis` — updated: external URL returns `false`, address-only returns `true`
- `TestGenerate_Integration_ExternalRedis` — compose template with/without external URL; verifies redis service, redis-data volume, env vars, and depends_on are present or absent as expected
- `TestPlugin_Init_RedisURL_InvalidScheme` — `http://` URL rejected by `buildRedisClient`
- `TestPlugin_Init_RedisURL_WithPoolSize` — `PoolSize` field accepted without panic
- `TestPlugin_Init_RedisURL_TLSScheme` — `rediss://` URL accepted by URL parser

All pass under `make check`.