### PR TITLE
feat(#366): implement egress request and response body size limits

### DIFF
--- a/internal/adapters/egress/body_size_test.go
+++ b/internal/adapters/egress/body_size_test.go
@@ -1,0 +1,508 @@
+package egress_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	egressadapter "github.com/vibewarden/vibewarden/internal/adapters/egress"
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+// newTestProxyWithLimits creates a Proxy configured with the given routes,
+// default body size limit, and default response size limit.
+func newTestProxyWithLimits(
+	t *testing.T,
+	routes []domainegress.Route,
+	client *http.Client,
+	defaultBodyLimit int64,
+	defaultRespLimit int64,
+) *egressadapter.Proxy {
+	t.Helper()
+	resolver := egressadapter.NewRouteResolver(routes)
+	cfg := egressadapter.ProxyConfig{
+		Listen:                   "127.0.0.1:0",
+		DefaultPolicy:            domainegress.PolicyDeny,
+		DefaultTimeout:           5 * time.Second,
+		Routes:                   routes,
+		DefaultBodySizeLimit:     defaultBodyLimit,
+		DefaultResponseSizeLimit: defaultRespLimit,
+	}
+	return egressadapter.NewProxy(cfg, resolver, client, nil)
+}
+
+// TestHandleRequest_RequestBodyLimit_ContentLengthExceeds verifies that a
+// request with Content-Length exceeding the limit is rejected with
+// ErrRequestBodyTooLarge before any upstream call is made.
+func TestHandleRequest_RequestBodyLimit_ContentLengthExceeds(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream must not be called when Content-Length exceeds body size limit")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithBodySizeLimit(100),
+	)
+	proxy := newTestProxyWithLimits(t, []domainegress.Route{route}, upstream.Client(), 0, 0)
+
+	headers := make(http.Header)
+	headers.Set("Content-Length", "200")
+	req, err := domainegress.NewEgressRequest("POST", upstream.URL+"/v1/data", headers, strings.NewReader("x"))
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	_, gotErr := proxy.HandleRequest(context.Background(), req)
+	if gotErr == nil {
+		t.Fatal("HandleRequest should return ErrRequestBodyTooLarge")
+	}
+	if gotErr != egressadapter.ErrRequestBodyTooLarge {
+		t.Errorf("error = %v, want ErrRequestBodyTooLarge", gotErr)
+	}
+}
+
+// TestHandleRequest_RequestBodyLimit_BodyExceeds verifies that a request
+// body that actually exceeds the limit during reading is rejected.
+func TestHandleRequest_RequestBodyLimit_BodyExceeds(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The upstream may or may not be called depending on when the read happens.
+		_, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	limit := int64(10)
+	body := strings.NewReader(strings.Repeat("x", 100)) // 100 bytes > 10 limit
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithBodySizeLimit(limit),
+	)
+	proxy := newTestProxyWithLimits(t, []domainegress.Route{route}, upstream.Client(), 0, 0)
+
+	req, err := domainegress.NewEgressRequest("POST", upstream.URL+"/v1/data", nil, body)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	_, gotErr := proxy.HandleRequest(context.Background(), req)
+	if gotErr == nil {
+		t.Fatal("HandleRequest should return an error when body exceeds limit")
+	}
+	if gotErr != egressadapter.ErrRequestBodyTooLarge {
+		t.Errorf("error = %v, want ErrRequestBodyTooLarge", gotErr)
+	}
+}
+
+// TestHandleRequest_RequestBodyLimit_BelowLimit verifies that a request body
+// within the limit is forwarded successfully.
+func TestHandleRequest_RequestBodyLimit_BelowLimit(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		w.Header().Set("X-Received-Bytes", fmt.Sprintf("%d", len(b)))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	body := strings.NewReader("short") // 5 bytes < 100 limit
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithBodySizeLimit(100),
+	)
+	proxy := newTestProxyWithLimits(t, []domainegress.Route{route}, upstream.Client(), 0, 0)
+
+	req, err := domainegress.NewEgressRequest("POST", upstream.URL+"/v1/data", nil, body)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest returned unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+// TestHandleRequest_DefaultBodySizeLimit verifies that the proxy-level default
+// body size limit applies when no per-route limit is configured.
+func TestHandleRequest_DefaultBodySizeLimit(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream must not be called when body exceeds default limit")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*") // no per-route limit
+	// Default body limit = 10 bytes; body = 100 bytes.
+	proxy := newTestProxyWithLimits(t, []domainegress.Route{route}, upstream.Client(), 10, 0)
+
+	headers := make(http.Header)
+	headers.Set("Content-Length", "100")
+	req, err := domainegress.NewEgressRequest("POST", upstream.URL+"/v1/data", headers, strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	_, gotErr := proxy.HandleRequest(context.Background(), req)
+	if gotErr != egressadapter.ErrRequestBodyTooLarge {
+		t.Errorf("error = %v, want ErrRequestBodyTooLarge", gotErr)
+	}
+}
+
+// TestHandleRequest_PerRouteLimitOverridesDefault verifies that a per-route
+// body size limit takes precedence over the proxy default.
+func TestHandleRequest_PerRouteLimitOverridesDefault(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	// Default = 5 bytes, route = 200 bytes. Body = 100 bytes.
+	// The per-route limit (200) is higher, so the request should pass.
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithBodySizeLimit(200),
+	)
+	proxy := newTestProxyWithLimits(t, []domainegress.Route{route}, upstream.Client(), 5, 0)
+
+	body := strings.NewReader(strings.Repeat("a", 100))
+	req, err := domainegress.NewEgressRequest("POST", upstream.URL+"/v1/data", nil, body)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest returned unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+// TestHTTPHandler_RequestBodyLimit_Returns413 verifies that the HTTP handler
+// returns 413 when the request body exceeds the size limit.
+func TestHTTPHandler_RequestBodyLimit_Returns413(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream must not be called")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithBodySizeLimit(10),
+	)
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	body := strings.NewReader(strings.Repeat("x", 100)) // 100 bytes > 10 limit
+	httpReq, err := http.NewRequest(http.MethodPost, proxyURL, body)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/data")
+	httpReq.ContentLength = 100
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}
+
+// TestHTTPHandler_ResponseSizeLimit_Truncates verifies that a response body
+// larger than the limit is truncated and the X-Egress-Response-Truncated
+// trailer is set.
+func TestHTTPHandler_ResponseSizeLimit_Truncates(t *testing.T) {
+	const limit = 10
+	const fullBody = "hello world this is more than ten bytes"
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(fullBody))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithResponseSizeLimit(limit),
+	)
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/data")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if int64(len(bodyBytes)) > limit {
+		t.Errorf("body length = %d, want <= %d (limit)", len(bodyBytes), limit)
+	}
+	if int64(len(bodyBytes)) != limit {
+		t.Errorf("body length = %d, want exactly %d bytes (limit)", len(bodyBytes), limit)
+	}
+
+	// The truncation trailer should be present.
+	truncated := resp.Trailer.Get("X-Egress-Response-Truncated")
+	if truncated != "true" {
+		t.Errorf("X-Egress-Response-Truncated trailer = %q, want %q", truncated, "true")
+	}
+}
+
+// TestHTTPHandler_ResponseSizeLimit_NoTruncation verifies that a response body
+// within the limit is passed through unmodified and no truncation header is set.
+func TestHTTPHandler_ResponseSizeLimit_NoTruncation(t *testing.T) {
+	const body = "short"
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithResponseSizeLimit(100),
+	)
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/data")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if string(bodyBytes) != body {
+		t.Errorf("body = %q, want %q", string(bodyBytes), body)
+	}
+
+	if resp.Trailer.Get("X-Egress-Response-Truncated") != "" {
+		t.Error("X-Egress-Response-Truncated trailer should not be set when body is within limit")
+	}
+}
+
+// TestHTTPHandler_DefaultResponseSizeLimit verifies that the proxy-level
+// default response size limit is applied when no per-route limit is set.
+func TestHTTPHandler_DefaultResponseSizeLimit(t *testing.T) {
+	const fullBody = "this response body is quite long and will be truncated"
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(fullBody))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*") // no per-route limit
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:                   "127.0.0.1:0",
+		DefaultPolicy:            domainegress.PolicyDeny,
+		DefaultTimeout:           5 * time.Second,
+		Routes:                   []domainegress.Route{route},
+		DefaultResponseSizeLimit: 10,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/data")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if int64(len(bodyBytes)) > 10 {
+		t.Errorf("body length = %d, want <= 10 (default response limit)", len(bodyBytes))
+	}
+
+	truncated := resp.Trailer.Get("X-Egress-Response-Truncated")
+	if truncated != "true" {
+		t.Errorf("X-Egress-Response-Truncated trailer = %q, want %q", truncated, "true")
+	}
+}
+
+// TestHTTPHandler_PerRouteResponseLimitOverridesDefault verifies that a
+// per-route response size limit takes precedence over the proxy default.
+func TestHTTPHandler_PerRouteResponseLimitOverridesDefault(t *testing.T) {
+	const fullBody = "hello world extended body"
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(fullBody))
+	}))
+	defer upstream.Close()
+
+	// Default = 5 bytes, route = 100 bytes. Body = 25 bytes.
+	// Per-route limit (100) is higher than body size, so no truncation.
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithResponseSizeLimit(100),
+	)
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:                   "127.0.0.1:0",
+		DefaultPolicy:            domainegress.PolicyDeny,
+		DefaultTimeout:           5 * time.Second,
+		Routes:                   []domainegress.Route{route},
+		DefaultResponseSizeLimit: 5,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/data")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if string(bodyBytes) != fullBody {
+		t.Errorf("body = %q, want %q (per-route limit should allow full body)", string(bodyBytes), fullBody)
+	}
+
+	if resp.Trailer.Get("X-Egress-Response-Truncated") != "" {
+		t.Error("X-Egress-Response-Truncated should not be set when per-route limit allows full body")
+	}
+}
+
+// TestHTTPHandler_NoSizeLimits verifies that requests and responses are
+// unaffected when no size limits are configured.
+func TestHTTPHandler_NoSizeLimits(t *testing.T) {
+	const body = "response body content"
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(fmt.Sprintf("received %d bytes; response: %s", len(b), body)))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*") // no limits
+	proxy := newTestProxyWithLimits(t, []domainegress.Route{route}, upstream.Client(), 0, 0)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	reqBody := strings.NewReader(strings.Repeat("x", 1000))
+	httpReq, err := http.NewRequest(http.MethodPost, proxyURL, reqBody)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/data")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	respBytes, _ := io.ReadAll(resp.Body)
+	if !bytes.Contains(respBytes, []byte("1000 bytes")) {
+		t.Errorf("response body %q should contain '1000 bytes'", string(respBytes))
+	}
+}

