### PR TITLE
feat(#356): implement core egress proxy listener and request forwarding

### DIFF
--- a/internal/adapters/egress/errors.go
+++ b/internal/adapters/egress/errors.go
@@ -1,0 +1,7 @@
+package egress
+
+import "errors"
+
+// ErrDeniedByPolicy is returned by Proxy.HandleRequest when the request does
+// not match any configured route and the default policy is deny.
+var ErrDeniedByPolicy = errors.New("egress: request denied by policy")

--- a/internal/adapters/egress/proxy.go
+++ b/internal/adapters/egress/proxy.go
@@ -1,0 +1,362 @@
+// Package egress implements the HTTP listener and request forwarding adapter
+// for the egress proxy plugin. It listens on a dedicated localhost port and
+// forwards outbound requests from the wrapped application to external services,
+// enforcing the configured allowlist and default policy.
+package egress
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+const (
+	// namedRoutePrefix is the URL path prefix for named-route requests.
+	namedRoutePrefix = "/_egress/"
+
+	// headerEgressURL is the request header used in transparent routing mode.
+	// The caller sets this header to the full target URL when POSTing to the proxy.
+	headerEgressURL = "X-Egress-URL"
+
+	// defaultListen is the default address the egress proxy binds to.
+	defaultListen = "127.0.0.1:8081"
+
+	// defaultTimeout is used when the configuration does not specify a timeout.
+	defaultTimeout = 30 * time.Second
+
+	// hopByHopHeaders lists headers that must not be forwarded to the upstream.
+	// These are connection-specific and must be stripped per RFC 7230 §6.1.
+)
+
+// hopByHopHeaders is the set of headers that must not be forwarded upstream.
+var hopByHopHeaders = map[string]struct{}{
+	"Connection":          {},
+	"Keep-Alive":          {},
+	"Proxy-Authenticate":  {},
+	"Proxy-Authorization": {},
+	"Te":                  {},
+	"Trailers":            {},
+	"Transfer-Encoding":   {},
+	"Upgrade":             {},
+}
+
+// ProxyConfig holds the resolved configuration for the egress proxy listener.
+type ProxyConfig struct {
+	// Listen is the TCP address to bind the proxy listener to.
+	// Defaults to "127.0.0.1:8081".
+	Listen string
+
+	// DefaultPolicy is the egress domain policy applied when no route matches.
+	DefaultPolicy domainegress.Policy
+
+	// DefaultTimeout is the global request timeout applied when a route does not
+	// specify its own timeout.
+	DefaultTimeout time.Duration
+
+	// Routes is the ordered list of configured egress routes.
+	// Routes are evaluated in declaration order; the first matching route wins.
+	Routes []domainegress.Route
+}
+
+// Proxy is an HTTP server that listens on a dedicated localhost port and
+// forwards outbound requests from the wrapped application to external services.
+// It supports two routing styles:
+//
+//   - Transparent: the caller sets the X-Egress-URL header containing the full
+//     target URL and sends the request to any path on the proxy address.
+//
+//   - Named: the caller addresses /_egress/{route-name}/rest/of/path. The proxy
+//     resolves the named route's pattern prefix to build the target URL.
+//
+// Proxy implements ports.EgressProxy.
+type Proxy struct {
+	cfg      ProxyConfig
+	resolver ports.RouteResolver
+	client   *http.Client
+	logger   *slog.Logger
+
+	listener net.Listener
+	server   *http.Server
+}
+
+// NewProxy creates a new Proxy from the given configuration, resolver, HTTP
+// client, and logger. Pass nil for client to use a default client with
+// sensible timeouts. Pass nil for logger to use slog.Default().
+func NewProxy(cfg ProxyConfig, resolver ports.RouteResolver, client *http.Client, logger *slog.Logger) *Proxy {
+	if cfg.Listen == "" {
+		cfg.Listen = defaultListen
+	}
+	if cfg.DefaultTimeout == 0 {
+		cfg.DefaultTimeout = defaultTimeout
+	}
+	if cfg.DefaultPolicy == "" {
+		cfg.DefaultPolicy = domainegress.PolicyDeny
+	}
+	if client == nil {
+		client = &http.Client{
+			Timeout: cfg.DefaultTimeout,
+			// Do not follow redirects automatically — let the caller decide.
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Proxy{
+		cfg:      cfg,
+		resolver: resolver,
+		client:   client,
+		logger:   logger,
+	}
+}
+
+// Start binds the TCP listener and begins serving egress requests.
+// Start returns immediately; the server continues running until Stop is called.
+func (p *Proxy) Start() error {
+	ln, err := net.Listen("tcp", p.cfg.Listen)
+	if err != nil {
+		return fmt.Errorf("binding egress proxy listener on %s: %w", p.cfg.Listen, err)
+	}
+	p.listener = ln
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", p.handleRequest)
+
+	p.server = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() {
+		if err := p.server.Serve(ln); err != nil && err != http.ErrServerClosed {
+			p.logger.Error("egress proxy stopped unexpectedly", "err", err)
+		}
+	}()
+
+	p.logger.Info("egress proxy listening", "addr", p.cfg.Listen)
+	return nil
+}
+
+// Addr returns the address the proxy is listening on.
+// Must only be called after a successful Start.
+func (p *Proxy) Addr() string {
+	if p.listener == nil {
+		return ""
+	}
+	return p.listener.Addr().String()
+}
+
+// Stop gracefully shuts down the egress proxy using the provided context.
+func (p *Proxy) Stop(ctx context.Context) error {
+	if p.server == nil {
+		return nil
+	}
+	if err := p.server.Shutdown(ctx); err != nil {
+		return fmt.Errorf("shutting down egress proxy: %w", err)
+	}
+	return nil
+}
+
+// HandleRequest implements ports.EgressProxy. It resolves the route for the
+// request, enforces the default policy, and forwards the request upstream.
+func (p *Proxy) HandleRequest(ctx context.Context, req domainegress.EgressRequest) (domainegress.EgressResponse, error) {
+	match, err := p.resolver.Resolve(ctx, req)
+	if err != nil {
+		return domainegress.EgressResponse{}, fmt.Errorf("resolving route: %w", err)
+	}
+
+	if !match.Matched {
+		if p.cfg.DefaultPolicy == domainegress.PolicyDeny {
+			return domainegress.EgressResponse{}, ErrDeniedByPolicy
+		}
+	}
+
+	return p.forward(ctx, req, match)
+}
+
+// handleRequest is the net/http handler registered on the proxy mux. It
+// extracts the egress request from the incoming HTTP request, delegates to
+// HandleRequest, and writes the upstream response back to the caller.
+func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
+	targetURL, err := p.resolveTargetURL(r)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("bad request: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	// Copy the incoming headers, stripping hop-by-hop entries.
+	outHeaders := cloneAndStripHopByHop(r.Header)
+	// Remove the proxy-specific header from the forwarded request.
+	outHeaders.Del(headerEgressURL)
+
+	egressReq, err := domainegress.NewEgressRequest(r.Method, targetURL, outHeaders, r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("invalid egress request: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	egressResp, err := p.HandleRequest(r.Context(), egressReq)
+	if err != nil {
+		if err == ErrDeniedByPolicy {
+			http.Error(w, "403 Forbidden: request denied by egress policy", http.StatusForbidden)
+			return
+		}
+		p.logger.ErrorContext(r.Context(), "egress forwarding error",
+			slog.String("target", targetURL),
+			slog.String("method", r.Method),
+			slog.String("err", err.Error()),
+		)
+		http.Error(w, "egress proxy error", http.StatusBadGateway)
+		return
+	}
+
+	// Write the upstream response back to the caller.
+	respBody, _ := egressResp.BodyRef.(io.ReadCloser)
+
+	for key, vals := range cloneAndStripHopByHop(egressResp.Header) {
+		for _, v := range vals {
+			w.Header().Add(key, v)
+		}
+	}
+	w.WriteHeader(egressResp.StatusCode)
+
+	if respBody != nil {
+		defer respBody.Close() //nolint:errcheck
+		if _, err := io.Copy(w, respBody); err != nil {
+			p.logger.WarnContext(r.Context(), "writing egress response body", "err", err)
+		}
+	}
+}
+
+// resolveTargetURL determines the destination URL from the HTTP request using
+// the two supported routing styles:
+//
+//  1. Named routing — path starts with /_egress/{route-name}/…
+//  2. Transparent routing — X-Egress-URL header contains the full target URL.
+func (p *Proxy) resolveTargetURL(r *http.Request) (string, error) {
+	// Named routing: /_egress/{route-name}/rest/of/path
+	if strings.HasPrefix(r.URL.Path, namedRoutePrefix) {
+		rest := strings.TrimPrefix(r.URL.Path, namedRoutePrefix)
+		// rest is "{route-name}/rest/of/path"
+		slashIdx := strings.Index(rest, "/")
+		var routeName, suffix string
+		if slashIdx == -1 {
+			routeName = rest
+			suffix = ""
+		} else {
+			routeName = rest[:slashIdx]
+			suffix = rest[slashIdx:] // includes leading slash
+		}
+		if routeName == "" {
+			return "", fmt.Errorf("named route: route name is required in path %q", r.URL.Path)
+		}
+		target, err := p.resolveNamedRoute(routeName, suffix, r.URL.RawQuery)
+		if err != nil {
+			return "", err
+		}
+		return target, nil
+	}
+
+	// Transparent routing: X-Egress-URL header.
+	if target := r.Header.Get(headerEgressURL); target != "" {
+		return target, nil
+	}
+
+	return "", fmt.Errorf("no target URL: set %s header or use /_egress/{route-name}/path", headerEgressURL)
+}
+
+// resolveNamedRoute looks up the named route and constructs the target URL by
+// replacing the route's URL scheme+host prefix with the suffix from the request
+// path. If the route pattern contains glob characters, the base URL is taken as
+// the longest non-glob prefix of the pattern.
+func (p *Proxy) resolveNamedRoute(routeName, suffix, rawQuery string) (string, error) {
+	for _, route := range p.cfg.Routes {
+		if route.Name() != routeName {
+			continue
+		}
+		base := strings.TrimRight(patternBase(route.Pattern()), "/")
+		target := base + suffix
+		if rawQuery != "" {
+			target += "?" + rawQuery
+		}
+		return target, nil
+	}
+	return "", fmt.Errorf("unknown named route %q", routeName)
+}
+
+// patternBase returns the longest concrete prefix of a glob pattern — i.e.
+// everything up to (but not including) the first glob metacharacter (*, ?, [).
+// If the pattern contains no metacharacters, the full pattern is returned.
+func patternBase(pattern string) string {
+	for i, ch := range pattern {
+		if ch == '*' || ch == '?' || ch == '[' {
+			return pattern[:i]
+		}
+	}
+	return pattern
+}
+
+// forward builds and executes an outbound HTTP request for the given egress
+// request and route match, then wraps the upstream response in an EgressResponse.
+func (p *Proxy) forward(ctx context.Context, req domainegress.EgressRequest, match domainegress.RouteMatch) (domainegress.EgressResponse, error) {
+	timeout := p.cfg.DefaultTimeout
+	if match.Matched && match.Route.Timeout() > 0 {
+		timeout = match.Route.Timeout()
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	body, _ := req.BodyRef.(io.Reader)
+	httpReq, err := http.NewRequestWithContext(reqCtx, req.Method, req.URL, body)
+	if err != nil {
+		return domainegress.EgressResponse{}, fmt.Errorf("building upstream request: %w", err)
+	}
+	for key, vals := range req.Header {
+		for _, v := range vals {
+			httpReq.Header.Add(key, v)
+		}
+	}
+
+	start := time.Now()
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return domainegress.EgressResponse{}, fmt.Errorf("forwarding request to %s: %w", req.URL, err)
+	}
+	duration := time.Since(start)
+
+	egressResp, err := domainegress.NewEgressResponse(resp.StatusCode, resp.Header, resp.Body, duration)
+	if err != nil {
+		resp.Body.Close() //nolint:errcheck
+		return domainegress.EgressResponse{}, fmt.Errorf("building egress response: %w", err)
+	}
+
+	return egressResp, nil
+}
+
+// cloneAndStripHopByHop returns a copy of h with all hop-by-hop headers removed.
+func cloneAndStripHopByHop(h http.Header) http.Header {
+	out := h.Clone()
+	for name := range hopByHopHeaders {
+		out.Del(name)
+	}
+	// Also strip headers listed in the Connection header value.
+	for _, conn := range h.Values("Connection") {
+		for _, f := range strings.Split(conn, ",") {
+			out.Del(strings.TrimSpace(f))
+		}
+	}
+	return out
+}
+
+// Interface guard — Proxy must implement ports.EgressProxy.
+var _ ports.EgressProxy = (*Proxy)(nil)

--- a/internal/adapters/egress/proxy_test.go
+++ b/internal/adapters/egress/proxy_test.go
@@ -1,0 +1,411 @@
+package egress_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	egressadapter "github.com/vibewarden/vibewarden/internal/adapters/egress"
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+// newTestRoute is a helper that creates a Route or fatals the test.
+func newTestRoute(t *testing.T, name, pattern string, opts ...domainegress.RouteOption) domainegress.Route {
+	t.Helper()
+	r, err := domainegress.NewRoute(name, pattern, opts...)
+	if err != nil {
+		t.Fatalf("NewRoute(%q, %q): %v", name, pattern, err)
+	}
+	return r
+}
+
+// newTestProxy creates a Proxy wired to the given routes and HTTP client.
+// The proxy does not start listening — tests call HandleRequest directly
+// or drive the HTTP handler via httptest.
+func newTestProxy(t *testing.T, routes []domainegress.Route, client *http.Client, policy domainegress.Policy) *egressadapter.Proxy {
+	t.Helper()
+	resolver := egressadapter.NewRouteResolver(routes)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  policy,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         routes,
+	}
+	return egressadapter.NewProxy(cfg, resolver, client, nil)
+}
+
+// TestHandleRequest_AllowedRoute verifies that a matched request is forwarded
+// and the upstream response is returned unchanged.
+func TestHandleRequest_AllowedRoute(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Custom", "yes")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "upstream", upstream.URL+"/v1/*")
+
+	proxy := newTestProxy(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest returned unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if resp.Duration <= 0 {
+		t.Error("Duration should be > 0")
+	}
+}
+
+// TestHandleRequest_DeniedByPolicy verifies that an unmatched request is
+// blocked with ErrDeniedByPolicy when default_policy is deny.
+func TestHandleRequest_DeniedByPolicy(t *testing.T) {
+	proxy := newTestProxy(t, nil, nil, domainegress.PolicyDeny)
+
+	req, err := domainegress.NewEgressRequest("GET", "https://api.unknown.example.com/", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	_, err = proxy.HandleRequest(context.Background(), req)
+	if err == nil {
+		t.Fatal("HandleRequest should have returned an error")
+	}
+	if err != egressadapter.ErrDeniedByPolicy {
+		t.Errorf("error = %v, want ErrDeniedByPolicy", err)
+	}
+}
+
+// TestHandleRequest_AllowPolicy verifies that an unmatched request is forwarded
+// when default_policy is allow.
+func TestHandleRequest_AllowPolicy(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	proxy := newTestProxy(t, nil, upstream.Client(), domainegress.PolicyAllow)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/anything", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest returned unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+}
+
+// TestHTTPHandler_TransparentRouting verifies that a request with the
+// X-Egress-URL header is forwarded to the specified target.
+func TestHTTPHandler_TransparentRouting(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The proxy must not forward the X-Egress-URL header upstream.
+		if r.Header.Get("X-Egress-URL") != "" {
+			t.Error("X-Egress-URL header must be stripped before forwarding")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("transparent"))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "upstream", upstream.URL+"/v1/*")
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	// Send a transparent-style request: any path, X-Egress-URL header set.
+	proxyURL := "http://" + proxy.Addr() + "/"
+	httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/resource")
+
+	// Use a plain client that speaks to the proxy (not the upstream client).
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "transparent" {
+		t.Errorf("body = %q, want %q", string(body), "transparent")
+	}
+}
+
+// TestHTTPHandler_NamedRouting verifies that a /_egress/{route-name}/path
+// request is forwarded to the route's configured endpoint.
+func TestHTTPHandler_NamedRouting(t *testing.T) {
+	var capturedPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer upstream.Close()
+
+	// Route pattern: upstream URL with /v1/* — base is upstream URL + "/v1/"
+	route := newTestRoute(t, "myapi", upstream.URL+"/v1/*")
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/_egress/myapi/charges"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+	resp, err := proxyClient.Get(proxyURL)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+	if capturedPath != "/v1/charges" {
+		t.Errorf("upstream received path %q, want %q", capturedPath, "/v1/charges")
+	}
+}
+
+// TestHTTPHandler_BlockedRequest verifies that an unmatched request returns 403
+// when default_policy is deny.
+func TestHTTPHandler_BlockedRequest(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream must not be called for blocked requests")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	// No routes configured — all requests will be unmatched.
+	resolver := egressadapter.NewRouteResolver(nil)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/blocked")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+}
+
+// TestHTTPHandler_MethodAndBodyPreserved verifies that the HTTP method, request
+// body, and custom headers are preserved when forwarding to the upstream.
+func TestHTTPHandler_MethodAndBodyPreserved(t *testing.T) {
+	var (
+		capturedMethod string
+		capturedBody   string
+		capturedHeader string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		b, _ := io.ReadAll(r.Body)
+		capturedBody = string(b)
+		capturedHeader = r.Header.Get("X-Custom-Header")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "upstream", upstream.URL+"/v1/*")
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	bodyStr := `{"amount":100}`
+	httpReq, err := http.NewRequest(http.MethodPost, proxyURL, strings.NewReader(bodyStr))
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/charges")
+	httpReq.Header.Set("X-Custom-Header", "my-value")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	if capturedMethod != http.MethodPost {
+		t.Errorf("upstream method = %q, want POST", capturedMethod)
+	}
+	if capturedBody != bodyStr {
+		t.Errorf("upstream body = %q, want %q", capturedBody, bodyStr)
+	}
+	if capturedHeader != "my-value" {
+		t.Errorf("upstream X-Custom-Header = %q, want %q", capturedHeader, "my-value")
+	}
+}
+
+// TestHTTPHandler_MissingTargetURL verifies that a request without a target URL
+// returns 400 Bad Request.
+func TestHTTPHandler_MissingTargetURL(t *testing.T) {
+	resolver := egressadapter.NewRouteResolver(nil)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, nil, nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	resp, err := proxyClient.Get(proxyURL)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+// TestHTTPHandler_GracefulShutdown verifies that Stop terminates the server
+// without error when called after Start.
+func TestHTTPHandler_GracefulShutdown(t *testing.T) {
+	resolver := egressadapter.NewRouteResolver(nil)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, nil, nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := proxy.Stop(ctx); err != nil {
+		t.Errorf("Stop returned error: %v", err)
+	}
+}
+
+// TestHTTPHandler_ResponseHeadersPreserved verifies that response headers from
+// the upstream are forwarded to the caller.
+func TestHTTPHandler_ResponseHeadersPreserved(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Rate-Limit-Remaining", "42")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "upstream", upstream.URL+"/v1/*")
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/resource")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if got := resp.Header.Get("X-Rate-Limit-Remaining"); got != "42" {
+		t.Errorf("X-Rate-Limit-Remaining = %q, want %q", got, "42")
+	}
+}

--- a/internal/adapters/egress/resolver.go
+++ b/internal/adapters/egress/resolver.go
@@ -1,0 +1,37 @@
+package egress
+
+import (
+	"context"
+
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// RouteResolver implements ports.RouteResolver using an in-memory ordered list
+// of routes. Routes are evaluated in declaration order; the first route whose
+// URL pattern and method constraints both match wins.
+type RouteResolver struct {
+	routes []domainegress.Route
+}
+
+// NewRouteResolver constructs a RouteResolver from the given route list.
+// Routes are evaluated in the order provided.
+func NewRouteResolver(routes []domainegress.Route) *RouteResolver {
+	return &RouteResolver{routes: routes}
+}
+
+// Resolve implements ports.RouteResolver. It iterates the configured routes in
+// order and returns the first RouteMatch where both the URL pattern and HTTP
+// method constraints are satisfied. When no route matches, it returns an
+// unmatched RouteMatch with Matched == false.
+func (r *RouteResolver) Resolve(_ context.Context, req domainegress.EgressRequest) (domainegress.RouteMatch, error) {
+	for _, route := range r.routes {
+		if route.MatchesURL(req.URL) && route.MatchesMethod(req.Method) {
+			return domainegress.NewRouteMatch(req, route), nil
+		}
+	}
+	return domainegress.NewUnmatchedRouteMatch(req), nil
+}
+
+// Interface guard — RouteResolver must implement ports.RouteResolver.
+var _ ports.RouteResolver = (*RouteResolver)(nil)

--- a/internal/adapters/egress/resolver_test.go
+++ b/internal/adapters/egress/resolver_test.go
@@ -1,0 +1,94 @@
+package egress_test
+
+import (
+	"context"
+	"testing"
+
+	egressadapter "github.com/vibewarden/vibewarden/internal/adapters/egress"
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+func TestRouteResolver_Resolve(t *testing.T) {
+	stripe := newTestRoute(t, "stripe", "https://api.stripe.com/v1/*")
+	github := newTestRoute(t, "github", "https://api.github.com/repos/*",
+		domainegress.WithMethods("GET"),
+	)
+
+	tests := []struct {
+		name        string
+		routes      []domainegress.Route
+		method      string
+		url         string
+		wantMatched bool
+		wantRoute   string
+	}{
+		{
+			name:        "matches stripe route",
+			routes:      []domainegress.Route{stripe, github},
+			method:      "POST",
+			url:         "https://api.stripe.com/v1/charges",
+			wantMatched: true,
+			wantRoute:   "stripe",
+		},
+		{
+			name:        "matches github route on GET",
+			routes:      []domainegress.Route{stripe, github},
+			method:      "GET",
+			url:         "https://api.github.com/repos/myrepo",
+			wantMatched: true,
+			wantRoute:   "github",
+		},
+		{
+			name:        "github route does not match POST",
+			routes:      []domainegress.Route{stripe, github},
+			method:      "POST",
+			url:         "https://api.github.com/repos/myrepo",
+			wantMatched: false,
+		},
+		{
+			name:        "no routes returns unmatched",
+			routes:      nil,
+			method:      "GET",
+			url:         "https://api.stripe.com/v1/charges",
+			wantMatched: false,
+		},
+		{
+			name:        "unknown URL returns unmatched",
+			routes:      []domainegress.Route{stripe},
+			method:      "GET",
+			url:         "https://api.unknown.example.com/",
+			wantMatched: false,
+		},
+		{
+			name:        "first matching route wins",
+			routes:      []domainegress.Route{stripe, stripe},
+			method:      "GET",
+			url:         "https://api.stripe.com/v1/charges",
+			wantMatched: true,
+			wantRoute:   "stripe",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := egressadapter.NewRouteResolver(tt.routes)
+
+			req, err := domainegress.NewEgressRequest(tt.method, tt.url, nil, nil)
+			if err != nil {
+				t.Fatalf("NewEgressRequest: %v", err)
+			}
+
+			match, err := resolver.Resolve(context.Background(), req)
+			if err != nil {
+				t.Fatalf("Resolve returned unexpected error: %v", err)
+			}
+
+			if match.Matched != tt.wantMatched {
+				t.Errorf("Matched = %v, want %v", match.Matched, tt.wantMatched)
+			}
+			if tt.wantMatched && match.Route.Name() != tt.wantRoute {
+				t.Errorf("Route.Name() = %q, want %q", match.Route.Name(), tt.wantRoute)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #356

## Summary

- Adds `internal/adapters/egress/proxy.go` — `Proxy` struct implementing `ports.EgressProxy`. Listens on a configurable address (default `127.0.0.1:8081`), supports two routing styles, enforces the default policy, strips hop-by-hop headers, preserves method/headers/body, and provides graceful shutdown via `Stop`.
- Adds `internal/adapters/egress/resolver.go` — `RouteResolver` implementing `ports.RouteResolver`. Matches incoming egress requests against the ordered route list by URL glob pattern and HTTP method; returns the first match or an unmatched result.
- Adds `internal/adapters/egress/errors.go` — `ErrDeniedByPolicy` sentinel error returned when a request is blocked by the default deny policy.

### Routing styles implemented

**Transparent**: caller sets `X-Egress-URL` header to the full destination URL and sends to any path on the proxy. The header is stripped before forwarding upstream.

**Named**: caller addresses `/_egress/{route-name}/rest/of/path`. The proxy looks up the route by name, derives the base URL from the route pattern (stripping glob metacharacters), and constructs the target URL as `base + suffix`.

### Policy enforcement

When no route matches and `DefaultPolicy` is `deny`, the HTTP handler returns `403 Forbidden`. When policy is `allow`, the request is forwarded without a route constraint.

## Test plan

- `TestHandleRequest_AllowedRoute` — matched request forwarded, upstream status returned
- `TestHandleRequest_DeniedByPolicy` — unmatched request returns `ErrDeniedByPolicy`
- `TestHandleRequest_AllowPolicy` — unmatched request forwarded under allow policy
- `TestHTTPHandler_TransparentRouting` — X-Egress-URL header forwarded correctly, header stripped
- `TestHTTPHandler_NamedRouting` — `/_egress/myapi/charges` resolves to correct upstream path
- `TestHTTPHandler_BlockedRequest` — HTTP 403 for unmatched request under deny policy
- `TestHTTPHandler_MethodAndBodyPreserved` — POST method, body, and custom headers reach upstream
- `TestHTTPHandler_MissingTargetURL` — 400 when neither routing style provides a target
- `TestHTTPHandler_GracefulShutdown` — Stop returns nil after Start
- `TestHTTPHandler_ResponseHeadersPreserved` — upstream response headers forwarded to caller
- `TestRouteResolver_Resolve` — table-driven: URL/method matching, method restriction, first-match wins

All tests pass under `make check` (includes `go test -race ./...`).