### PR TITLE
feat(#368): implement per-route egress mTLS client certificates

### DIFF
--- a/internal/adapters/egress/errors.go
+++ b/internal/adapters/egress/errors.go
@@ -26,3 +26,9 @@ var ErrRequestBodyTooLarge = errors.New("egress: request body exceeds size limit
 // route's AllowInsecure flag is set. The HTTP handler converts this into a
 // 400 Bad Request response.
 var ErrInsecureURL = errors.New("egress: plain HTTP is not allowed; use HTTPS or set allow_insecure")
+
+// ErrMTLSHandshakeFailed is returned (wrapped) when the upstream TLS handshake
+// fails for a route that has an mTLS client certificate configured. It is used
+// to emit a structured egress.mtls_error event and log the failure with
+// additional context.
+var ErrMTLSHandshakeFailed = errors.New("egress: mTLS handshake failed")

--- a/internal/adapters/egress/mtls.go
+++ b/internal/adapters/egress/mtls.go
@@ -1,0 +1,141 @@
+package egress
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+// MTLSClientMap is a map from route name to a dedicated *http.Client that
+// carries the route's mTLS client certificate. Routes without an MTLSConfig
+// are not present in the map; the proxy falls back to its default client.
+type MTLSClientMap map[string]*http.Client
+
+// BuildMTLSClients reads the cert/key/CA files for every route that has a
+// non-zero MTLSConfig, validates them, and constructs a dedicated *http.Client
+// per route. The returned map is keyed by route name.
+//
+// The base transport is cloned from baseTransport for each route so that SSRF
+// guards and other per-proxy dial hooks are inherited. Pass nil to clone from
+// http.DefaultTransport.
+//
+// An error is returned if any cert, key, or CA file for any route cannot be
+// read or parsed. The error message identifies the offending route name.
+func BuildMTLSClients(routes []domainegress.Route, baseTransport *http.Transport) (MTLSClientMap, error) {
+	m := make(MTLSClientMap)
+	for _, route := range routes {
+		cfg := route.MTLS()
+		if cfg.IsZero() {
+			continue
+		}
+		client, err := buildMTLSClient(cfg, baseTransport)
+		if err != nil {
+			return nil, fmt.Errorf("route %q mTLS config: %w", route.Name(), err)
+		}
+		m[route.Name()] = client
+	}
+	return m, nil
+}
+
+// buildMTLSClient constructs an *http.Client for a single MTLSConfig.
+func buildMTLSClient(cfg domainegress.MTLSConfig, baseTransport *http.Transport) (*http.Client, error) {
+	tlsCert, err := loadClientCert(cfg.CertPath, cfg.KeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var rootCAs *x509.CertPool
+	if cfg.CAPath != "" {
+		rootCAs, err = loadCACert(cfg.CAPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var t *http.Transport
+	if baseTransport != nil {
+		t = baseTransport.Clone()
+	} else {
+		t = http.DefaultTransport.(*http.Transport).Clone()
+	}
+
+	if t.TLSClientConfig == nil {
+		t.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	} else {
+		t.TLSClientConfig = t.TLSClientConfig.Clone()
+	}
+	t.TLSClientConfig.MinVersion = tls.VersionTLS12
+	t.TLSClientConfig.Certificates = []tls.Certificate{tlsCert}
+	if rootCAs != nil {
+		t.TLSClientConfig.RootCAs = rootCAs
+	}
+
+	return &http.Client{
+		Transport: t,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}, nil
+}
+
+// loadClientCert reads and parses a PEM-encoded certificate and private key
+// pair from the given file paths. Returns an error when either path is empty,
+// either file cannot be read, or the cert/key pair is not valid PEM.
+func loadClientCert(certPath, keyPath string) (tls.Certificate, error) {
+	if certPath == "" {
+		return tls.Certificate{}, fmt.Errorf("cert_path is required for mTLS")
+	}
+	if keyPath == "" {
+		return tls.Certificate{}, fmt.Errorf("key_path is required for mTLS")
+	}
+
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("reading client cert %q: %w", certPath, err)
+	}
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("reading client key %q: %w", keyPath, err)
+	}
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("parsing client cert/key pair (%q, %q): %w", certPath, keyPath, err)
+	}
+	return cert, nil
+}
+
+// loadCACert reads and parses a PEM-encoded CA certificate bundle from the
+// given file path and returns a populated *x509.CertPool. Returns an error
+// when the file cannot be read or contains no valid PEM certificates.
+func loadCACert(caPath string) (*x509.CertPool, error) {
+	caPEM, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading CA cert %q: %w", caPath, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("CA cert file %q contains no valid PEM certificates", caPath)
+	}
+	return pool, nil
+}
+
+// isMTLSError reports whether err looks like a TLS handshake failure.
+// net/http wraps TLS errors in *url.Error; we inspect the error message for
+// known TLS alert strings since the underlying tls package errors are not
+// exported in a way that is stable across Go versions.
+func isMTLSError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "tls:") ||
+		strings.Contains(msg, "TLS handshake") ||
+		strings.Contains(msg, "certificate") ||
+		strings.Contains(msg, "handshake failure")
+}