--- a/internal/adapters/egress/errors.go
+++ b/internal/adapters/egress/errors.go
@@ -15,3 +15,8 @@ var ErrCircuitOpen = errors.New("egress: circuit breaker is open")
 // rate limiter has run out of tokens and the request is rejected before any
 // upstream contact is made.
 var ErrRateLimitExceeded = errors.New("egress: rate limit exceeded")
+
+// ErrRequestBodyTooLarge is returned by Proxy.HandleRequest when the incoming
+// request body exceeds the configured body size limit. The HTTP handler converts
+// this into a 413 Request Entity Too Large response.
+var ErrRequestBodyTooLarge = errors.New("egress: request body exceeds size limit")

--- a/internal/adapters/egress/proxy.go
+++ b/internal/adapters/egress/proxy.go
@@ -45,6 +45,10 @@ const (
 	// defaultListen is the default address the egress proxy binds to.
 	defaultListen = "127.0.0.1:8081"
 
+	// headerResponseTruncated is set on responses whose body was truncated
+	// because it exceeded the configured response size limit.
+	headerResponseTruncated = "X-Egress-Response-Truncated"
+
 	// defaultTimeout is used when the configuration does not specify a timeout.
 	defaultTimeout = 30 * time.Second
 
@@ -80,6 +84,16 @@ type ProxyConfig struct {
 	// DefaultTimeout is the global request timeout applied when a route does not
 	// specify its own timeout.
 	DefaultTimeout time.Duration
+
+	// DefaultBodySizeLimit is the global maximum allowed request body size in
+	// bytes. Applied when the matched route does not set its own BodySizeLimit.
+	// A value of 0 means no global limit.
+	DefaultBodySizeLimit int64
+
+	// DefaultResponseSizeLimit is the global maximum allowed response body size
+	// in bytes. Applied when the matched route does not set its own
+	// ResponseSizeLimit. A value of 0 means no global limit.
+	DefaultResponseSizeLimit int64
 
 	// Routes is the ordered list of configured egress routes.
 	// Routes are evaluated in declaration order; the first matching route wins.
@@ -222,7 +236,7 @@ func (p *Proxy) Stop(ctx context.Context) error {
 
 // HandleRequest implements ports.EgressProxy. It resolves the route for the
 // request, enforces the default policy, checks the per-route circuit breaker,
-// and forwards the request upstream.
+// enforces body size limits, and forwards the request upstream.
 func (p *Proxy) HandleRequest(ctx context.Context, req domainegress.EgressRequest) (domainegress.EgressResponse, error) {
 	match, err := p.resolver.Resolve(ctx, req)
 	if err != nil {
@@ -257,8 +271,96 @@ func (p *Proxy) HandleRequest(ctx context.Context, req domainegress.EgressReques
 		}
 	}
 
-	return p.forward(ctx, req, match)
+	// Enforce request body size limit. The effective limit is the per-route
+	// value when set, otherwise the proxy-level default.
+	bodySizeLimit := p.cfg.DefaultBodySizeLimit
+	if match.Matched && match.Route.BodySizeLimit() > 0 {
+		bodySizeLimit = match.Route.BodySizeLimit()
+	}
+	if bodySizeLimit > 0 {
+		limited, limitErr := p.enforceRequestBodyLimit(ctx, req, bodySizeLimit)
+		if limitErr != nil {
+			return domainegress.EgressResponse{}, limitErr
+		}
+		req = limited
+	}
+
+	resp, forwardErr := p.forward(ctx, req, match)
+	if forwardErr != nil {
+		// Unwrap transport errors that wrap ErrRequestBodyTooLarge — this happens
+		// when the HTTP client tries to send a body that exceeds the limit.
+		if errors.Is(forwardErr, ErrRequestBodyTooLarge) {
+			p.logger.WarnContext(ctx, "egress.body_size_exceeded",
+				slog.String("event_type", "egress.body_size_exceeded"),
+				slog.String("kind", "request"),
+				slog.String("url", req.URL),
+				slog.String("method", req.Method),
+				slog.Int64("limit_bytes", bodySizeLimit),
+			)
+			return domainegress.EgressResponse{}, ErrRequestBodyTooLarge
+		}
+		return domainegress.EgressResponse{}, forwardErr
+	}
+	return resp, nil
 }
+
+// enforceRequestBodyLimit checks whether the request body exceeds the limit and
+// returns a (possibly modified) EgressRequest.
+//
+// Fast path: when Content-Length is present and already exceeds the limit,
+// ErrRequestBodyTooLarge is returned immediately without reading the body.
+//
+// Slow path: the body is wrapped with a limitedBody reader that returns
+// ErrRequestBodyTooLarge if more than limit bytes are read.
+func (p *Proxy) enforceRequestBodyLimit(ctx context.Context, req domainegress.EgressRequest, limit int64) (domainegress.EgressRequest, error) {
+	// Fast path: check Content-Length header first to avoid reading the body.
+	if cl := req.Header.Get("Content-Length"); cl != "" {
+		var n int64
+		if _, err := fmt.Sscanf(cl, "%d", &n); err == nil && n > limit {
+			p.logger.WarnContext(ctx, "egress.body_size_exceeded",
+				slog.String("event_type", "egress.body_size_exceeded"),
+				slog.String("kind", "request"),
+				slog.String("url", req.URL),
+				slog.String("method", req.Method),
+				slog.Int64("limit_bytes", limit),
+				slog.Int64("content_length", n),
+			)
+			return req, ErrRequestBodyTooLarge
+		}
+	}
+
+	// Slow path: wrap the body so over-limit reads surface as ErrRequestBodyTooLarge.
+	if body, ok := req.BodyRef.(io.Reader); ok && body != nil {
+		req.BodyRef = &limitedBody{
+			r:     io.LimitReader(body, limit+1),
+			limit: limit,
+		}
+	}
+	return req, nil
+}
+
+// limitedBody is an io.ReadCloser that wraps an io.LimitReader and returns
+// ErrRequestBodyTooLarge when the caller attempts to read more than limit bytes.
+type limitedBody struct {
+	r     io.Reader
+	limit int64
+	read  int64
+}
+
+// Read implements io.Reader. It returns ErrRequestBodyTooLarge when more than
+// limit bytes have been read from the underlying stream.
+func (lb *limitedBody) Read(p []byte) (int, error) {
+	n, err := lb.r.Read(p)
+	lb.read += int64(n)
+	if lb.read > lb.limit {
+		return n, ErrRequestBodyTooLarge
+	}
+	return n, err
+}
+
+// Close implements io.Closer. It is a no-op because the underlying LimitReader
+// does not implement io.Closer.
+func (lb *limitedBody) Close() error { return nil }
 
 // handleRequest is the net/http handler registered on the proxy mux. It
 // extracts the egress request from the incoming HTTP request, delegates to
@@ -285,6 +387,16 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if err == ErrDeniedByPolicy {
 			http.Error(w, "403 Forbidden: request denied by egress policy", http.StatusForbidden)
+			return
+		}
+		if err == ErrRequestBodyTooLarge {
+			p.logger.WarnContext(r.Context(), "egress.body_size_exceeded",
+				slog.String("event_type", "egress.body_size_exceeded"),
+				slog.String("kind", "request"),
+				slog.String("target", targetURL),
+				slog.String("method", r.Method),
+			)
+			http.Error(w, "413 Request Entity Too Large: request body exceeds egress size limit", http.StatusRequestEntityTooLarge)
 			return
 		}
 		if err == ErrCircuitOpen {
@@ -349,7 +461,19 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 	// Write the upstream response back to the caller.
 	respBody, _ := egressResp.BodyRef.(io.ReadCloser)
 
-	for key, vals := range cloneAndStripHopByHop(egressResp.Header) {
+	// Determine the effective response size limit before sending headers so we
+	// can declare the truncation trailer key in advance.
+	respSizeLimit := p.responseSizeLimitFor(egressReq)
+
+	respHeaders := cloneAndStripHopByHop(egressResp.Header)
+	// When a response size limit is active we cannot forward Content-Length
+	// because the actual bytes written may be fewer than the upstream reported.
+	// Removing it forces chunked transfer encoding, which is required for
+	// HTTP/1.1 trailers to work correctly.
+	if respSizeLimit > 0 {
+		respHeaders.Del("Content-Length")
+	}
+	for key, vals := range respHeaders {
 		for _, v := range vals {
 			w.Header().Add(key, v)
 		}
@@ -358,14 +482,54 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 	if egressResp.Attempts > 0 {
 		w.Header().Set(headerEgressAttempts, fmt.Sprintf("%d", egressResp.Attempts))
 	}
+	// Announce the truncation trailer so HTTP/1.1 clients can read it after the body.
+	if respSizeLimit > 0 {
+		w.Header().Add("Trailer", headerResponseTruncated)
+	}
 	w.WriteHeader(egressResp.StatusCode)
 
 	if respBody != nil {
 		defer respBody.Close() //nolint:errcheck
-		if _, err := io.Copy(w, respBody); err != nil {
-			p.logger.WarnContext(r.Context(), "writing egress response body", "err", err)
+
+		if respSizeLimit > 0 {
+			// Copy at most respSizeLimit bytes.
+			written, copyErr := io.Copy(w, io.LimitReader(respBody, respSizeLimit))
+			// Try to read one more byte to detect whether the body was truncated.
+			var probe [1]byte
+			n, _ := respBody.Read(probe[:])
+			if n > 0 {
+				// Body exceeded the limit — log and set the truncation trailer.
+				p.logger.WarnContext(r.Context(), "egress.body_size_exceeded",
+					slog.String("event_type", "egress.body_size_exceeded"),
+					slog.String("kind", "response"),
+					slog.String("target", targetURL),
+					slog.String("method", r.Method),
+					slog.Int64("limit_bytes", respSizeLimit),
+					slog.Int64("bytes_written", written),
+				)
+				w.Header().Set(headerResponseTruncated, "true")
+			}
+			if copyErr != nil {
+				p.logger.WarnContext(r.Context(), "writing egress response body", "err", copyErr)
+			}
+		} else {
+			if _, err := io.Copy(w, respBody); err != nil {
+				p.logger.WarnContext(r.Context(), "writing egress response body", "err", err)
+			}
 		}
 	}
+}
+
+// responseSizeLimitFor returns the effective response size limit for the given
+// egress request. The per-route limit takes precedence over the proxy default.
+func (p *Proxy) responseSizeLimitFor(req domainegress.EgressRequest) int64 {
+	// Re-resolve the route to get per-route settings. We use a background
+	// context because this is a cheap in-memory lookup.
+	match, err := p.resolver.Resolve(context.Background(), req)
+	if err == nil && match.Matched && match.Route.ResponseSizeLimit() > 0 {
+		return match.Route.ResponseSizeLimit()
+	}
+	return p.cfg.DefaultResponseSizeLimit
 }
 
 // resolveTargetURL determines the destination URL from the HTTP request using

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1523,6 +1523,24 @@ func validateEgressConfig(cfg EgressConfig) []string {
 		}
 	}
 
+	// default_body_size_limit validation.
+	if cfg.DefaultBodySizeLimit != "" {
+		if _, err := ParseBodySize(cfg.DefaultBodySizeLimit); err != nil {
+			errs = append(errs, fmt.Sprintf(
+				"egress.default_body_size_limit: %s", err.Error(),
+			))
+		}
+	}
+
+	// default_response_size_limit validation.
+	if cfg.DefaultResponseSizeLimit != "" {
+		if _, err := ParseBodySize(cfg.DefaultResponseSizeLimit); err != nil {
+			errs = append(errs, fmt.Sprintf(
+				"egress.default_response_size_limit: %s", err.Error(),
+			))
+		}
+	}
+
 	// routes validation.
 	routeNames := make(map[string]bool, len(cfg.Routes))
 	for i, r := range cfg.Routes {
@@ -1589,6 +1607,13 @@ func validateEgressConfig(cfg EgressConfig) []string {
 		if r.BodySizeLimit != "" {
 			if _, err := ParseBodySize(r.BodySizeLimit); err != nil {
 				errs = append(errs, fmt.Sprintf("%s.body_size_limit: %s", prefix, err.Error()))
+			}
+		}
+
+		// response_size_limit validation.
+		if r.ResponseSizeLimit != "" {
+			if _, err := ParseBodySize(r.ResponseSizeLimit); err != nil {
+				errs = append(errs, fmt.Sprintf("%s.response_size_limit: %s", prefix, err.Error()))
 			}
 		}
 

--- a/internal/config/egress.go
+++ b/internal/config/egress.go
@@ -19,6 +19,16 @@ type EgressConfig struct {
 	// specify its own timeout. Accepts Go duration strings (e.g. "30s"). Default: "30s".
 	DefaultTimeout string `mapstructure:"default_timeout"`
 
+	// DefaultBodySizeLimit is the global maximum allowed request body size applied
+	// when a route does not specify its own body_size_limit. Human-readable string
+	// (e.g. "50MB"). Empty string means no global limit.
+	DefaultBodySizeLimit string `mapstructure:"default_body_size_limit"`
+
+	// DefaultResponseSizeLimit is the global maximum allowed response body size
+	// applied when a route does not specify its own response_size_limit.
+	// Human-readable string (e.g. "50MB"). Empty string means no global limit.
+	DefaultResponseSizeLimit string `mapstructure:"default_response_size_limit"`
+
 	// DNS holds DNS-level protection settings.
 	DNS EgressDNSConfig `mapstructure:"dns"`
 
@@ -82,8 +92,14 @@ type EgressRouteConfig struct {
 	Retries EgressRetryConfig `mapstructure:"retries"`
 
 	// BodySizeLimit is the maximum allowed request body size as a human-readable
-	// string (e.g. "50MB"). When empty, no body size limit is applied.
+	// string (e.g. "50MB"). When empty, EgressConfig.DefaultBodySizeLimit is used.
 	BodySizeLimit string `mapstructure:"body_size_limit"`
+
+	// ResponseSizeLimit is the maximum allowed response body size as a
+	// human-readable string (e.g. "50MB"). When the upstream response body exceeds
+	// this limit it is truncated and a warning header is added to the response.
+	// When empty, EgressConfig.DefaultResponseSizeLimit is used.
+	ResponseSizeLimit string `mapstructure:"response_size_limit"`
 }
 
 // EgressCircuitBreakerConfig holds circuit breaker parameters for an egress route.

--- a/internal/config/egress_test.go
+++ b/internal/config/egress_test.go
@@ -416,6 +416,94 @@ func TestValidate_EgressBodySizeLimit(t *testing.T) {
 	}
 }
 
+// TestValidate_EgressResponseSizeLimit verifies per-route response size limit parsing.
+func TestValidate_EgressResponseSizeLimit(t *testing.T) {
+	tests := []struct {
+		name              string
+		responseSizeLimit string
+		wantErr           bool
+	}{
+		{"empty is valid", "", false},
+		{"50MB is valid", "50MB", false},
+		{"1GB is valid", "1GB", false},
+		{"invalid unit", "50XB", true},
+		{"no numeric value", "MB", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Egress: config.EgressConfig{
+					Enabled: true,
+					Routes: []config.EgressRouteConfig{
+						{Name: "r", Pattern: "https://api.example.com/**", ResponseSizeLimit: tt.responseSizeLimit},
+					},
+				},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidate_EgressDefaultBodySizeLimit verifies global default body size limit parsing.
+func TestValidate_EgressDefaultBodySizeLimit(t *testing.T) {
+	tests := []struct {
+		name    string
+		limit   string
+		wantErr bool
+	}{
+		{"empty is valid (no limit)", "", false},
+		{"10MB is valid", "10MB", false},
+		{"invalid unit", "10XB", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Egress: config.EgressConfig{
+					Enabled:              true,
+					DefaultBodySizeLimit: tt.limit,
+				},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidate_EgressDefaultResponseSizeLimit verifies global default response size limit parsing.
+func TestValidate_EgressDefaultResponseSizeLimit(t *testing.T) {
+	tests := []struct {
+		name    string
+		limit   string
+		wantErr bool
+	}{
+		{"empty is valid (no limit)", "", false},
+		{"100MB is valid", "100MB", false},
+		{"invalid unit", "100ZB", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Egress: config.EgressConfig{
+					Enabled:                  true,
+					DefaultResponseSizeLimit: tt.limit,
+				},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // TestValidate_EgressSecretInjection verifies that partial secret config is rejected.
 func TestValidate_EgressSecretInjection(t *testing.T) {
 	tests := []struct {

--- a/internal/domain/egress/route.go
+++ b/internal/domain/egress/route.go
@@ -96,28 +96,30 @@ type SecretConfig struct {
 //
 // Routes are equal when their names are equal — name is the natural key.
 type Route struct {
-	name           string
-	pattern        string
-	methods        []string
-	timeout        time.Duration
-	secret         SecretConfig
-	headers        HeadersConfig
-	rateLimit      string
-	circuitBreaker CircuitBreakerConfig
-	retry          RetryConfig
-	bodySizeLimit  int64
+	name              string
+	pattern           string
+	methods           []string
+	timeout           time.Duration
+	secret            SecretConfig
+	headers           HeadersConfig
+	rateLimit         string
+	circuitBreaker    CircuitBreakerConfig
+	retry             RetryConfig
+	bodySizeLimit     int64
+	responseSizeLimit int64
 }
 
 // routeOptions carries optional fields supplied via functional options.
 type routeOptions struct {
-	methods        []string
-	timeout        time.Duration
-	secret         SecretConfig
-	headers        HeadersConfig
-	rateLimit      string
-	circuitBreaker CircuitBreakerConfig
-	retry          RetryConfig
-	bodySizeLimit  int64
+	methods           []string
+	timeout           time.Duration
+	secret            SecretConfig
+	headers           HeadersConfig
+	rateLimit         string
+	circuitBreaker    CircuitBreakerConfig
+	retry             RetryConfig
+	bodySizeLimit     int64
+	responseSizeLimit int64
 }
 
 // RouteOption is a functional option for NewRoute.
@@ -154,10 +156,19 @@ func WithRetry(cfg RetryConfig) RouteOption {
 	return func(o *routeOptions) { o.retry = cfg }
 }
 
-// WithBodySizeLimit sets the maximum allowed response body size in bytes.
-// A value of 0 means no limit.
+// WithBodySizeLimit sets the maximum allowed request body size in bytes for this
+// route. Requests whose body exceeds this limit are rejected with 413. A value
+// of 0 means no per-route limit (the proxy default applies).
 func WithBodySizeLimit(bytes int64) RouteOption {
 	return func(o *routeOptions) { o.bodySizeLimit = bytes }
+}
+
+// WithResponseSizeLimit sets the maximum allowed response body size in bytes for
+// this route. When the upstream response body exceeds this limit the body is
+// truncated and a warning header is added. A value of 0 means no per-route limit
+// (the proxy default applies).
+func WithResponseSizeLimit(bytes int64) RouteOption {
+	return func(o *routeOptions) { o.responseSizeLimit = bytes }
 }
 
 // WithHeaders configures per-route header injection and stripping rules.
@@ -185,16 +196,17 @@ func NewRoute(name, pattern string, opts ...RouteOption) (Route, error) {
 	}
 
 	return Route{
-		name:           name,
-		pattern:        pattern,
-		methods:        o.methods,
-		timeout:        o.timeout,
-		secret:         o.secret,
-		headers:        o.headers,
-		rateLimit:      o.rateLimit,
-		circuitBreaker: o.circuitBreaker,
-		retry:          o.retry,
-		bodySizeLimit:  o.bodySizeLimit,
+		name:              name,
+		pattern:           pattern,
+		methods:           o.methods,
+		timeout:           o.timeout,
+		secret:            o.secret,
+		headers:           o.headers,
+		rateLimit:         o.rateLimit,
+		circuitBreaker:    o.circuitBreaker,
+		retry:             o.retry,
+		bodySizeLimit:     o.bodySizeLimit,
+		responseSizeLimit: o.responseSizeLimit,
 	}, nil
 }
 
@@ -225,9 +237,13 @@ func (r Route) CircuitBreaker() CircuitBreakerConfig { return r.circuitBreaker }
 // Retry returns the retry configuration for this route.
 func (r Route) Retry() RetryConfig { return r.retry }
 
-// BodySizeLimit returns the maximum allowed body size in bytes for this route.
-// A value of 0 means no limit.
+// BodySizeLimit returns the maximum allowed request body size in bytes for this
+// route. A value of 0 means no per-route limit.
 func (r Route) BodySizeLimit() int64 { return r.bodySizeLimit }
+
+// ResponseSizeLimit returns the maximum allowed response body size in bytes for
+// this route. A value of 0 means no per-route limit.
+func (r Route) ResponseSizeLimit() int64 { return r.responseSizeLimit }
 
 // Headers returns the per-route header manipulation configuration.
 func (r Route) Headers() HeadersConfig { return r.headers }

--- a/internal/domain/egress/route_test.go
+++ b/internal/domain/egress/route_test.go
@@ -82,6 +82,7 @@ func TestNewRoute_Accessors(t *testing.T) {
 		egress.WithCircuitBreaker(cb),
 		egress.WithRetry(retry),
 		egress.WithBodySizeLimit(52428800),
+		egress.WithResponseSizeLimit(10485760),
 	)
 	if err != nil {
 		t.Fatalf("NewRoute() unexpected error: %v", err)
@@ -102,11 +103,29 @@ func TestNewRoute_Accessors(t *testing.T) {
 	if got := r.BodySizeLimit(); got != 52428800 {
 		t.Errorf("BodySizeLimit() = %d, want %d", got, 52428800)
 	}
+	if got := r.ResponseSizeLimit(); got != 10485760 {
+		t.Errorf("ResponseSizeLimit() = %d, want %d", got, 10485760)
+	}
 	if got := r.Secret(); got != secret {
 		t.Errorf("Secret() = %+v, want %+v", got, secret)
 	}
 	if got := r.CircuitBreaker(); got != cb {
 		t.Errorf("CircuitBreaker() = %+v, want %+v", got, cb)
+	}
+}
+
+// TestNewRoute_SizeLimitDefaults verifies that BodySizeLimit and
+// ResponseSizeLimit default to 0 (no limit) when not set.
+func TestNewRoute_SizeLimitDefaults(t *testing.T) {
+	r, err := egress.NewRoute("r", "https://example.com/**")
+	if err != nil {
+		t.Fatalf("NewRoute() unexpected error: %v", err)
+	}
+	if got := r.BodySizeLimit(); got != 0 {
+		t.Errorf("BodySizeLimit() = %d, want 0 (no limit by default)", got)
+	}
+	if got := r.ResponseSizeLimit(); got != 0 {
+		t.Errorf("ResponseSizeLimit() = %d, want 0 (no limit by default)", got)
 	}
 }
 


### PR DESCRIPTION
Closes #366

## Summary

- **Domain (`internal/domain/egress/route.go`)**: added `responseSizeLimit` field with `WithResponseSizeLimit` option and `ResponseSizeLimit()` accessor; clarified `WithBodySizeLimit` godoc to be request-scoped.
- **Config (`internal/config/egress.go`, `config.go`)**: added `ResponseSizeLimit` to `EgressRouteConfig` and `DefaultBodySizeLimit`/`DefaultResponseSizeLimit` to `EgressConfig`; validation via `ParseBodySize` (already implemented in `config/bodysize.go`).
- **Adapter (`internal/adapters/egress/proxy.go`)**: per-route limits override proxy-level defaults; two enforcement mechanisms:
  - **Request body**: fast-path Content-Length check (returns `ErrRequestBodyTooLarge` immediately); slow-path `limitedBody` LimitReader wrapper that surfaces `ErrRequestBodyTooLarge` when the actual body is read by the HTTP transport. HTTP handler converts this to 413.
  - **Response body**: strips `Content-Length` (required for chunked trailers), copies with `io.LimitReader(body, limit)`, probes one extra byte to detect truncation, sets `X-Egress-Response-Truncated: true` HTTP trailer.
- **Errors (`internal/adapters/egress/errors.go`)**: added `ErrRequestBodyTooLarge`.
- **Structured log**: `egress.body_size_exceeded` event with `kind` (`"request"` or `"response"`), `url`/`target`, `method`, `limit_bytes`, and when applicable `content_length` or `bytes_written`.
- **Tests (`internal/adapters/egress/body_size_test.go`)**: 11 new tests covering Content-Length fast-path, slow-path body read, below-limit pass-through, default limits, per-route override of defaults, HTTP 413 handler response, response truncation with trailer, no-truncation pass-through, and no-limits baseline.

## Test plan

- [ ] `go test ./internal/adapters/egress/... -run "Body|ResponseSize|RequestBody|PerRoute|DefaultBody|DefaultResponse|NoSizeLimits" -v`
- [ ] `go test ./internal/domain/egress/... -v`
- [ ] `go test ./internal/config/... -run "EgressBodySizeLimit|EgressResponseSizeLimit|EgressDefault" -v`
- [ ] `make check` — all checks pass
