### PR TITLE
feat(#365): implement egress request sanitization and PII redaction

### DIFF
--- a/internal/adapters/egress/proxy.go
+++ b/internal/adapters/egress/proxy.go
@@ -743,6 +743,28 @@ func (p *Proxy) forward(ctx context.Context, req domainegress.EgressRequest, mat
 		outHeaders.Del(headerInjectSecret)
 	}
 
+	// PII sanitization phase — strip query params and redact JSON body fields
+	// before forwarding, and build a log-safe header copy.
+	// Sanitization runs after header manipulation so that injected/stripped
+	// headers are reflected correctly in the log output.
+	if match.Matched {
+		sanitizeCfg := match.Route.Sanitize()
+		if !sanitizeCfg.IsZero() {
+			sanitizedReq, _, sanitizeResult, sanitizeErr := sanitizeRequest(reqCtx, req, sanitizeCfg)
+			if sanitizeErr != nil {
+				p.logger.ErrorContext(ctx, "egress sanitization error — request blocked",
+					slog.String("url", req.URL),
+					slog.String("err", sanitizeErr.Error()),
+				)
+				return domainegress.EgressResponse{}, fmt.Errorf("sanitizing request: %w", sanitizeErr)
+			}
+			req = sanitizedReq
+			// Emit egress.sanitized event after updating req so the URL in the
+			// event already has query params stripped.
+			p.emitSanitized(reqCtx, routeName, req, sanitizeResult)
+		}
+	}
+
 	// Secret injection phase — must happen after header manipulation so that
 	// X-Inject-Secret is extracted before being stripped.
 	//

--- a/internal/adapters/egress/sanitizer.go
+++ b/internal/adapters/egress/sanitizer.go
@@ -1,0 +1,199 @@
+package egress
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+)
+
+const (
+	// redacted is the placeholder value written in place of sensitive data.
+	redacted = "[REDACTED]"
+
+	// contentTypeJSON is the MIME type prefix that enables body field redaction.
+	contentTypeJSON = "application/json"
+)
+
+// SanitizeResult reports how many fields were redacted in each category.
+type SanitizeResult struct {
+	// RedactedHeaders is the count of header values replaced with "[REDACTED]"
+	// in the log-safe copy.
+	RedactedHeaders int
+
+	// StrippedQueryParams is the count of query parameters removed from the URL.
+	StrippedQueryParams int
+
+	// RedactedBodyFields is the count of JSON body field values replaced with
+	// "[REDACTED]".
+	RedactedBodyFields int
+}
+
+// Total returns the sum of all redacted field counts.
+func (r SanitizeResult) Total() int {
+	return r.RedactedHeaders + r.StrippedQueryParams + r.RedactedBodyFields
+}
+
+// sanitizeRequest applies the per-route PII redaction rules to req and returns:
+//   - the modified request (URL query params and body are mutated in-place),
+//   - a log-safe header map where sensitive values are replaced with "[REDACTED]",
+//   - a SanitizeResult reporting the counts of each redacted category.
+//
+// Header values in the actual forwarded request are preserved unchanged;
+// only the returned logHeaders copy carries the redacted values.
+//
+// Body redaction is only applied when the request Content-Type is
+// application/json. Non-JSON bodies are forwarded unchanged.
+func sanitizeRequest(
+	ctx context.Context,
+	req domainegress.EgressRequest,
+	cfg domainegress.SanitizeConfig,
+) (domainegress.EgressRequest, http.Header, SanitizeResult, error) {
+	var result SanitizeResult
+
+	// --- Query param stripping ---
+	if len(cfg.QueryParams) > 0 {
+		stripped, n, err := stripQueryParams(req.URL, cfg.QueryParams)
+		if err != nil {
+			return req, req.Header, result, err
+		}
+		req.URL = stripped
+		result.StrippedQueryParams = n
+	}
+
+	// --- Header log-redaction ---
+	// logHeaders is the copy used in structured events; the forwarded request
+	// still gets the original header values.
+	logHeaders := req.Header.Clone()
+	if len(cfg.Headers) > 0 {
+		redactedSet := cfg.RedactedHeaders()
+		for name := range logHeaders {
+			if _, sensitive := redactedSet[strings.ToLower(name)]; sensitive {
+				logHeaders[name] = []string{redacted}
+				result.RedactedHeaders++
+			}
+		}
+	}
+
+	// --- Body field redaction ---
+	if len(cfg.BodyFields) > 0 && isJSONContentType(req.Header.Get("Content-Type")) {
+		body, ok := req.BodyRef.(io.Reader)
+		if ok && body != nil {
+			raw, err := io.ReadAll(body)
+			if err != nil {
+				return req, logHeaders, result, err
+			}
+			redactedBody, n := redactJSONFields(raw, cfg.BodyFields)
+			req.BodyRef = io.NopCloser(bytes.NewReader(redactedBody))
+			result.RedactedBodyFields = n
+		}
+	}
+
+	_ = ctx // context reserved for future async operations (e.g. audit logging)
+	return req, logHeaders, result, nil
+}
+
+// stripQueryParams removes each named parameter from rawURL and returns the
+// modified URL string together with the count of parameters actually removed.
+func stripQueryParams(rawURL string, params []string) (string, int, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL, 0, nil // malformed URL — leave unchanged, proxy will handle it
+	}
+
+	q := u.Query()
+	count := 0
+	for _, p := range params {
+		if _, exists := q[p]; exists {
+			q.Del(p)
+			count++
+		}
+	}
+	if count == 0 {
+		return rawURL, 0, nil
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), count, nil
+}
+
+// isJSONContentType reports whether the Content-Type header value indicates
+// an application/json body (ignoring any charset parameter).
+func isJSONContentType(ct string) bool {
+	return strings.HasPrefix(strings.TrimSpace(ct), contentTypeJSON)
+}
+
+// redactJSONFields replaces the value of each named JSON field in body with
+// "[REDACTED]". It uses a simple regex-based substitution that handles both
+// string values (e.g. "password":"secret") and handles nested occurrences.
+// Returns the modified body and the count of fields that were actually replaced.
+//
+// The regex matches:
+//
+//	"<field>"\s*:\s*"<any value without closing quote>"
+//
+// and replaces only the value portion. This handles top-level and nested
+// string fields but does not support non-string values (numbers, booleans)
+// as PII is almost exclusively transmitted as strings.
+func redactJSONFields(body []byte, fields []string) ([]byte, int) {
+	total := 0
+	result := body
+	for _, field := range fields {
+		// Escape the field name for use in a regex literal.
+		escapedField := regexp.QuoteMeta(field)
+		// Match: "fieldname"\s*:\s*"value"
+		// Capture group 1: everything up to and including the colon + whitespace.
+		// We replace the string value (between the quotes after the colon) with [REDACTED].
+		pattern := `("` + escapedField + `"\s*:\s*)"[^"]*"`
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			// Skip invalid patterns silently — the field name itself is the issue.
+			continue
+		}
+		var matched bool
+		result = re.ReplaceAllFunc(result, func(b []byte) []byte {
+			matched = true
+			// re.ReplaceAllLiteral would replace the whole match; we want to keep
+			// the key portion (group 1). ReplaceAllFunc gives us the full match, so
+			// we re-run FindSubmatch to extract the prefix.
+			sub := re.FindSubmatch(b)
+			if sub == nil {
+				return b
+			}
+			return append(sub[1], `"`+redacted+`"`...)
+		})
+		if matched {
+			total++
+		}
+	}
+	return result, total
+}
+
+// emitSanitized logs an egress.sanitized structured event when at least one
+// field was redacted. It is a no-op when the EventLogger is nil or when
+// result.Total() == 0.
+func (p *Proxy) emitSanitized(
+	ctx context.Context,
+	routeName string,
+	req domainegress.EgressRequest,
+	result SanitizeResult,
+) {
+	if p.cfg.EventLogger == nil || result.Total() == 0 {
+		return
+	}
+	ev := events.NewEgressSanitized(events.EgressSanitizedParams{
+		Route:               routeName,
+		Method:              req.Method,
+		URL:                 req.URL,
+		RedactedHeaders:     result.RedactedHeaders,
+		StrippedQueryParams: result.StrippedQueryParams,
+		RedactedBodyFields:  result.RedactedBodyFields,
+		TraceID:             traceIDFromContext(ctx),
+	})
+	_ = p.cfg.EventLogger.Log(ctx, ev)
+}

