### PR TITLE
feat(#363): egress timeouts and retry with exponential backoff

### DIFF
--- a/internal/adapters/egress/proxy.go
+++ b/internal/adapters/egress/proxy.go
@@ -19,6 +19,17 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
+// retryableStatusCodes is the set of HTTP status codes that are considered
+// transient and eligible for retry.
+var retryableStatusCodes = map[int]struct{}{
+	http.StatusRequestTimeout:      {}, // 408
+	http.StatusTooManyRequests:     {}, // 429
+	http.StatusInternalServerError: {}, // 500
+	http.StatusBadGateway:          {}, // 502
+	http.StatusServiceUnavailable:  {}, // 503
+	http.StatusGatewayTimeout:      {}, // 504
+}
+
 const (
 	// namedRoutePrefix is the URL path prefix for named-route requests.
 	namedRoutePrefix = "/_egress/"
@@ -27,11 +38,19 @@ const (
 	// The caller sets this header to the full target URL when POSTing to the proxy.
 	headerEgressURL = "X-Egress-URL"
 
+	// headerEgressAttempts is the response header that reports the total number
+	// of upstream attempts made (initial + retries).
+	headerEgressAttempts = "X-Egress-Attempts"
+
 	// defaultListen is the default address the egress proxy binds to.
 	defaultListen = "127.0.0.1:8081"
 
 	// defaultTimeout is used when the configuration does not specify a timeout.
 	defaultTimeout = 30 * time.Second
+
+	// defaultRetryInitialBackoff is the base wait duration before the first retry
+	// when RetryConfig.InitialBackoff is zero.
+	defaultRetryInitialBackoff = 100 * time.Millisecond
 
 	// hopByHopHeaders lists headers that must not be forwarded to the upstream.
 	// These are connection-specific and must be stripped per RFC 7230 §6.1.
@@ -243,6 +262,16 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "403 Forbidden: "+ssrfErr.Error(), http.StatusForbidden)
 			return
 		}
+		// A deadline-exceeded error from context.WithTimeout in forward() means
+		// the upstream did not respond within the configured timeout.
+		if isTimeoutError(err) {
+			p.logger.WarnContext(r.Context(), "egress request timed out",
+				slog.String("target", targetURL),
+				slog.String("method", r.Method),
+			)
+			http.Error(w, "504 Gateway Timeout: upstream did not respond in time", http.StatusGatewayTimeout)
+			return
+		}
 		p.logger.ErrorContext(r.Context(), "egress forwarding error",
 			slog.String("target", targetURL),
 			slog.String("method", r.Method),
@@ -259,6 +288,10 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 		for _, v := range vals {
 			w.Header().Add(key, v)
 		}
+	}
+	// Report total attempt count (initial + retries) to the caller.
+	if egressResp.Attempts > 0 {
+		w.Header().Set(headerEgressAttempts, fmt.Sprintf("%d", egressResp.Attempts))
 	}
 	w.WriteHeader(egressResp.StatusCode)
 
@@ -348,6 +381,11 @@ func patternBase(pattern string) string {
 //     carries a SecretConfig or the request carries an X-Inject-Secret header.
 //  2. After receiving: per-route and default sensitive response headers are
 //     stripped before the response is returned to the caller.
+//
+// When the matched route has a RetryConfig, transient failures on idempotent
+// methods are retried with exponential or fixed backoff. Each retry attempt is
+// logged as an egress.retry structured event. A timeout from context.WithTimeout
+// is returned as-is so the HTTP handler can respond with 504.
 func (p *Proxy) forward(ctx context.Context, req domainegress.EgressRequest, match domainegress.RouteMatch) (domainegress.EgressResponse, error) {
 	timeout := p.cfg.DefaultTimeout
 	if match.Matched && match.Route.Timeout() > 0 {
@@ -384,39 +422,141 @@ func (p *Proxy) forward(ctx context.Context, req domainegress.EgressRequest, mat
 		return domainegress.EgressResponse{}, fmt.Errorf("secret injection: %w", err)
 	}
 
-	body, _ := req.BodyRef.(io.Reader)
-	httpReq, err := http.NewRequestWithContext(reqCtx, req.Method, req.URL, body)
-	if err != nil {
-		return domainegress.EgressResponse{}, fmt.Errorf("building upstream request: %w", err)
-	}
-	for key, vals := range outHeaders {
-		for _, v := range vals {
-			httpReq.Header.Add(key, v)
+	// Determine retry parameters. Retry is only attempted for matched routes
+	// that carry a RetryConfig with Max > 0 and an idempotent method.
+	retryCfg := domainegress.RetryConfig{}
+	retryEnabled := false
+	if match.Matched {
+		rc := match.Route.Retry()
+		if rc.Max > 0 && rc.IsRetryableMethod(req.Method) {
+			retryCfg = rc
+			retryEnabled = true
 		}
 	}
 
-	start := time.Now()
-	resp, err := p.client.Do(httpReq)
-	if err != nil {
-		return domainegress.EgressResponse{}, fmt.Errorf("forwarding request to %s: %w", req.URL, err)
+	maxAttempts := 1
+	if retryEnabled {
+		maxAttempts = 1 + retryCfg.Max
 	}
+
+	initialBackoff := retryCfg.InitialBackoff
+	if initialBackoff <= 0 {
+		initialBackoff = defaultRetryInitialBackoff
+	}
+
+	var (
+		lastResp     *http.Response
+		lastErr      error
+		start        = time.Now()
+		attemptsDone int
+	)
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		attemptsDone = attempt
+
+		// Each attempt needs a fresh HTTP request because the body and context
+		// cannot be reused after the first send.
+		body, _ := req.BodyRef.(io.Reader)
+		httpReq, err := http.NewRequestWithContext(reqCtx, req.Method, req.URL, body)
+		if err != nil {
+			return domainegress.EgressResponse{}, fmt.Errorf("building upstream request: %w", err)
+		}
+		for key, vals := range outHeaders {
+			for _, v := range vals {
+				httpReq.Header.Add(key, v)
+			}
+		}
+
+		resp, err := p.client.Do(httpReq)
+
+		if err != nil {
+			lastErr = err
+			lastResp = nil
+
+			// A context deadline/cancellation is a timeout — do not retry, surface
+			// it immediately so the caller can return 504.
+			if isTimeoutError(err) {
+				p.logger.WarnContext(ctx, "egress.timeout",
+					slog.String("event_type", "egress.timeout"),
+					slog.String("url", req.URL),
+					slog.String("method", req.Method),
+					slog.Int("attempt", attempt),
+				)
+				return domainegress.EgressResponse{}, fmt.Errorf("forwarding request to %s: %w", req.URL, err)
+			}
+
+			if retryEnabled && attempt < maxAttempts {
+				backoff := computeBackoff(retryCfg.Backoff, initialBackoff, attempt)
+				p.logger.WarnContext(ctx, "egress.retry",
+					slog.String("event_type", "egress.retry"),
+					slog.String("url", req.URL),
+					slog.String("method", req.Method),
+					slog.Int("attempt", attempt),
+					slog.Int("max_attempts", maxAttempts),
+					slog.String("backoff", backoff.String()),
+					slog.String("reason", err.Error()),
+				)
+				if !sleep(reqCtx, backoff) {
+					// Context cancelled during backoff — surface timeout.
+					return domainegress.EgressResponse{}, fmt.Errorf("forwarding request to %s: %w", req.URL, reqCtx.Err())
+				}
+				continue
+			}
+
+			return domainegress.EgressResponse{}, fmt.Errorf("forwarding request to %s: %w", req.URL, err)
+		}
+
+		// We have a response. Check whether it is a retryable status code.
+		if retryEnabled && attempt < maxAttempts {
+			if _, retryable := retryableStatusCodes[resp.StatusCode]; retryable {
+				// Drain and close the body before retrying to free the connection.
+				resp.Body.Close() //nolint:errcheck
+				backoff := computeBackoff(retryCfg.Backoff, initialBackoff, attempt)
+				p.logger.WarnContext(ctx, "egress.retry",
+					slog.String("event_type", "egress.retry"),
+					slog.String("url", req.URL),
+					slog.String("method", req.Method),
+					slog.Int("attempt", attempt),
+					slog.Int("max_attempts", maxAttempts),
+					slog.String("backoff", backoff.String()),
+					slog.String("reason", fmt.Sprintf("status %d", resp.StatusCode)),
+				)
+				if !sleep(reqCtx, backoff) {
+					return domainegress.EgressResponse{}, fmt.Errorf("forwarding request to %s: %w", req.URL, reqCtx.Err())
+				}
+				continue
+			}
+		}
+
+		lastResp = resp
+		lastErr = nil
+		break
+	}
+
+	if lastErr != nil {
+		return domainegress.EgressResponse{}, fmt.Errorf("forwarding request to %s: %w", req.URL, lastErr)
+	}
+
 	duration := time.Since(start)
 
 	// Apply per-route response header stripping (also strips default sensitive headers).
 	var respHeaders http.Header
 	if match.Matched {
-		respHeaders = match.Route.Headers().ApplyToResponse(resp.Header)
+		respHeaders = match.Route.Headers().ApplyToResponse(lastResp.Header)
 	} else {
 		// Apply default sensitive-header stripping on unmatched requests too.
-		respHeaders = domainegress.HeadersConfig{}.ApplyToResponse(resp.Header)
+		respHeaders = domainegress.HeadersConfig{}.ApplyToResponse(lastResp.Header)
 	}
 
-	egressResp, err := domainegress.NewEgressResponse(resp.StatusCode, respHeaders, resp.Body, duration)
+	egressResp, err := domainegress.NewEgressResponse(lastResp.StatusCode, respHeaders, lastResp.Body, duration)
 	if err != nil {
-		resp.Body.Close() //nolint:errcheck
+		lastResp.Body.Close() //nolint:errcheck
 		return domainegress.EgressResponse{}, fmt.Errorf("building egress response: %w", err)
 	}
 
+	// Record the total number of upstream attempts so the HTTP handler can set
+	// the X-Egress-Attempts response header.
+	egressResp.Attempts = attemptsDone
 	return egressResp, nil
 }
 
@@ -502,6 +642,52 @@ func cloneAndStripHopByHop(h http.Header) http.Header {
 		}
 	}
 	return out
+}
+
+// computeBackoff returns the wait duration before attempt number n (1-based)
+// using the given strategy. For exponential backoff the base is doubled on each
+// attempt: base * 2^(n-1). For fixed backoff the same base is always returned.
+func computeBackoff(strategy domainegress.RetryBackoff, base time.Duration, attempt int) time.Duration {
+	if strategy == domainegress.RetryBackoffFixed {
+		return base
+	}
+	// Default: exponential. Shift by (attempt-1) doublings.
+	shift := attempt - 1
+	if shift > 30 {
+		shift = 30 // guard against overflow on absurdly high Max values
+	}
+	return base * (1 << uint(shift))
+}
+
+// sleep blocks for d using a timer that respects context cancellation.
+// Returns true if the sleep completed, false if the context was cancelled first.
+func sleep(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+// isTimeoutError reports whether err represents a context deadline exceeded or
+// context cancellation originating from the per-request timeout. It also covers
+// net/http timeout errors that wrap url.Error with a Timeout() method.
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	// net/http wraps transport errors in *url.Error; check the Timeout() method.
+	var netErr interface{ Timeout() bool }
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+	return false
 }
 
 // Interface guard — Proxy must implement ports.EgressProxy.

--- a/internal/adapters/egress/retry_timeout_test.go
+++ b/internal/adapters/egress/retry_timeout_test.go
@@ -1,0 +1,430 @@
+package egress_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	egressadapter "github.com/vibewarden/vibewarden/internal/adapters/egress"
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+// TestForward_PerRouteTimeout_Returns504 verifies that a per-route timeout that
+// is shorter than the upstream response time causes the proxy to return 504 to
+// the caller via the HTTP handler.
+func TestForward_PerRouteTimeout_Returns504(t *testing.T) {
+	// Upstream sleeps longer than the route timeout.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "slow", upstream.URL+"/v1/*",
+		domainegress.WithTimeout(50*time.Millisecond),
+	)
+
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/resource")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusGatewayTimeout {
+		t.Errorf("StatusCode = %d, want %d (504 Gateway Timeout)", resp.StatusCode, http.StatusGatewayTimeout)
+	}
+}
+
+// TestForward_DefaultTimeout_Returns504 verifies that the global default timeout
+// also causes 504 when the upstream is too slow.
+func TestForward_DefaultTimeout_Returns504(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "slow", upstream.URL+"/v1/*")
+
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 50 * time.Millisecond, // very short global timeout
+		Routes:         []domainegress.Route{route},
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/resource")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusGatewayTimeout {
+		t.Errorf("StatusCode = %d, want %d (504 Gateway Timeout)", resp.StatusCode, http.StatusGatewayTimeout)
+	}
+}
+
+// TestForward_RetryOnTransientStatus verifies that a route with RetryConfig
+// retries on a retryable status code and ultimately returns the successful
+// response. The X-Egress-Attempts header must reflect total attempt count.
+func TestForward_RetryOnTransientStatus(t *testing.T) {
+	var callCount atomic.Int32
+
+	// First two calls return 503, third returns 200.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := callCount.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithRetry(domainegress.RetryConfig{
+			Max:            3,
+			Methods:        []string{"GET"},
+			Backoff:        domainegress.RetryBackoffFixed,
+			InitialBackoff: 5 * time.Millisecond,
+		}),
+	)
+
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/resource")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok" {
+		t.Errorf("body = %q, want %q", string(body), "ok")
+	}
+
+	// Three upstream calls should have been made (2 failures + 1 success).
+	if got := callCount.Load(); got != 3 {
+		t.Errorf("upstream call count = %d, want 3", got)
+	}
+
+	// X-Egress-Attempts must be set to 3.
+	if got := resp.Header.Get("X-Egress-Attempts"); got != "3" {
+		t.Errorf("X-Egress-Attempts = %q, want %q", got, "3")
+	}
+}
+
+// TestForward_NoRetryOnNonIdempotentMethod verifies that POST requests are NOT
+// retried by default (POST is not idempotent).
+func TestForward_NoRetryOnNonIdempotentMethod(t *testing.T) {
+	var callCount atomic.Int32
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithRetry(domainegress.RetryConfig{
+			Max:            3,
+			Backoff:        domainegress.RetryBackoffFixed,
+			InitialBackoff: 5 * time.Millisecond,
+			// Methods is empty — defaults to idempotent set (GET, HEAD, PUT, DELETE)
+		}),
+	)
+
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	httpReq, err := http.NewRequest(http.MethodPost, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/resource")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	// POST must not be retried — upstream should be called exactly once.
+	if got := callCount.Load(); got != 1 {
+		t.Errorf("upstream call count = %d, want 1 (POST must not be retried)", got)
+	}
+
+	// X-Egress-Attempts must be 1 (no retries).
+	if got := resp.Header.Get("X-Egress-Attempts"); got != "1" {
+		t.Errorf("X-Egress-Attempts = %q, want %q", got, "1")
+	}
+}
+
+// TestForward_RetryExhausted verifies that when all retry attempts fail, the
+// last error response is returned to the caller (not an error).
+func TestForward_RetryExhausted(t *testing.T) {
+	var callCount atomic.Int32
+
+	// Always return 503.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithRetry(domainegress.RetryConfig{
+			Max:            2,
+			Methods:        []string{"GET"},
+			Backoff:        domainegress.RetryBackoffFixed,
+			InitialBackoff: 5 * time.Millisecond,
+		}),
+	)
+
+	proxy := newTestProxy(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest returned unexpected error: %v", err)
+	}
+
+	// After exhausting 3 total attempts (1 initial + 2 retries), the last 503
+	// is returned as the response (not an error).
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+
+	if got := callCount.Load(); got != 3 {
+		t.Errorf("upstream call count = %d, want 3", got)
+	}
+
+	if resp.Attempts != 3 {
+		t.Errorf("Attempts = %d, want 3", resp.Attempts)
+	}
+}
+
+// TestForward_NoRetry_AttemptsIsOne verifies that when no retry is configured,
+// Attempts is set to 1 on a successful response.
+func TestForward_NoRetry_AttemptsIsOne(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*")
+	proxy := newTestProxy(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+
+	if resp.Attempts != 1 {
+		t.Errorf("Attempts = %d, want 1", resp.Attempts)
+	}
+}
+
+// TestForward_ExponentialBackoff verifies that exponential backoff doubles the
+// wait time on each attempt. We test computeBackoff indirectly by measuring
+// total elapsed time: 3 attempts with 10ms base should take at least 10+20=30ms.
+func TestForward_ExponentialBackoff(t *testing.T) {
+	var callCount atomic.Int32
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := callCount.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithRetry(domainegress.RetryConfig{
+			Max:            3,
+			Methods:        []string{"GET"},
+			Backoff:        domainegress.RetryBackoffExponential,
+			InitialBackoff: 10 * time.Millisecond,
+		}),
+	)
+
+	proxy := newTestProxy(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	start := time.Now()
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	// 2 retries with exponential backoff: 10ms + 20ms = at least 30ms.
+	const minElapsed = 25 * time.Millisecond // slight tolerance
+	if elapsed < minElapsed {
+		t.Errorf("elapsed %v < %v — exponential backoff not applied", elapsed, minElapsed)
+	}
+}
+
+// TestForward_RetryIdempotentMethods verifies that only GET, HEAD, PUT, DELETE
+// are retried by default when Methods is empty.
+func TestForward_RetryIdempotentMethods(t *testing.T) {
+	tests := []struct {
+		method      string
+		shouldRetry bool
+	}{
+		{"GET", true},
+		{"HEAD", true},
+		{"PUT", true},
+		{"DELETE", true},
+		{"POST", false},
+		{"PATCH", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s shouldRetry=%v", tt.method, tt.shouldRetry), func(t *testing.T) {
+			var callCount atomic.Int32
+
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callCount.Add(1)
+				// HEAD must not write a body per RFC 9110.
+				if r.Method == http.MethodHead {
+					w.WriteHeader(http.StatusServiceUnavailable)
+					return
+				}
+				w.WriteHeader(http.StatusServiceUnavailable)
+			}))
+			defer upstream.Close()
+
+			route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+				domainegress.WithRetry(domainegress.RetryConfig{
+					Max:            2,
+					Backoff:        domainegress.RetryBackoffFixed,
+					InitialBackoff: 2 * time.Millisecond,
+					// Methods empty — uses default idempotent set.
+				}),
+			)
+
+			proxy := newTestProxy(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny)
+
+			req, err := domainegress.NewEgressRequest(tt.method, upstream.URL+"/v1/resource", nil, nil)
+			if err != nil {
+				t.Fatalf("NewEgressRequest: %v", err)
+			}
+
+			_, _ = proxy.HandleRequest(context.Background(), req)
+
+			got := callCount.Load()
+			var want int32
+			if tt.shouldRetry {
+				want = 3 // 1 initial + 2 retries
+			} else {
+				want = 1
+			}
+			if got != want {
+				t.Errorf("callCount = %d, want %d (method %s)", got, want, tt.method)
+			}
+		})
+	}
+}