--- a/internal/adapters/egress/mtls_test.go
+++ b/internal/adapters/egress/mtls_test.go
@@ -1,0 +1,449 @@
+package egress_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	egressadapter "github.com/vibewarden/vibewarden/internal/adapters/egress"
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+// generateSelfSignedCA creates a self-signed CA certificate and returns the
+// parsed cert, the private key, and the DER-encoded certificate bytes.
+func generateSelfSignedCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generateSelfSignedCA: generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("generateSelfSignedCA: create cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("generateSelfSignedCA: parse cert: %v", err)
+	}
+	return cert, key, certDER
+}
+
+// generateClientCert creates a client certificate signed by the given CA.
+// Returns PEM-encoded certificate and private key bytes.
+func generateClientCert(t *testing.T, caCert *x509.Certificate, caKey *ecdsa.PrivateKey) (certPEM []byte, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generateClientCert: generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("generateClientCert: create cert: %v", err)
+	}
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("generateClientCert: marshal key: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+	return certPEM, keyPEM
+}
+
+// writeTempFile writes data to a named file inside dir and returns the path.
+func writeTempFile(t *testing.T, dir, name string, data []byte) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, data, 0600); err != nil {
+		t.Fatalf("writeTempFile %s: %v", p, err)
+	}
+	return p
+}
+
+// newMTLSTestServer starts an HTTPS test server that requires client
+// certificate authentication. The server accepts client certificates signed by
+// clientCA. It returns the server and a client configured to trust the server's
+// certificate (but without any client cert — callers must add one to test mTLS).
+func newMTLSTestServer(t *testing.T, clientCA *x509.Certificate) *httptest.Server {
+	t.Helper()
+
+	clientCAPool := x509.NewCertPool()
+	clientCAPool.AddCert(clientCA)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+			http.Error(w, "missing client cert", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("mtls-ok"))
+	})
+
+	srv := httptest.NewUnstartedServer(mux)
+	// Start with TLS first so httptest sets up its own server cert and CA pool.
+	srv.StartTLS()
+	// Now layer in client auth on top of the existing TLS config.
+	srv.TLS.ClientAuth = tls.RequireAnyClientCert
+	srv.TLS.ClientCAs = clientCAPool
+	return srv
+}
+
+// TestBuildMTLSClients_Valid verifies that BuildMTLSClients returns a dedicated
+// client for each route with a non-zero MTLSConfig and no entry for plain routes.
+func TestBuildMTLSClients_Valid(t *testing.T) {
+	dir := t.TempDir()
+	caCert, caKey, _ := generateSelfSignedCA(t)
+	certPEM, keyPEM := generateClientCert(t, caCert, caKey)
+	certPath := writeTempFile(t, dir, "client.crt", certPEM)
+	keyPath := writeTempFile(t, dir, "client.key", keyPEM)
+
+	routeWithMTLS, err := domainegress.NewRoute("secure", "https://api.example.com/*",
+		domainegress.WithMTLS(domainegress.MTLSConfig{
+			CertPath: certPath,
+			KeyPath:  keyPath,
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+	routeWithout, err := domainegress.NewRoute("plain", "https://other.example.com/*")
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+
+	clients, err := egressadapter.BuildMTLSClients([]domainegress.Route{routeWithMTLS, routeWithout}, nil)
+	if err != nil {
+		t.Fatalf("BuildMTLSClients: %v", err)
+	}
+	if _, ok := clients["secure"]; !ok {
+		t.Error("expected a client for route 'secure', got none")
+	}
+	if _, ok := clients["plain"]; ok {
+		t.Error("expected no client for route 'plain', got one")
+	}
+}
+
+// TestBuildMTLSClients_MissingCertFile verifies that BuildMTLSClients returns
+// an error when the cert file path does not exist.
+func TestBuildMTLSClients_MissingCertFile(t *testing.T) {
+	route, err := domainegress.NewRoute("secure", "https://api.example.com/*",
+		domainegress.WithMTLS(domainegress.MTLSConfig{
+			CertPath: "/nonexistent/client.crt",
+			KeyPath:  "/nonexistent/client.key",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+	_, buildErr := egressadapter.BuildMTLSClients([]domainegress.Route{route}, nil)
+	if buildErr == nil {
+		t.Fatal("BuildMTLSClients: expected error for missing cert file, got nil")
+	}
+}
+
+// TestBuildMTLSClients_InvalidPEM verifies that BuildMTLSClients returns an
+// error when the cert/key files contain invalid PEM data.
+func TestBuildMTLSClients_InvalidPEM(t *testing.T) {
+	dir := t.TempDir()
+	certPath := writeTempFile(t, dir, "client.crt", []byte("not-valid-pem"))
+	keyPath := writeTempFile(t, dir, "client.key", []byte("not-valid-pem"))
+
+	route, err := domainegress.NewRoute("secure", "https://api.example.com/*",
+		domainegress.WithMTLS(domainegress.MTLSConfig{
+			CertPath: certPath,
+			KeyPath:  keyPath,
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+	_, buildErr := egressadapter.BuildMTLSClients([]domainegress.Route{route}, nil)
+	if buildErr == nil {
+		t.Fatal("BuildMTLSClients: expected error for invalid PEM, got nil")
+	}
+}
+
+// TestBuildMTLSClients_WithCA verifies that BuildMTLSClients succeeds when a
+// valid CA path is provided alongside the cert and key.
+func TestBuildMTLSClients_WithCA(t *testing.T) {
+	dir := t.TempDir()
+	caCert, caKey, caCertDER := generateSelfSignedCA(t)
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
+	caPath := writeTempFile(t, dir, "ca.crt", caPEM)
+	certPEM, keyPEM := generateClientCert(t, caCert, caKey)
+	certPath := writeTempFile(t, dir, "client.crt", certPEM)
+	keyPath := writeTempFile(t, dir, "client.key", keyPEM)
+
+	route, err := domainegress.NewRoute("secure", "https://api.example.com/*",
+		domainegress.WithMTLS(domainegress.MTLSConfig{
+			CertPath: certPath,
+			KeyPath:  keyPath,
+			CAPath:   caPath,
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+	clients, buildErr := egressadapter.BuildMTLSClients([]domainegress.Route{route}, nil)
+	if buildErr != nil {
+		t.Fatalf("BuildMTLSClients: unexpected error: %v", buildErr)
+	}
+	if clients["secure"] == nil {
+		t.Error("expected non-nil client for 'secure' route")
+	}
+}
+
+// TestBuildMTLSClients_InvalidCA verifies that BuildMTLSClients returns an
+// error when the CA file contains no valid PEM certificates.
+func TestBuildMTLSClients_InvalidCA(t *testing.T) {
+	dir := t.TempDir()
+	caCert, caKey, _ := generateSelfSignedCA(t)
+	certPEM, keyPEM := generateClientCert(t, caCert, caKey)
+	certPath := writeTempFile(t, dir, "client.crt", certPEM)
+	keyPath := writeTempFile(t, dir, "client.key", keyPEM)
+	caPath := writeTempFile(t, dir, "ca.crt", []byte("not-valid-pem"))
+
+	route, err := domainegress.NewRoute("secure", "https://api.example.com/*",
+		domainegress.WithMTLS(domainegress.MTLSConfig{
+			CertPath: certPath,
+			KeyPath:  keyPath,
+			CAPath:   caPath,
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+	_, buildErr := egressadapter.BuildMTLSClients([]domainegress.Route{route}, nil)
+	if buildErr == nil {
+		t.Fatal("BuildMTLSClients: expected error for invalid CA PEM, got nil")
+	}
+}
+
+// TestBuildMTLSClients_EmptyRoutes verifies that BuildMTLSClients with no
+// routes returns an empty (non-nil) map without error.
+func TestBuildMTLSClients_EmptyRoutes(t *testing.T) {
+	clients, err := egressadapter.BuildMTLSClients(nil, nil)
+	if err != nil {
+		t.Fatalf("BuildMTLSClients(nil): unexpected error: %v", err)
+	}
+	if clients == nil {
+		t.Error("BuildMTLSClients(nil): expected non-nil map, got nil")
+	}
+	if len(clients) != 0 {
+		t.Errorf("BuildMTLSClients(nil): expected empty map, got %d entries", len(clients))
+	}
+}
+
+// TestProxy_MTLSClientUsed verifies end-to-end that the proxy presents the
+// configured client certificate when forwarding to an mTLS upstream and the
+// request succeeds with HTTP 200.
+func TestProxy_MTLSClientUsed(t *testing.T) {
+	dir := t.TempDir()
+
+	// Generate a CA that will sign the client cert.
+	caCert, caKey, _ := generateSelfSignedCA(t)
+	certPEM, keyPEM := generateClientCert(t, caCert, caKey)
+	certPath := writeTempFile(t, dir, "client.crt", certPEM)
+	keyPath := writeTempFile(t, dir, "client.key", keyPEM)
+
+	// Start the mTLS test server — it requires a client cert signed by caCert.
+	mtlsSrv := newMTLSTestServer(t, caCert)
+	defer mtlsSrv.Close()
+
+	route, err := domainegress.NewRoute("mtls-api", mtlsSrv.URL+"/api/*",
+		domainegress.WithMTLS(domainegress.MTLSConfig{
+			CertPath: certPath,
+			KeyPath:  keyPath,
+			// No CAPath — trust the server cert via the base transport below.
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+	routes := []domainegress.Route{route}
+
+	// Use the test server's transport as the base so the mTLS client inherits
+	// the server's self-signed cert in the trust store, then layer in the
+	// client certificate.
+	baseTransport := mtlsSrv.Client().Transport.(*http.Transport)
+	mtlsClients, err := egressadapter.BuildMTLSClients(routes, baseTransport)
+	if err != nil {
+		t.Fatalf("BuildMTLSClients: %v", err)
+	}
+
+	resolver := egressadapter.NewRouteResolver(routes)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         routes,
+		MTLSClients:    mtlsClients,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, mtlsSrv.Client(), nil)
+
+	req, err := domainegress.NewEgressRequest("GET", mtlsSrv.URL+"/api/resource", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	resp, handleErr := proxy.HandleRequest(context.Background(), req)
+	if handleErr != nil {
+		t.Fatalf("HandleRequest: unexpected error: %v", handleErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+// TestProxy_MTLSMissingClientCert verifies that when the upstream server
+// requires client authentication but the proxy has no mTLS client configured
+// for the route, the TLS handshake fails and the request returns an error.
+func TestProxy_MTLSMissingClientCert(t *testing.T) {
+	caCert, _, _ := generateSelfSignedCA(t)
+
+	// Start the mTLS test server (requires client cert).
+	mtlsSrv := newMTLSTestServer(t, caCert)
+	defer mtlsSrv.Close()
+
+	route, err := domainegress.NewRoute("mtls-api", mtlsSrv.URL+"/api/*")
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+	routes := []domainegress.Route{route}
+
+	resolver := egressadapter.NewRouteResolver(routes)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         routes,
+		// No MTLSClients — proxy uses default client without a client cert.
+	}
+	// Use the test server's client (trusts the server cert) but no client cert
+	// configured — the server should reject the TLS handshake.
+	proxy := egressadapter.NewProxy(cfg, resolver, mtlsSrv.Client(), nil)
+
+	req, err := domainegress.NewEgressRequest("GET", mtlsSrv.URL+"/api/resource", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+
+	_, handleErr := proxy.HandleRequest(context.Background(), req)
+	if handleErr == nil {
+		t.Fatal("HandleRequest: expected TLS error, got nil")
+	}
+}
+
+// TestMTLSConfig_IsZero verifies that MTLSConfig.IsZero returns the correct
+// value for all combinations of fields.
+func TestMTLSConfig_IsZero(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  domainegress.MTLSConfig
+		want bool
+	}{
+		{
+			name: "zero value",
+			cfg:  domainegress.MTLSConfig{},
+			want: true,
+		},
+		{
+			name: "only cert path",
+			cfg:  domainegress.MTLSConfig{CertPath: "/tmp/cert.pem"},
+			want: false,
+		},
+		{
+			name: "only key path",
+			cfg:  domainegress.MTLSConfig{KeyPath: "/tmp/key.pem"},
+			want: false,
+		},
+		{
+			name: "only ca path",
+			cfg:  domainegress.MTLSConfig{CAPath: "/tmp/ca.pem"},
+			want: false,
+		},
+		{
+			name: "cert and key",
+			cfg:  domainegress.MTLSConfig{CertPath: "/tmp/cert.pem", KeyPath: "/tmp/key.pem"},
+			want: false,
+		},
+		{
+			name: "all fields",
+			cfg: domainegress.MTLSConfig{
+				CertPath: "/tmp/cert.pem",
+				KeyPath:  "/tmp/key.pem",
+				CAPath:   "/tmp/ca.pem",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.IsZero()
+			if got != tt.want {
+				t.Errorf("MTLSConfig(%+v).IsZero() = %v, want %v", tt.cfg, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRoute_MTLS verifies that the MTLS accessor returns the value set via
+// WithMTLS.
+func TestRoute_MTLS(t *testing.T) {
+	want := domainegress.MTLSConfig{
+		CertPath: "/tmp/cert.pem",
+		KeyPath:  "/tmp/key.pem",
+		CAPath:   "/tmp/ca.pem",
+	}
+	route, err := domainegress.NewRoute("secure", "https://api.example.com/*",
+		domainegress.WithMTLS(want),
+	)
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+	got := route.MTLS()
+	if got != want {
+		t.Errorf("Route.MTLS() = %+v, want %+v", got, want)
+	}
+}
+
+// TestRoute_MTLS_ZeroWhenNotConfigured verifies that a route created without
+// WithMTLS returns a zero MTLSConfig.
+func TestRoute_MTLS_ZeroWhenNotConfigured(t *testing.T) {
+	route, err := domainegress.NewRoute("plain", "https://api.example.com/*")
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+	if !route.MTLS().IsZero() {
+		t.Errorf("Route.MTLS() should be zero when not configured, got %+v", route.MTLS())
+	}
+}

--- a/internal/adapters/egress/proxy.go
+++ b/internal/adapters/egress/proxy.go
@@ -150,6 +150,12 @@ type ProxyConfig struct {
 	// headers (W3C traceparent). Requires Tracer to also be set.
 	// When nil, no trace context is propagated.
 	Propagator ports.TextMapPropagator
+
+	// MTLSClients is an optional per-route map of *http.Client instances that
+	// carry route-specific mTLS client certificates. When a matched route has
+	// an entry in this map, its dedicated client is used for that request
+	// instead of the proxy default client. Build this map with BuildMTLSClients.
+	MTLSClients MTLSClientMap
 }
 
 // Proxy is an HTTP server that listens on a dedicated localhost port and
@@ -510,6 +516,16 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "429 Too Many Requests: egress rate limit exceeded", http.StatusTooManyRequests)
 			return
 		}
+		if errors.Is(err, ErrMTLSHandshakeFailed) {
+			p.logger.ErrorContext(r.Context(), "egress.mtls_error",
+				slog.String("event_type", "egress.mtls_error"),
+				slog.String("target", targetURL),
+				slog.String("method", r.Method),
+				slog.String("err", err.Error()),
+			)
+			http.Error(w, "502 Bad Gateway: mTLS handshake failed", http.StatusBadGateway)
+			return
+		}
 		var ssrfErr *SSRFBlockedError
 		if errors.As(err, &ssrfErr) {
 			p.logger.WarnContext(r.Context(), "egress SSRF protection blocked request",
@@ -833,11 +849,37 @@ func (p *Proxy) forward(ctx context.Context, req domainegress.EgressRequest, mat
 			p.cfg.Propagator.Inject(reqCtx, httpHeaderCarrier(httpReq.Header))
 		}
 
-		resp, err := p.client.Do(httpReq)
+		// Use a per-route mTLS client when one has been configured for this
+		// route; otherwise fall back to the proxy default client.
+		activeClient := p.client
+		if match.Matched {
+			if mtlsClient, ok := p.cfg.MTLSClients[match.Route.Name()]; ok {
+				activeClient = mtlsClient
+			}
+		}
+
+		resp, err := activeClient.Do(httpReq)
 
 		if err != nil {
 			lastErr = err
 			lastResp = nil
+
+			// A TLS handshake failure on a route with an mTLS client certificate
+			// is logged as a structured egress.mtls_error event and surfaced
+			// immediately without retrying (the cert mismatch will not resolve
+			// itself on retry).
+			if match.Matched && !match.Route.MTLS().IsZero() && isMTLSError(err) {
+				p.logger.ErrorContext(ctx, "egress.mtls_error",
+					slog.String("event_type", "egress.mtls_error"),
+					slog.String("url", req.URL),
+					slog.String("method", req.Method),
+					slog.String("route", routeName),
+					slog.String("err", err.Error()),
+				)
+				wrappedErr := fmt.Errorf("%w: %w", ErrMTLSHandshakeFailed, err)
+				p.recordEgressError(spanCtx, span, match, req, routeName, attempt, time.Since(start), wrappedErr)
+				return domainegress.EgressResponse{}, wrappedErr
+			}
 
 			// A context deadline/cancellation is a timeout — do not retry, surface
 			// it immediately so the caller can return 504.

--- a/internal/domain/egress/route.go
+++ b/internal/domain/egress/route.go
@@ -75,6 +75,29 @@ func (r RetryConfig) IsRetryableMethod(method string) bool {
 	return false
 }
 
+// MTLSConfig holds mutual-TLS client certificate parameters for a route.
+// When non-zero, the egress proxy presents the configured client certificate
+// during the TLS handshake with the upstream.
+type MTLSConfig struct {
+	// CertPath is the filesystem path to the PEM-encoded client certificate.
+	// Must be set together with KeyPath.
+	CertPath string
+
+	// KeyPath is the filesystem path to the PEM-encoded private key for the
+	// client certificate. Must be set together with CertPath.
+	KeyPath string
+
+	// CAPath is an optional filesystem path to a PEM-encoded CA certificate
+	// bundle used to verify the server's certificate. When empty the system
+	// root CA pool is used.
+	CAPath string
+}
+
+// IsZero reports whether this MTLSConfig is the zero value (no mTLS configured).
+func (m MTLSConfig) IsZero() bool {
+	return m.CertPath == "" && m.KeyPath == "" && m.CAPath == ""
+}
+
 // SecretConfig holds secret injection parameters for a route.
 type SecretConfig struct {
 	// Name is the OpenBao secret name to fetch and inject.
@@ -109,6 +132,7 @@ type Route struct {
 	responseSizeLimit int64
 	allowInsecure     bool
 	sanitize          SanitizeConfig
+	mtls              MTLSConfig
 }
 
 // routeOptions carries optional fields supplied via functional options.
@@ -124,6 +148,7 @@ type routeOptions struct {
 	responseSizeLimit int64
 	allowInsecure     bool
 	sanitize          SanitizeConfig
+	mtls              MTLSConfig
 }
 
 // RouteOption is a functional option for NewRoute.
@@ -195,6 +220,15 @@ func WithSanitize(cfg SanitizeConfig) RouteOption {
 	return func(o *routeOptions) { o.sanitize = cfg }
 }
 
+// WithMTLS configures mutual-TLS client certificate authentication for this
+// route. When set, the egress proxy presents the given client certificate
+// during the TLS handshake with the upstream. The cert/key files must contain
+// valid PEM-encoded data; the CA file is optional and, when provided, is used
+// to verify the server's certificate instead of the system root CA pool.
+func WithMTLS(cfg MTLSConfig) RouteOption {
+	return func(o *routeOptions) { o.mtls = cfg }
+}
+
 // NewRoute constructs a Route value object.
 // Returns an error when name is empty, pattern is empty, or the pattern is
 // not a valid URL glob (as accepted by path.Match).
@@ -228,6 +262,7 @@ func NewRoute(name, pattern string, opts ...RouteOption) (Route, error) {
 		responseSizeLimit: o.responseSizeLimit,
 		allowInsecure:     o.allowInsecure,
 		sanitize:          o.sanitize,
+		mtls:              o.mtls,
 	}, nil
 }
 
@@ -277,6 +312,10 @@ func (r Route) AllowInsecure() bool { return r.allowInsecure }
 // Sanitize returns the per-route PII redaction configuration.
 // A zero SanitizeConfig means no sanitization rules are applied.
 func (r Route) Sanitize() SanitizeConfig { return r.sanitize }
+
+// MTLS returns the mutual-TLS client certificate configuration for this route.
+// A zero MTLSConfig means no mTLS is configured.
+func (r Route) MTLS() MTLSConfig { return r.mtls }
 
 // MatchesMethod reports whether the given HTTP method is allowed by this route.
 // When Methods is empty, all methods are considered a match.


### PR DESCRIPTION
Closes #368

## Summary

- Added `MTLSConfig` value object to `internal/domain/egress/route.go` with `CertPath`, `KeyPath`, and optional `CAPath` fields, plus `IsZero()` predicate
- Added `WithMTLS(MTLSConfig)` functional option and `MTLS() MTLSConfig` accessor to `Route`
- Created `internal/adapters/egress/mtls.go` with `BuildMTLSClients` — reads cert/key/CA PEM files at startup, validates them, and builds a dedicated `*http.Client` per route that carries the client certificate
- Added `MTLSClients MTLSClientMap` field to `ProxyConfig`; `Proxy.forward()` selects the per-route client when one is present, falling back to the default client otherwise
- Added `ErrMTLSHandshakeFailed` sentinel; TLS handshake failures on mTLS routes are detected via error message inspection, logged as structured `egress.mtls_error` events, and surfaced immediately (no retry)
- HTTP handler returns `502 Bad Gateway` on `ErrMTLSHandshakeFailed`

## Test plan

- `TestBuildMTLSClients_Valid` — route with MTLSConfig gets a client, route without does not
- `TestBuildMTLSClients_MissingCertFile` — error on missing cert/key file
- `TestBuildMTLSClients_InvalidPEM` — error on non-PEM cert/key content
- `TestBuildMTLSClients_WithCA` — CA path accepted and included
- `TestBuildMTLSClients_InvalidCA` — error on non-PEM CA content
- `TestBuildMTLSClients_EmptyRoutes` — nil routes returns empty non-nil map
- `TestProxy_MTLSClientUsed` — end-to-end: proxy presents client cert to mTLS server, gets 200
- `TestProxy_MTLSMissingClientCert` — end-to-end: server requiring client cert rejects connection when proxy has no cert
- `TestMTLSConfig_IsZero` — table-driven, all field combinations
- `TestRoute_MTLS` / `TestRoute_MTLS_ZeroWhenNotConfigured` — accessor correctness