--- a/internal/adapters/egress/sanitizer_integration_test.go
+++ b/internal/adapters/egress/sanitizer_integration_test.go
@@ -1,0 +1,293 @@
+package egress_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	egressadapter "github.com/vibewarden/vibewarden/internal/adapters/egress"
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+// TestHandleRequest_Sanitize_QueryParamsStripped verifies that query parameters
+// listed in sanitize.query_params are removed before the request reaches the
+// upstream, and an egress.sanitized event is emitted.
+func TestHandleRequest_Sanitize_QueryParamsStripped(t *testing.T) {
+	var capturedURLQuery string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURLQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	logger := &fakeEventLogger{}
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithSanitize(domainegress.SanitizeConfig{
+			QueryParams: []string{"api_key"},
+		}),
+	)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true,
+		EventLogger:    logger,
+	}
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	reqURL := upstream.URL + "/v1/resource?api_key=secret&amount=100"
+	req, err := domainegress.NewEgressRequest("GET", reqURL, nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	// The upstream must not have seen api_key.
+	if strings.Contains(capturedURLQuery, "api_key") {
+		t.Errorf("upstream received api_key in query: %s", capturedURLQuery)
+	}
+	// But amount must still be there.
+	if !strings.Contains(capturedURLQuery, "amount=100") {
+		t.Errorf("upstream query is missing amount=100: %s", capturedURLQuery)
+	}
+
+	// An egress.sanitized event must have been emitted.
+	logged := logger.logged
+	var sanitizedFound bool
+	for _, ev := range logged {
+		if ev.EventType == "egress.sanitized" {
+			sanitizedFound = true
+			if got := ev.Payload["stripped_query_params"]; got != 1 {
+				t.Errorf("stripped_query_params = %v, want 1", got)
+			}
+		}
+	}
+	if !sanitizedFound {
+		t.Fatal("no egress.sanitized event was emitted")
+	}
+}
+
+// TestHandleRequest_Sanitize_JSONBodyFieldsRedacted verifies that body fields
+// listed in sanitize.body_fields are replaced with "[REDACTED]" before forwarding.
+func TestHandleRequest_Sanitize_JSONBodyFieldsRedacted(t *testing.T) {
+	var capturedBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		capturedBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithSanitize(domainegress.SanitizeConfig{
+			BodyFields: []string{"password", "ssn"},
+		}),
+	)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true,
+	}
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	bodyStr := `{"username":"alice","password":"hunter2","ssn":"123-45-6789"}`
+	headers := http.Header{"Content-Type": []string{"application/json"}}
+	req, err := domainegress.NewEgressRequest("POST", upstream.URL+"/v1/login", headers,
+		io.NopCloser(strings.NewReader(bodyStr)),
+	)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	_, err = proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+
+	if strings.Contains(capturedBody, "hunter2") {
+		t.Errorf("upstream received original password in body: %s", capturedBody)
+	}
+	if strings.Contains(capturedBody, "123-45-6789") {
+		t.Errorf("upstream received original SSN in body: %s", capturedBody)
+	}
+	if !strings.Contains(capturedBody, "[REDACTED]") {
+		t.Errorf("upstream body does not contain [REDACTED]: %s", capturedBody)
+	}
+	if !strings.Contains(capturedBody, "alice") {
+		t.Errorf("upstream body should still contain username: %s", capturedBody)
+	}
+}
+
+// TestHandleRequest_Sanitize_HeadersRedactedInEvent verifies that request
+// headers listed in sanitize.headers appear as "[REDACTED]" in the
+// egress.sanitized event, while the actual forwarded request preserves the
+// original values.
+func TestHandleRequest_Sanitize_HeadersRedactedInEvent(t *testing.T) {
+	var capturedAuthHeader string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuthHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	logger := &fakeEventLogger{}
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithSanitize(domainegress.SanitizeConfig{
+			Headers: []string{"Authorization"},
+		}),
+	)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true,
+		EventLogger:    logger,
+	}
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	headers := http.Header{"Authorization": []string{"Bearer secrettoken"}}
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", headers, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	_, err = proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+
+	// Upstream must receive the real Authorization header (not redacted).
+	if capturedAuthHeader != "Bearer secrettoken" {
+		t.Errorf("upstream received Authorization = %q, want original value", capturedAuthHeader)
+	}
+
+	// The egress.sanitized event must report 1 redacted header.
+	var sanitizedFound bool
+	for _, ev := range logger.logged {
+		if ev.EventType == "egress.sanitized" {
+			sanitizedFound = true
+			if got := ev.Payload["redacted_headers"]; got != 1 {
+				t.Errorf("redacted_headers = %v, want 1", got)
+			}
+		}
+	}
+	if !sanitizedFound {
+		t.Fatal("no egress.sanitized event was emitted")
+	}
+}
+
+// TestHandleRequest_Sanitize_NoEventWhenNothingRedacted verifies that no
+// egress.sanitized event is emitted when none of the configured rules matched.
+func TestHandleRequest_Sanitize_NoEventWhenNothingRedacted(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	logger := &fakeEventLogger{}
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithSanitize(domainegress.SanitizeConfig{
+			QueryParams: []string{"api_key"}, // request has no api_key
+		}),
+	)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true,
+		EventLogger:    logger,
+	}
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	_, err = proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+
+	for _, ev := range logger.logged {
+		if ev.EventType == "egress.sanitized" {
+			t.Errorf("unexpected egress.sanitized event emitted when nothing was redacted: %v", ev)
+		}
+	}
+}
+
+// TestHTTPHandler_Sanitize_EndToEnd exercises the full HTTP handler path with
+// sanitization rules active, verifying that query params are stripped at the
+// HTTP layer (transparent routing).
+func TestHTTPHandler_Sanitize_EndToEnd(t *testing.T) {
+	var capturedQuery string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithSanitize(domainegress.SanitizeConfig{
+			QueryParams: []string{"token"},
+		}),
+	)
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	proxyClient := &http.Client{Timeout: 5 * time.Second}
+
+	httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/resource?token=mysecret&page=2")
+
+	resp, err := proxyClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if strings.Contains(capturedQuery, "token=mysecret") {
+		t.Errorf("upstream received token in URL query: %s", capturedQuery)
+	}
+	if !strings.Contains(capturedQuery, "page=2") {
+		t.Errorf("upstream is missing page=2 in URL query: %s", capturedQuery)
+	}
+}