--- a/internal/domain/egress/response.go
+++ b/internal/domain/egress/response.go
@@ -25,6 +25,11 @@ type EgressResponse struct {
 	// Duration is the wall-clock time elapsed from sending the request to
 	// receiving the response headers from the upstream service.
 	Duration time.Duration
+
+	// Attempts is the total number of upstream attempts made to obtain this
+	// response, counting the initial request and any retries. A value of 1
+	// means no retries were performed. Zero means the field was not set.
+	Attempts int
 }
 
 // NewEgressResponse constructs an EgressResponse.

--- a/internal/domain/egress/route.go
+++ b/internal/domain/egress/route.go
@@ -37,11 +37,42 @@ type RetryConfig struct {
 	Max int
 
 	// Methods is the set of HTTP methods eligible for retry (e.g. ["GET", "PUT"]).
-	// When empty, all methods are retried.
+	// When empty the default idempotent set is used (GET, HEAD, PUT, DELETE).
 	Methods []string
 
 	// Backoff selects the backoff strategy. Defaults to exponential when empty.
 	Backoff RetryBackoff
+
+	// InitialBackoff is the base wait duration before the first retry.
+	// Defaults to 100 ms when zero.
+	InitialBackoff time.Duration
+}
+
+// defaultIdempotentMethods is the set of HTTP methods that are safe to retry
+// by default because they are idempotent per RFC 9110.
+var defaultIdempotentMethods = map[string]struct{}{
+	"GET":    {},
+	"HEAD":   {},
+	"PUT":    {},
+	"DELETE": {},
+}
+
+// IsRetryableMethod reports whether method is eligible for retry under this
+// RetryConfig. When Methods is empty the default idempotent set is used
+// (GET, HEAD, PUT, DELETE). Otherwise only methods listed in Methods are
+// eligible.
+func (r RetryConfig) IsRetryableMethod(method string) bool {
+	upper := strings.ToUpper(method)
+	if len(r.Methods) == 0 {
+		_, ok := defaultIdempotentMethods[upper]
+		return ok
+	}
+	for _, m := range r.Methods {
+		if strings.ToUpper(m) == upper {
+			return true
+		}
+	}
+	return false
 }
 
 // SecretConfig holds secret injection parameters for a route.

