### PR TITLE
feat(#360): add per-route egress circuit breaker

### DIFF
--- a/internal/adapters/egress/circuit_breakers.go
+++ b/internal/adapters/egress/circuit_breakers.go
@@ -1,0 +1,222 @@
+// Package egress implements the HTTP listener and request forwarding adapter
+// for the egress proxy plugin.
+package egress
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	domainresilience "github.com/vibewarden/vibewarden/internal/domain/resilience"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// circuitBreakerEntry holds the concurrency-safe state for a single per-route
+// circuit breaker backed by the domain entity.
+type circuitBreakerEntry struct {
+	mu        sync.Mutex
+	cb        *domainresilience.CircuitBreaker
+	routeName string
+	cfg       domainresilience.CircuitBreakerConfig
+}
+
+// isOpen returns true when the circuit is open and requests should be rejected.
+// It advances the state from Open to HalfOpen when the reset timeout expires.
+func (e *circuitBreakerEntry) isOpen() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.cb.IsOpen(time.Now())
+}
+
+// recordSuccess records a successful upstream response and returns the previous
+// state so callers can detect HalfOpen→Closed transitions.
+func (e *circuitBreakerEntry) recordSuccess() domainresilience.State {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.cb.RecordSuccess()
+}
+
+// recordFailure records a failed upstream response and returns the previous
+// state together with a boolean indicating whether a state transition occurred.
+func (e *circuitBreakerEntry) recordFailure() (previous domainresilience.State, transitioned bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.cb.RecordFailure(time.Now())
+}
+
+// CircuitBreakerRegistry maintains one circuit breaker per named egress route.
+// It is safe for concurrent use. Each entry is created lazily on first access
+// and is only created when the route has a non-zero CircuitBreakerConfig.
+type CircuitBreakerRegistry struct {
+	mu      sync.Mutex
+	entries map[string]*circuitBreakerEntry
+
+	logger  *slog.Logger
+	eventFn ports.EventLogger
+}
+
+// NewCircuitBreakerRegistry creates a CircuitBreakerRegistry. Pass nil for
+// logger to use slog.Default(). Pass nil for eventFn to disable structured
+// event emission.
+func NewCircuitBreakerRegistry(logger *slog.Logger, eventFn ports.EventLogger) *CircuitBreakerRegistry {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &CircuitBreakerRegistry{
+		entries: make(map[string]*circuitBreakerEntry),
+		logger:  logger,
+		eventFn: eventFn,
+	}
+}
+
+// getOrCreate returns the circuit breaker for the given route, creating it if
+// it does not yet exist. Returns (nil, nil) when the route has no circuit
+// breaker configuration (Threshold == 0 || ResetAfter == 0).
+func (r *CircuitBreakerRegistry) getOrCreate(route domainegress.Route) (*circuitBreakerEntry, error) {
+	cbCfg := route.CircuitBreaker()
+	if cbCfg.Threshold <= 0 || cbCfg.ResetAfter <= 0 {
+		return nil, nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if e, ok := r.entries[route.Name()]; ok {
+		return e, nil
+	}
+
+	domainCfg := domainresilience.CircuitBreakerConfig{
+		Threshold: cbCfg.Threshold,
+		Timeout:   cbCfg.ResetAfter,
+	}
+	cb, err := domainresilience.NewCircuitBreaker(domainCfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating circuit breaker for route %q: %w", route.Name(), err)
+	}
+
+	entry := &circuitBreakerEntry{
+		cb:        cb,
+		routeName: route.Name(),
+		cfg:       domainCfg,
+	}
+	r.entries[route.Name()] = entry
+	return entry, nil
+}
+
+// IsOpen returns true when the per-route circuit breaker for the matched route
+// is in the open state and the request should be rejected immediately. It
+// returns false when the route has no circuit breaker configured.
+func (r *CircuitBreakerRegistry) IsOpen(ctx context.Context, route domainegress.Route) (bool, error) {
+	entry, err := r.getOrCreate(route)
+	if err != nil {
+		return false, err
+	}
+	if entry == nil {
+		return false, nil
+	}
+
+	prevState := func() domainresilience.State {
+		entry.mu.Lock()
+		defer entry.mu.Unlock()
+		return entry.cb.State()
+	}()
+
+	open := entry.isOpen()
+
+	// Detect Open → HalfOpen transition to emit the structured event.
+	newState := func() domainresilience.State {
+		entry.mu.Lock()
+		defer entry.mu.Unlock()
+		return entry.cb.State()
+	}()
+	if prevState == domainresilience.StateOpen && newState == domainresilience.StateHalfOpen {
+		r.logger.InfoContext(ctx, "egress.circuit_breaker.half_open",
+			slog.String("event_type", "egress.circuit_breaker.half_open"),
+			slog.String("route", route.Name()),
+		)
+	}
+
+	return open, nil
+}
+
+// RecordSuccess records a successful upstream response for the given route's
+// circuit breaker. When the circuit was in HalfOpen state and transitions to
+// Closed, a structured egress.circuit_breaker.closed event is emitted.
+// Has no effect when the route has no circuit breaker configured.
+func (r *CircuitBreakerRegistry) RecordSuccess(ctx context.Context, route domainegress.Route) {
+	entry, err := r.getOrCreate(route)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "egress circuit breaker: failed to get entry on success",
+			slog.String("route", route.Name()),
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+	if entry == nil {
+		return
+	}
+
+	previous := entry.recordSuccess()
+	if previous == domainresilience.StateHalfOpen {
+		// HalfOpen → Closed transition.
+		r.logger.InfoContext(ctx, "egress.circuit_breaker.closed",
+			slog.String("event_type", events.EventTypeEgressCircuitBreakerClosed),
+			slog.String("route", route.Name()),
+		)
+		r.emitEvent(ctx, events.NewEgressCircuitBreakerClosed(events.EgressCircuitBreakerClosedParams{
+			Route: route.Name(),
+		}))
+	}
+}
+
+// RecordFailure records a failed upstream response for the given route's circuit
+// breaker. When the failure threshold is reached (Closed→Open) or a probe fails
+// (HalfOpen→Open), a structured egress.circuit_breaker.opened event is emitted.
+// Has no effect when the route has no circuit breaker configured.
+func (r *CircuitBreakerRegistry) RecordFailure(ctx context.Context, route domainegress.Route) {
+	entry, err := r.getOrCreate(route)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "egress circuit breaker: failed to get entry on failure",
+			slog.String("route", route.Name()),
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+	if entry == nil {
+		return
+	}
+
+	_, transitioned := entry.recordFailure()
+	if transitioned {
+		// Closed→Open or HalfOpen→Open.
+		r.logger.WarnContext(ctx, "egress.circuit_breaker.opened",
+			slog.String("event_type", events.EventTypeEgressCircuitBreakerOpened),
+			slog.String("route", route.Name()),
+			slog.Int("threshold", entry.cfg.Threshold),
+			slog.Float64("timeout_seconds", entry.cfg.Timeout.Seconds()),
+		)
+		r.emitEvent(ctx, events.NewEgressCircuitBreakerOpened(events.EgressCircuitBreakerOpenedParams{
+			Route:          route.Name(),
+			Threshold:      entry.cfg.Threshold,
+			TimeoutSeconds: entry.cfg.Timeout.Seconds(),
+		}))
+	}
+}
+
+// emitEvent sends a structured event via the EventLogger. Failures are logged
+// but do not interrupt request handling.
+func (r *CircuitBreakerRegistry) emitEvent(ctx context.Context, ev events.Event) {
+	if r.eventFn == nil {
+		return
+	}
+	if err := r.eventFn.Log(ctx, ev); err != nil {
+		r.logger.Error("egress circuit breaker: failed to emit event",
+			slog.String("event_type", ev.EventType),
+			slog.String("err", err.Error()),
+		)
+	}
+}

--- a/internal/adapters/egress/circuit_breakers_test.go
+++ b/internal/adapters/egress/circuit_breakers_test.go
@@ -1,0 +1,514 @@
+package egress_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	egressadapter "github.com/vibewarden/vibewarden/internal/adapters/egress"
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+)
+
+// fakeEventLogger records emitted events for circuit breaker test assertions.
+type fakeEventLogger struct {
+	mu     sync.Mutex
+	logged []events.Event
+}
+
+func (f *fakeEventLogger) Log(_ context.Context, ev events.Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.logged = append(f.logged, ev)
+	return nil
+}
+
+func (f *fakeEventLogger) eventTypes() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.logged))
+	for i, e := range f.logged {
+		out[i] = e.EventType
+	}
+	return out
+}
+
+func (f *fakeEventLogger) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.logged)
+}
+
+// newTestProxyWithCB creates a Proxy wired to the given routes, HTTP client,
+// and circuit breaker registry.
+func newTestProxyWithCB(
+	t *testing.T,
+	routes []domainegress.Route,
+	client *http.Client,
+	policy domainegress.Policy,
+	cb *egressadapter.CircuitBreakerRegistry,
+) *egressadapter.Proxy {
+	t.Helper()
+	resolver := egressadapter.NewRouteResolver(routes)
+	cfg := egressadapter.ProxyConfig{
+		Listen:          "127.0.0.1:0",
+		DefaultPolicy:   policy,
+		DefaultTimeout:  5 * time.Second,
+		Routes:          routes,
+		CircuitBreakers: cb,
+	}
+	return egressadapter.NewProxy(cfg, resolver, client, nil)
+}
+
+// TestCircuitBreakerRegistry_NoConfig verifies that a route without a
+// CircuitBreakerConfig does not block any requests.
+func TestCircuitBreakerRegistry_NoConfig(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	// Route without circuit breaker configuration (zero value).
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*")
+
+	el := &fakeEventLogger{}
+	cb := egressadapter.NewCircuitBreakerRegistry(nil, el)
+	proxy := newTestProxyWithCB(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny, cb)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest returned unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	// No events should be emitted for a route without a circuit breaker.
+	if got := el.count(); got != 0 {
+		t.Errorf("event count = %d, want 0", got)
+	}
+}
+
+// TestCircuitBreakerRegistry_TripsAfterThreshold verifies that the circuit
+// opens after the configured number of consecutive failures.
+func TestCircuitBreakerRegistry_TripsAfterThreshold(t *testing.T) {
+	var callCount atomic.Int32
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithCircuitBreaker(domainegress.CircuitBreakerConfig{
+			Threshold:  3,
+			ResetAfter: 10 * time.Second,
+		}),
+	)
+
+	el := &fakeEventLogger{}
+	cb := egressadapter.NewCircuitBreakerRegistry(nil, el)
+	proxy := newTestProxyWithCB(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny, cb)
+
+	doRequest := func() (int, error) {
+		req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+		if err != nil {
+			t.Fatalf("NewEgressRequest: %v", err)
+		}
+		resp, err := proxy.HandleRequest(context.Background(), req)
+		if err != nil {
+			return 0, err
+		}
+		return resp.StatusCode, nil
+	}
+
+	// First three requests should pass through to the upstream (which returns 500).
+	for i := 0; i < 3; i++ {
+		status, err := doRequest()
+		if err != nil {
+			t.Fatalf("request %d returned unexpected error: %v", i+1, err)
+		}
+		if status != http.StatusInternalServerError {
+			t.Errorf("request %d: StatusCode = %d, want %d", i+1, status, http.StatusInternalServerError)
+		}
+	}
+
+	// Upstream should have been called exactly 3 times.
+	if got := callCount.Load(); got != 3 {
+		t.Errorf("upstream call count after threshold = %d, want 3", got)
+	}
+
+	// The circuit should now be open — next request must be rejected with ErrCircuitOpen.
+	_, err := doRequest()
+	if err != egressadapter.ErrCircuitOpen {
+		t.Errorf("fourth request error = %v, want ErrCircuitOpen", err)
+	}
+
+	// Upstream must NOT have been called a fourth time.
+	if got := callCount.Load(); got != 3 {
+		t.Errorf("upstream call count after open circuit = %d, want 3", got)
+	}
+
+	// A single egress.circuit_breaker.opened event must have been emitted.
+	types := el.eventTypes()
+	if len(types) != 1 || types[0] != events.EventTypeEgressCircuitBreakerOpened {
+		t.Errorf("events = %v, want [%s]", types, events.EventTypeEgressCircuitBreakerOpened)
+	}
+}
+
+// TestCircuitBreakerRegistry_HTTP503OnOpenCircuit verifies that the HTTP
+// handler returns 503 when the circuit is open.
+func TestCircuitBreakerRegistry_HTTP503OnOpenCircuit(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithCircuitBreaker(domainegress.CircuitBreakerConfig{
+			Threshold:  2,
+			ResetAfter: 30 * time.Second,
+		}),
+	)
+
+	cb := egressadapter.NewCircuitBreakerRegistry(nil, nil)
+
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:          "127.0.0.1:0",
+		DefaultPolicy:   domainegress.PolicyDeny,
+		DefaultTimeout:  5 * time.Second,
+		Routes:          []domainegress.Route{route},
+		CircuitBreakers: cb,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	sendRequest := func() int {
+		httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+		if err != nil {
+			t.Fatalf("http.NewRequest: %v", err)
+		}
+		httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/resource")
+		resp, err := proxyClient.Do(httpReq)
+		if err != nil {
+			t.Fatalf("proxy request: %v", err)
+		}
+		resp.Body.Close() //nolint:errcheck
+		return resp.StatusCode
+	}
+
+	// First two requests trip the circuit (threshold = 2).
+	for i := 0; i < 2; i++ {
+		if got := sendRequest(); got != http.StatusBadGateway {
+			// Upstream returns 500, which forward() converts to a 502 upstream error
+			// response (no error returned because the response was received).
+			// Actually 500 is returned as the status since we get a response back.
+			// The circuit records the failure but returns the upstream status.
+			_ = got // accept whatever status the upstream sends back
+		}
+	}
+
+	// Third request: circuit is open → 503.
+	if got := sendRequest(); got != http.StatusServiceUnavailable {
+		t.Errorf("StatusCode on open circuit = %d, want %d", got, http.StatusServiceUnavailable)
+	}
+}
+
+// TestCircuitBreakerRegistry_ClosesAfterReset verifies that the circuit breaker
+// returns to Closed after the reset timeout and a successful probe.
+func TestCircuitBreakerRegistry_ClosesAfterReset(t *testing.T) {
+	var failNext atomic.Bool
+	failNext.Store(true)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if failNext.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithCircuitBreaker(domainegress.CircuitBreakerConfig{
+			Threshold:  2,
+			ResetAfter: 50 * time.Millisecond, // very short so tests stay fast
+		}),
+	)
+
+	el := &fakeEventLogger{}
+	cb := egressadapter.NewCircuitBreakerRegistry(nil, el)
+	proxy := newTestProxyWithCB(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny, cb)
+
+	doRequest := func() error {
+		req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+		if err != nil {
+			t.Fatalf("NewEgressRequest: %v", err)
+		}
+		_, err = proxy.HandleRequest(context.Background(), req)
+		return err
+	}
+
+	// Trip the circuit.
+	for i := 0; i < 2; i++ {
+		if err := doRequest(); err != nil && err != egressadapter.ErrCircuitOpen {
+			// Transport or upstream failure — acceptable here.
+		}
+	}
+
+	// Circuit should now be open.
+	if err := doRequest(); err != egressadapter.ErrCircuitOpen {
+		t.Fatalf("expected ErrCircuitOpen after threshold, got %v", err)
+	}
+
+	// Wait for the reset timeout to expire.
+	time.Sleep(100 * time.Millisecond)
+
+	// Allow the upstream to succeed now.
+	failNext.Store(false)
+
+	// The probe request should go through (HalfOpen → Closed).
+	if err := doRequest(); err != nil {
+		t.Errorf("probe request failed unexpectedly: %v", err)
+	}
+
+	// Subsequent requests should also succeed (Closed state).
+	if err := doRequest(); err != nil {
+		t.Errorf("post-probe request failed: %v", err)
+	}
+
+	// A circuit_breaker.closed event must have been emitted.
+	types := el.eventTypes()
+	found := false
+	for _, et := range types {
+		if et == events.EventTypeEgressCircuitBreakerClosed {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("events = %v, want at least one %s", types, events.EventTypeEgressCircuitBreakerClosed)
+	}
+}
+
+// TestCircuitBreakerRegistry_NilRegistrySkipsChecks verifies that when
+// CircuitBreakers is nil in ProxyConfig, all requests proceed normally.
+func TestCircuitBreakerRegistry_NilRegistrySkipsChecks(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithCircuitBreaker(domainegress.CircuitBreakerConfig{
+			Threshold:  1,
+			ResetAfter: 10 * time.Second,
+		}),
+	)
+
+	// Proxy with nil CircuitBreakers — circuit breaking disabled.
+	proxy := newTestProxy(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest returned unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+// TestCircuitBreakerRegistry_TransportErrorCountsAsFailure verifies that a
+// transport-level error (e.g., connection refused) counts as a failure.
+func TestCircuitBreakerRegistry_TransportErrorCountsAsFailure(t *testing.T) {
+	// Point the route at a port that is not listening.
+	unreachableURL := "http://127.0.0.1:19999"
+
+	route := newTestRoute(t, "api", unreachableURL+"/v1/*",
+		domainegress.WithCircuitBreaker(domainegress.CircuitBreakerConfig{
+			Threshold:  2,
+			ResetAfter: 10 * time.Second,
+		}),
+	)
+
+	el := &fakeEventLogger{}
+	cb := egressadapter.NewCircuitBreakerRegistry(nil, el)
+	proxy := newTestProxyWithCB(t, []domainegress.Route{route}, nil, domainegress.PolicyDeny, cb)
+
+	doRequest := func() error {
+		req, err := domainegress.NewEgressRequest("GET", unreachableURL+"/v1/resource", nil, nil)
+		if err != nil {
+			t.Fatalf("NewEgressRequest: %v", err)
+		}
+		_, err = proxy.HandleRequest(context.Background(), req)
+		return err
+	}
+
+	// Two transport failures should trip the circuit.
+	for i := 0; i < 2; i++ {
+		if err := doRequest(); err == nil {
+			t.Fatalf("request %d: expected transport error, got nil", i+1)
+		}
+	}
+
+	// Next request should be rejected by the open circuit — not a transport error.
+	if err := doRequest(); err != egressadapter.ErrCircuitOpen {
+		t.Errorf("expected ErrCircuitOpen after transport failures, got %v", err)
+	}
+
+	// A circuit_breaker.opened event must have been emitted.
+	types := el.eventTypes()
+	if len(types) == 0 || types[len(types)-1] != events.EventTypeEgressCircuitBreakerOpened {
+		t.Errorf("events = %v, want last event to be %s", types, events.EventTypeEgressCircuitBreakerOpened)
+	}
+}
+
+// TestCircuitBreakerRegistry_IndependentPerRoute verifies that circuit breakers
+// are isolated per route — one route tripping does not affect another.
+func TestCircuitBreakerRegistry_IndependentPerRoute(t *testing.T) {
+	goodUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer goodUpstream.Close()
+
+	badUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer badUpstream.Close()
+
+	routeGood := newTestRoute(t, "good", goodUpstream.URL+"/v1/*",
+		domainegress.WithCircuitBreaker(domainegress.CircuitBreakerConfig{
+			Threshold:  2,
+			ResetAfter: 10 * time.Second,
+		}),
+	)
+	routeBad := newTestRoute(t, "bad", badUpstream.URL+"/v1/*",
+		domainegress.WithCircuitBreaker(domainegress.CircuitBreakerConfig{
+			Threshold:  2,
+			ResetAfter: 10 * time.Second,
+		}),
+	)
+
+	cb := egressadapter.NewCircuitBreakerRegistry(nil, nil)
+	proxy := newTestProxyWithCB(t,
+		[]domainegress.Route{routeGood, routeBad},
+		// Use a client that can reach both test servers.
+		http.DefaultClient,
+		domainegress.PolicyDeny,
+		cb,
+	)
+
+	doRequest := func(url string) error {
+		req, err := domainegress.NewEgressRequest("GET", url, nil, nil)
+		if err != nil {
+			t.Fatalf("NewEgressRequest: %v", err)
+		}
+		_, err = proxy.HandleRequest(context.Background(), req)
+		return err
+	}
+
+	// Trip the "bad" route circuit.
+	for i := 0; i < 2; i++ {
+		_ = doRequest(badUpstream.URL + "/v1/resource")
+	}
+
+	// "bad" route circuit should now be open.
+	if err := doRequest(badUpstream.URL + "/v1/resource"); err != egressadapter.ErrCircuitOpen {
+		t.Errorf("bad route: expected ErrCircuitOpen, got %v", err)
+	}
+
+	// "good" route circuit must still be closed — requests pass through.
+	if err := doRequest(goodUpstream.URL + "/v1/resource"); err != nil {
+		t.Errorf("good route: unexpected error: %v", err)
+	}
+}
+
+// TestEventPayload_CircuitBreakerOpened verifies that the
+// egress.circuit_breaker.opened event carries the expected payload fields.
+func TestEventPayload_CircuitBreakerOpened(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	const (
+		routeName  = "payments"
+		threshold  = 2
+		resetAfter = 5 * time.Second
+	)
+
+	route := newTestRoute(t, routeName, upstream.URL+"/v1/*",
+		domainegress.WithCircuitBreaker(domainegress.CircuitBreakerConfig{
+			Threshold:  threshold,
+			ResetAfter: resetAfter,
+		}),
+	)
+
+	el := &fakeEventLogger{}
+	cb := egressadapter.NewCircuitBreakerRegistry(nil, el)
+	proxy := newTestProxyWithCB(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny, cb)
+
+	for i := 0; i < threshold; i++ {
+		req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+		if err != nil {
+			t.Fatalf("NewEgressRequest: %v", err)
+		}
+		_, _ = proxy.HandleRequest(context.Background(), req)
+	}
+
+	evTypes := el.eventTypes()
+	if len(evTypes) == 0 {
+		t.Fatal("no events emitted")
+	}
+
+	el.mu.Lock()
+	var openedEv events.Event
+	for _, e := range el.logged {
+		if e.EventType == events.EventTypeEgressCircuitBreakerOpened {
+			openedEv = e
+			break
+		}
+	}
+	el.mu.Unlock()
+
+	if openedEv.EventType == "" {
+		t.Fatalf("no %s event found in %v", events.EventTypeEgressCircuitBreakerOpened, evTypes)
+	}
+	if openedEv.SchemaVersion != "v1" {
+		t.Errorf("SchemaVersion = %q, want %q", openedEv.SchemaVersion, "v1")
+	}
+	if got, ok := openedEv.Payload["route"].(string); !ok || got != routeName {
+		t.Errorf("payload.route = %v, want %q", openedEv.Payload["route"], routeName)
+	}
+	if got, ok := openedEv.Payload["threshold"].(int); !ok || got != threshold {
+		t.Errorf("payload.threshold = %v, want %d", openedEv.Payload["threshold"], threshold)
+	}
+	if got, ok := openedEv.Payload["timeout_seconds"].(float64); !ok || got != resetAfter.Seconds() {
+		t.Errorf("payload.timeout_seconds = %v, want %f", openedEv.Payload["timeout_seconds"], resetAfter.Seconds())
+	}
+	if openedEv.AISummary == "" {
+		t.Error("AISummary must not be empty")
+	}
+}

--- a/internal/adapters/egress/errors.go
+++ b/internal/adapters/egress/errors.go
@@ -5,3 +5,8 @@ import "errors"
 // ErrDeniedByPolicy is returned by Proxy.HandleRequest when the request does
 // not match any configured route and the default policy is deny.
 var ErrDeniedByPolicy = errors.New("egress: request denied by policy")
+
+// ErrCircuitOpen is returned by Proxy.HandleRequest when the per-route circuit
+// breaker is in the open state and the request is short-circuited before any
+// upstream contact is made.
+var ErrCircuitOpen = errors.New("egress: circuit breaker is open")

--- a/internal/adapters/egress/proxy.go
+++ b/internal/adapters/egress/proxy.go
@@ -96,6 +96,12 @@ type ProxyConfig struct {
 	// When nil, no secret injection is performed even if a route is configured
 	// with a SecretConfig.
 	SecretInjector ports.SecretInjector
+
+	// CircuitBreakers, when non-nil, is the per-route circuit breaker registry
+	// used to short-circuit requests to routes whose upstream has been failing.
+	// When nil, circuit breaking is disabled for all routes regardless of their
+	// CircuitBreakerConfig.
+	CircuitBreakers *CircuitBreakerRegistry
 }
 
 // Proxy is an HTTP server that listens on a dedicated localhost port and
@@ -209,7 +215,8 @@ func (p *Proxy) Stop(ctx context.Context) error {
 }
 
 // HandleRequest implements ports.EgressProxy. It resolves the route for the
-// request, enforces the default policy, and forwards the request upstream.
+// request, enforces the default policy, checks the per-route circuit breaker,
+// and forwards the request upstream.
 func (p *Proxy) HandleRequest(ctx context.Context, req domainegress.EgressRequest) (domainegress.EgressResponse, error) {
 	match, err := p.resolver.Resolve(ctx, req)
 	if err != nil {
@@ -219,6 +226,17 @@ func (p *Proxy) HandleRequest(ctx context.Context, req domainegress.EgressReques
 	if !match.Matched {
 		if p.cfg.DefaultPolicy == domainegress.PolicyDeny {
 			return domainegress.EgressResponse{}, ErrDeniedByPolicy
+		}
+	}
+
+	// Check per-route circuit breaker before attempting the upstream call.
+	if match.Matched && p.cfg.CircuitBreakers != nil {
+		open, cbErr := p.cfg.CircuitBreakers.IsOpen(ctx, match.Route)
+		if cbErr != nil {
+			return domainegress.EgressResponse{}, fmt.Errorf("circuit breaker check: %w", cbErr)
+		}
+		if open {
+			return domainegress.EgressResponse{}, ErrCircuitOpen
 		}
 	}
 
@@ -250,6 +268,14 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if err == ErrDeniedByPolicy {
 			http.Error(w, "403 Forbidden: request denied by egress policy", http.StatusForbidden)
+			return
+		}
+		if err == ErrCircuitOpen {
+			p.logger.WarnContext(r.Context(), "egress circuit breaker open — request rejected",
+				slog.String("target", targetURL),
+				slog.String("method", r.Method),
+			)
+			http.Error(w, "503 Service Unavailable: egress circuit breaker is open", http.StatusServiceUnavailable)
 			return
 		}
 		var ssrfErr *SSRFBlockedError
@@ -482,6 +508,9 @@ func (p *Proxy) forward(ctx context.Context, req domainegress.EgressRequest, mat
 					slog.String("method", req.Method),
 					slog.Int("attempt", attempt),
 				)
+				if match.Matched && p.cfg.CircuitBreakers != nil {
+					p.cfg.CircuitBreakers.RecordFailure(ctx, match.Route)
+				}
 				return domainegress.EgressResponse{}, fmt.Errorf("forwarding request to %s: %w", req.URL, err)
 			}
 
@@ -498,11 +527,17 @@ func (p *Proxy) forward(ctx context.Context, req domainegress.EgressRequest, mat
 				)
 				if !sleep(reqCtx, backoff) {
 					// Context cancelled during backoff — surface timeout.
+					if match.Matched && p.cfg.CircuitBreakers != nil {
+						p.cfg.CircuitBreakers.RecordFailure(ctx, match.Route)
+					}
 					return domainegress.EgressResponse{}, fmt.Errorf("forwarding request to %s: %w", req.URL, reqCtx.Err())
 				}
 				continue
 			}
 
+			if match.Matched && p.cfg.CircuitBreakers != nil {
+				p.cfg.CircuitBreakers.RecordFailure(ctx, match.Route)
+			}
 			return domainegress.EgressResponse{}, fmt.Errorf("forwarding request to %s: %w", req.URL, err)
 		}
 
@@ -535,6 +570,15 @@ func (p *Proxy) forward(ctx context.Context, req domainegress.EgressRequest, mat
 
 	if lastErr != nil {
 		return domainegress.EgressResponse{}, fmt.Errorf("forwarding request to %s: %w", req.URL, lastErr)
+	}
+
+	// Record circuit breaker outcome based on the final response status.
+	if match.Matched && p.cfg.CircuitBreakers != nil {
+		if isFailureStatus(lastResp.StatusCode) {
+			p.cfg.CircuitBreakers.RecordFailure(ctx, match.Route)
+		} else {
+			p.cfg.CircuitBreakers.RecordSuccess(ctx, match.Route)
+		}
 	}
 
 	duration := time.Since(start)
@@ -688,6 +732,13 @@ func isTimeoutError(err error) bool {
 		return netErr.Timeout()
 	}
 	return false
+}
+
+// isFailureStatus reports whether the given HTTP status code should be treated
+// as an upstream failure for circuit breaker purposes. 5xx server errors are
+// considered failures; client errors (4xx) and successful responses are not.
+func isFailureStatus(code int) bool {
+	return code >= http.StatusInternalServerError
 }
 
 // Interface guard — Proxy must implement ports.EgressProxy.

--- a/internal/domain/events/egress.go
+++ b/internal/domain/events/egress.go
@@ -1,0 +1,78 @@
+package events
+
+import (
+	"fmt"
+	"time"
+)
+
+// Egress circuit breaker event type constants.
+const (
+	// EventTypeEgressCircuitBreakerOpened is emitted when a per-route egress
+	// circuit breaker trips from Closed to Open because consecutive upstream
+	// failures reached the configured threshold.
+	EventTypeEgressCircuitBreakerOpened = "egress.circuit_breaker.opened"
+
+	// EventTypeEgressCircuitBreakerClosed is emitted when a per-route egress
+	// circuit breaker returns to Closed after a successful probe request confirms
+	// that the upstream has recovered.
+	EventTypeEgressCircuitBreakerClosed = "egress.circuit_breaker.closed"
+)
+
+// EgressCircuitBreakerOpenedParams contains the parameters needed to construct
+// an egress.circuit_breaker.opened event.
+type EgressCircuitBreakerOpenedParams struct {
+	// Route is the egress route name whose circuit tripped.
+	Route string
+
+	// Threshold is the consecutive failure count that tripped the circuit.
+	Threshold int
+
+	// TimeoutSeconds is the duration the circuit will remain open before
+	// allowing a probe request, in seconds.
+	TimeoutSeconds float64
+}
+
+// NewEgressCircuitBreakerOpened creates an egress.circuit_breaker.opened event
+// indicating that the per-route circuit breaker has tripped and all outbound
+// requests to that route are being short-circuited with 503.
+func NewEgressCircuitBreakerOpened(params EgressCircuitBreakerOpenedParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeEgressCircuitBreakerOpened,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"Egress circuit breaker opened for route %q after %d consecutive failures; upstream blocked for %.0fs",
+			params.Route, params.Threshold, params.TimeoutSeconds,
+		),
+		Payload: map[string]any{
+			"route":           params.Route,
+			"threshold":       params.Threshold,
+			"timeout_seconds": params.TimeoutSeconds,
+		},
+	}
+}
+
+// EgressCircuitBreakerClosedParams contains the parameters needed to construct
+// an egress.circuit_breaker.closed event.
+type EgressCircuitBreakerClosedParams struct {
+	// Route is the egress route name whose circuit closed.
+	Route string
+}
+
+// NewEgressCircuitBreakerClosed creates an egress.circuit_breaker.closed event
+// indicating that the per-route circuit breaker has returned to normal operation
+// after a successful upstream probe.
+func NewEgressCircuitBreakerClosed(params EgressCircuitBreakerClosedParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeEgressCircuitBreakerClosed,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"Egress circuit breaker closed for route %q; upstream recovered and traffic is flowing normally",
+			params.Route,
+		),
+		Payload: map[string]any{
+			"route": params.Route,
+		},
+	}
+}


