### PR TITLE
feat(#362): add per-route rate limiting to egress proxy

### DIFF
--- a/internal/adapters/egress/errors.go
+++ b/internal/adapters/egress/errors.go
@@ -10,3 +10,8 @@ var ErrDeniedByPolicy = errors.New("egress: request denied by policy")
 // breaker is in the open state and the request is short-circuited before any
 // upstream contact is made.
 var ErrCircuitOpen = errors.New("egress: circuit breaker is open")
+
+// ErrRateLimitExceeded is returned by Proxy.HandleRequest when the per-route
+// rate limiter has run out of tokens and the request is rejected before any
+// upstream contact is made.
+var ErrRateLimitExceeded = errors.New("egress: rate limit exceeded")

--- a/internal/adapters/egress/proxy.go
+++ b/internal/adapters/egress/proxy.go
@@ -102,6 +102,12 @@ type ProxyConfig struct {
 	// When nil, circuit breaking is disabled for all routes regardless of their
 	// CircuitBreakerConfig.
 	CircuitBreakers *CircuitBreakerRegistry
+
+	// RateLimiters, when non-nil, is the per-route token-bucket rate limiter
+	// registry. Requests that exceed the configured rate are rejected with a
+	// 429 Too Many Requests response before any upstream contact is made. When
+	// nil, per-route rate limiting is disabled regardless of route configuration.
+	RateLimiters *RateLimiterRegistry
 }
 
 // Proxy is an HTTP server that listens on a dedicated localhost port and
@@ -240,6 +246,17 @@ func (p *Proxy) HandleRequest(ctx context.Context, req domainegress.EgressReques
 		}
 	}
 
+	// Check per-route rate limit before attempting the upstream call.
+	if match.Matched && p.cfg.RateLimiters != nil {
+		allowed, rlErr := p.cfg.RateLimiters.Allow(ctx, match.Route)
+		if rlErr != nil {
+			return domainegress.EgressResponse{}, fmt.Errorf("rate limit check: %w", rlErr)
+		}
+		if !allowed {
+			return domainegress.EgressResponse{}, ErrRateLimitExceeded
+		}
+	}
+
 	return p.forward(ctx, req, match)
 }
 
@@ -276,6 +293,28 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 				slog.String("method", r.Method),
 			)
 			http.Error(w, "503 Service Unavailable: egress circuit breaker is open", http.StatusServiceUnavailable)
+			return
+		}
+		if err == ErrRateLimitExceeded {
+			// Resolve the matched route to compute Retry-After.
+			retryAfter := "1"
+			if p.cfg.RateLimiters != nil {
+				egressReq2, reqErr := domainegress.NewEgressRequest(r.Method, targetURL, nil, nil)
+				if reqErr == nil {
+					if m2, resolveErr := p.resolver.Resolve(r.Context(), egressReq2); resolveErr == nil && m2.Matched {
+						if secs, raErr := p.cfg.RateLimiters.RetryAfterSeconds(m2.Route); raErr == nil {
+							retryAfter = retryAfterHeader(secs)
+						}
+					}
+				}
+			}
+			p.logger.WarnContext(r.Context(), "egress rate limit exceeded — request rejected",
+				slog.String("target", targetURL),
+				slog.String("method", r.Method),
+				slog.String("retry_after", retryAfter),
+			)
+			w.Header().Set("Retry-After", retryAfter)
+			http.Error(w, "429 Too Many Requests: egress rate limit exceeded", http.StatusTooManyRequests)
 			return
 		}
 		var ssrfErr *SSRFBlockedError