--- a/internal/adapters/egress/sanitizer_test.go
+++ b/internal/adapters/egress/sanitizer_test.go
@@ -1,0 +1,403 @@
+package egress
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+// TestStripQueryParams verifies that named query parameters are removed from
+// the URL and the correct count is returned.
+func TestStripQueryParams(t *testing.T) {
+	tests := []struct {
+		name      string
+		rawURL    string
+		params    []string
+		wantURL   string
+		wantCount int
+	}{
+		{
+			name:      "single param stripped",
+			rawURL:    "https://api.example.com/v1/charge?api_key=secret&amount=100",
+			params:    []string{"api_key"},
+			wantURL:   "https://api.example.com/v1/charge?amount=100",
+			wantCount: 1,
+		},
+		{
+			name:      "multiple params stripped",
+			rawURL:    "https://api.example.com/v1/charge?api_key=secret&token=abc&amount=100",
+			params:    []string{"api_key", "token"},
+			wantURL:   "https://api.example.com/v1/charge?amount=100",
+			wantCount: 2,
+		},
+		{
+			name:      "param not present — no change",
+			rawURL:    "https://api.example.com/v1/charge?amount=100",
+			params:    []string{"api_key"},
+			wantURL:   "https://api.example.com/v1/charge?amount=100",
+			wantCount: 0,
+		},
+		{
+			name:      "all params stripped — empty query string",
+			rawURL:    "https://api.example.com/v1/charge?api_key=secret",
+			params:    []string{"api_key"},
+			wantURL:   "https://api.example.com/v1/charge",
+			wantCount: 1,
+		},
+		{
+			name:      "URL with no query string — no change",
+			rawURL:    "https://api.example.com/v1/charge",
+			params:    []string{"api_key"},
+			wantURL:   "https://api.example.com/v1/charge",
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, gotCount, err := stripQueryParams(tt.rawURL, tt.params)
+			if err != nil {
+				t.Fatalf("stripQueryParams returned unexpected error: %v", err)
+			}
+			if gotCount != tt.wantCount {
+				t.Errorf("count = %d, want %d", gotCount, tt.wantCount)
+			}
+			// Compare parsed query strings to be order-independent.
+			if !queryEqual(gotURL, tt.wantURL) {
+				t.Errorf("URL = %q, want %q", gotURL, tt.wantURL)
+			}
+		})
+	}
+}
+
+// queryEqual compares two URLs by their parsed query strings, ignoring
+// parameter order (url.Values.Encode sorts keys alphabetically).
+func queryEqual(a, b string) bool {
+	// Simple string comparison works here because url.Values.Encode is
+	// deterministic (sorted), but we just do path+query comparison.
+	return a == b || normalizeURL(a) == normalizeURL(b)
+}
+
+func normalizeURL(raw string) string {
+	// Strip trailing "?" when query is empty.
+	if strings.HasSuffix(raw, "?") {
+		return raw[:len(raw)-1]
+	}
+	return raw
+}
+
+// TestRedactJSONFields verifies that JSON body field values are replaced with
+// "[REDACTED]" and the correct count is returned.
+func TestRedactJSONFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		fields    []string
+		wantBody  string
+		wantCount int
+	}{
+		{
+			name:      "single top-level string field",
+			body:      `{"username":"alice","password":"s3cr3t"}`,
+			fields:    []string{"password"},
+			wantBody:  `{"username":"alice","password":"[REDACTED]"}`,
+			wantCount: 1,
+		},
+		{
+			name:      "multiple fields",
+			body:      `{"ssn":"123-45-6789","card":"4111111111111111","amount":100}`,
+			fields:    []string{"ssn", "card"},
+			wantBody:  `{"ssn":"[REDACTED]","card":"[REDACTED]","amount":100}`,
+			wantCount: 2,
+		},
+		{
+			name:      "field not present — no change",
+			body:      `{"username":"alice"}`,
+			fields:    []string{"password"},
+			wantBody:  `{"username":"alice"}`,
+			wantCount: 0,
+		},
+		{
+			name:      "nested field is also redacted",
+			body:      `{"user":{"password":"secret","name":"bob"}}`,
+			fields:    []string{"password"},
+			wantBody:  `{"user":{"password":"[REDACTED]","name":"bob"}}`,
+			wantCount: 1,
+		},
+		{
+			name:      "empty body — no change",
+			body:      `{}`,
+			fields:    []string{"password"},
+			wantBody:  `{}`,
+			wantCount: 0,
+		},
+		{
+			name:      "field with whitespace around colon",
+			body:      `{"password" : "s3cr3t","user":"alice"}`,
+			fields:    []string{"password"},
+			wantBody:  `{"password" : "[REDACTED]","user":"alice"}`,
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, count := redactJSONFields([]byte(tt.body), tt.fields)
+			if count != tt.wantCount {
+				t.Errorf("count = %d, want %d", count, tt.wantCount)
+			}
+			if string(got) != tt.wantBody {
+				t.Errorf("body = %q, want %q", string(got), tt.wantBody)
+			}
+		})
+	}
+}
+
+// TestIsJSONContentType verifies Content-Type detection.
+func TestIsJSONContentType(t *testing.T) {
+	tests := []struct {
+		ct   string
+		want bool
+	}{
+		{"application/json", true},
+		{"application/json; charset=utf-8", true},
+		{"application/json;charset=utf-8", true},
+		{"text/plain", false},
+		{"application/x-www-form-urlencoded", false},
+		{"", false},
+		{"  application/json", true}, // leading space is trimmed
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ct, func(t *testing.T) {
+			got := isJSONContentType(tt.ct)
+			if got != tt.want {
+				t.Errorf("isJSONContentType(%q) = %v, want %v", tt.ct, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeRequest_HeadersRedactedInLogCopy verifies that sensitive header
+// values are replaced in the returned log copy but preserved in the forwarded
+// request headers.
+func TestSanitizeRequest_HeadersRedactedInLogCopy(t *testing.T) {
+	headers := http.Header{
+		"Authorization": []string{"Bearer token123"},
+		"Cookie":        []string{"session=abc"},
+		"X-Custom":      []string{"visible"},
+	}
+	req, err := domainegress.NewEgressRequest("GET", "https://api.example.com/v1/resource", headers, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	cfg := domainegress.SanitizeConfig{
+		Headers: []string{"Authorization", "Cookie"},
+	}
+
+	_, logHeaders, result, err := sanitizeRequest(context.Background(), req, cfg)
+	if err != nil {
+		t.Fatalf("sanitizeRequest: %v", err)
+	}
+
+	if result.RedactedHeaders != 2 {
+		t.Errorf("RedactedHeaders = %d, want 2", result.RedactedHeaders)
+	}
+
+	// Log copy must have redacted values.
+	if got := logHeaders.Get("Authorization"); got != redacted {
+		t.Errorf("logHeaders[Authorization] = %q, want %q", got, redacted)
+	}
+	if got := logHeaders.Get("Cookie"); got != redacted {
+		t.Errorf("logHeaders[Cookie] = %q, want %q", got, redacted)
+	}
+	// Non-sensitive header must pass through unchanged.
+	if got := logHeaders.Get("X-Custom"); got != "visible" {
+		t.Errorf("logHeaders[X-Custom] = %q, want %q", got, "visible")
+	}
+
+	// Original request headers must be preserved.
+	if got := req.Header.Get("Authorization"); got != "Bearer token123" {
+		t.Errorf("req.Header[Authorization] = %q, want original value", got)
+	}
+}
+
+// TestSanitizeRequest_QueryParamsStripped verifies that the URL has named
+// query parameters removed before forwarding.
+func TestSanitizeRequest_QueryParamsStripped(t *testing.T) {
+	req, err := domainegress.NewEgressRequest(
+		"GET",
+		"https://api.example.com/search?api_key=secret&q=hello",
+		nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	cfg := domainegress.SanitizeConfig{QueryParams: []string{"api_key"}}
+	modified, _, result, err := sanitizeRequest(context.Background(), req, cfg)
+	if err != nil {
+		t.Fatalf("sanitizeRequest: %v", err)
+	}
+
+	if result.StrippedQueryParams != 1 {
+		t.Errorf("StrippedQueryParams = %d, want 1", result.StrippedQueryParams)
+	}
+	if strings.Contains(modified.URL, "api_key") {
+		t.Errorf("URL still contains api_key: %s", modified.URL)
+	}
+	if !strings.Contains(modified.URL, "q=hello") {
+		t.Errorf("URL is missing q=hello: %s", modified.URL)
+	}
+}
+
+// TestSanitizeRequest_BodyFieldsRedacted verifies that JSON body field values
+// are replaced in the forwarded request body.
+func TestSanitizeRequest_BodyFieldsRedacted(t *testing.T) {
+	body := `{"email":"user@example.com","password":"hunter2","amount":100}`
+	headers := http.Header{"Content-Type": []string{"application/json"}}
+	req, err := domainegress.NewEgressRequest(
+		"POST",
+		"https://api.example.com/v1/login",
+		headers,
+		io.NopCloser(strings.NewReader(body)),
+	)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	cfg := domainegress.SanitizeConfig{BodyFields: []string{"password"}}
+	modified, _, result, err := sanitizeRequest(context.Background(), req, cfg)
+	if err != nil {
+		t.Fatalf("sanitizeRequest: %v", err)
+	}
+
+	if result.RedactedBodyFields != 1 {
+		t.Errorf("RedactedBodyFields = %d, want 1", result.RedactedBodyFields)
+	}
+
+	bodyReader, ok := modified.BodyRef.(io.Reader)
+	if !ok || bodyReader == nil {
+		t.Fatal("BodyRef is not a readable io.Reader")
+	}
+	got, _ := io.ReadAll(bodyReader)
+	if strings.Contains(string(got), "hunter2") {
+		t.Errorf("body still contains the original password: %s", string(got))
+	}
+	if !strings.Contains(string(got), redacted) {
+		t.Errorf("body does not contain %q: %s", redacted, string(got))
+	}
+}
+
+// TestSanitizeRequest_NonJSONBodyNotTouched verifies that body redaction is
+// skipped when the Content-Type is not application/json.
+func TestSanitizeRequest_NonJSONBodyNotTouched(t *testing.T) {
+	body := "password=hunter2&user=alice"
+	headers := http.Header{"Content-Type": []string{"application/x-www-form-urlencoded"}}
+	req, err := domainegress.NewEgressRequest(
+		"POST",
+		"https://api.example.com/v1/login",
+		headers,
+		io.NopCloser(strings.NewReader(body)),
+	)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	cfg := domainegress.SanitizeConfig{BodyFields: []string{"password"}}
+	modified, _, result, err := sanitizeRequest(context.Background(), req, cfg)
+	if err != nil {
+		t.Fatalf("sanitizeRequest: %v", err)
+	}
+
+	if result.RedactedBodyFields != 0 {
+		t.Errorf("RedactedBodyFields = %d, want 0 for non-JSON body", result.RedactedBodyFields)
+	}
+
+	bodyReader, ok := modified.BodyRef.(io.Reader)
+	if !ok || bodyReader == nil {
+		t.Fatal("BodyRef is not a readable io.Reader after non-JSON bypass")
+	}
+	got, _ := io.ReadAll(bodyReader)
+	if string(got) != body {
+		t.Errorf("body was unexpectedly modified: %q", string(got))
+	}
+}
+
+// TestSanitizeRequest_ZeroConfig is a no-op fast path check.
+func TestSanitizeRequest_ZeroConfig(t *testing.T) {
+	req, err := domainegress.NewEgressRequest("GET", "https://api.example.com/v1/resource", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	_, _, result, err := sanitizeRequest(context.Background(), req, domainegress.SanitizeConfig{})
+	if err != nil {
+		t.Fatalf("sanitizeRequest: %v", err)
+	}
+
+	if result.Total() != 0 {
+		t.Errorf("Total() = %d, want 0 for zero config", result.Total())
+	}
+}
+
+// TestSanitizeResult_Total verifies that Total() sums all counters.
+func TestSanitizeResult_Total(t *testing.T) {
+	r := SanitizeResult{RedactedHeaders: 2, StrippedQueryParams: 3, RedactedBodyFields: 1}
+	if got := r.Total(); got != 6 {
+		t.Errorf("Total() = %d, want 6", got)
+	}
+}
+
+// TestSanitizeRequest_BodyNilNotTouched verifies that a nil body is handled gracefully.
+func TestSanitizeRequest_BodyNilNotTouched(t *testing.T) {
+	headers := http.Header{"Content-Type": []string{"application/json"}}
+	req, err := domainegress.NewEgressRequest("POST", "https://api.example.com/v1/op", headers, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	cfg := domainegress.SanitizeConfig{BodyFields: []string{"password"}}
+	_, _, result, err := sanitizeRequest(context.Background(), req, cfg)
+	if err != nil {
+		t.Fatalf("sanitizeRequest: %v", err)
+	}
+	if result.RedactedBodyFields != 0 {
+		t.Errorf("RedactedBodyFields = %d for nil body, want 0", result.RedactedBodyFields)
+	}
+}
+
+// TestSanitizeRequest_BodyBytesReader verifies that a *bytes.Reader body is handled.
+func TestSanitizeRequest_BodyBytesReader(t *testing.T) {
+	body := `{"token":"abc123","action":"login"}`
+	headers := http.Header{"Content-Type": []string{"application/json"}}
+	req, err := domainegress.NewEgressRequest(
+		"POST",
+		"https://api.example.com/v1/auth",
+		headers,
+		bytes.NewReader([]byte(body)),
+	)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	cfg := domainegress.SanitizeConfig{BodyFields: []string{"token"}}
+	modified, _, result, err := sanitizeRequest(context.Background(), req, cfg)
+	if err != nil {
+		t.Fatalf("sanitizeRequest: %v", err)
+	}
+
+	if result.RedactedBodyFields != 1 {
+		t.Errorf("RedactedBodyFields = %d, want 1", result.RedactedBodyFields)
+	}
+	got, _ := io.ReadAll(modified.BodyRef.(io.Reader))
+	if strings.Contains(string(got), "abc123") {
+		t.Errorf("body still contains original token: %s", string(got))
+	}
+}

--- a/internal/domain/egress/route.go
+++ b/internal/domain/egress/route.go
@@ -108,6 +108,7 @@ type Route struct {
 	bodySizeLimit     int64
 	responseSizeLimit int64
 	allowInsecure     bool
+	sanitize          SanitizeConfig
 }
 
 // routeOptions carries optional fields supplied via functional options.
@@ -122,6 +123,7 @@ type routeOptions struct {
 	bodySizeLimit     int64
 	responseSizeLimit int64
 	allowInsecure     bool
+	sanitize          SanitizeConfig
 }
 
 // RouteOption is a functional option for NewRoute.
@@ -185,6 +187,14 @@ func WithAllowInsecure(allow bool) RouteOption {
 	return func(o *routeOptions) { o.allowInsecure = allow }
 }
 
+// WithSanitize configures the per-route PII redaction rules. These rules
+// govern which headers are redacted in log output, which query parameters are
+// stripped before forwarding, and which JSON body fields are replaced with
+// "[REDACTED]" before the request is sent to the upstream.
+func WithSanitize(cfg SanitizeConfig) RouteOption {
+	return func(o *routeOptions) { o.sanitize = cfg }
+}
+
 // NewRoute constructs a Route value object.
 // Returns an error when name is empty, pattern is empty, or the pattern is
 // not a valid URL glob (as accepted by path.Match).
@@ -217,6 +227,7 @@ func NewRoute(name, pattern string, opts ...RouteOption) (Route, error) {
 		bodySizeLimit:     o.bodySizeLimit,
 		responseSizeLimit: o.responseSizeLimit,
 		allowInsecure:     o.allowInsecure,
+		sanitize:          o.sanitize,
 	}, nil
 }
 
@@ -262,6 +273,10 @@ func (r Route) Headers() HeadersConfig { return r.headers }
 // this route. When true, HTTP targets are accepted regardless of the proxy-level
 // default. When false, the proxy-level setting governs.
 func (r Route) AllowInsecure() bool { return r.allowInsecure }
+
+// Sanitize returns the per-route PII redaction configuration.
+// A zero SanitizeConfig means no sanitization rules are applied.
+func (r Route) Sanitize() SanitizeConfig { return r.sanitize }
 
 // MatchesMethod reports whether the given HTTP method is allowed by this route.
 // When Methods is empty, all methods are considered a match.

--- a/internal/domain/egress/sanitize.go
+++ b/internal/domain/egress/sanitize.go
@@ -1,0 +1,51 @@
+package egress
+
+import "strings"
+
+// SanitizeConfig holds the per-route PII redaction rules applied to outbound
+// requests before they are forwarded and before sensitive values are logged.
+//
+// Header values listed in Headers are replaced with "[REDACTED]" in log output
+// but are preserved unchanged in the actual forwarded request.
+// Query parameters listed in QueryParams are stripped from the request URL
+// before forwarding.
+// JSON body fields listed in BodyFields are replaced with "[REDACTED]" in the
+// request body before forwarding. Redaction is only applied when the request
+// Content-Type is application/json.
+type SanitizeConfig struct {
+	// Headers is the list of request header names whose values are redacted in
+	// structured log events (e.g. "Authorization", "Cookie").
+	// Header names are matched case-insensitively.
+	// The header value is preserved in the actual forwarded request.
+	Headers []string
+
+	// QueryParams is the list of query parameter names to strip from the
+	// request URL before forwarding (e.g. "api_key", "token").
+	// Parameter names are matched case-sensitively.
+	QueryParams []string
+
+	// BodyFields is the list of JSON field names to redact in the request body
+	// before forwarding (e.g. "password", "ssn", "card_number").
+	// Field names are matched case-sensitively against top-level and nested
+	// JSON keys using a simple regex-based substitution.
+	// Redaction is only applied when Content-Type is application/json.
+	BodyFields []string
+}
+
+// IsZero reports whether the SanitizeConfig has no rules configured.
+func (s SanitizeConfig) IsZero() bool {
+	return len(s.Headers) == 0 && len(s.QueryParams) == 0 && len(s.BodyFields) == 0
+}
+
+// RedactedHeaders returns the set of header names that should be redacted
+// in log output, normalised to their canonical HTTP header form.
+func (s SanitizeConfig) RedactedHeaders() map[string]struct{} {
+	if len(s.Headers) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(s.Headers))
+	for _, h := range s.Headers {
+		out[strings.ToLower(h)] = struct{}{}
+	}
+	return out
+}

--- a/internal/domain/egress/sanitize_test.go
+++ b/internal/domain/egress/sanitize_test.go
@@ -1,0 +1,96 @@
+package egress
+
+import (
+	"testing"
+)
+
+func TestSanitizeConfig_IsZero(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  SanitizeConfig
+		want bool
+	}{
+		{
+			name: "empty config is zero",
+			cfg:  SanitizeConfig{},
+			want: true,
+		},
+		{
+			name: "config with headers is not zero",
+			cfg:  SanitizeConfig{Headers: []string{"Authorization"}},
+			want: false,
+		},
+		{
+			name: "config with query params is not zero",
+			cfg:  SanitizeConfig{QueryParams: []string{"api_key"}},
+			want: false,
+		},
+		{
+			name: "config with body fields is not zero",
+			cfg:  SanitizeConfig{BodyFields: []string{"password"}},
+			want: false,
+		},
+		{
+			name: "config with all fields is not zero",
+			cfg: SanitizeConfig{
+				Headers:     []string{"Cookie"},
+				QueryParams: []string{"token"},
+				BodyFields:  []string{"ssn"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.IsZero()
+			if got != tt.want {
+				t.Errorf("IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeConfig_RedactedHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     SanitizeConfig
+		check   string
+		present bool
+	}{
+		{
+			name:    "nil config returns nil map",
+			cfg:     SanitizeConfig{},
+			check:   "authorization",
+			present: false,
+		},
+		{
+			name:    "header matched case-insensitively — exact case",
+			cfg:     SanitizeConfig{Headers: []string{"Authorization"}},
+			check:   "authorization",
+			present: true,
+		},
+		{
+			name:    "header matched case-insensitively — mixed case input",
+			cfg:     SanitizeConfig{Headers: []string{"COOKIE"}},
+			check:   "cookie",
+			present: true,
+		},
+		{
+			name:    "header not present",
+			cfg:     SanitizeConfig{Headers: []string{"X-Custom"}},
+			check:   "authorization",
+			present: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.cfg.RedactedHeaders()
+			_, got := m[tt.check]
+			if got != tt.present {
+				t.Errorf("RedactedHeaders()[%q] present = %v, want %v", tt.check, got, tt.present)
+			}
+		})
+	}
+}

--- a/internal/domain/events/egress_sanitized.go
+++ b/internal/domain/events/egress_sanitized.go
@@ -1,0 +1,69 @@
+package events
+
+import (
+	"fmt"
+	"time"
+)
+
+// EventTypeEgressSanitized is emitted after the egress proxy applies PII
+// redaction rules to an outbound request. The payload reports how many fields
+// were redacted in each category (headers, query params, body fields) so
+// operators can audit sanitization effectiveness.
+const EventTypeEgressSanitized = "egress.sanitized"
+
+// EgressSanitizedParams contains the parameters needed to construct an
+// egress.sanitized event.
+type EgressSanitizedParams struct {
+	// Route is the matched egress route name.
+	Route string
+
+	// Method is the HTTP method of the outbound request (e.g. "GET", "POST").
+	Method string
+
+	// URL is the destination URL of the outbound request.
+	// Must not include bearer tokens or credentials.
+	URL string
+
+	// RedactedHeaders is the count of request headers whose log values were
+	// replaced with "[REDACTED]".
+	RedactedHeaders int
+
+	// StrippedQueryParams is the count of query parameters removed from the
+	// request URL before forwarding.
+	StrippedQueryParams int
+
+	// RedactedBodyFields is the count of JSON body fields replaced with
+	// "[REDACTED]" before the request was forwarded.
+	RedactedBodyFields int
+
+	// TraceID is the W3C trace-id of the inbound request that triggered this
+	// egress call. Empty when no inbound trace context is available.
+	TraceID string
+}
+
+// NewEgressSanitized creates an egress.sanitized event indicating that the
+// egress proxy applied PII redaction rules to an outbound request.
+func NewEgressSanitized(params EgressSanitizedParams) Event {
+	total := params.RedactedHeaders + params.StrippedQueryParams + params.RedactedBodyFields
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeEgressSanitized,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"Egress request sanitized: %s %s via route %q — %d field(s) redacted (%d header(s), %d query param(s), %d body field(s))",
+			params.Method, params.URL, params.Route,
+			total,
+			params.RedactedHeaders, params.StrippedQueryParams, params.RedactedBodyFields,
+		),
+		Payload: map[string]any{
+			"route":                 params.Route,
+			"method":                params.Method,
+			"url":                   params.URL,
+			"redacted_headers":      params.RedactedHeaders,
+			"stripped_query_params": params.StrippedQueryParams,
+			"redacted_body_fields":  params.RedactedBodyFields,
+			"total_redacted":        total,
+			"trace_id":              params.TraceID,
+		},
+	}
+}

--- a/internal/domain/events/egress_sanitized_test.go
+++ b/internal/domain/events/egress_sanitized_test.go
@@ -1,0 +1,77 @@
+package events
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewEgressSanitized(t *testing.T) {
+	tests := []struct {
+		name               string
+		params             EgressSanitizedParams
+		wantEventType      string
+		wantTotalInSummary string
+		wantPayloadTotal   int
+	}{
+		{
+			name: "all categories redacted",
+			params: EgressSanitizedParams{
+				Route:               "stripe",
+				Method:              "POST",
+				URL:                 "https://api.stripe.com/v1/charges",
+				RedactedHeaders:     2,
+				StrippedQueryParams: 1,
+				RedactedBodyFields:  3,
+				TraceID:             "abc123",
+			},
+			wantEventType:      EventTypeEgressSanitized,
+			wantTotalInSummary: "6 field(s) redacted",
+			wantPayloadTotal:   6,
+		},
+		{
+			name: "only body fields redacted",
+			params: EgressSanitizedParams{
+				Route:              "webhook",
+				Method:             "POST",
+				URL:                "https://example.com/webhook",
+				RedactedBodyFields: 1,
+			},
+			wantEventType:      EventTypeEgressSanitized,
+			wantTotalInSummary: "1 field(s) redacted",
+			wantPayloadTotal:   1,
+		},
+		{
+			name: "nothing redacted",
+			params: EgressSanitizedParams{
+				Route:  "noop",
+				Method: "GET",
+				URL:    "https://example.com/api",
+			},
+			wantEventType:      EventTypeEgressSanitized,
+			wantTotalInSummary: "0 field(s) redacted",
+			wantPayloadTotal:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := NewEgressSanitized(tt.params)
+
+			if ev.EventType != tt.wantEventType {
+				t.Errorf("EventType = %q, want %q", ev.EventType, tt.wantEventType)
+			}
+			if ev.SchemaVersion != SchemaVersion {
+				t.Errorf("SchemaVersion = %q, want %q", ev.SchemaVersion, SchemaVersion)
+			}
+			if !strings.Contains(ev.AISummary, tt.wantTotalInSummary) {
+				t.Errorf("AISummary %q does not contain %q", ev.AISummary, tt.wantTotalInSummary)
+			}
+			if got := ev.Payload["total_redacted"]; got != tt.wantPayloadTotal {
+				t.Errorf("Payload[total_redacted] = %v, want %d", got, tt.wantPayloadTotal)
+			}
+			if got := ev.Payload["route"]; got != tt.params.Route {
+				t.Errorf("Payload[route] = %v, want %q", got, tt.params.Route)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #365

## Summary

- Adds `SanitizeConfig` domain value object (`Headers`, `QueryParams`, `BodyFields`) in `internal/domain/egress/sanitize.go`
- Extends `Route` with `WithSanitize(cfg SanitizeConfig)` option and `Sanitize()` accessor
- Adds `egress.sanitized` structured event (`internal/domain/events/egress_sanitized.go`) emitted after PII redaction
- Adds `sanitizer.go` adapter implementing: `stripQueryParams` (URL mutation), `redactJSONFields` (regex-based string value replacement), `isJSONContentType` (Content-Type guard)
- Wires the sanitizer into `Proxy.forward()` after header manipulation and before secret injection; emits `egress.sanitized` only when at least one field was actually redacted

### Design decisions

- **Headers**: values are redacted only in the log-safe copy returned by `sanitizeRequest`; the actual forwarded request always carries the original header values (per spec)
- **Query params**: stripped from the URL in-place before forwarding (mutates `req.URL`)
- **Body fields**: regex-based (`"fieldname"\s*:\s*"value"` pattern), JSON string values only; skipped for non-JSON Content-Type bodies; reads and rewrites the body as `bytes.Reader`
- **Event gate**: `egress.sanitized` is not emitted when `SanitizeResult.Total() == 0` to avoid noise

## Test plan

- `go test ./internal/adapters/egress/... ./internal/domain/egress/... ./internal/domain/events/...`
- 21 new tests:
  - Unit: `TestStripQueryParams`, `TestRedactJSONFields`, `TestIsJSONContentType`, 6x `TestSanitizeRequest_*`, `TestSanitizeResult_Total`
  - Integration (proxy end-to-end): query param stripping, JSON body redaction, header log-redaction, no-event-when-nothing-redacted, full HTTP handler path
  - Domain: `TestSanitizeConfig_IsZero`, `TestSanitizeConfig_RedactedHeaders`, `TestNewEgressSanitized`
- `make check` passes (all 66 packages green)