--- a/internal/domain/egress/route_test.go
+++ b/internal/domain/egress/route_test.go
@@ -110,6 +110,85 @@ func TestNewRoute_Accessors(t *testing.T) {
 	}
 }
 
+func TestRetryConfig_IsRetryableMethod(t *testing.T) {
+	tests := []struct {
+		name   string
+		cfg    egress.RetryConfig
+		method string
+		want   bool
+	}{
+		{
+			name:   "empty methods: GET is retryable by default",
+			cfg:    egress.RetryConfig{},
+			method: "GET",
+			want:   true,
+		},
+		{
+			name:   "empty methods: HEAD is retryable by default",
+			cfg:    egress.RetryConfig{},
+			method: "HEAD",
+			want:   true,
+		},
+		{
+			name:   "empty methods: PUT is retryable by default",
+			cfg:    egress.RetryConfig{},
+			method: "PUT",
+			want:   true,
+		},
+		{
+			name:   "empty methods: DELETE is retryable by default",
+			cfg:    egress.RetryConfig{},
+			method: "DELETE",
+			want:   true,
+		},
+		{
+			name:   "empty methods: POST is NOT retryable by default",
+			cfg:    egress.RetryConfig{},
+			method: "POST",
+			want:   false,
+		},
+		{
+			name:   "empty methods: PATCH is NOT retryable by default",
+			cfg:    egress.RetryConfig{},
+			method: "PATCH",
+			want:   false,
+		},
+		{
+			name:   "explicit methods: listed method is retryable",
+			cfg:    egress.RetryConfig{Methods: []string{"GET", "POST"}},
+			method: "POST",
+			want:   true,
+		},
+		{
+			name:   "explicit methods: unlisted method is not retryable",
+			cfg:    egress.RetryConfig{Methods: []string{"GET"}},
+			method: "DELETE",
+			want:   false,
+		},
+		{
+			name:   "case insensitive match in explicit methods",
+			cfg:    egress.RetryConfig{Methods: []string{"get"}},
+			method: "GET",
+			want:   true,
+		},
+		{
+			name:   "case insensitive match in default idempotent set",
+			cfg:    egress.RetryConfig{},
+			method: "get",
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.IsRetryableMethod(tt.method)
+			if got != tt.want {
+				t.Errorf("IsRetryableMethod(%q) = %v, want %v", tt.method, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRoute_MatchesMethod(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
Closes #363

## Summary

- **Per-route timeout returning 504**: `forward()` applies `context.WithTimeout` using `Route.Timeout()` when set, falling back to `ProxyConfig.DefaultTimeout`. When the deadline is exceeded the HTTP handler returns `504 Gateway Timeout` instead of `502`.
- **Retry with backoff**: When a matched route's `RetryConfig` has `Max > 0` and the request method is retryable, transient failures (status codes 408, 429, 500, 502, 503, 504, and network errors) trigger up to `Max` additional attempts. Backoff is exponential (default) or fixed per `RetryConfig.Backoff`.
- **Idempotent-only by default**: When `RetryConfig.Methods` is empty, only GET, HEAD, PUT, DELETE are retried (RFC 9110 idempotent set). Explicit `Methods` overrides this.
- **Structured events**: each retry emits an `egress.retry` log event; each timeout emits `egress.timeout` — both carry `event_type`, `url`, `method`, `attempt`, `max_attempts`, `backoff`, and `reason`.
- **X-Egress-Attempts header**: total upstream attempts (initial + retries) are written to `X-Egress-Attempts` on the response.
- **`RetryConfig.InitialBackoff`** field added to domain (defaults to 100 ms).
- **`RetryConfig.IsRetryableMethod()`** pure domain method added.
- **`EgressResponse.Attempts`** field added to carry attempt count from adapter to HTTP handler.

## Files changed

- `internal/domain/egress/route.go` — `RetryConfig.InitialBackoff`, `IsRetryableMethod()`, `defaultIdempotentMethods`
- `internal/domain/egress/response.go` — `EgressResponse.Attempts` field
- `internal/adapters/egress/proxy.go` — retry loop in `forward()`, `isTimeoutError()`, `computeBackoff()`, `sleep()`, `retryableStatusCodes`, `headerEgressAttempts`, 504 branch in HTTP handler
- `internal/adapters/egress/retry_timeout_test.go` — new test file (8 test functions)
- `internal/domain/egress/route_test.go` — `TestRetryConfig_IsRetryableMethod` table test

## Test plan

- [ ] `make check` passes (all tests green, no vet or format errors)
- [ ] `TestForward_PerRouteTimeout_Returns504` — per-route timeout returns 504
- [ ] `TestForward_DefaultTimeout_Returns504` — global default timeout returns 504
- [ ] `TestForward_RetryOnTransientStatus` — 2x503 then 200, `X-Egress-Attempts: 3`
- [ ] `TestForward_NoRetryOnNonIdempotentMethod` — POST not retried, `X-Egress-Attempts: 1`
- [ ] `TestForward_RetryExhausted` — all retries fail, last 503 returned as response
- [ ] `TestForward_NoRetry_AttemptsIsOne` — no retry config, `Attempts == 1`
- [ ] `TestForward_ExponentialBackoff` — elapsed time validates doubling
- [ ] `TestForward_RetryIdempotentMethods` — GET/HEAD/PUT/DELETE retried; POST/PATCH not
- [ ] `TestRetryConfig_IsRetryableMethod` — domain table test covering all branches