--- a/internal/adapters/egress/rate_limiters.go
+++ b/internal/adapters/egress/rate_limiters.go
@@ -1,0 +1,232 @@
+// Package egress implements the HTTP listener and request forwarding adapter
+// for the egress proxy plugin.
+package egress
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// rateLimiterEntry holds the concurrency-safe token-bucket limiter for a single
+// named egress route.
+type rateLimiterEntry struct {
+	mu        sync.Mutex
+	limiter   *rate.Limiter
+	rps       float64
+	routeName string
+}
+
+// allow reports whether the next request token is available. It is safe for
+// concurrent use.
+func (e *rateLimiterEntry) allow() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.limiter.Allow()
+}
+
+// retryAfter returns how many seconds the caller should wait until one token
+// is available.
+func (e *rateLimiterEntry) retryAfter() float64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	// Reserve a future token to get the delay, then cancel the reservation so
+	// that the actual token bucket is not drained.
+	r := e.limiter.Reserve()
+	delay := r.Delay()
+	r.Cancel()
+	if delay <= 0 {
+		return 0
+	}
+	return delay.Seconds()
+}
+
+// RateLimiterRegistry maintains one token-bucket limiter per named egress route.
+// Entries are created lazily on first access and are only created when the route
+// carries a non-empty rate limit expression. It is safe for concurrent use.
+type RateLimiterRegistry struct {
+	mu      sync.Mutex
+	entries map[string]*rateLimiterEntry
+
+	logger  *slog.Logger
+	eventFn ports.EventLogger
+}
+
+// NewRateLimiterRegistry creates a RateLimiterRegistry. Pass nil for logger to
+// use slog.Default(). Pass nil for eventFn to disable structured event emission.
+func NewRateLimiterRegistry(logger *slog.Logger, eventFn ports.EventLogger) *RateLimiterRegistry {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &RateLimiterRegistry{
+		entries: make(map[string]*rateLimiterEntry),
+		logger:  logger,
+		eventFn: eventFn,
+	}
+}
+
+// parseRateLimit parses a rate limit expression and returns requests per second.
+// Supported formats:
+//
+//	"<n>/s"  — n requests per second
+//	"<n>/m"  — n requests per minute  (converted to per-second)
+//	"<n>/h"  — n requests per hour    (converted to per-second)
+//
+// Returns an error when the expression is empty, malformed, or non-positive.
+func parseRateLimit(expr string) (float64, error) {
+	if expr == "" {
+		return 0, fmt.Errorf("rate limit expression is empty")
+	}
+	parts := strings.SplitN(expr, "/", 2)
+	if len(parts) != 2 {
+		return 0, fmt.Errorf("rate limit expression %q: expected format <n>/<unit> (e.g. \"100/s\")", expr)
+	}
+	n, err := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("rate limit expression %q: count must be a positive number", expr)
+	}
+	unit := strings.TrimSpace(strings.ToLower(parts[1]))
+	switch unit {
+	case "s":
+		return n, nil
+	case "m":
+		return n / 60.0, nil
+	case "h":
+		return n / 3600.0, nil
+	default:
+		return 0, fmt.Errorf("rate limit expression %q: unsupported unit %q (use s, m, or h)", expr, unit)
+	}
+}
+
+// getOrCreate returns the rate limiter entry for the given route, creating it
+// lazily on first access. Returns (nil, nil) when the route has no rate limit
+// configured (empty RateLimit() string).
+func (r *RateLimiterRegistry) getOrCreate(route domainegress.Route) (*rateLimiterEntry, error) {
+	expr := route.RateLimit()
+	if expr == "" {
+		return nil, nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if e, ok := r.entries[route.Name()]; ok {
+		return e, nil
+	}
+
+	rps, err := parseRateLimit(expr)
+	if err != nil {
+		return nil, fmt.Errorf("parsing rate limit for route %q: %w", route.Name(), err)
+	}
+
+	// Burst is set to the ceiling of rps so that small-rps routes still accept
+	// at least one request per token-bucket fill, and high-rps routes get a
+	// proportional burst. Minimum burst is 1.
+	burst := int(math.Ceil(rps))
+	if burst < 1 {
+		burst = 1
+	}
+
+	entry := &rateLimiterEntry{
+		limiter:   rate.NewLimiter(rate.Limit(rps), burst),
+		rps:       rps,
+		routeName: route.Name(),
+	}
+	r.entries[route.Name()] = entry
+	return entry, nil
+}
+
+// Allow reports whether the request is within the rate limit for the given
+// route. It returns (true, nil) when the route has no rate limit configured.
+// It returns (false, nil) when the token bucket is exhausted. It returns a
+// non-nil error only when the rate limit expression is malformed.
+func (r *RateLimiterRegistry) Allow(ctx context.Context, route domainegress.Route) (bool, error) {
+	entry, err := r.getOrCreate(route)
+	if err != nil {
+		return false, err
+	}
+	if entry == nil {
+		return true, nil
+	}
+
+	allowed := entry.allow()
+	if !allowed {
+		retryAfter := entry.retryAfter()
+		r.logger.WarnContext(ctx, "egress.rate_limit_hit",
+			slog.String("event_type", events.EventTypeEgressRateLimitHit),
+			slog.String("route", route.Name()),
+			slog.Float64("limit_rps", entry.rps),
+			slog.Float64("retry_after_seconds", retryAfter),
+		)
+		r.emitEvent(ctx, events.NewEgressRateLimitHit(events.EgressRateLimitHitParams{
+			Route:             route.Name(),
+			Limit:             entry.rps,
+			RetryAfterSeconds: retryAfter,
+		}))
+	}
+	return allowed, nil
+}
+
+// RetryAfterSeconds returns how many seconds until one token is available for
+// the given route. Returns 0 for routes without a rate limit configuration.
+// This value is used to populate the Retry-After response header.
+func (r *RateLimiterRegistry) RetryAfterSeconds(route domainegress.Route) (float64, error) {
+	entry, err := r.getOrCreate(route)
+	if err != nil {
+		return 0, err
+	}
+	if entry == nil {
+		return 0, nil
+	}
+	d := entry.retryAfter()
+	// Always return at least 1 second so Retry-After is meaningful.
+	if d < 1 {
+		return 1, nil
+	}
+	return math.Ceil(d), nil
+}
+
+// emitEvent sends a structured event via the EventLogger. Failures are logged
+// but do not interrupt request handling.
+func (r *RateLimiterRegistry) emitEvent(ctx context.Context, ev events.Event) {
+	if r.eventFn == nil {
+		return
+	}
+	if err := r.eventFn.Log(ctx, ev); err != nil {
+		r.logger.Error("egress rate limiter: failed to emit event",
+			slog.String("event_type", ev.EventType),
+			slog.String("err", err.Error()),
+		)
+	}
+}
+
+// retryAfterHeader formats a float64 number of seconds as an integer string
+// suitable for the Retry-After HTTP response header (RFC 9110 §10.2.4).
+func retryAfterHeader(seconds float64) string {
+	s := int(math.Ceil(seconds))
+	if s < 1 {
+		s = 1
+	}
+	return strconv.Itoa(s)
+}
+
+// Interface guard — RateLimiterRegistry must satisfy the types used by Proxy.
+var _ interface {
+	Allow(ctx context.Context, route domainegress.Route) (bool, error)
+	RetryAfterSeconds(route domainegress.Route) (float64, error)
+} = (*RateLimiterRegistry)(nil)
+
+// rateLimiterClock is a small helper so tests can substitute a fake clock for
+// time.Now() calls inside the rate limiter. Only used internally.
+var rateLimiterClock = time.Now //nolint:unused

--- a/internal/adapters/egress/rate_limiters_internal_test.go
+++ b/internal/adapters/egress/rate_limiters_internal_test.go
@@ -1,0 +1,119 @@
+package egress
+
+import (
+	"testing"
+)
+
+// TestParseRateLimit_TableDriven exercises the parseRateLimit function with
+// valid and invalid inputs.
+func TestParseRateLimit_TableDriven(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		wantRPS float64
+		wantErr bool
+	}{
+		{
+			name:    "per second",
+			expr:    "60/s",
+			wantRPS: 60,
+		},
+		{
+			name:    "per minute",
+			expr:    "120/m",
+			wantRPS: 2, // 120/60
+		},
+		{
+			name:    "per hour",
+			expr:    "3600/h",
+			wantRPS: 1, // 3600/3600
+		},
+		{
+			name:    "single per minute",
+			expr:    "1/m",
+			wantRPS: 1.0 / 60.0,
+		},
+		{
+			name:    "spaces around parts",
+			expr:    " 10 / s ",
+			wantRPS: 10,
+		},
+		{
+			name:    "uppercase unit",
+			expr:    "5/S",
+			wantRPS: 5,
+		},
+		{
+			name:    "empty expression",
+			expr:    "",
+			wantErr: true,
+		},
+		{
+			name:    "missing unit",
+			expr:    "100",
+			wantErr: true,
+		},
+		{
+			name:    "invalid count",
+			expr:    "abc/s",
+			wantErr: true,
+		},
+		{
+			name:    "zero count",
+			expr:    "0/s",
+			wantErr: true,
+		},
+		{
+			name:    "negative count",
+			expr:    "-5/s",
+			wantErr: true,
+		},
+		{
+			name:    "unknown unit",
+			expr:    "100/d",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRateLimit(tt.expr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseRateLimit(%q) error = %v, wantErr %v", tt.expr, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				const epsilon = 1e-9
+				diff := got - tt.wantRPS
+				if diff < -epsilon || diff > epsilon {
+					t.Errorf("parseRateLimit(%q) = %f, want %f", tt.expr, got, tt.wantRPS)
+				}
+			}
+		})
+	}
+}
+
+// TestRetryAfterHeader_Values verifies that retryAfterHeader always returns a
+// string representing a positive integer >= 1.
+func TestRetryAfterHeader_Values(t *testing.T) {
+	tests := []struct {
+		name    string
+		seconds float64
+		want    string
+	}{
+		{"zero", 0, "1"},
+		{"negative", -5, "1"},
+		{"one", 1, "1"},
+		{"fractional", 1.3, "2"},
+		{"exact two", 2.0, "2"},
+		{"large", 300.7, "301"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := retryAfterHeader(tt.seconds)
+			if got != tt.want {
+				t.Errorf("retryAfterHeader(%f) = %q, want %q", tt.seconds, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/adapters/egress/rate_limiters_test.go
+++ b/internal/adapters/egress/rate_limiters_test.go
@@ -1,0 +1,357 @@
+package egress_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	egressadapter "github.com/vibewarden/vibewarden/internal/adapters/egress"
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+)
+
+// newTestProxyWithRL creates a Proxy wired to the given routes, HTTP client,
+// and rate limiter registry.
+func newTestProxyWithRL(
+	t *testing.T,
+	routes []domainegress.Route,
+	client *http.Client,
+	policy domainegress.Policy,
+	rl *egressadapter.RateLimiterRegistry,
+) *egressadapter.Proxy {
+	t.Helper()
+	resolver := egressadapter.NewRouteResolver(routes)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  policy,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         routes,
+		RateLimiters:   rl,
+	}
+	return egressadapter.NewProxy(cfg, resolver, client, nil)
+}
+
+// ---- parseRateLimit (via RateLimiterRegistry.Allow) ----
+
+// TestParseRateLimit_ValidExpressions verifies that well-formed expressions are
+// accepted and that no error is returned on the first Allow call.
+func TestParseRateLimit_ValidExpressions(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{"per_second", "60/s"},
+		{"per_minute", "120/m"},
+		{"per_hour", "3600/h"},
+		{"fractional_per_minute", "1/m"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer upstream.Close()
+
+			route := newTestRoute(t, "api", upstream.URL+"/v1/*", domainegress.WithRateLimit(tt.expr))
+			rl := egressadapter.NewRateLimiterRegistry(nil, nil)
+			proxy := newTestProxyWithRL(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny, rl)
+
+			req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+			if err != nil {
+				t.Fatalf("NewEgressRequest: %v", err)
+			}
+			resp, err := proxy.HandleRequest(context.Background(), req)
+			if err != nil {
+				t.Fatalf("HandleRequest returned unexpected error: %v", err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+			}
+		})
+	}
+}
+
+// TestRateLimiterRegistry_NoConfig verifies that a route without a rate limit
+// configuration passes all requests through unconditionally.
+func TestRateLimiterRegistry_NoConfig(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	// Route without any rate limit.
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*")
+	el := &fakeEventLogger{}
+	rl := egressadapter.NewRateLimiterRegistry(nil, el)
+	proxy := newTestProxyWithRL(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny, rl)
+
+	for i := 0; i < 10; i++ {
+		req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+		if err != nil {
+			t.Fatalf("NewEgressRequest: %v", err)
+		}
+		resp, err := proxy.HandleRequest(context.Background(), req)
+		if err != nil {
+			t.Fatalf("request %d returned unexpected error: %v", i+1, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("request %d: StatusCode = %d, want %d", i+1, resp.StatusCode, http.StatusOK)
+		}
+	}
+	// No rate_limit_hit events should be emitted.
+	if got := el.count(); got != 0 {
+		t.Errorf("event count = %d, want 0", got)
+	}
+}
+
+// TestRateLimiterRegistry_ExceedsLimit verifies that after exhausting the token
+// bucket, HandleRequest returns ErrRateLimitExceeded.
+func TestRateLimiterRegistry_ExceedsLimit(t *testing.T) {
+	var callCount atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	// 1 request per second, burst = 1. First request consumes the burst token;
+	// second request should be rejected immediately.
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*", domainegress.WithRateLimit("1/s"))
+	el := &fakeEventLogger{}
+	rl := egressadapter.NewRateLimiterRegistry(nil, el)
+	proxy := newTestProxyWithRL(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny, rl)
+
+	doRequest := func() (int, error) {
+		req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+		if err != nil {
+			t.Fatalf("NewEgressRequest: %v", err)
+		}
+		resp, err := proxy.HandleRequest(context.Background(), req)
+		if err != nil {
+			return 0, err
+		}
+		return resp.StatusCode, nil
+	}
+
+	// First request: token available — should succeed.
+	status, err := doRequest()
+	if err != nil {
+		t.Fatalf("first request error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Errorf("first request: StatusCode = %d, want %d", status, http.StatusOK)
+	}
+	if callCount.Load() != 1 {
+		t.Errorf("upstream call count after first request = %d, want 1", callCount.Load())
+	}
+
+	// Second request: bucket exhausted — must return ErrRateLimitExceeded.
+	_, err = doRequest()
+	if err != egressadapter.ErrRateLimitExceeded {
+		t.Errorf("second request error = %v, want ErrRateLimitExceeded", err)
+	}
+
+	// Upstream must NOT have been called a second time.
+	if callCount.Load() != 1 {
+		t.Errorf("upstream call count after rate limit = %d, want 1", callCount.Load())
+	}
+
+	// An egress.rate_limit_hit event must have been emitted.
+	types := el.eventTypes()
+	if len(types) != 1 || types[0] != events.EventTypeEgressRateLimitHit {
+		t.Errorf("events = %v, want [%s]", types, events.EventTypeEgressRateLimitHit)
+	}
+}
+
+// TestRateLimiterRegistry_HTTP429OnExceeded verifies that the HTTP handler
+// returns 429 with a Retry-After header when the rate limit is exceeded.
+func TestRateLimiterRegistry_HTTP429OnExceeded(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*", domainegress.WithRateLimit("1/s"))
+	rl := egressadapter.NewRateLimiterRegistry(nil, nil)
+
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		RateLimiters:   rl,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	sendRequest := func() *http.Response {
+		httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+		if err != nil {
+			t.Fatalf("http.NewRequest: %v", err)
+		}
+		httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/resource")
+		resp, err := proxyClient.Do(httpReq)
+		if err != nil {
+			t.Fatalf("proxy request: %v", err)
+		}
+		return resp
+	}
+
+	// First request consumes the burst token.
+	resp1 := sendRequest()
+	resp1.Body.Close() //nolint:errcheck
+	if resp1.StatusCode != http.StatusOK {
+		t.Errorf("first request: StatusCode = %d, want %d", resp1.StatusCode, http.StatusOK)
+	}
+
+	// Second request: rate limit exceeded → 429.
+	resp2 := sendRequest()
+	resp2.Body.Close() //nolint:errcheck
+	if resp2.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("second request: StatusCode = %d, want %d", resp2.StatusCode, http.StatusTooManyRequests)
+	}
+	if ra := resp2.Header.Get("Retry-After"); ra == "" {
+		t.Error("second request: Retry-After header is missing")
+	}
+}
+
+// TestRateLimiterRegistry_NilRegistrySkipsChecks verifies that when
+// RateLimiters is nil in ProxyConfig, all requests proceed normally even when
+// the route has a rate limit configured.
+func TestRateLimiterRegistry_NilRegistrySkipsChecks(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*", domainegress.WithRateLimit("1/s"))
+	// Proxy with nil RateLimiters — rate limiting disabled.
+	proxy := newTestProxy(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny)
+
+	for i := 0; i < 5; i++ {
+		req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+		if err != nil {
+			t.Fatalf("NewEgressRequest: %v", err)
+		}
+		resp, err := proxy.HandleRequest(context.Background(), req)
+		if err != nil {
+			t.Fatalf("request %d returned unexpected error: %v", i+1, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("request %d: StatusCode = %d, want %d", i+1, resp.StatusCode, http.StatusOK)
+		}
+	}
+}
+
+// TestRateLimiterRegistry_IndependentPerRoute verifies that rate limiters are
+// isolated per route — exhausting one route's bucket does not affect another.
+func TestRateLimiterRegistry_IndependentPerRoute(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	// routeA has a very tight limit (1/s, burst 1).
+	// routeB has a generous limit (1000/s) — effectively unlimited for this test.
+	routeA := newTestRoute(t, "a", upstream.URL+"/a/*", domainegress.WithRateLimit("1/s"))
+	routeB := newTestRoute(t, "b", upstream.URL+"/b/*", domainegress.WithRateLimit("1000/s"))
+
+	rl := egressadapter.NewRateLimiterRegistry(nil, nil)
+	proxy := newTestProxyWithRL(t,
+		[]domainegress.Route{routeA, routeB},
+		upstream.Client(),
+		domainegress.PolicyDeny,
+		rl,
+	)
+
+	doRequest := func(url string) error {
+		req, err := domainegress.NewEgressRequest("GET", url, nil, nil)
+		if err != nil {
+			t.Fatalf("NewEgressRequest: %v", err)
+		}
+		_, err = proxy.HandleRequest(context.Background(), req)
+		return err
+	}
+
+	// Exhaust routeA's bucket.
+	if err := doRequest(upstream.URL + "/a/resource"); err != nil {
+		t.Fatalf("routeA first request: %v", err)
+	}
+	if err := doRequest(upstream.URL + "/a/resource"); err != egressadapter.ErrRateLimitExceeded {
+		t.Errorf("routeA second request: want ErrRateLimitExceeded, got %v", err)
+	}
+
+	// routeB must still accept requests.
+	if err := doRequest(upstream.URL + "/b/resource"); err != nil {
+		t.Errorf("routeB: unexpected error: %v", err)
+	}
+}
+
+// TestRateLimiterRegistry_EventPayload verifies that the egress.rate_limit_hit
+// event carries the expected payload fields.
+func TestRateLimiterRegistry_EventPayload(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	const routeName = "payments"
+	route := newTestRoute(t, routeName, upstream.URL+"/v1/*", domainegress.WithRateLimit("1/s"))
+	el := &fakeEventLogger{}
+	rl := egressadapter.NewRateLimiterRegistry(nil, el)
+	proxy := newTestProxyWithRL(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny, rl)
+
+	doRequest := func() error {
+		req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+		if err != nil {
+			t.Fatalf("NewEgressRequest: %v", err)
+		}
+		_, err = proxy.HandleRequest(context.Background(), req)
+		return err
+	}
+
+	// Consume the burst token.
+	_ = doRequest()
+	// Trigger the rate limit.
+	_ = doRequest()
+
+	el.mu.Lock()
+	var hitEv events.Event
+	for _, e := range el.logged {
+		if e.EventType == events.EventTypeEgressRateLimitHit {
+			hitEv = e
+			break
+		}
+	}
+	el.mu.Unlock()
+
+	if hitEv.EventType == "" {
+		t.Fatalf("no %s event found", events.EventTypeEgressRateLimitHit)
+	}
+	if hitEv.SchemaVersion != "v1" {
+		t.Errorf("SchemaVersion = %q, want %q", hitEv.SchemaVersion, "v1")
+	}
+	if got, ok := hitEv.Payload["route"].(string); !ok || got != routeName {
+		t.Errorf("payload.route = %v, want %q", hitEv.Payload["route"], routeName)
+	}
+	if _, ok := hitEv.Payload["limit"].(float64); !ok {
+		t.Errorf("payload.limit is not float64: %T", hitEv.Payload["limit"])
+	}
+	if _, ok := hitEv.Payload["retry_after_seconds"].(float64); !ok {
+		t.Errorf("payload.retry_after_seconds is not float64: %T", hitEv.Payload["retry_after_seconds"])
+	}
+	if hitEv.AISummary == "" {
+		t.Error("AISummary must not be empty")
+	}
+}

--- a/internal/domain/events/egress.go
+++ b/internal/domain/events/egress.go
@@ -76,3 +76,39 @@ func NewEgressCircuitBreakerClosed(params EgressCircuitBreakerClosedParams) Even
 		},
 	}
 }
+
+// EventTypeEgressRateLimitHit is emitted when an outbound request to a named
+// egress route is rejected because the per-route rate limit has been exceeded.
+const EventTypeEgressRateLimitHit = "egress.rate_limit_hit"
+
+// EgressRateLimitHitParams contains the parameters needed to construct an
+// egress.rate_limit_hit event.
+type EgressRateLimitHitParams struct {
+	// Route is the egress route name whose rate limit was exceeded.
+	Route string
+
+	// Limit is the configured rate limit in requests per second.
+	Limit float64
+
+	// RetryAfterSeconds is how many seconds the caller should wait before retrying.
+	RetryAfterSeconds float64
+}
+
+// NewEgressRateLimitHit creates an egress.rate_limit_hit event indicating that
+// an outbound request was rejected because the per-route rate limit was exceeded.
+func NewEgressRateLimitHit(params EgressRateLimitHitParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeEgressRateLimitHit,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"Egress rate limit exceeded for route %q (limit %.2f req/s); retry after %.0fs",
+			params.Route, params.Limit, params.RetryAfterSeconds,
+		),
+		Payload: map[string]any{
+			"route":               params.Route,
+			"limit":               params.Limit,
+			"retry_after_seconds": params.RetryAfterSeconds,
+		},
+	}
+}

