### PR TITLE
feat(#358): implement egress proxy domain types, ports, and config schema

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,9 @@ type Config struct {
 
 	// WAF configures the Web Application Firewall plugins.
 	WAF WAFConfig `mapstructure:"waf"`
+
+	// Egress configures the egress proxy plugin for outbound API call control.
+	Egress EgressConfig `mapstructure:"egress"`
 }
 
 // DatabasePoolConfig holds connection pool settings for PostgreSQL.
@@ -1470,10 +1473,126 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// egress validation.
+	if c.Egress.Enabled {
+		egressErrs := validateEgressConfig(c.Egress)
+		errs = append(errs, egressErrs...)
+	}
+
 	if len(errs) > 0 {
 		return fmt.Errorf("%s", strings.Join(errs, "; "))
 	}
 	return nil
+}
+
+// validateEgressConfig validates the egress proxy configuration and returns
+// a slice of error strings (one per violation). An empty slice means the
+// configuration is valid.
+func validateEgressConfig(cfg EgressConfig) []string {
+	var errs []string
+
+	// default_policy validation.
+	switch cfg.DefaultPolicy {
+	case "", "deny", "allow":
+		// valid — empty falls back to "deny" via Load defaults
+	default:
+		errs = append(errs, fmt.Sprintf(
+			"egress.default_policy %q is invalid; accepted values: \"allow\", \"deny\"",
+			cfg.DefaultPolicy,
+		))
+	}
+
+	// default_timeout validation.
+	if cfg.DefaultTimeout != "" {
+		if _, err := time.ParseDuration(cfg.DefaultTimeout); err != nil {
+			errs = append(errs, fmt.Sprintf(
+				"egress.default_timeout %q is not a valid duration: %s",
+				cfg.DefaultTimeout, err.Error(),
+			))
+		}
+	}
+
+	// routes validation.
+	routeNames := make(map[string]bool, len(cfg.Routes))
+	for i, r := range cfg.Routes {
+		prefix := fmt.Sprintf("egress.routes[%d]", i)
+
+		if r.Name == "" {
+			errs = append(errs, fmt.Sprintf("%s.name is required", prefix))
+		} else if routeNames[r.Name] {
+			errs = append(errs, fmt.Sprintf("%s.name %q is a duplicate; route names must be unique", prefix, r.Name))
+		} else {
+			routeNames[r.Name] = true
+		}
+
+		if r.Pattern == "" {
+			errs = append(errs, fmt.Sprintf("%s.pattern is required", prefix))
+		} else {
+			if !strings.HasPrefix(r.Pattern, "http://") && !strings.HasPrefix(r.Pattern, "https://") {
+				errs = append(errs, fmt.Sprintf("%s.pattern %q must start with http:// or https://", prefix, r.Pattern))
+			}
+		}
+
+		if r.Timeout != "" {
+			if _, err := time.ParseDuration(r.Timeout); err != nil {
+				errs = append(errs, fmt.Sprintf(
+					"%s.timeout %q is not a valid duration: %s",
+					prefix, r.Timeout, err.Error(),
+				))
+			}
+		}
+
+		// circuit_breaker validation: both threshold and reset_after must be set together.
+		cb := r.CircuitBreaker
+		hasCBThreshold := cb.Threshold != 0
+		hasCBReset := cb.ResetAfter != ""
+		if hasCBThreshold || hasCBReset {
+			if cb.Threshold <= 0 {
+				errs = append(errs, fmt.Sprintf("%s.circuit_breaker.threshold must be > 0", prefix))
+			}
+			if cb.ResetAfter == "" {
+				errs = append(errs, fmt.Sprintf("%s.circuit_breaker.reset_after is required when circuit_breaker.threshold is set", prefix))
+			} else if _, err := time.ParseDuration(cb.ResetAfter); err != nil {
+				errs = append(errs, fmt.Sprintf(
+					"%s.circuit_breaker.reset_after %q is not a valid duration: %s",
+					prefix, cb.ResetAfter, err.Error(),
+				))
+			}
+		}
+
+		// retries validation.
+		if r.Retries.Max < 0 {
+			errs = append(errs, fmt.Sprintf("%s.retries.max must be >= 0", prefix))
+		}
+		switch r.Retries.Backoff {
+		case "", "exponential", "fixed":
+			// valid
+		default:
+			errs = append(errs, fmt.Sprintf(
+				"%s.retries.backoff %q is invalid; accepted values: \"exponential\", \"fixed\"",
+				prefix, r.Retries.Backoff,
+			))
+		}
+
+		// body_size_limit validation.
+		if r.BodySizeLimit != "" {
+			if _, err := ParseBodySize(r.BodySizeLimit); err != nil {
+				errs = append(errs, fmt.Sprintf("%s.body_size_limit: %s", prefix, err.Error()))
+			}
+		}
+
+		// secret injection: if any secret field is set, name and header are required.
+		if r.SecretFormat != "" || r.SecretHeader != "" {
+			if r.Secret == "" {
+				errs = append(errs, fmt.Sprintf("%s.secret is required when secret_header or secret_format is set", prefix))
+			}
+			if r.SecretHeader == "" {
+				errs = append(errs, fmt.Sprintf("%s.secret_header is required when secret or secret_format is set", prefix))
+			}
+		}
+	}
+
+	return errs
 }
 
 // validatePostgresURL returns an error if s is not a valid postgres:// URL.
