### PR TITLE
feat(#371): enforce TLS on egress routes with per-route override

### DIFF
--- a/internal/adapters/egress/body_size_test.go
+++ b/internal/adapters/egress/body_size_test.go
@@ -33,6 +33,7 @@ func newTestProxyWithLimits(
 		Routes:                   routes,
 		DefaultBodySizeLimit:     defaultBodyLimit,
 		DefaultResponseSizeLimit: defaultRespLimit,
+		AllowInsecure:            true, // test servers are HTTP
 	}
 	return egressadapter.NewProxy(cfg, resolver, client, nil)
 }
@@ -202,6 +203,7 @@ func TestHTTPHandler_RequestBodyLimit_Returns413(t *testing.T) {
 	)
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:  true, // test server is HTTP
 		Listen:         "127.0.0.1:0",
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
@@ -254,6 +256,7 @@ func TestHTTPHandler_ResponseSizeLimit_Truncates(t *testing.T) {
 	)
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:  true, // test server is HTTP
 		Listen:         "127.0.0.1:0",
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
@@ -316,6 +319,7 @@ func TestHTTPHandler_ResponseSizeLimit_NoTruncation(t *testing.T) {
 	)
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:  true, // test server is HTTP
 		Listen:         "127.0.0.1:0",
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
@@ -367,6 +371,7 @@ func TestHTTPHandler_DefaultResponseSizeLimit(t *testing.T) {
 	route := newTestRoute(t, "api", upstream.URL+"/v1/*") // no per-route limit
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:            true, // test server is HTTP
 		Listen:                   "127.0.0.1:0",
 		DefaultPolicy:            domainegress.PolicyDeny,
 		DefaultTimeout:           5 * time.Second,
@@ -424,6 +429,7 @@ func TestHTTPHandler_PerRouteResponseLimitOverridesDefault(t *testing.T) {
 	)
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:            true, // test server is HTTP
 		Listen:                   "127.0.0.1:0",
 		DefaultPolicy:            domainegress.PolicyDeny,
 		DefaultTimeout:           5 * time.Second,

--- a/internal/adapters/egress/circuit_breakers_test.go
+++ b/internal/adapters/egress/circuit_breakers_test.go
@@ -55,6 +55,7 @@ func newTestProxyWithCB(
 	t.Helper()
 	resolver := egressadapter.NewRouteResolver(routes)
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:   true, // test server is HTTP
 		Listen:          "127.0.0.1:0",
 		DefaultPolicy:   policy,
 		DefaultTimeout:  5 * time.Second,
@@ -184,6 +185,7 @@ func TestCircuitBreakerRegistry_HTTP503OnOpenCircuit(t *testing.T) {
 
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:   true, // test server is HTTP
 		Listen:          "127.0.0.1:0",
 		DefaultPolicy:   domainegress.PolicyDeny,
 		DefaultTimeout:  5 * time.Second,

--- a/internal/adapters/egress/errors.go
+++ b/internal/adapters/egress/errors.go
@@ -20,3 +20,9 @@ var ErrRateLimitExceeded = errors.New("egress: rate limit exceeded")
 // request body exceeds the configured body size limit. The HTTP handler converts
 // this into a 413 Request Entity Too Large response.
 var ErrRequestBodyTooLarge = errors.New("egress: request body exceeds size limit")
+
+// ErrInsecureURL is returned by Proxy.HandleRequest when the target URL uses
+// plain HTTP and neither the proxy-level AllowInsecure flag nor the matched
+// route's AllowInsecure flag is set. The HTTP handler converts this into a
+// 400 Bad Request response.
+var ErrInsecureURL = errors.New("egress: plain HTTP is not allowed; use HTTPS or set allow_insecure")

--- a/internal/adapters/egress/proxy.go
+++ b/internal/adapters/egress/proxy.go
@@ -6,6 +6,7 @@ package egress
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -122,6 +123,11 @@ type ProxyConfig struct {
 	// 429 Too Many Requests response before any upstream contact is made. When
 	// nil, per-route rate limiting is disabled regardless of route configuration.
 	RateLimiters *RateLimiterRegistry
+
+	// AllowInsecure, when true, permits plain HTTP egress requests globally.
+	// By default only HTTPS targets are allowed. Individual routes can also
+	// override this with their AllowInsecure field.
+	AllowInsecure bool
 }
 
 // Proxy is an HTTP server that listens on a dedicated localhost port and
@@ -167,6 +173,13 @@ func NewProxy(cfg ProxyConfig, resolver ports.RouteResolver, client *http.Client
 		transport := http.DefaultTransport.(*http.Transport).Clone()
 		if cfg.SSRFGuard != nil {
 			transport.DialContext = cfg.SSRFGuard.DialContext
+		}
+		// Enforce TLS 1.2 as minimum version on all outbound connections.
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		} else {
+			transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+			transport.TLSClientConfig.MinVersion = tls.VersionTLS12
 		}
 		client = &http.Client{
 			Timeout:   cfg.DefaultTimeout,
@@ -246,6 +259,21 @@ func (p *Proxy) HandleRequest(ctx context.Context, req domainegress.EgressReques
 	if !match.Matched {
 		if p.cfg.DefaultPolicy == domainegress.PolicyDeny {
 			return domainegress.EgressResponse{}, ErrDeniedByPolicy
+		}
+	}
+
+	// Enforce TLS: reject plain HTTP targets unless explicitly permitted.
+	// The effective allow_insecure flag is: per-route flag OR global flag.
+	if strings.HasPrefix(req.URL, "http://") {
+		routeAllows := match.Matched && match.Route.AllowInsecure()
+		if !routeAllows && !p.cfg.AllowInsecure {
+			p.logger.WarnContext(ctx, "egress.tls_error",
+				slog.String("event_type", "egress.tls_error"),
+				slog.String("url", req.URL),
+				slog.String("method", req.Method),
+				slog.String("reason", "plain HTTP not allowed"),
+			)
+			return domainegress.EgressResponse{}, ErrInsecureURL
 		}
 	}
 
@@ -387,6 +415,16 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if err == ErrDeniedByPolicy {
 			http.Error(w, "403 Forbidden: request denied by egress policy", http.StatusForbidden)
+			return
+		}
+		if err == ErrInsecureURL {
+			p.logger.WarnContext(r.Context(), "egress.tls_error",
+				slog.String("event_type", "egress.tls_error"),
+				slog.String("target", targetURL),
+				slog.String("method", r.Method),
+				slog.String("reason", "plain HTTP not allowed"),
+			)
+			http.Error(w, "400 Bad Request: "+ErrInsecureURL.Error(), http.StatusBadRequest)
 			return
 		}
 		if err == ErrRequestBodyTooLarge {

--- a/internal/adapters/egress/proxy_headers_test.go
+++ b/internal/adapters/egress/proxy_headers_test.go
@@ -98,6 +98,7 @@ func TestHandleRequest_XInjectSecretAlwaysStripped(t *testing.T) {
 	route := newTestRoute(t, "api", upstream.URL+"/v1/*")
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:  true, // test server is HTTP
 		Listen:         "127.0.0.1:0",
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
@@ -142,6 +143,7 @@ func TestHandleRequest_XInjectSecretStrippedOnAllowPolicy(t *testing.T) {
 	// No routes — request falls through to allow policy, but injection still happens.
 	resolver := egressadapter.NewRouteResolver(nil)
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:  true, // test server is HTTP
 		Listen:         "127.0.0.1:0",
 		DefaultPolicy:  domainegress.PolicyAllow,
 		DefaultTimeout: 5 * time.Second,
@@ -283,6 +285,7 @@ func TestHTTPHandler_InjectHeaderEndToEnd(t *testing.T) {
 	route := newTestRoute(t, "api", upstream.URL+"/v1/*", domainegress.WithHeaders(hdrCfg))
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:  true, // test server is HTTP
 		Listen:         "127.0.0.1:0",
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
@@ -333,6 +336,7 @@ func TestHTTPHandler_SensitiveResponseHeadersStrippedEndToEnd(t *testing.T) {
 	route := newTestRoute(t, "api", upstream.URL+"/v1/*")
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:  true, // test server is HTTP
 		Listen:         "127.0.0.1:0",
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,

--- a/internal/adapters/egress/proxy_test.go
+++ b/internal/adapters/egress/proxy_test.go
@@ -27,6 +27,8 @@ func newTestRoute(t *testing.T, name, pattern string, opts ...domainegress.Route
 // newTestProxy creates a Proxy wired to the given routes and HTTP client.
 // The proxy does not start listening — tests call HandleRequest directly
 // or drive the HTTP handler via httptest.
+// AllowInsecure is set to true so tests using plain-HTTP test servers are not
+// blocked by TLS enforcement.
 func newTestProxy(t *testing.T, routes []domainegress.Route, client *http.Client, policy domainegress.Policy) *egressadapter.Proxy {
 	t.Helper()
 	resolver := egressadapter.NewRouteResolver(routes)
@@ -35,6 +37,7 @@ func newTestProxy(t *testing.T, routes []domainegress.Route, client *http.Client
 		DefaultPolicy:  policy,
 		DefaultTimeout: 5 * time.Second,
 		Routes:         routes,
+		AllowInsecure:  true, // test servers are HTTP
 	}
 	return egressadapter.NewProxy(cfg, resolver, client, nil)
 }
@@ -133,6 +136,7 @@ func TestHTTPHandler_TransparentRouting(t *testing.T) {
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
 		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true, // test server is HTTP
 	}
 	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
 
@@ -184,6 +188,7 @@ func TestHTTPHandler_NamedRouting(t *testing.T) {
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
 		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true, // test server is HTTP
 	}
 	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
 
@@ -275,6 +280,7 @@ func TestHTTPHandler_MethodAndBodyPreserved(t *testing.T) {
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
 		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true, // test server is HTTP
 	}
 	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
 
@@ -383,6 +389,7 @@ func TestHTTPHandler_ResponseHeadersPreserved(t *testing.T) {
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
 		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true, // test server is HTTP
 	}
 	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
 
@@ -430,6 +437,7 @@ func TestHandleRequest_SSRFGuard_BlocksPrivateIP(t *testing.T) {
 		DefaultPolicy:  domainegress.PolicyAllow, // allow so the route check passes
 		DefaultTimeout: 5 * time.Second,
 		SSRFGuard:      guard,
+		AllowInsecure:  true, // TLS enforcement is not what this test exercises
 	}
 	proxy := egressadapter.NewProxy(cfg, resolver, nil, nil)
 
@@ -465,6 +473,7 @@ func TestHTTPHandler_SSRFGuard_Returns403(t *testing.T) {
 		DefaultPolicy:  domainegress.PolicyAllow,
 		DefaultTimeout: 5 * time.Second,
 		SSRFGuard:      guard,
+		AllowInsecure:  true, // TLS enforcement is not what this test exercises
 	}
 	proxy := egressadapter.NewProxy(cfg, resolver, nil, nil)
 
@@ -527,6 +536,7 @@ func TestHTTPHandler_SSRFGuard_AllowedPrivateExemption(t *testing.T) {
 		DefaultTimeout: 5 * time.Second,
 		Routes:         []domainegress.Route{route},
 		SSRFGuard:      guard,
+		AllowInsecure:  true, // TLS enforcement is not what this test exercises
 	}
 	proxy := egressadapter.NewProxy(cfg, resolver, nil, nil)
 

--- a/internal/adapters/egress/rate_limiters_test.go
+++ b/internal/adapters/egress/rate_limiters_test.go
@@ -25,6 +25,7 @@ func newTestProxyWithRL(
 	t.Helper()
 	resolver := egressadapter.NewRouteResolver(routes)
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:  true, // test server is HTTP
 		Listen:         "127.0.0.1:0",
 		DefaultPolicy:  policy,
 		DefaultTimeout: 5 * time.Second,
@@ -179,6 +180,7 @@ func TestRateLimiterRegistry_HTTP429OnExceeded(t *testing.T) {
 
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:  true, // test server is HTTP
 		Listen:         "127.0.0.1:0",
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,

--- a/internal/adapters/egress/retry_timeout_test.go
+++ b/internal/adapters/egress/retry_timeout_test.go
@@ -35,6 +35,7 @@ func TestForward_PerRouteTimeout_Returns504(t *testing.T) {
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
 		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true, // test server is HTTP
 	}
 	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
 
@@ -80,6 +81,7 @@ func TestForward_DefaultTimeout_Returns504(t *testing.T) {
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 50 * time.Millisecond, // very short global timeout
 		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true, // test server is HTTP
 	}
 	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
 
@@ -141,6 +143,7 @@ func TestForward_RetryOnTransientStatus(t *testing.T) {
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
 		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true, // test server is HTTP
 	}
 	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
 
@@ -210,6 +213,7 @@ func TestForward_NoRetryOnNonIdempotentMethod(t *testing.T) {
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
 		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true, // test server is HTTP
 	}
 	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
 

--- a/internal/adapters/egress/secret_injector_test.go
+++ b/internal/adapters/egress/secret_injector_test.go
@@ -242,6 +242,7 @@ func TestProxy_SecretInjection_PerRoute(t *testing.T) {
 
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:  true, // test server is HTTP
 		Listen:         "127.0.0.1:0",
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
@@ -293,6 +294,7 @@ func TestProxy_SecretInjection_DynamicHeader(t *testing.T) {
 
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:  true, // test server is HTTP
 		Listen:         "127.0.0.1:0",
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
@@ -347,6 +349,7 @@ func TestProxy_SecretInjection_FailClosed(t *testing.T) {
 
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:  true, // test server is HTTP
 		Listen:         "127.0.0.1:0",
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
@@ -392,6 +395,7 @@ func TestProxy_SecretInjection_NoInjectorConfigured(t *testing.T) {
 
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:  true, // test server is HTTP
 		Listen:         "127.0.0.1:0",
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
@@ -431,6 +435,7 @@ func TestProxy_SecretInjection_XInjectSecretStripped(t *testing.T) {
 
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:  true, // test server is HTTP
 		Listen:         "127.0.0.1:0",
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,
@@ -482,6 +487,7 @@ func TestProxy_SecretInjection_HTTPHandler_FailClosed(t *testing.T) {
 
 	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
 	cfg := egressadapter.ProxyConfig{
+		AllowInsecure:  true, // test server is HTTP
 		Listen:         "127.0.0.1:0",
 		DefaultPolicy:  domainegress.PolicyDeny,
 		DefaultTimeout: 5 * time.Second,

--- a/internal/adapters/egress/tls_enforcement_test.go
+++ b/internal/adapters/egress/tls_enforcement_test.go
@@ -1,0 +1,251 @@
+package egress_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	egressadapter "github.com/vibewarden/vibewarden/internal/adapters/egress"
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+// newTLSTestProxy creates a Proxy with the given AllowInsecure flag and routes,
+// wired to the given HTTP client. Starts listening on an OS-assigned port.
+func newTLSTestProxy(t *testing.T, allowInsecure bool, routes []domainegress.Route, client *http.Client) *egressadapter.Proxy {
+	t.Helper()
+	resolver := egressadapter.NewRouteResolver(routes)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyAllow,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         routes,
+		AllowInsecure:  allowInsecure,
+	}
+	return egressadapter.NewProxy(cfg, resolver, client, nil)
+}
+
+// TestHandleRequest_TLSEnforcement verifies that plain HTTP egress targets are
+// rejected by default and allowed only when the appropriate flag is set.
+func TestHandleRequest_TLSEnforcement(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+	// upstream.URL is http:// because httptest.NewServer is plain HTTP.
+
+	tests := []struct {
+		name         string
+		globalAllow  bool
+		routeAllow   bool
+		targetIsHTTP bool
+		wantErr      error
+		wantNoErr    bool
+	}{
+		{
+			name:         "HTTPS target always allowed (global deny insecure)",
+			globalAllow:  false,
+			routeAllow:   false,
+			targetIsHTTP: false,
+			wantNoErr:    true,
+		},
+		{
+			name:         "HTTP target blocked by default",
+			globalAllow:  false,
+			routeAllow:   false,
+			targetIsHTTP: true,
+			wantErr:      egressadapter.ErrInsecureURL,
+		},
+		{
+			name:         "HTTP target allowed when global allow_insecure is true",
+			globalAllow:  true,
+			routeAllow:   false,
+			targetIsHTTP: true,
+			wantNoErr:    true,
+		},
+		{
+			name:         "HTTP target allowed when route allow_insecure is true",
+			globalAllow:  false,
+			routeAllow:   true,
+			targetIsHTTP: true,
+			wantNoErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				targetURL string
+				routes    []domainegress.Route
+				client    *http.Client
+			)
+
+			if tt.targetIsHTTP {
+				// Point to the plain-HTTP test server.
+				targetURL = upstream.URL + "/test"
+				routeOpts := []domainegress.RouteOption{}
+				if tt.routeAllow {
+					routeOpts = append(routeOpts, domainegress.WithAllowInsecure(true))
+				}
+				route, err := domainegress.NewRoute("test", upstream.URL+"/test", routeOpts...)
+				if err != nil {
+					t.Fatalf("NewRoute: %v", err)
+				}
+				routes = []domainegress.Route{route}
+				client = upstream.Client()
+			} else {
+				// Use an HTTPS test server.
+				tlsServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}))
+				defer tlsServer.Close()
+				targetURL = tlsServer.URL + "/test"
+				route, err := domainegress.NewRoute("test", tlsServer.URL+"/test")
+				if err != nil {
+					t.Fatalf("NewRoute: %v", err)
+				}
+				routes = []domainegress.Route{route}
+				client = tlsServer.Client()
+			}
+
+			proxy := newTLSTestProxy(t, tt.globalAllow, routes, client)
+
+			req, err := domainegress.NewEgressRequest("GET", targetURL, nil, nil)
+			if err != nil {
+				t.Fatalf("NewEgressRequest: %v", err)
+			}
+
+			_, handleErr := proxy.HandleRequest(context.Background(), req)
+
+			if tt.wantNoErr {
+				if handleErr != nil {
+					t.Errorf("HandleRequest() unexpected error: %v", handleErr)
+				}
+				return
+			}
+			if handleErr == nil {
+				t.Fatal("HandleRequest() expected an error, got nil")
+			}
+			if tt.wantErr != nil && handleErr != tt.wantErr {
+				t.Errorf("HandleRequest() error = %v, want %v", handleErr, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestHandleRequest_TLSEnforcement_UnmatchedRoute verifies that unmatched HTTP
+// requests (policy=allow) are still blocked by the TLS enforcement check.
+func TestHandleRequest_TLSEnforcement_UnmatchedRoute(t *testing.T) {
+	resolver := egressadapter.NewRouteResolver(nil)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyAllow,
+		DefaultTimeout: 5 * time.Second,
+		AllowInsecure:  false,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, nil, nil)
+
+	req, err := domainegress.NewEgressRequest("GET", "http://some-external-api.example.com/data", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	_, handleErr := proxy.HandleRequest(context.Background(), req)
+	if handleErr == nil {
+		t.Fatal("HandleRequest() expected ErrInsecureURL, got nil")
+	}
+	if handleErr != egressadapter.ErrInsecureURL {
+		t.Errorf("HandleRequest() error = %v, want ErrInsecureURL", handleErr)
+	}
+}
+
+// TestHTTPHandler_TLSEnforcement_Returns400 verifies that the HTTP handler
+// returns 400 Bad Request when the egress target is plain HTTP and insecure
+// requests are not allowed.
+func TestHTTPHandler_TLSEnforcement_Returns400(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream must not be called for TLS-blocked requests")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	resolver := egressadapter.NewRouteResolver(nil)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyAllow,
+		DefaultTimeout: 5 * time.Second,
+		AllowInsecure:  false,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	// Target a plain HTTP URL — the TLS enforcement must block it.
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/api/data")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode = %d, want %d (plain HTTP must be rejected)", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+// TestHTTPHandler_TLSEnforcement_AllowInsecure_Passes verifies that the HTTP
+// handler forwards plain HTTP requests when allow_insecure is true.
+func TestHTTPHandler_TLSEnforcement_AllowInsecure_Passes(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("insecure-ok"))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "test", upstream.URL+"/api/*")
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/api/resource")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}

--- a/internal/config/egress.go
+++ b/internal/config/egress.go
@@ -15,6 +15,11 @@ type EgressConfig struct {
 	// match any configured route. Accepted values: "allow", "deny" (default: "deny").
 	DefaultPolicy string `mapstructure:"default_policy"`
 
+	// AllowInsecure, when true, permits plain HTTP egress requests globally.
+	// By default only HTTPS targets are allowed. Individual routes can also
+	// override this with their own allow_insecure field.
+	AllowInsecure bool `mapstructure:"allow_insecure"`
+
 	// DefaultTimeout is the global request timeout applied when a route does not
 	// specify its own timeout. Accepts Go duration strings (e.g. "30s"). Default: "30s".
 	DefaultTimeout string `mapstructure:"default_timeout"`
@@ -100,6 +105,11 @@ type EgressRouteConfig struct {
 	// this limit it is truncated and a warning header is added to the response.
 	// When empty, EgressConfig.DefaultResponseSizeLimit is used.
 	ResponseSizeLimit string `mapstructure:"response_size_limit"`
+
+	// AllowInsecure, when true, permits plain HTTP egress requests for this
+	// specific route, overriding the global egress.allow_insecure setting.
+	// When false (default), only HTTPS targets are accepted.
+	AllowInsecure bool `mapstructure:"allow_insecure"`
 }
 
 // EgressCircuitBreakerConfig holds circuit breaker parameters for an egress route.

--- a/internal/domain/egress/route.go
+++ b/internal/domain/egress/route.go
@@ -107,6 +107,7 @@ type Route struct {
 	retry             RetryConfig
 	bodySizeLimit     int64
 	responseSizeLimit int64
+	allowInsecure     bool
 }
 
 // routeOptions carries optional fields supplied via functional options.
@@ -120,6 +121,7 @@ type routeOptions struct {
 	retry             RetryConfig
 	bodySizeLimit     int64
 	responseSizeLimit int64
+	allowInsecure     bool
 }
 
 // RouteOption is a functional option for NewRoute.
@@ -176,6 +178,13 @@ func WithHeaders(cfg HeadersConfig) RouteOption {
 	return func(o *routeOptions) { o.headers = cfg }
 }
 
+// WithAllowInsecure permits plain HTTP egress requests for this route,
+// overriding the global egress.allow_insecure setting.
+// When not set, the proxy-level default governs whether HTTP is allowed.
+func WithAllowInsecure(allow bool) RouteOption {
+	return func(o *routeOptions) { o.allowInsecure = allow }
+}
+
 // NewRoute constructs a Route value object.
 // Returns an error when name is empty, pattern is empty, or the pattern is
 // not a valid URL glob (as accepted by path.Match).
@@ -207,6 +216,7 @@ func NewRoute(name, pattern string, opts ...RouteOption) (Route, error) {
 		retry:             o.retry,
 		bodySizeLimit:     o.bodySizeLimit,
 		responseSizeLimit: o.responseSizeLimit,
+		allowInsecure:     o.allowInsecure,
 	}, nil
 }
 
@@ -247,6 +257,11 @@ func (r Route) ResponseSizeLimit() int64 { return r.responseSizeLimit }
 
 // Headers returns the per-route header manipulation configuration.
 func (r Route) Headers() HeadersConfig { return r.headers }
+
+// AllowInsecure reports whether plain HTTP egress requests are permitted for
+// this route. When true, HTTP targets are accepted regardless of the proxy-level
+// default. When false, the proxy-level setting governs.
+func (r Route) AllowInsecure() bool { return r.allowInsecure }
 
 // MatchesMethod reports whether the given HTTP method is allowed by this route.
 // When Methods is empty, all methods are considered a match.

--- a/internal/domain/egress/route_test.go
+++ b/internal/domain/egress/route_test.go
@@ -129,6 +129,43 @@ func TestNewRoute_SizeLimitDefaults(t *testing.T) {
 	}
 }
 
+// TestNewRoute_AllowInsecure verifies the AllowInsecure accessor and option.
+func TestNewRoute_AllowInsecure(t *testing.T) {
+	tests := []struct {
+		name         string
+		opts         []egress.RouteOption
+		wantInsecure bool
+	}{
+		{
+			name:         "default is false",
+			opts:         nil,
+			wantInsecure: false,
+		},
+		{
+			name:         "WithAllowInsecure(true) sets true",
+			opts:         []egress.RouteOption{egress.WithAllowInsecure(true)},
+			wantInsecure: true,
+		},
+		{
+			name:         "WithAllowInsecure(false) keeps false",
+			opts:         []egress.RouteOption{egress.WithAllowInsecure(false)},
+			wantInsecure: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := egress.NewRoute("r", "https://example.com/**", tt.opts...)
+			if err != nil {
+				t.Fatalf("NewRoute() unexpected error: %v", err)
+			}
+			if got := r.AllowInsecure(); got != tt.wantInsecure {
+				t.Errorf("AllowInsecure() = %v, want %v", got, tt.wantInsecure)
+			}
+		})
+	}
+}
+
 func TestRetryConfig_IsRetryableMethod(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
Closes #371

## Summary

- By default, only HTTPS targets are allowed for egress routes; plain HTTP requests are rejected with `ErrInsecureURL` (HTTP 400 Bad Request)
- Global override: `egress.allow_insecure: true` in config permits HTTP globally
- Per-route override: `allow_insecure: true` on a route permits HTTP for that specific route, regardless of the global setting
- TLS minimum version set to 1.2 on the default egress HTTP transport (`crypto/tls.VersionTLS12`)
- Structured log event `egress.tls_error` emitted on blocked insecure requests
- `ErrInsecureURL` sentinel error added to `errors.go`

## Architecture touchpoints

- `internal/domain/egress/route.go` — added `allowInsecure bool` field, `WithAllowInsecure(bool)` option, `AllowInsecure()` accessor
- `internal/adapters/egress/errors.go` — added `ErrInsecureURL`
- `internal/adapters/egress/proxy.go` — added `AllowInsecure bool` to `ProxyConfig`, TLS min version on transport, enforcement check in `HandleRequest`, 400 handler in `handleRequest`
- `internal/config/egress.go` — added `AllowInsecure bool` to `EgressConfig` and `EgressRouteConfig`

## Test plan

- `TestHandleRequest_TLSEnforcement` — table-driven: HTTPS always allowed, HTTP blocked by default, HTTP allowed by global flag, HTTP allowed by per-route flag
- `TestHandleRequest_TLSEnforcement_UnmatchedRoute` — unmatched HTTP request on allow-policy proxy is still blocked
- `TestHTTPHandler_TLSEnforcement_Returns400` — HTTP handler returns 400 for blocked HTTP target
- `TestHTTPHandler_TLSEnforcement_AllowInsecure_Passes` — HTTP handler forwards when `AllowInsecure: true`
- `TestNewRoute_AllowInsecure` — domain layer: accessor and option behaviour
- All existing tests updated to set `AllowInsecure: true` where they use plain-HTTP test servers