### PR TITLE
feat(#361): implement egress secret injection via OpenBao

### DIFF
--- a/internal/adapters/egress/proxy.go
+++ b/internal/adapters/egress/proxy.go
@@ -71,6 +71,12 @@ type ProxyConfig struct {
 	// resolves target hostnames, and blocks requests that resolve to private
 	// or reserved IP addresses. When nil, no SSRF protection is applied.
 	SSRFGuard *SSRFGuard
+
+	// SecretInjector, when non-nil, is called for routes that have a SecretConfig
+	// to fetch and inject the secret value as a request header before forwarding.
+	// When nil, no secret injection is performed even if a route is configured
+	// with a SecretConfig.
+	SecretInjector ports.SecretInjector
 }
 
 // Proxy is an HTTP server that listens on a dedicated localhost port and
@@ -92,6 +98,11 @@ type Proxy struct {
 
 	listener net.Listener
 	server   *http.Server
+}
+
+// secretInjector returns the configured SecretInjector or nil.
+func (p *Proxy) secretInjector() ports.SecretInjector {
+	return p.cfg.SecretInjector
 }
 
 // NewProxy creates a new Proxy from the given configuration, resolver, HTTP
@@ -333,6 +344,8 @@ func patternBase(pattern string) string {
 // Header manipulation is applied in two phases:
 //  1. Before forwarding: per-route injection and stripping rules are applied to
 //     the outbound request headers (including always stripping X-Inject-Secret).
+//     Secret injection from OpenBao is performed here when the matched route
+//     carries a SecretConfig or the request carries an X-Inject-Secret header.
 //  2. After receiving: per-route and default sensitive response headers are
 //     stripped before the response is returned to the caller.
 func (p *Proxy) forward(ctx context.Context, req domainegress.EgressRequest, match domainegress.RouteMatch) (domainegress.EgressResponse, error) {
@@ -351,7 +364,24 @@ func (p *Proxy) forward(ctx context.Context, req domainegress.EgressRequest, mat
 	} else {
 		// Always strip X-Inject-Secret even on unmatched (allow-policy) requests.
 		outHeaders = req.Header.Clone()
-		outHeaders.Del("X-Inject-Secret")
+		outHeaders.Del(headerInjectSecret)
+	}
+
+	// Secret injection phase — must happen after header manipulation so that
+	// X-Inject-Secret is extracted before being stripped.
+	//
+	// Two injection sources are supported (in priority order):
+	//  1. Per-route static SecretConfig from the route definition.
+	//  2. Dynamic X-Inject-Secret request header set by the application.
+	//
+	// If secret injection is required but no injector is configured, or if the
+	// injector returns an error, the request is blocked (fail-closed).
+	if err := p.applySecretInjection(reqCtx, req.Header, match, outHeaders); err != nil {
+		p.logger.ErrorContext(ctx, "egress secret injection failed — request blocked",
+			slog.String("url", req.URL),
+			slog.String("err", err.Error()),
+		)
+		return domainegress.EgressResponse{}, fmt.Errorf("secret injection: %w", err)
 	}
 
 	body, _ := req.BodyRef.(io.Reader)
@@ -388,6 +418,75 @@ func (p *Proxy) forward(ctx context.Context, req domainegress.EgressRequest, mat
 	}
 
 	return egressResp, nil
+}
+
+// applySecretInjection resolves and injects secret values into outHeaders.
+//
+// It handles two injection modes:
+//  1. Per-route static injection: when the matched route has a non-empty
+//     SecretConfig.Name the injector fetches that secret and sets the header.
+//  2. Dynamic injection: when the original request carries X-Inject-Secret,
+//     that value is treated as the secret name. The secret is injected as a
+//     plain value on the Authorization header unless the route provides a
+//     SecretConfig that overrides the header name and format.
+//
+// X-Inject-Secret is always removed from outHeaders before this function
+// returns, whether or not injection succeeds.
+//
+// Returns an error when injection is required but fails; callers must treat
+// this as a hard failure and block the request.
+func (p *Proxy) applySecretInjection(
+	ctx context.Context,
+	originalHeaders http.Header,
+	match domainegress.RouteMatch,
+	outHeaders http.Header,
+) error {
+	// Always strip X-Inject-Secret from the outbound headers — it must never
+	// reach the upstream regardless of the outcome.
+	dynamicSecretName := originalHeaders.Get(headerInjectSecret)
+	outHeaders.Del(headerInjectSecret)
+
+	// Determine which injection to perform.
+	var cfg domainegress.SecretConfig
+	if match.Matched && match.Route.Secret().Name != "" {
+		// Per-route static injection takes precedence.
+		cfg = match.Route.Secret()
+	} else if dynamicSecretName != "" {
+		// Dynamic injection: use the secret name from the request header.
+		// Default to injecting as a plain Authorization header value.
+		cfg = domainegress.SecretConfig{
+			Name:   dynamicSecretName,
+			Header: "Authorization",
+			Format: "",
+		}
+		// If the route provides header/format overrides but no secret name,
+		// apply them to the dynamic injection.
+		if match.Matched {
+			routeSec := match.Route.Secret()
+			if routeSec.Header != "" {
+				cfg.Header = routeSec.Header
+			}
+			if routeSec.Format != "" {
+				cfg.Format = routeSec.Format
+			}
+		}
+	} else {
+		// No injection required.
+		return nil
+	}
+
+	injector := p.secretInjector()
+	if injector == nil {
+		return fmt.Errorf("secret injection required for %q but no SecretInjector is configured", cfg.Name)
+	}
+
+	header, value, err := injector.Inject(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	outHeaders.Set(header, value)
+	return nil
 }
 
 // cloneAndStripHopByHop returns a copy of h with all hop-by-hop headers removed.

--- a/internal/adapters/egress/proxy_headers_test.go
+++ b/internal/adapters/egress/proxy_headers_test.go
@@ -76,6 +76,9 @@ func TestHandleRequest_RequestHeaderStripping(t *testing.T) {
 
 // TestHandleRequest_XInjectSecretAlwaysStripped verifies that X-Inject-Secret
 // is never forwarded upstream, even when no explicit StripRequestHeaders is set.
+// When X-Inject-Secret is present the proxy performs dynamic injection using the
+// configured SecretInjector; the header itself is always stripped from the outbound
+// request before forwarding.
 func TestHandleRequest_XInjectSecretAlwaysStripped(t *testing.T) {
 	var capturedSecret string
 
@@ -85,9 +88,23 @@ func TestHandleRequest_XInjectSecretAlwaysStripped(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	// No explicit header config — X-Inject-Secret should still be stripped.
+	// Provide an injector with the secret the dynamic header will request.
+	store := newFakeSecretStore(map[string]map[string]string{
+		"my-secret-name": {"value": "injected-value"},
+	})
+	injector := egressadapter.NewSecretInjector(store, egressadapter.SecretInjectorConfig{})
+
+	// No explicit header config — X-Inject-Secret triggers dynamic injection.
 	route := newTestRoute(t, "api", upstream.URL+"/v1/*")
-	proxy := newTestProxy(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny)
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		SecretInjector: injector,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
 
 	incoming := http.Header{"X-Inject-Secret": []string{"my-secret-name"}}
 	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", incoming, nil)
@@ -104,8 +121,10 @@ func TestHandleRequest_XInjectSecretAlwaysStripped(t *testing.T) {
 	}
 }
 
-// TestHandleRequest_XInjectSecretStrippedOnAllowPolicy verifies that
-// X-Inject-Secret is stripped even when default_policy is allow (unmatched route).
+// TestHandleRequest_XInjectSecretStrippedOnAllowPolicy verifies that when
+// X-Inject-Secret is present on an allow-policy (unmatched) request, the proxy
+// performs dynamic injection — resolving the secret and injecting it as the
+// Authorization header — and always strips X-Inject-Secret before forwarding.
 func TestHandleRequest_XInjectSecretStrippedOnAllowPolicy(t *testing.T) {
 	var capturedSecret string
 
@@ -115,8 +134,20 @@ func TestHandleRequest_XInjectSecretStrippedOnAllowPolicy(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	// No routes — request falls through to allow policy.
-	proxy := newTestProxy(t, nil, upstream.Client(), domainegress.PolicyAllow)
+	store := newFakeSecretStore(map[string]map[string]string{
+		"leaked-secret": {"value": "safe-injected-value"},
+	})
+	injector := egressadapter.NewSecretInjector(store, egressadapter.SecretInjectorConfig{})
+
+	// No routes — request falls through to allow policy, but injection still happens.
+	resolver := egressadapter.NewRouteResolver(nil)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyAllow,
+		DefaultTimeout: 5 * time.Second,
+		SecretInjector: injector,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
 
 	incoming := http.Header{"X-Inject-Secret": []string{"leaked-secret"}}
 	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/anything", incoming, nil)

--- a/internal/adapters/egress/secret_injector.go
+++ b/internal/adapters/egress/secret_injector.go
@@ -1,0 +1,138 @@
+// Package egress implements the HTTP listener and request forwarding adapter
+// for the egress proxy plugin.
+package egress
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+const (
+	// defaultSecretTTL is how long a resolved secret value is cached before
+	// being re-fetched from the secret store.
+	defaultSecretTTL = 5 * time.Minute
+
+	// secretValuePlaceholder is the template placeholder replaced with the
+	// resolved secret value when formatting the header value.
+	secretValuePlaceholder = "{value}"
+
+	// headerInjectSecret is the request header an application sends to
+	// dynamically request a secret by name on a per-request basis.
+	// It is always stripped before the request is forwarded upstream.
+	headerInjectSecret = "X-Inject-Secret"
+)
+
+// cachedSecret holds a resolved secret value and the time it expires.
+type cachedSecret struct {
+	value     string
+	expiresAt time.Time
+}
+
+// SecretInjectorConfig holds the configuration for a SecretInjector.
+type SecretInjectorConfig struct {
+	// TTL is how long a resolved secret value is cached. Defaults to 5 minutes.
+	TTL time.Duration
+}
+
+// SecretInjector resolves secret values from a SecretStore, caches them with a
+// configurable TTL, formats the value using the route's format template, and
+// returns the header name and formatted value ready for injection.
+//
+// SecretInjector implements ports.SecretInjector.
+type SecretInjector struct {
+	store ports.SecretStore
+	ttl   time.Duration
+
+	mu    sync.Mutex
+	cache map[string]cachedSecret
+}
+
+// NewSecretInjector creates a new SecretInjector backed by store.
+// Pass a zero-value SecretInjectorConfig to use defaults.
+func NewSecretInjector(store ports.SecretStore, cfg SecretInjectorConfig) *SecretInjector {
+	ttl := cfg.TTL
+	if ttl <= 0 {
+		ttl = defaultSecretTTL
+	}
+	return &SecretInjector{
+		store: store,
+		ttl:   ttl,
+		cache: make(map[string]cachedSecret),
+	}
+}
+
+// Inject implements ports.SecretInjector.
+//
+// It fetches the secret at cfg.Name from the backing store (using a cached
+// value when one is still fresh), formats it by replacing "{value}" in
+// cfg.Format with the secret value, and returns the header name (cfg.Header)
+// and the formatted value.
+//
+// When cfg.Format is empty, the raw secret value is returned without
+// modification.
+//
+// The resolved secret value is never written to any log or error message.
+func (s *SecretInjector) Inject(ctx context.Context, cfg domainegress.SecretConfig) (header, value string, err error) {
+	raw, err := s.resolve(ctx, cfg.Name)
+	if err != nil {
+		// Return a safe error that does not include the secret value.
+		return "", "", fmt.Errorf("egress secret injection: resolving %q: %w", cfg.Name, err)
+	}
+
+	formatted := formatSecretValue(cfg.Format, raw)
+	return cfg.Header, formatted, nil
+}
+
+// resolve returns the secret value for name, using the in-memory cache when
+// the entry is still fresh. On a cache miss (or expiry) it calls the store.
+func (s *SecretInjector) resolve(ctx context.Context, name string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if entry, ok := s.cache[name]; ok && time.Now().Before(entry.expiresAt) {
+		return entry.value, nil
+	}
+
+	data, err := s.store.Get(ctx, name)
+	if err != nil {
+		return "", fmt.Errorf("fetching secret: %w", err)
+	}
+
+	// Convention: the injected value is stored under the "value" key.
+	// If that key is absent but the map has exactly one entry, use that entry.
+	raw, ok := data["value"]
+	if !ok {
+		for _, v := range data {
+			raw = v
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return "", fmt.Errorf("secret %q has no usable value key", name)
+	}
+
+	s.cache[name] = cachedSecret{
+		value:     raw,
+		expiresAt: time.Now().Add(s.ttl),
+	}
+	return raw, nil
+}
+
+// formatSecretValue replaces "{value}" in format with val.
+// When format is empty, val is returned unchanged.
+func formatSecretValue(format, val string) string {
+	if format == "" {
+		return val
+	}
+	return strings.ReplaceAll(format, secretValuePlaceholder, val)
+}
+
+// Interface guard — SecretInjector must implement ports.SecretInjector.
+var _ ports.SecretInjector = (*SecretInjector)(nil)

--- a/internal/adapters/egress/secret_injector_test.go
+++ b/internal/adapters/egress/secret_injector_test.go
@@ -1,0 +1,518 @@
+package egress_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	egressadapter "github.com/vibewarden/vibewarden/internal/adapters/egress"
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+// fakeSecretStore is a simple in-memory SecretStore used in tests.
+// It deliberately does not log secret values.
+type fakeSecretStore struct {
+	secrets map[string]map[string]string
+	callLog []string // records which secret names were fetched
+}
+
+func newFakeSecretStore(secrets map[string]map[string]string) *fakeSecretStore {
+	return &fakeSecretStore{secrets: secrets}
+}
+
+func (f *fakeSecretStore) Get(_ context.Context, path string) (map[string]string, error) {
+	f.callLog = append(f.callLog, path)
+	data, ok := f.secrets[path]
+	if !ok {
+		return nil, errors.New("secret not found: " + path)
+	}
+	return data, nil
+}
+
+func (f *fakeSecretStore) Put(_ context.Context, _ string, _ map[string]string) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeSecretStore) Delete(_ context.Context, _ string) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeSecretStore) List(_ context.Context, _ string) ([]string, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeSecretStore) Health(_ context.Context) error {
+	return nil
+}
+
+// TestSecretInjector_Inject tests Inject for various SecretConfig inputs.
+func TestSecretInjector_Inject(t *testing.T) {
+	store := newFakeSecretStore(map[string]map[string]string{
+		"stripe/api_key": {"value": "sk_test_abc123"},
+		"github/token":   {"value": "ghp_xyz"},
+		"multi-key":      {"token": "tok_multi", "extra": "ignored"},
+		"single-nonval":  {"api_key": "raw_value"},
+	})
+
+	tests := []struct {
+		name       string
+		cfg        domainegress.SecretConfig
+		wantHeader string
+		wantValue  string
+		wantErr    bool
+	}{
+		{
+			name: "bearer format injection",
+			cfg: domainegress.SecretConfig{
+				Name:   "stripe/api_key",
+				Header: "Authorization",
+				Format: "Bearer {value}",
+			},
+			wantHeader: "Authorization",
+			wantValue:  "Bearer sk_test_abc123",
+		},
+		{
+			name: "plain value injection (no format)",
+			cfg: domainegress.SecretConfig{
+				Name:   "github/token",
+				Header: "Authorization",
+				Format: "",
+			},
+			wantHeader: "Authorization",
+			wantValue:  "ghp_xyz",
+		},
+		{
+			name: "custom header name",
+			cfg: domainegress.SecretConfig{
+				Name:   "stripe/api_key",
+				Header: "X-Api-Key",
+				Format: "",
+			},
+			wantHeader: "X-Api-Key",
+			wantValue:  "sk_test_abc123",
+		},
+		{
+			name: "token format",
+			cfg: domainegress.SecretConfig{
+				Name:   "github/token",
+				Header: "Authorization",
+				Format: "token {value}",
+			},
+			wantHeader: "Authorization",
+			wantValue:  "token ghp_xyz",
+		},
+		{
+			name: "multi-key secret falls back to first value when 'value' key missing",
+			cfg: domainegress.SecretConfig{
+				Name:   "single-nonval",
+				Header: "X-Api-Key",
+				Format: "",
+			},
+			wantHeader: "X-Api-Key",
+			wantValue:  "raw_value",
+		},
+		{
+			name: "missing secret returns error",
+			cfg: domainegress.SecretConfig{
+				Name:   "nonexistent/secret",
+				Header: "Authorization",
+				Format: "Bearer {value}",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			injector := egressadapter.NewSecretInjector(store, egressadapter.SecretInjectorConfig{})
+
+			header, value, err := injector.Inject(context.Background(), tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Inject() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if header != tt.wantHeader {
+				t.Errorf("header = %q, want %q", header, tt.wantHeader)
+			}
+			if value != tt.wantValue {
+				t.Errorf("value = %q, want %q", value, tt.wantValue)
+			}
+		})
+	}
+}
+
+// TestSecretInjector_Caching verifies that a second Inject call for the same
+// secret name does not call the store again within the TTL.
+func TestSecretInjector_Caching(t *testing.T) {
+	store := newFakeSecretStore(map[string]map[string]string{
+		"cached/key": {"value": "secret_val"},
+	})
+
+	injector := egressadapter.NewSecretInjector(store, egressadapter.SecretInjectorConfig{
+		TTL: 10 * time.Minute,
+	})
+
+	cfg := domainegress.SecretConfig{
+		Name:   "cached/key",
+		Header: "Authorization",
+		Format: "Bearer {value}",
+	}
+
+	if _, _, err := injector.Inject(context.Background(), cfg); err != nil {
+		t.Fatalf("first Inject() error = %v", err)
+	}
+	if _, _, err := injector.Inject(context.Background(), cfg); err != nil {
+		t.Fatalf("second Inject() error = %v", err)
+	}
+
+	if len(store.callLog) != 1 {
+		t.Errorf("store.Get called %d times, want 1 (second call should use cache)", len(store.callLog))
+	}
+}
+
+// TestSecretInjector_CacheExpiry verifies that after the TTL expires a new
+// store fetch is performed.
+func TestSecretInjector_CacheExpiry(t *testing.T) {
+	store := newFakeSecretStore(map[string]map[string]string{
+		"expiry/key": {"value": "fresh_val"},
+	})
+
+	injector := egressadapter.NewSecretInjector(store, egressadapter.SecretInjectorConfig{
+		TTL: 1 * time.Millisecond, // expire almost immediately
+	})
+
+	cfg := domainegress.SecretConfig{
+		Name:   "expiry/key",
+		Header: "Authorization",
+		Format: "",
+	}
+
+	if _, _, err := injector.Inject(context.Background(), cfg); err != nil {
+		t.Fatalf("first Inject() error = %v", err)
+	}
+
+	// Wait for the TTL to expire.
+	time.Sleep(5 * time.Millisecond)
+
+	if _, _, err := injector.Inject(context.Background(), cfg); err != nil {
+		t.Fatalf("second Inject() error = %v", err)
+	}
+
+	if len(store.callLog) != 2 {
+		t.Errorf("store.Get called %d times, want 2 (cache should have expired)", len(store.callLog))
+	}
+}
+
+// TestProxy_SecretInjection_PerRoute verifies that the proxy injects the
+// per-route static secret into the upstream request headers.
+func TestProxy_SecretInjection_PerRoute(t *testing.T) {
+	var capturedAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		// X-Inject-Secret must always be stripped before reaching upstream.
+		if r.Header.Get("X-Inject-Secret") != "" {
+			t.Error("X-Inject-Secret must not reach the upstream")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	store := newFakeSecretStore(map[string]map[string]string{
+		"stripe/key": {"value": "sk_live_test"},
+	})
+	injector := egressadapter.NewSecretInjector(store, egressadapter.SecretInjectorConfig{})
+
+	route, err := domainegress.NewRoute("stripe", upstream.URL+"/v1/*",
+		domainegress.WithSecret(domainegress.SecretConfig{
+			Name:   "stripe/key",
+			Header: "Authorization",
+			Format: "Bearer {value}",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		SecretInjector: injector,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/charges", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if capturedAuth != "Bearer sk_live_test" {
+		t.Errorf("upstream Authorization = %q, want %q", capturedAuth, "Bearer sk_live_test")
+	}
+}
+
+// TestProxy_SecretInjection_DynamicHeader verifies that X-Inject-Secret is
+// used as the secret name when no per-route SecretConfig.Name is set.
+func TestProxy_SecretInjection_DynamicHeader(t *testing.T) {
+	var capturedAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		if r.Header.Get("X-Inject-Secret") != "" {
+			t.Error("X-Inject-Secret must not reach the upstream")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	store := newFakeSecretStore(map[string]map[string]string{
+		"github/token": {"value": "ghp_dynamic"},
+	})
+	injector := egressadapter.NewSecretInjector(store, egressadapter.SecretInjectorConfig{})
+
+	// Route has no SecretConfig — injection is driven by the X-Inject-Secret header.
+	route, err := domainegress.NewRoute("github", upstream.URL+"/api/*")
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		SecretInjector: injector,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	inHeaders := http.Header{}
+	inHeaders.Set("X-Inject-Secret", "github/token")
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/api/repos", inHeaders, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if capturedAuth != "ghp_dynamic" {
+		t.Errorf("upstream Authorization = %q, want %q", capturedAuth, "ghp_dynamic")
+	}
+}
+
+// TestProxy_SecretInjection_FailClosed verifies that a request is blocked when
+// secret resolution fails, even when the route is matched.
+func TestProxy_SecretInjection_FailClosed(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream must not be called when secret injection fails")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	// Store has no entry for the secret the route requires.
+	store := newFakeSecretStore(map[string]map[string]string{})
+	injector := egressadapter.NewSecretInjector(store, egressadapter.SecretInjectorConfig{})
+
+	route, err := domainegress.NewRoute("stripe", upstream.URL+"/v1/*",
+		domainegress.WithSecret(domainegress.SecretConfig{
+			Name:   "stripe/missing",
+			Header: "Authorization",
+			Format: "Bearer {value}",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		SecretInjector: injector,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/charges", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	_, err = proxy.HandleRequest(context.Background(), req)
+	if err == nil {
+		t.Fatal("HandleRequest should have returned an error when secret injection fails")
+	}
+	if !strings.Contains(err.Error(), "secret injection") {
+		t.Errorf("error = %q, want it to mention 'secret injection'", err.Error())
+	}
+}
+
+// TestProxy_SecretInjection_NoInjectorConfigured verifies that when a route
+// requires secret injection but no SecretInjector is wired into the proxy,
+// the request is blocked (fail-closed).
+func TestProxy_SecretInjection_NoInjectorConfigured(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream must not be called when no injector is configured")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	route, err := domainegress.NewRoute("stripe", upstream.URL+"/v1/*",
+		domainegress.WithSecret(domainegress.SecretConfig{
+			Name:   "stripe/key",
+			Header: "Authorization",
+			Format: "Bearer {value}",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		// SecretInjector deliberately omitted.
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/charges", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	_, err = proxy.HandleRequest(context.Background(), req)
+	if err == nil {
+		t.Fatal("HandleRequest should return an error when injector is required but absent")
+	}
+}
+
+// TestProxy_SecretInjection_XInjectSecretStripped verifies that X-Inject-Secret
+// is always stripped from the outbound request even when no injection occurs
+// (e.g. no injector configured, unmatched route).
+func TestProxy_SecretInjection_XInjectSecretStripped(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Inject-Secret") != "" {
+			t.Error("X-Inject-Secret must be stripped, but it reached the upstream")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	// Route with no SecretConfig and no injector: dynamic header must still be stripped.
+	route, err := domainegress.NewRoute("plain", upstream.URL+"/v1/*")
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		// No SecretInjector — X-Inject-Secret present but no injector configured.
+		// The route has no SecretConfig so no injection is required; the header
+		// must simply be stripped.
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	inHeaders := http.Header{}
+	inHeaders.Set("X-Inject-Secret", "any/secret")
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", inHeaders, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	// This should fail because there is no injector but X-Inject-Secret is present.
+	// The proxy must block the request (fail-closed) even for the dynamic case.
+	_, err = proxy.HandleRequest(context.Background(), req)
+	if err == nil {
+		t.Fatal("HandleRequest should return an error when dynamic injection is requested without an injector")
+	}
+}
+
+// TestProxy_SecretInjection_HTTPHandler verifies the full HTTP handler path:
+// a request with X-Inject-Secret returns 502 when no injector is wired.
+func TestProxy_SecretInjection_HTTPHandler_FailClosed(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream must not be called")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	store := newFakeSecretStore(map[string]map[string]string{})
+	injector := egressadapter.NewSecretInjector(store, egressadapter.SecretInjectorConfig{})
+
+	route, err := domainegress.NewRoute("stripe", upstream.URL+"/v1/*",
+		domainegress.WithSecret(domainegress.SecretConfig{
+			Name:   "stripe/missing",
+			Header: "Authorization",
+			Format: "Bearer {value}",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		SecretInjector: injector,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/charges")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("StatusCode = %d, want %d (secret injection failure must return 502); body: %s",
+			resp.StatusCode, http.StatusBadGateway, body)
+	}
+}

--- a/internal/ports/egress.go
+++ b/internal/ports/egress.go
@@ -29,3 +29,21 @@ type RouteResolver interface {
 	// Returns an error only on internal failures (e.g. malformed configuration).
 	Resolve(ctx context.Context, req egress.EgressRequest) (egress.RouteMatch, error)
 }
+
+// SecretInjector is the outbound port for fetching and formatting secret values
+// before they are injected into outbound request headers.
+//
+// Implementations must cache resolved values with a TTL to avoid hammering
+// the secret store on every request, and must never log the resolved value.
+type SecretInjector interface {
+	// Inject resolves the secret named by cfg.Name, formats it according to
+	// cfg.Format, and returns the header name and formatted value to inject.
+	//
+	// The header name is cfg.Header. The value is produced by replacing
+	// "{value}" in cfg.Format with the resolved secret value. If cfg.Format is
+	// empty the raw secret value is returned directly.
+	//
+	// Returns an error when the secret cannot be resolved; callers must block
+	// the request in that case (fail-closed).
+	Inject(ctx context.Context, cfg egress.SecretConfig) (header, value string, err error)
+}


### PR DESCRIPTION
Closes #361

## Summary

- Added `SecretInjector` outbound port to `internal/ports/egress.go` — a clean interface for fetching, formatting, and injecting secrets before request forwarding
- Created `internal/adapters/egress/secret_injector.go` implementing the port with TTL-based in-memory caching and `"{value}"` format template expansion
- Wired the injector into `Proxy.forward()` via `applySecretInjection()`, which handles two injection modes:
  1. **Per-route static injection** — route has `SecretConfig.Name` set; injector fetches the named secret and injects it using the configured header and format
  2. **Dynamic injection** — request carries `X-Inject-Secret` header; the value is used as the secret name; defaults to `Authorization` header unless the route overrides it
- Fail-closed: any injection failure (secret not found, store unreachable, no injector configured) blocks the request and logs a structured error — the secret value is never logged
- `X-Inject-Secret` is always stripped before the request reaches the upstream, regardless of injection success or failure
- Updated two existing tests that tested pre-injection stripping behavior to reflect the new fail-closed dynamic injection semantics

## Test plan

- `TestSecretInjector_Inject` — table-driven: Bearer format, plain value, custom header, token format, fallback key, missing secret
- `TestSecretInjector_Caching` — second call within TTL hits cache, not store
- `TestSecretInjector_CacheExpiry` — after TTL expires, store is called again
- `TestProxy_SecretInjection_PerRoute` — per-route `SecretConfig` injects correct `Authorization` header
- `TestProxy_SecretInjection_DynamicHeader` — `X-Inject-Secret` drives dynamic injection
- `TestProxy_SecretInjection_FailClosed` — missing secret blocks request
- `TestProxy_SecretInjection_NoInjectorConfigured` — required injection with no injector blocks request
- `TestProxy_SecretInjection_XInjectSecretStripped` — dynamic header with no injector blocks (fail-closed)
- `TestProxy_SecretInjection_HTTPHandler_FailClosed` — full HTTP handler returns 502 on injection failure
- `make check` passes (all 70+ packages, format, vet, build, tests)