--- a/internal/domain/events/egress_ratelimit_test.go
+++ b/internal/domain/events/egress_ratelimit_test.go
@@ -1,0 +1,65 @@
+package events_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+)
+
+// TestNewEgressRateLimitHit verifies that NewEgressRateLimitHit produces a
+// well-formed event with the correct type, schema version, and payload fields.
+func TestNewEgressRateLimitHit(t *testing.T) {
+	params := events.EgressRateLimitHitParams{
+		Route:             "payments",
+		Limit:             100.0,
+		RetryAfterSeconds: 1.0,
+	}
+	before := time.Now()
+	ev := events.NewEgressRateLimitHit(params)
+	after := time.Now()
+
+	if ev.EventType != events.EventTypeEgressRateLimitHit {
+		t.Errorf("EventType = %q, want %q", ev.EventType, events.EventTypeEgressRateLimitHit)
+	}
+	if ev.SchemaVersion != events.SchemaVersion {
+		t.Errorf("SchemaVersion = %q, want %q", ev.SchemaVersion, events.SchemaVersion)
+	}
+	if ev.Timestamp.Before(before) || ev.Timestamp.After(after) {
+		t.Errorf("Timestamp %v not in expected range [%v, %v]", ev.Timestamp, before, after)
+	}
+	if ev.AISummary == "" {
+		t.Error("AISummary must not be empty")
+	}
+	if got, ok := ev.Payload["route"].(string); !ok || got != "payments" {
+		t.Errorf("Payload[route] = %v, want %q", ev.Payload["route"], "payments")
+	}
+	if got, ok := ev.Payload["limit"].(float64); !ok || got != 100.0 {
+		t.Errorf("Payload[limit] = %v, want 100.0", ev.Payload["limit"])
+	}
+	if got, ok := ev.Payload["retry_after_seconds"].(float64); !ok || got != 1.0 {
+		t.Errorf("Payload[retry_after_seconds] = %v, want 1.0", ev.Payload["retry_after_seconds"])
+	}
+}
+
+// TestNewEgressRateLimitHit_AISummaryContainsRoute verifies that the AI summary
+// includes the route name and the limit for quick at-a-glance diagnosis.
+func TestNewEgressRateLimitHit_AISummaryContainsRoute(t *testing.T) {
+	ev := events.NewEgressRateLimitHit(events.EgressRateLimitHitParams{
+		Route:             "stripe-api",
+		Limit:             50.0,
+		RetryAfterSeconds: 2.0,
+	})
+	for _, want := range []string{"stripe-api", "50"} {
+		found := false
+		for i := 0; i < len(ev.AISummary)-len(want)+1; i++ {
+			if ev.AISummary[i:i+len(want)] == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("AISummary %q does not contain %q", ev.AISummary, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #362

## Summary

- Added `RateLimiterRegistry` in `internal/adapters/egress/rate_limiters.go` — a concurrency-safe per-route token-bucket registry backed by `golang.org/x/time/rate` (BSD-3, already in deps). Mirrors the `CircuitBreakerRegistry` structure.
- `parseRateLimit` accepts `<n>/s`, `<n>/m`, `<n>/h` expressions and converts everything to requests-per-second.
- `ProxyConfig.RateLimiters` field wires the registry into the proxy. When nil, rate limiting is disabled for all routes (same nil-is-disabled pattern as circuit breakers).
- `HandleRequest` checks the rate limit after the circuit breaker check and before forwarding.
- `handleRequest` (HTTP layer) returns 429 with a `Retry-After` header when `ErrRateLimitExceeded` is returned.
- New sentinel error `ErrRateLimitExceeded` added to `errors.go`.
- New domain event `egress.rate_limit_hit` (`EventTypeEgressRateLimitHit`) added to `internal/domain/events/egress.go` with `route`, `limit`, and `retry_after_seconds` payload fields.

## Test plan

- `TestParseRateLimit_TableDriven` — 13 table-driven cases covering valid and invalid expressions including edge cases (zero, negative, unknown unit, spaces).
- `TestRetryAfterHeader_Values` — 6 cases for the header formatter.
- `TestRateLimiterRegistry_NoConfig` — route without rate limit passes all requests through; no events emitted.
- `TestRateLimiterRegistry_ExceedsLimit` — burst-1 limiter: first request passes, second returns `ErrRateLimitExceeded`; upstream not called; event emitted.
- `TestRateLimiterRegistry_HTTP429OnExceeded` — end-to-end HTTP test: second request receives 429 with `Retry-After` header.
- `TestRateLimiterRegistry_NilRegistrySkipsChecks` — nil registry disables enforcement even when route has a rate limit.
- `TestRateLimiterRegistry_IndependentPerRoute` — exhausting route A does not affect route B.
- `TestRateLimiterRegistry_EventPayload` — verifies `egress.rate_limit_hit` event fields.
- `TestNewEgressRateLimitHit` / `TestNewEgressRateLimitHit_AISummaryContainsRoute` — domain event unit tests.

All pass under `go test -race ./...`.