### PR DESCRIPTION
Closes #360

## Summary

- **New domain events** (`internal/domain/events/egress.go`): `egress.circuit_breaker.opened` and `egress.circuit_breaker.closed` with full `schema_version`, `ai_summary`, and `payload` fields (route name, threshold, timeout_seconds).
- **CircuitBreakerRegistry** (`internal/adapters/egress/circuit_breakers.go`): per-route lazy-initialised circuit breakers backed by the existing `domain/resilience.CircuitBreaker` entity, each protected by its own mutex, emitting structured events on every Closed->Open and HalfOpen->Closed transition.
- **Proxy wiring** (`internal/adapters/egress/proxy.go`): `ProxyConfig.CircuitBreakers` field; `HandleRequest` checks `IsOpen` before forwarding (returns `ErrCircuitOpen` -> HTTP 503); `forward` calls `RecordSuccess`/`RecordFailure` after every upstream outcome including all transport-error early-return paths (timeout, connection refused, context cancelled during backoff).
- **New error sentinel** (`internal/adapters/egress/errors.go`): `ErrCircuitOpen`.

## Test plan

- `TestCircuitBreakerRegistry_NoConfig` -- route without CB config passes through.
- `TestCircuitBreakerRegistry_TripsAfterThreshold` -- 3 consecutive 500s open the circuit; 4th call returns `ErrCircuitOpen`; upstream not contacted; one `egress.circuit_breaker.opened` event emitted.
- `TestCircuitBreakerRegistry_HTTP503OnOpenCircuit` -- HTTP handler returns 503 when circuit is open.
- `TestCircuitBreakerRegistry_ClosesAfterReset` -- circuit reopens after timeout, successful probe closes it; `egress.circuit_breaker.closed` event emitted.
- `TestCircuitBreakerRegistry_NilRegistrySkipsChecks` -- nil `CircuitBreakers` in config disables all checking.
- `TestCircuitBreakerRegistry_TransportErrorCountsAsFailure` -- connection-refused errors count toward threshold.
- `TestCircuitBreakerRegistry_IndependentPerRoute` -- tripping one route does not affect another.
- `TestEventPayload_CircuitBreakerOpened` -- asserts `schema_version`, `route`, `threshold`, `timeout_seconds`, `ai_summary` on the opened event.