@@ -1656,6 +1775,12 @@ func Load(configPath string) (*Config, error) {
 	v.SetDefault("waf.rules.xss", true)
 	v.SetDefault("waf.rules.path_traversal", true)
 	v.SetDefault("waf.rules.command_injection", true)
+	v.SetDefault("egress.enabled", false)
+	v.SetDefault("egress.listen", "127.0.0.1:8081")
+	v.SetDefault("egress.default_policy", "deny")
+	v.SetDefault("egress.default_timeout", "30s")
+	v.SetDefault("egress.dns.block_private", true)
+	v.SetDefault("egress.routes", []EgressRouteConfig{})
 
 	// Config file
 	if configPath != "" {

--- a/internal/config/egress.go
+++ b/internal/config/egress.go
@@ -1,0 +1,106 @@
+package config
+
+// EgressConfig holds configuration for the egress proxy plugin.
+// When enabled, the egress proxy listens on a separate port and forwards
+// outbound HTTP requests from the wrapped application to external services,
+// applying allowlisting, secret injection, rate limiting, and circuit breaking.
+type EgressConfig struct {
+	// Enabled toggles the egress proxy plugin (default: false).
+	Enabled bool `mapstructure:"enabled"`
+
+	// Listen is the address the egress proxy binds to (default: "127.0.0.1:8081").
+	Listen string `mapstructure:"listen"`
+
+	// DefaultPolicy determines the disposition for outbound requests that do not
+	// match any configured route. Accepted values: "allow", "deny" (default: "deny").
+	DefaultPolicy string `mapstructure:"default_policy"`
+
+	// DefaultTimeout is the global request timeout applied when a route does not
+	// specify its own timeout. Accepts Go duration strings (e.g. "30s"). Default: "30s".
+	DefaultTimeout string `mapstructure:"default_timeout"`
+
+	// DNS holds DNS-level protection settings.
+	DNS EgressDNSConfig `mapstructure:"dns"`
+
+	// Routes is the ordered list of egress route definitions.
+	// Routes are evaluated in declaration order; the first matching route wins.
+	Routes []EgressRouteConfig `mapstructure:"routes"`
+}
+
+// EgressDNSConfig holds DNS-level protection settings for the egress proxy.
+type EgressDNSConfig struct {
+	// BlockPrivate, when true, prevents the egress proxy from forwarding requests
+	// to private or loopback IP addresses (RFC 1918, RFC 4193, loopback).
+	// This mitigates SSRF attacks. Default: true.
+	BlockPrivate bool `mapstructure:"block_private"`
+}
+
+// EgressRouteConfig describes a single egress allowlist entry in the YAML config.
+type EgressRouteConfig struct {
+	// Name is the unique human-readable identifier for this route (required).
+	Name string `mapstructure:"name"`
+
+	// Pattern is the URL glob pattern matched against outbound request URLs
+	// (required). Must start with "http://" or "https://".
+	// Example: "https://api.stripe.com/**"
+	Pattern string `mapstructure:"pattern"`
+
+	// Methods restricts the route to the specified HTTP methods (e.g. ["GET", "POST"]).
+	// When empty, all methods are matched.
+	Methods []string `mapstructure:"methods"`
+
+	// Timeout is the per-route request timeout as a duration string (e.g. "10s").
+	// When empty, EgressConfig.DefaultTimeout is used.
+	Timeout string `mapstructure:"timeout"`
+
+	// Secret is the name of the OpenBao secret to fetch and inject.
+	Secret string `mapstructure:"secret"`
+
+	// SecretHeader is the HTTP request header into which the secret value is injected.
+	// Example: "Authorization"
+	SecretHeader string `mapstructure:"secret_header"`
+
+	// SecretFormat is the value template. The literal "{value}" is replaced with the
+	// resolved secret value. Example: "Bearer {value}"
+	SecretFormat string `mapstructure:"secret_format"`
+
+	// RateLimit is the rate limit expression for this route (e.g. "100/s").
+	// When empty, no per-route rate limit is applied.
+	RateLimit string `mapstructure:"rate_limit"`
+
+	// CircuitBreaker holds circuit breaker settings for this route.
+	CircuitBreaker EgressCircuitBreakerConfig `mapstructure:"circuit_breaker"`
+
+	// Retries holds retry-with-backoff settings for this route.
+	Retries EgressRetryConfig `mapstructure:"retries"`
+
+	// BodySizeLimit is the maximum allowed request body size as a human-readable
+	// string (e.g. "50MB"). When empty, no body size limit is applied.
+	BodySizeLimit string `mapstructure:"body_size_limit"`
+}
+
+// EgressCircuitBreakerConfig holds circuit breaker parameters for an egress route.
+type EgressCircuitBreakerConfig struct {
+	// Threshold is the number of consecutive failures required to trip the circuit.
+	// Must be > 0 when the circuit breaker is configured.
+	Threshold int `mapstructure:"threshold"`
+
+	// ResetAfter is how long the circuit stays open before allowing a probe request,
+	// as a duration string (e.g. "30s"). Must be > 0 when the circuit breaker is configured.
+	ResetAfter string `mapstructure:"reset_after"`
+}
+
+// EgressRetryConfig holds retry-with-backoff parameters for an egress route.
+type EgressRetryConfig struct {
+	// Max is the maximum number of retry attempts (not counting the initial request).
+	// Must be >= 1 when retries are configured.
+	Max int `mapstructure:"max"`
+
+	// Methods is the set of HTTP methods eligible for retry (e.g. ["GET", "PUT"]).
+	// When empty, all methods are retried.
+	Methods []string `mapstructure:"methods"`
+
+	// Backoff selects the backoff strategy: "exponential" or "fixed".
+	// Defaults to "exponential" when empty.
+	Backoff string `mapstructure:"backoff"`
+}

--- a/internal/config/egress_test.go
+++ b/internal/config/egress_test.go
@@ -1,0 +1,413 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+// TestValidate_EgressDisabled verifies that no egress validation runs when egress
+// is disabled, even if routes have invalid fields.
+func TestValidate_EgressDisabled(t *testing.T) {
+	cfg := config.Config{
+		Egress: config.EgressConfig{
+			Enabled: false,
+			Routes: []config.EgressRouteConfig{
+				{Name: "", Pattern: ""},
+			},
+		},
+	}
+	// Should not error because egress is disabled.
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() with egress disabled returned unexpected error: %v", err)
+	}
+}
+
+// TestValidate_EgressDefaultPolicy verifies valid and invalid default_policy values.
+func TestValidate_EgressDefaultPolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  string
+		wantErr bool
+	}{
+		{"deny is valid", "deny", false},
+		{"allow is valid", "allow", false},
+		{"empty is valid (uses default)", "", false},
+		{"unknown is invalid", "block", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Egress: config.EgressConfig{
+					Enabled:       true,
+					DefaultPolicy: tt.policy,
+				},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidate_EgressDefaultTimeout verifies valid and invalid default_timeout values.
+func TestValidate_EgressDefaultTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout string
+		wantErr bool
+	}{
+		{"valid 30s", "30s", false},
+		{"valid 1m", "1m", false},
+		{"empty is valid (uses default)", "", false},
+		{"invalid string", "notaduration", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Egress: config.EgressConfig{
+					Enabled:        true,
+					DefaultTimeout: tt.timeout,
+				},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidate_EgressRouteName verifies that route names are required and unique.
+func TestValidate_EgressRouteName(t *testing.T) {
+	tests := []struct {
+		name    string
+		routes  []config.EgressRouteConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "unique names are valid",
+			routes: []config.EgressRouteConfig{
+				{Name: "stripe", Pattern: "https://api.stripe.com/**"},
+				{Name: "github", Pattern: "https://api.github.com/**"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty name is invalid",
+			routes: []config.EgressRouteConfig{
+				{Name: "", Pattern: "https://api.stripe.com/**"},
+			},
+			wantErr: true,
+			errMsg:  "name is required",
+		},
+		{
+			name: "duplicate names are invalid",
+			routes: []config.EgressRouteConfig{
+				{Name: "stripe", Pattern: "https://api.stripe.com/**"},
+				{Name: "stripe", Pattern: "https://api2.stripe.com/**"},
+			},
+			wantErr: true,
+			errMsg:  "duplicate",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Egress: config.EgressConfig{
+					Enabled: true,
+					Routes:  tt.routes,
+				},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.errMsg != "" {
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+// TestValidate_EgressRoutePattern verifies that route patterns are required and valid.
+func TestValidate_EgressRoutePattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		wantErr bool
+	}{
+		{"https pattern is valid", "https://api.stripe.com/**", false},
+		{"http pattern is valid", "http://localhost/**", false},
+		{"empty pattern is invalid", "", true},
+		{"pattern without scheme is invalid", "api.stripe.com/**", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Egress: config.EgressConfig{
+					Enabled: true,
+					Routes: []config.EgressRouteConfig{
+						{Name: "r", Pattern: tt.pattern},
+					},
+				},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() with pattern %q: error = %v, wantErr %v", tt.pattern, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidate_EgressRouteTimeout verifies per-route timeout validation.
+func TestValidate_EgressRouteTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout string
+		wantErr bool
+	}{
+		{"valid timeout", "10s", false},
+		{"empty timeout is valid", "", false},
+		{"invalid timeout", "bad", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Egress: config.EgressConfig{
+					Enabled: true,
+					Routes: []config.EgressRouteConfig{
+						{Name: "r", Pattern: "https://api.example.com/**", Timeout: tt.timeout},
+					},
+				},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidate_EgressCircuitBreaker verifies circuit breaker field validation.
+func TestValidate_EgressCircuitBreaker(t *testing.T) {
+	tests := []struct {
+		name    string
+		cb      config.EgressCircuitBreakerConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "zero CB config is valid (not configured)",
+			cb:      config.EgressCircuitBreakerConfig{},
+			wantErr: false,
+		},
+		{
+			name:    "valid CB config",
+			cb:      config.EgressCircuitBreakerConfig{Threshold: 5, ResetAfter: "30s"},
+			wantErr: false,
+		},
+		{
+			name:    "threshold set without reset_after",
+			cb:      config.EgressCircuitBreakerConfig{Threshold: 5, ResetAfter: ""},
+			wantErr: true,
+			errMsg:  "reset_after is required",
+		},
+		{
+			name:    "threshold must be positive",
+			cb:      config.EgressCircuitBreakerConfig{Threshold: -1, ResetAfter: "30s"},
+			wantErr: true,
+			errMsg:  "threshold must be > 0",
+		},
+		{
+			name:    "invalid reset_after duration",
+			cb:      config.EgressCircuitBreakerConfig{Threshold: 3, ResetAfter: "nope"},
+			wantErr: true,
+			errMsg:  "reset_after",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Egress: config.EgressConfig{
+					Enabled: true,
+					Routes: []config.EgressRouteConfig{
+						{Name: "r", Pattern: "https://api.example.com/**", CircuitBreaker: tt.cb},
+					},
+				},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.errMsg != "" {
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+// TestValidate_EgressRetries verifies retry field validation.
+func TestValidate_EgressRetries(t *testing.T) {
+	tests := []struct {
+		name    string
+		retries config.EgressRetryConfig
+		wantErr bool
+	}{
+		{
+			name:    "zero retries config is valid (not configured)",
+			retries: config.EgressRetryConfig{},
+			wantErr: false,
+		},
+		{
+			name:    "valid retries config",
+			retries: config.EgressRetryConfig{Max: 3, Backoff: "exponential"},
+			wantErr: false,
+		},
+		{
+			name:    "fixed backoff is valid",
+			retries: config.EgressRetryConfig{Max: 2, Backoff: "fixed"},
+			wantErr: false,
+		},
+		{
+			name:    "empty backoff is valid",
+			retries: config.EgressRetryConfig{Max: 3, Backoff: ""},
+			wantErr: false,
+		},
+		{
+			name:    "invalid backoff",
+			retries: config.EgressRetryConfig{Max: 3, Backoff: "random"},
+			wantErr: true,
+		},
+		{
+			name:    "negative max is invalid",
+			retries: config.EgressRetryConfig{Max: -1},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Egress: config.EgressConfig{
+					Enabled: true,
+					Routes: []config.EgressRouteConfig{
+						{Name: "r", Pattern: "https://api.example.com/**", Retries: tt.retries},
+					},
+				},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidate_EgressBodySizeLimit verifies body size limit parsing.
+func TestValidate_EgressBodySizeLimit(t *testing.T) {
+	tests := []struct {
+		name          string
+		bodySizeLimit string
+		wantErr       bool
+	}{
+		{"empty is valid", "", false},
+		{"50MB is valid", "50MB", false},
+		{"1GB is valid", "1GB", false},
+		{"invalid unit", "50XB", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Egress: config.EgressConfig{
+					Enabled: true,
+					Routes: []config.EgressRouteConfig{
+						{Name: "r", Pattern: "https://api.example.com/**", BodySizeLimit: tt.bodySizeLimit},
+					},
+				},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidate_EgressSecretInjection verifies that partial secret config is rejected.
+func TestValidate_EgressSecretInjection(t *testing.T) {
+	tests := []struct {
+		name         string
+		secret       string
+		secretHeader string
+		secretFormat string
+		wantErr      bool
+	}{
+		{
+			name:    "no secret fields is valid",
+			wantErr: false,
+		},
+		{
+			name:         "all secret fields is valid",
+			secret:       "stripe_key",
+			secretHeader: "Authorization",
+			secretFormat: "Bearer {value}",
+			wantErr:      false,
+		},
+		{
+			name:         "header set without secret name",
+			secretHeader: "Authorization",
+			wantErr:      true,
+		},
+		{
+			name:         "format set without secret name",
+			secretFormat: "Bearer {value}",
+			wantErr:      true,
+		},
+		{
+			name:         "header set without secret_header",
+			secret:       "stripe_key",
+			secretFormat: "Bearer {value}",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Egress: config.EgressConfig{
+					Enabled: true,
+					Routes: []config.EgressRouteConfig{
+						{
+							Name:         "r",
+							Pattern:      "https://api.example.com/**",
+							Secret:       tt.secret,
+							SecretHeader: tt.secretHeader,
+							SecretFormat: tt.secretFormat,
+						},
+					},
+				},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/domain/egress/policy.go
+++ b/internal/domain/egress/policy.go
@@ -1,0 +1,38 @@
+// Package egress contains the domain model for the egress proxy plugin.
+// This package has zero external dependencies — only the Go standard library.
+//
+// The egress proxy intercepts outbound API calls made by the wrapped application
+// and applies allowlisting, secret injection, rate limiting, circuit breaking,
+// and structured logging before forwarding requests to external services.
+package egress
+
+import "errors"
+
+// Policy determines the default disposition for egress traffic that does not
+// match any configured route.
+type Policy string
+
+const (
+	// PolicyAllow permits egress traffic that does not match any route.
+	// Use with caution — prefer PolicyDeny for production deployments.
+	PolicyAllow Policy = "allow"
+
+	// PolicyDeny blocks egress traffic that does not match any route.
+	// This is the recommended default for production deployments.
+	PolicyDeny Policy = "deny"
+)
+
+// Validate returns an error when the policy value is not recognised.
+func (p Policy) Validate() error {
+	switch p {
+	case PolicyAllow, PolicyDeny:
+		return nil
+	case "":
+		return errors.New("egress policy cannot be empty")
+	default:
+		return errors.New("egress policy must be \"allow\" or \"deny\"")
+	}
+}
+
+// String returns the string representation of the policy.
+func (p Policy) String() string { return string(p) }

--- a/internal/domain/egress/policy_test.go
+++ b/internal/domain/egress/policy_test.go
@@ -1,0 +1,68 @@
+package egress_test
+
+import (
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+func TestPolicy_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  egress.Policy
+		wantErr bool
+	}{
+		{
+			name:    "allow is valid",
+			policy:  egress.PolicyAllow,
+			wantErr: false,
+		},
+		{
+			name:    "deny is valid",
+			policy:  egress.PolicyDeny,
+			wantErr: false,
+		},
+		{
+			name:    "empty is invalid",
+			policy:  "",
+			wantErr: true,
+		},
+		{
+			name:    "unknown value is invalid",
+			policy:  egress.Policy("block"),
+			wantErr: true,
+		},
+		{
+			name:    "mixed case is invalid",
+			policy:  egress.Policy("Allow"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.policy.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Policy(%q).Validate() error = %v, wantErr %v", tt.policy, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPolicy_String(t *testing.T) {
+	tests := []struct {
+		policy egress.Policy
+		want   string
+	}{
+		{egress.PolicyAllow, "allow"},
+		{egress.PolicyDeny, "deny"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.policy), func(t *testing.T) {
+			if got := tt.policy.String(); got != tt.want {
+				t.Errorf("Policy.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/domain/egress/request.go
+++ b/internal/domain/egress/request.go
@@ -1,0 +1,45 @@
+package egress
+
+import (
+	"errors"
+	"net/http"
+)
+
+// EgressRequest is a value object that carries the details of an outbound
+// HTTP request intercepted by the egress proxy. The body is referenced by an
+// opaque handle rather than held in memory to avoid large allocations.
+type EgressRequest struct {
+	// Method is the HTTP method of the outbound request (e.g. "GET", "POST").
+	Method string
+
+	// URL is the destination URL of the outbound request.
+	URL string
+
+	// Header contains the HTTP headers sent with the request.
+	// The egress proxy may add, modify, or remove headers before forwarding.
+	Header http.Header
+
+	// BodyRef is an opaque reference to the request body stream.
+	// A nil value indicates an empty body.
+	BodyRef interface{}
+}
+
+// NewEgressRequest constructs an EgressRequest.
+// Returns an error when method or URL is empty.
+func NewEgressRequest(method, rawURL string, header http.Header, bodyRef interface{}) (EgressRequest, error) {
+	if method == "" {
+		return EgressRequest{}, errors.New("egress request method cannot be empty")
+	}
+	if rawURL == "" {
+		return EgressRequest{}, errors.New("egress request URL cannot be empty")
+	}
+	if header == nil {
+		header = make(http.Header)
+	}
+	return EgressRequest{
+		Method:  method,
+		URL:     rawURL,
+		Header:  header,
+		BodyRef: bodyRef,
+	}, nil
+}

--- a/internal/domain/egress/request_test.go
+++ b/internal/domain/egress/request_test.go
@@ -1,0 +1,68 @@
+package egress_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+func TestNewEgressRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		method  string
+		url     string
+		header  http.Header
+		bodyRef interface{}
+		wantErr bool
+	}{
+		{
+			name:    "valid request",
+			method:  "GET",
+			url:     "https://api.stripe.com/v1/charges",
+			header:  http.Header{"Authorization": []string{"Bearer tok"}},
+			bodyRef: nil,
+			wantErr: false,
+		},
+		{
+			name:    "empty method",
+			method:  "",
+			url:     "https://api.stripe.com/v1/charges",
+			wantErr: true,
+		},
+		{
+			name:    "empty URL",
+			method:  "GET",
+			url:     "",
+			wantErr: true,
+		},
+		{
+			name:    "nil header is replaced with empty header",
+			method:  "POST",
+			url:     "https://api.example.com/",
+			header:  nil,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := egress.NewEgressRequest(tt.method, tt.url, tt.header, tt.bodyRef)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewEgressRequest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if req.Method != tt.method {
+					t.Errorf("Method = %q, want %q", req.Method, tt.method)
+				}
+				if req.URL != tt.url {
+					t.Errorf("URL = %q, want %q", req.URL, tt.url)
+				}
+				if req.Header == nil {
+					t.Error("Header must not be nil after construction")
+				}
+			}
+		})
+	}
+}

--- a/internal/domain/egress/response.go
+++ b/internal/domain/egress/response.go
@@ -1,0 +1,45 @@
+package egress
+
+import (
+	"errors"
+	"net/http"
+	"time"
+)
+
+// EgressResponse is a value object that carries the details of an outbound
+// HTTP response received from an upstream service and forwarded back to the
+// wrapped application. The body is referenced by an opaque handle rather than
+// held in memory to avoid large allocations.
+type EgressResponse struct {
+	// StatusCode is the HTTP status code returned by the upstream service.
+	StatusCode int
+
+	// Header contains the HTTP response headers returned by the upstream service.
+	// The egress proxy may strip or add headers before forwarding to the caller.
+	Header http.Header
+
+	// BodyRef is an opaque reference to the response body stream.
+	// A nil value indicates an empty body.
+	BodyRef interface{}
+
+	// Duration is the wall-clock time elapsed from sending the request to
+	// receiving the response headers from the upstream service.
+	Duration time.Duration
+}
+
+// NewEgressResponse constructs an EgressResponse.
+// Returns an error when statusCode is not a valid HTTP status (100–599).
+func NewEgressResponse(statusCode int, header http.Header, bodyRef interface{}, duration time.Duration) (EgressResponse, error) {
+	if statusCode < 100 || statusCode > 599 {
+		return EgressResponse{}, errors.New("egress response status code must be in range 100-599")
+	}
+	if header == nil {
+		header = make(http.Header)
+	}
+	return EgressResponse{
+		StatusCode: statusCode,
+		Header:     header,
+		BodyRef:    bodyRef,
+		Duration:   duration,
+	}, nil
+}

--- a/internal/domain/egress/response_test.go
+++ b/internal/domain/egress/response_test.go
@@ -1,0 +1,80 @@
+package egress_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+func TestNewEgressResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		header     http.Header
+		bodyRef    interface{}
+		duration   time.Duration
+		wantErr    bool
+	}{
+		{
+			name:       "valid 200 response",
+			statusCode: 200,
+			header:     http.Header{"Content-Type": []string{"application/json"}},
+			duration:   42 * time.Millisecond,
+			wantErr:    false,
+		},
+		{
+			name:       "valid 100 (lower boundary)",
+			statusCode: 100,
+			wantErr:    false,
+		},
+		{
+			name:       "valid 599 (upper boundary)",
+			statusCode: 599,
+			wantErr:    false,
+		},
+		{
+			name:       "invalid status 99",
+			statusCode: 99,
+			wantErr:    true,
+		},
+		{
+			name:       "invalid status 600",
+			statusCode: 600,
+			wantErr:    true,
+		},
+		{
+			name:       "invalid status 0",
+			statusCode: 0,
+			wantErr:    true,
+		},
+		{
+			name:       "nil header is replaced with empty header",
+			statusCode: 204,
+			header:     nil,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := egress.NewEgressResponse(tt.statusCode, tt.header, tt.bodyRef, tt.duration)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewEgressResponse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if resp.StatusCode != tt.statusCode {
+					t.Errorf("StatusCode = %d, want %d", resp.StatusCode, tt.statusCode)
+				}
+				if resp.Header == nil {
+					t.Error("Header must not be nil after construction")
+				}
+				if resp.Duration != tt.duration {
+					t.Errorf("Duration = %v, want %v", resp.Duration, tt.duration)
+				}
+			}
+		})
+	}
+}

--- a/internal/domain/egress/route.go
+++ b/internal/domain/egress/route.go
@@ -1,0 +1,229 @@
+package egress
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+)
+
+// CircuitBreakerConfig holds the parameters that drive per-route circuit breaking.
+type CircuitBreakerConfig struct {
+	// Threshold is the number of consecutive failures required to trip the circuit.
+	// Must be > 0 when used.
+	Threshold int
+
+	// ResetAfter is how long the circuit stays open before allowing a probe request.
+	// Must be > 0 when used.
+	ResetAfter time.Duration
+}
+
+// RetryBackoff selects the backoff strategy for retry attempts.
+type RetryBackoff string
+
+const (
+	// RetryBackoffExponential doubles the wait time on each retry.
+	RetryBackoffExponential RetryBackoff = "exponential"
+
+	// RetryBackoffFixed uses a constant wait time between retries.
+	RetryBackoffFixed RetryBackoff = "fixed"
+)
+
+// RetryConfig holds retry-with-backoff parameters for a route.
+type RetryConfig struct {
+	// Max is the maximum number of retry attempts (not counting the initial request).
+	// Must be >= 1 when used.
+	Max int
+
+	// Methods is the set of HTTP methods eligible for retry (e.g. ["GET", "PUT"]).
+	// When empty, all methods are retried.
+	Methods []string
+
+	// Backoff selects the backoff strategy. Defaults to exponential when empty.
+	Backoff RetryBackoff
+}
+
+// SecretConfig holds secret injection parameters for a route.
+type SecretConfig struct {
+	// Name is the OpenBao secret name to fetch and inject.
+	Name string
+
+	// Header is the HTTP request header into which the secret value is injected.
+	// Example: "Authorization"
+	Header string
+
+	// Format is the value template. The literal "{value}" is replaced with the
+	// resolved secret value.
+	// Example: "Bearer {value}"
+	Format string
+}
+
+// Route is an immutable value object that describes a single egress allowlist
+// entry. A route matches outbound requests by URL glob pattern and applies the
+// configured security, resilience, and observability settings.
+//
+// Routes are equal when their names are equal — name is the natural key.
+type Route struct {
+	name           string
+	pattern        string
+	methods        []string
+	timeout        time.Duration
+	secret         SecretConfig
+	rateLimit      string
+	circuitBreaker CircuitBreakerConfig
+	retry          RetryConfig
+	bodySizeLimit  int64
+}
+
+// routeOptions carries optional fields supplied via functional options.
+type routeOptions struct {
+	methods        []string
+	timeout        time.Duration
+	secret         SecretConfig
+	rateLimit      string
+	circuitBreaker CircuitBreakerConfig
+	retry          RetryConfig
+	bodySizeLimit  int64
+}
+
+// RouteOption is a functional option for NewRoute.
+type RouteOption func(*routeOptions)
+
+// WithMethods restricts the route to the given HTTP methods (e.g. "GET", "POST").
+// An empty slice means all methods are matched.
+func WithMethods(methods ...string) RouteOption {
+	return func(o *routeOptions) { o.methods = methods }
+}
+
+// WithTimeout sets the per-route request timeout. A zero value means no timeout.
+func WithTimeout(d time.Duration) RouteOption {
+	return func(o *routeOptions) { o.timeout = d }
+}
+
+// WithSecret configures secret injection for requests matched by this route.
+func WithSecret(cfg SecretConfig) RouteOption {
+	return func(o *routeOptions) { o.secret = cfg }
+}
+
+// WithRateLimit sets the rate limit expression for this route (e.g. "100/s").
+func WithRateLimit(expr string) RouteOption {
+	return func(o *routeOptions) { o.rateLimit = expr }
+}
+
+// WithCircuitBreaker configures the circuit breaker for this route.
+func WithCircuitBreaker(cfg CircuitBreakerConfig) RouteOption {
+	return func(o *routeOptions) { o.circuitBreaker = cfg }
+}
+
+// WithRetry configures retry-with-backoff for this route.
+func WithRetry(cfg RetryConfig) RouteOption {
+	return func(o *routeOptions) { o.retry = cfg }
+}
+
+// WithBodySizeLimit sets the maximum allowed response body size in bytes.
+// A value of 0 means no limit.
+func WithBodySizeLimit(bytes int64) RouteOption {
+	return func(o *routeOptions) { o.bodySizeLimit = bytes }
+}
+
+// NewRoute constructs a Route value object.
+// Returns an error when name is empty, pattern is empty, or the pattern is
+// not a valid URL glob (as accepted by path.Match).
+func NewRoute(name, pattern string, opts ...RouteOption) (Route, error) {
+	if name == "" {
+		return Route{}, errors.New("route name cannot be empty")
+	}
+	if pattern == "" {
+		return Route{}, errors.New("route pattern cannot be empty")
+	}
+	if err := validatePattern(pattern); err != nil {
+		return Route{}, fmt.Errorf("route pattern %q: %w", pattern, err)
+	}
+
+	o := &routeOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return Route{
+		name:           name,
+		pattern:        pattern,
+		methods:        o.methods,
+		timeout:        o.timeout,
+		secret:         o.secret,
+		rateLimit:      o.rateLimit,
+		circuitBreaker: o.circuitBreaker,
+		retry:          o.retry,
+		bodySizeLimit:  o.bodySizeLimit,
+	}, nil
+}
+
+// Name returns the unique identifier for this route.
+func (r Route) Name() string { return r.name }
+
+// Pattern returns the URL glob pattern used to match outbound requests.
+func (r Route) Pattern() string { return r.pattern }
+
+// Methods returns the HTTP methods this route applies to.
+// An empty slice means all methods are matched.
+func (r Route) Methods() []string { return r.methods }
+
+// Timeout returns the per-route request timeout.
+// A zero value means no timeout override — the global default is used.
+func (r Route) Timeout() time.Duration { return r.timeout }
+
+// Secret returns the secret injection configuration for this route.
+func (r Route) Secret() SecretConfig { return r.secret }
+
+// RateLimit returns the rate limit expression for this route (e.g. "100/s").
+// An empty string means no per-route rate limit.
+func (r Route) RateLimit() string { return r.rateLimit }
+
+// CircuitBreaker returns the circuit breaker configuration for this route.
+func (r Route) CircuitBreaker() CircuitBreakerConfig { return r.circuitBreaker }
+
+// Retry returns the retry configuration for this route.
+func (r Route) Retry() RetryConfig { return r.retry }
+
+// BodySizeLimit returns the maximum allowed body size in bytes for this route.
+// A value of 0 means no limit.
+func (r Route) BodySizeLimit() int64 { return r.bodySizeLimit }
+
+// MatchesMethod reports whether the given HTTP method is allowed by this route.
+// When Methods is empty, all methods are considered a match.
+func (r Route) MatchesMethod(method string) bool {
+	if len(r.methods) == 0 {
+		return true
+	}
+	upper := strings.ToUpper(method)
+	for _, m := range r.methods {
+		if strings.ToUpper(m) == upper {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchesURL reports whether rawURL matches this route's glob pattern.
+// It returns false when rawURL is malformed.
+func (r Route) MatchesURL(rawURL string) bool {
+	matched, err := path.Match(r.pattern, rawURL)
+	if err != nil {
+		return false
+	}
+	return matched
+}
+
+// validatePattern returns an error when the pattern is not a valid path.Match
+// glob expression, or is missing the URL scheme prefix.
+func validatePattern(pattern string) error {
+	// path.Match returns ErrBadPattern on malformed glob syntax.
+	if _, err := path.Match(pattern, ""); err != nil {
+		return fmt.Errorf("invalid glob syntax: %w", err)
+	}
+	if !strings.HasPrefix(pattern, "http://") && !strings.HasPrefix(pattern, "https://") {
+		return errors.New("pattern must start with http:// or https://")
+	}
+	return nil
+}

--- a/internal/domain/egress/route_match.go
+++ b/internal/domain/egress/route_match.go
@@ -1,0 +1,35 @@
+package egress
+
+// RouteMatch is a value object that pairs an EgressRequest with the Route
+// that was resolved for it. It is produced by the RouteResolver port and
+// consumed by the EgressProxy port to apply per-route settings.
+type RouteMatch struct {
+	// Request is the outbound request being evaluated.
+	Request EgressRequest
+
+	// Route is the matched route configuration.
+	// Callers should check Matched before accessing Route.
+	Route Route
+
+	// Matched is true when a route was found for the request.
+	// When false, the egress proxy applies the default policy.
+	Matched bool
+}
+
+// NewRouteMatch constructs a RouteMatch indicating that a route was found.
+func NewRouteMatch(req EgressRequest, route Route) RouteMatch {
+	return RouteMatch{
+		Request: req,
+		Route:   route,
+		Matched: true,
+	}
+}
+
+// NewUnmatchedRouteMatch constructs a RouteMatch indicating that no route
+// matched the request. The egress proxy applies the default policy.
+func NewUnmatchedRouteMatch(req EgressRequest) RouteMatch {
+	return RouteMatch{
+		Request: req,
+		Matched: false,
+	}
+}

--- a/internal/domain/egress/route_match_test.go
+++ b/internal/domain/egress/route_match_test.go
@@ -1,0 +1,44 @@
+package egress_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+func TestNewRouteMatch(t *testing.T) {
+	req, err := egress.NewEgressRequest("GET", "https://api.stripe.com/v1/charges", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest() error: %v", err)
+	}
+	route, err := egress.NewRoute("stripe", "https://api.stripe.com/v1/*")
+	if err != nil {
+		t.Fatalf("NewRoute() error: %v", err)
+	}
+
+	m := egress.NewRouteMatch(req, route)
+
+	if !m.Matched {
+		t.Error("Matched = false, want true")
+	}
+	if m.Route.Name() != route.Name() {
+		t.Errorf("Route.Name() = %q, want %q", m.Route.Name(), route.Name())
+	}
+}
+
+func TestNewUnmatchedRouteMatch(t *testing.T) {
+	req, err := egress.NewEgressRequest("DELETE", "https://api.unknown.com/", http.Header{}, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest() error: %v", err)
+	}
+
+	m := egress.NewUnmatchedRouteMatch(req)
+
+	if m.Matched {
+		t.Error("Matched = true, want false")
+	}
+	if m.Request.URL != req.URL {
+		t.Errorf("Request.URL = %q, want %q", m.Request.URL, req.URL)
+	}
+}

--- a/internal/domain/egress/route_test.go
+++ b/internal/domain/egress/route_test.go
@@ -1,0 +1,213 @@
+package egress_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+func TestNewRoute_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		rName   string
+		pattern string
+		wantErr bool
+	}{
+		{
+			name:    "valid route",
+			rName:   "stripe",
+			pattern: "https://api.stripe.com/**",
+			wantErr: false,
+		},
+		{
+			name:    "empty name",
+			rName:   "",
+			pattern: "https://api.stripe.com/**",
+			wantErr: true,
+		},
+		{
+			name:    "empty pattern",
+			rName:   "stripe",
+			pattern: "",
+			wantErr: true,
+		},
+		{
+			name:    "pattern without scheme",
+			rName:   "stripe",
+			pattern: "api.stripe.com/**",
+			wantErr: true,
+		},
+		{
+			name:    "http scheme is valid",
+			rName:   "local",
+			pattern: "http://localhost/**",
+			wantErr: false,
+		},
+		{
+			name:    "invalid glob syntax",
+			rName:   "bad",
+			pattern: "https://api.stripe.com/[invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := egress.NewRoute(tt.rName, tt.pattern)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewRoute(%q, %q) error = %v, wantErr %v", tt.rName, tt.pattern, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewRoute_Accessors(t *testing.T) {
+	timeout := 10 * time.Second
+	secret := egress.SecretConfig{
+		Name:   "stripe_key",
+		Header: "Authorization",
+		Format: "Bearer {value}",
+	}
+	cb := egress.CircuitBreakerConfig{Threshold: 5, ResetAfter: 30 * time.Second}
+	retry := egress.RetryConfig{Max: 3, Methods: []string{"GET"}, Backoff: egress.RetryBackoffExponential}
+
+	r, err := egress.NewRoute(
+		"stripe",
+		"https://api.stripe.com/**",
+		egress.WithMethods("GET", "POST"),
+		egress.WithTimeout(timeout),
+		egress.WithSecret(secret),
+		egress.WithRateLimit("100/s"),
+		egress.WithCircuitBreaker(cb),
+		egress.WithRetry(retry),
+		egress.WithBodySizeLimit(52428800),
+	)
+	if err != nil {
+		t.Fatalf("NewRoute() unexpected error: %v", err)
+	}
+
+	if got := r.Name(); got != "stripe" {
+		t.Errorf("Name() = %q, want %q", got, "stripe")
+	}
+	if got := r.Pattern(); got != "https://api.stripe.com/**" {
+		t.Errorf("Pattern() = %q, want %q", got, "https://api.stripe.com/**")
+	}
+	if got := r.Timeout(); got != timeout {
+		t.Errorf("Timeout() = %v, want %v", got, timeout)
+	}
+	if got := r.RateLimit(); got != "100/s" {
+		t.Errorf("RateLimit() = %q, want %q", got, "100/s")
+	}
+	if got := r.BodySizeLimit(); got != 52428800 {
+		t.Errorf("BodySizeLimit() = %d, want %d", got, 52428800)
+	}
+	if got := r.Secret(); got != secret {
+		t.Errorf("Secret() = %+v, want %+v", got, secret)
+	}
+	if got := r.CircuitBreaker(); got != cb {
+		t.Errorf("CircuitBreaker() = %+v, want %+v", got, cb)
+	}
+}
+
+func TestRoute_MatchesMethod(t *testing.T) {
+	tests := []struct {
+		name         string
+		routeMethods []string
+		method       string
+		want         bool
+	}{
+		{
+			name:         "empty methods matches any",
+			routeMethods: nil,
+			method:       "DELETE",
+			want:         true,
+		},
+		{
+			name:         "method in list matches",
+			routeMethods: []string{"GET", "POST"},
+			method:       "GET",
+			want:         true,
+		},
+		{
+			name:         "method not in list no match",
+			routeMethods: []string{"GET", "POST"},
+			method:       "DELETE",
+			want:         false,
+		},
+		{
+			name:         "case insensitive match",
+			routeMethods: []string{"get"},
+			method:       "GET",
+			want:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []egress.RouteOption{}
+			if len(tt.routeMethods) > 0 {
+				opts = append(opts, egress.WithMethods(tt.routeMethods...))
+			}
+			r, err := egress.NewRoute("r", "https://example.com/**", opts...)
+			if err != nil {
+				t.Fatalf("NewRoute() error: %v", err)
+			}
+			if got := r.MatchesMethod(tt.method); got != tt.want {
+				t.Errorf("MatchesMethod(%q) = %v, want %v", tt.method, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRoute_MatchesURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		url     string
+		want    bool
+	}{
+		{
+			name:    "exact match",
+			pattern: "https://api.stripe.com/v1/charges",
+			url:     "https://api.stripe.com/v1/charges",
+			want:    true,
+		},
+		{
+			name:    "glob wildcard matches path segment",
+			pattern: "https://api.stripe.com/v1/*",
+			url:     "https://api.stripe.com/v1/charges",
+			want:    true,
+		},
+		{
+			name:    "double star glob matches nested path",
+			pattern: "https://api.stripe.com/**",
+			url:     "https://api.stripe.com/v1/customers/cus_123",
+			want:    false, // path.Match ** is not recursive in stdlib
+		},
+		{
+			name:    "no match on different domain",
+			pattern: "https://api.stripe.com/v1/*",
+			url:     "https://api.github.com/v1/repos",
+			want:    false,
+		},
+		{
+			name:    "question mark matches single char",
+			pattern: "https://api.stripe.com/v?/charges",
+			url:     "https://api.stripe.com/v1/charges",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := egress.NewRoute("r", tt.pattern)
+			if err != nil {
+				t.Fatalf("NewRoute() error: %v", err)
+			}
+			if got := r.MatchesURL(tt.url); got != tt.want {
+				t.Errorf("MatchesURL(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ports/egress.go
+++ b/internal/ports/egress.go
@@ -1,0 +1,31 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+// EgressProxy is the outbound port for the egress proxy plugin.
+// Implementations intercept outbound HTTP requests, apply per-route security
+// and resilience settings, and forward the request to the external service.
+type EgressProxy interface {
+	// HandleRequest processes an outbound HTTP request.
+	// It looks up the matching route, applies security settings (secret injection,
+	// rate limiting, circuit breaking), forwards the request, and returns the
+	// response. Returns an error when the request is denied by policy, the circuit
+	// is open, or the upstream returns a non-recoverable error.
+	HandleRequest(ctx context.Context, req egress.EgressRequest) (egress.EgressResponse, error)
+}
+
+// RouteResolver is the outbound port for resolving an egress request to its
+// configured route. Implementations consult the loaded configuration to find
+// the first route whose pattern matches the request URL and whose methods
+// include the request method.
+type RouteResolver interface {
+	// Resolve attempts to match the given request against the configured routes.
+	// It returns an EgressRequest paired with the matched Route (Matched == true)
+	// or an unmatched result (Matched == false) when no route is found.
+	// Returns an error only on internal failures (e.g. malformed configuration).
+	Resolve(ctx context.Context, req egress.EgressRequest) (egress.RouteMatch, error)
+}


### PR DESCRIPTION
Closes #358

## Summary

- **`internal/domain/egress/`** — new package with zero external dependencies:
  - `Policy` enum (`allow`/`deny`) with `Validate()` method
  - `Route` value object with functional options (`WithMethods`, `WithTimeout`, `WithSecret`, `WithRateLimit`, `WithCircuitBreaker`, `WithRetry`, `WithBodySizeLimit`), `MatchesMethod()`, and `MatchesURL()` helpers
  - `SecretConfig`, `CircuitBreakerConfig`, `RetryConfig` value objects embedded in `Route`
  - `EgressRequest` — method, URL, headers, opaque body reference
  - `EgressResponse` — status code (validated 100–599), headers, opaque body reference, duration
  - `RouteMatch` — pairs a request with its matched route; `NewUnmatchedRouteMatch` for policy fallback

- **`internal/ports/egress.go`** — two port interfaces:
  - `EgressProxy.HandleRequest(ctx, EgressRequest) (EgressResponse, error)`
  - `RouteResolver.Resolve(ctx, EgressRequest) (RouteMatch, error)`

- **`internal/config/egress.go`** — `EgressConfig` with `mapstructure` tags covering all fields from the epic config example: `enabled`, `listen`, `default_policy`, `default_timeout`, `dns.block_private`, `routes[]` (name, pattern, methods, timeout, secret, secret_header, secret_format, rate_limit, circuit_breaker, retries, body_size_limit)

- **`internal/config/config.go`** — `Egress EgressConfig` field on `Config`; Load defaults (`enabled=false`, `listen=127.0.0.1:8081`, `default_policy=deny`, `default_timeout=30s`, `dns.block_private=true`); `validateEgressConfig` covering policy enum, timeout parsing, route name uniqueness, pattern scheme prefix, per-route timeout, circuit breaker fields, retry backoff enum, body size limit parsing, and secret injection field consistency

## Test plan

- `internal/domain/egress`: 95.6% statement coverage — policy, route construction/accessors, method matching, URL matching, request/response construction, route match variants
- `internal/config`: table-driven tests for all egress validation branches — disabled skip, default_policy, default_timeout, route names (empty/duplicate), patterns, timeouts, circuit breaker, retries, body_size_limit, secret injection
- `make check` passes (format, vet, build, race-test across all packages including demo-app)
