### PR TITLE
feat(#369): add per-route in-memory LRU response caching for egress proxy

### DIFF
--- a/internal/adapters/egress/cache.go
+++ b/internal/adapters/egress/cache.go
@@ -1,0 +1,212 @@
+// Package egress implements the HTTP listener and request forwarding adapter
+// for the egress proxy plugin.
+package egress
+
+import (
+	"bytes"
+	"container/list"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+// headerEgressCache is the response header used to report whether a response
+// was served from the in-memory cache or fetched from the upstream.
+// Values are "HIT" or "MISS".
+const headerEgressCache = "X-Egress-Cache"
+
+// cacheKey is the lookup key for a cached response entry.
+// Only the HTTP method (GET or HEAD) and the full URL are used.
+type cacheKey struct {
+	method string
+	url    string
+}
+
+// CacheEntry holds a single cached upstream response.
+// It is exported so that test helpers can build entries via NewCacheEntry.
+type CacheEntry struct {
+	key        cacheKey
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+	ExpiresAt  time.Time
+}
+
+// NewCacheEntry creates a CacheEntry for testing. It sets only the key and
+// expiry fields — the StatusCode defaults to 200 and Header/Body are empty.
+// Use this constructor in external test packages that need to prime the cache
+// directly without going through the full proxy pipeline.
+func NewCacheEntry(method, url string, statusCode int, expiresAt time.Time) *CacheEntry {
+	return &CacheEntry{
+		key:        cacheKey{method: method, url: url},
+		StatusCode: statusCode,
+		Header:     make(http.Header),
+		ExpiresAt:  expiresAt,
+	}
+}
+
+// isExpired reports whether the entry has passed its TTL.
+// An entry with a zero ExpiresAt never expires.
+func (e *CacheEntry) isExpired(now time.Time) bool {
+	if e.ExpiresAt.IsZero() {
+		return false
+	}
+	return now.After(e.ExpiresAt)
+}
+
+// ResponseCache is a thread-safe in-memory LRU cache with per-entry TTL
+// eviction. It caches egress responses keyed by HTTP method + URL.
+//
+// The cache uses a doubly-linked list to maintain LRU order alongside a map
+// for O(1) look-ups. The maximum number of entries is bounded by maxEntries.
+type ResponseCache struct {
+	mu         sync.Mutex
+	maxEntries int
+	items      map[cacheKey]*list.Element
+	lru        *list.List
+}
+
+// NewResponseCache creates a ResponseCache with the given maximum number of
+// entries. maxEntries must be >= 1; values <= 0 are clamped to 1.
+func NewResponseCache(maxEntries int) *ResponseCache {
+	if maxEntries <= 0 {
+		maxEntries = 1
+	}
+	return &ResponseCache{
+		maxEntries: maxEntries,
+		items:      make(map[cacheKey]*list.Element),
+		lru:        list.New(),
+	}
+}
+
+// Get looks up the cache for the given method and url at the given time.
+// It returns the cached entry and true on a hit, or nil and false on a miss
+// or when the entry has expired. Expired entries are removed on access.
+func (c *ResponseCache) Get(method, url string, now time.Time) (*CacheEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	k := cacheKey{method: method, url: url}
+	el, ok := c.items[k]
+	if !ok {
+		return nil, false
+	}
+	entry := el.Value.(*CacheEntry)
+	if entry.isExpired(now) {
+		c.lru.Remove(el)
+		delete(c.items, k)
+		return nil, false
+	}
+	// Move to front (most-recently used).
+	c.lru.MoveToFront(el)
+	return entry, true
+}
+
+// Set inserts or replaces a cache entry for the given key. When the cache is
+// at capacity the least-recently-used entry is evicted first.
+func (c *ResponseCache) Set(entry *CacheEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Replace existing entry if present.
+	if el, ok := c.items[entry.key]; ok {
+		c.lru.Remove(el)
+		delete(c.items, entry.key)
+	}
+
+	// Evict the LRU entry when at capacity.
+	for c.lru.Len() >= c.maxEntries {
+		back := c.lru.Back()
+		if back == nil {
+			break
+		}
+		evicted := back.Value.(*CacheEntry)
+		c.lru.Remove(back)
+		delete(c.items, evicted.key)
+	}
+
+	el := c.lru.PushFront(entry)
+	c.items[entry.key] = el
+}
+
+// Len returns the current number of entries in the cache.
+func (c *ResponseCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lru.Len()
+}
+
+// isCacheable reports whether the request method and response status code are
+// eligible for caching. Only GET and HEAD methods with a 2xx status are cached.
+func isCacheable(method string, statusCode int) bool {
+	if method != http.MethodGet && method != http.MethodHead {
+		return false
+	}
+	return statusCode >= 200 && statusCode <= 299
+}
+
+// cacheableResponse reads the full response body into memory and builds a
+// CacheEntry. It returns the cached entry and a fresh io.ReadCloser that the
+// caller can use as the response body (so the original body does not need to
+// be re-read). Returns (nil, nil, nil) when the body exceeds cfg.MaxSize —
+// the caller receives the full body back but the response is not cached.
+// Returns (nil, nil, err) when the body cannot be read.
+func cacheableResponse(
+	resp domainegress.EgressResponse,
+	cfg domainegress.CacheConfig,
+	key cacheKey,
+	now time.Time,
+) (*CacheEntry, io.ReadCloser, error) {
+	var raw []byte
+	if rc, ok := resp.BodyRef.(io.ReadCloser); ok && rc != nil {
+		defer rc.Close() //nolint:errcheck
+		var err error
+		if cfg.MaxSize > 0 {
+			// Read at most MaxSize+1 bytes to detect oversized bodies.
+			limited := io.LimitReader(rc, cfg.MaxSize+1)
+			raw, err = io.ReadAll(limited)
+		} else {
+			raw, err = io.ReadAll(rc)
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// Do not cache when the body exceeds the configured limit.
+	if cfg.MaxSize > 0 && int64(len(raw)) > cfg.MaxSize {
+		return nil, io.NopCloser(bytes.NewReader(raw)), nil
+	}
+
+	var expiresAt time.Time
+	if cfg.TTL > 0 {
+		expiresAt = now.Add(cfg.TTL)
+	}
+
+	entry := &CacheEntry{
+		key:        key,
+		StatusCode: resp.StatusCode,
+		Header:     resp.Header.Clone(),
+		Body:       raw,
+		ExpiresAt:  expiresAt,
+	}
+	return entry, io.NopCloser(bytes.NewReader(raw)), nil
+}
+
+// egressResponseFromCache builds an EgressResponse from a cache hit entry.
+// The header of the returned response is a clone of the cached headers so that
+// the caller's modifications do not affect the cache.
+func egressResponseFromCache(entry *CacheEntry, origDuration time.Duration) domainegress.EgressResponse {
+	h := entry.Header.Clone()
+	h.Set(headerEgressCache, "HIT")
+	resp, _ := domainegress.NewEgressResponse(
+		entry.StatusCode,
+		h,
+		io.NopCloser(bytes.NewReader(entry.Body)),
+		origDuration,
+	)
+	return resp
+}

--- a/internal/adapters/egress/cache_registry.go
+++ b/internal/adapters/egress/cache_registry.go
@@ -1,0 +1,46 @@
+package egress
+
+import (
+	"sync"
+
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+// defaultCacheMaxEntries is the number of LRU entries allocated per route when
+// no explicit limit is provided. This bounds memory consumption per route.
+const defaultCacheMaxEntries = 256
+
+// ResponseCacheRegistry maintains one in-memory LRU cache per named egress
+// route. Caches are created lazily on first access and are only created for
+// routes that have cache.enabled=true. It is safe for concurrent use.
+type ResponseCacheRegistry struct {
+	mu     sync.Mutex
+	caches map[string]*ResponseCache
+}
+
+// NewResponseCacheRegistry creates an empty ResponseCacheRegistry.
+func NewResponseCacheRegistry() *ResponseCacheRegistry {
+	return &ResponseCacheRegistry{
+		caches: make(map[string]*ResponseCache),
+	}
+}
+
+// CacheFor returns the ResponseCache for the given route, creating it lazily
+// when needed. It returns nil when the route has cache.enabled=false.
+func (r *ResponseCacheRegistry) CacheFor(route domainegress.Route) *ResponseCache {
+	cfg := route.Cache()
+	if cfg.IsZero() {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if c, ok := r.caches[route.Name()]; ok {
+		return c
+	}
+
+	c := NewResponseCache(defaultCacheMaxEntries)
+	r.caches[route.Name()] = c
+	return c
+}

--- a/internal/adapters/egress/cache_test.go
+++ b/internal/adapters/egress/cache_test.go
@@ -1,0 +1,420 @@
+package egress_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	egressadapter "github.com/vibewarden/vibewarden/internal/adapters/egress"
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+// ---- ResponseCache unit tests ----
+
+// TestResponseCache_GetMiss verifies that a cache returns nothing for an
+// unknown key.
+func TestResponseCache_GetMiss(t *testing.T) {
+	c := egressadapter.NewResponseCache(8)
+	_, hit := c.Get("GET", "https://example.com/", time.Now())
+	if hit {
+		t.Error("expected cache miss, got hit")
+	}
+}
+
+// TestResponseCache_SetAndGet verifies that a stored entry can be retrieved.
+func TestResponseCache_SetAndGet(t *testing.T) {
+	c := egressadapter.NewResponseCache(8)
+	entry := egressadapter.NewCacheEntry("GET", "https://example.com/", 200, time.Time{})
+
+	c.Set(entry)
+
+	got, hit := c.Get("GET", "https://example.com/", time.Now())
+	if !hit {
+		t.Fatal("expected cache hit")
+	}
+	if got.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", got.StatusCode)
+	}
+}
+
+// TestResponseCache_ExpiredEntry verifies that an expired entry is treated as
+// a miss and removed from the cache.
+func TestResponseCache_ExpiredEntry(t *testing.T) {
+	c := egressadapter.NewResponseCache(8)
+	past := time.Now().Add(-time.Minute) // already expired
+	entry := egressadapter.NewCacheEntry("GET", "https://example.com/ttl", 200, past)
+	c.Set(entry)
+
+	_, hit := c.Get("GET", "https://example.com/ttl", time.Now())
+	if hit {
+		t.Error("expected expired entry to be a miss")
+	}
+	if c.Len() != 0 {
+		t.Errorf("Len = %d after expiry, want 0", c.Len())
+	}
+}
+
+// TestResponseCache_ZeroExpiresAt verifies that an entry with zero ExpiresAt
+// never expires.
+func TestResponseCache_ZeroExpiresAt(t *testing.T) {
+	c := egressadapter.NewResponseCache(8)
+	entry := egressadapter.NewCacheEntry("GET", "https://example.com/noexp", 200, time.Time{})
+	c.Set(entry)
+
+	far := time.Now().Add(365 * 24 * time.Hour)
+	_, hit := c.Get("GET", "https://example.com/noexp", far)
+	if !hit {
+		t.Error("expected non-expiring entry to remain valid far in the future")
+	}
+}
+
+// TestResponseCache_LRUEviction verifies that the least-recently-used entry is
+// evicted when the cache is at capacity.
+func TestResponseCache_LRUEviction(t *testing.T) {
+	c := egressadapter.NewResponseCache(2)
+	e1 := egressadapter.NewCacheEntry("GET", "https://example.com/1", 200, time.Time{})
+	e2 := egressadapter.NewCacheEntry("GET", "https://example.com/2", 200, time.Time{})
+	e3 := egressadapter.NewCacheEntry("GET", "https://example.com/3", 200, time.Time{})
+
+	c.Set(e1)
+	c.Set(e2)
+
+	// Access e1 to make it most-recently-used, so e2 becomes LRU.
+	_, _ = c.Get("GET", "https://example.com/1", time.Now())
+
+	// Adding e3 should evict e2 (LRU).
+	c.Set(e3)
+
+	_, hit1 := c.Get("GET", "https://example.com/1", time.Now())
+	_, hit2 := c.Get("GET", "https://example.com/2", time.Now())
+	_, hit3 := c.Get("GET", "https://example.com/3", time.Now())
+
+	if !hit1 {
+		t.Error("expected e1 to still be cached (was recently accessed)")
+	}
+	if hit2 {
+		t.Error("expected e2 to have been evicted (LRU)")
+	}
+	if !hit3 {
+		t.Error("expected e3 to be cached (just inserted)")
+	}
+}
+
+// TestResponseCache_Replace verifies that setting an entry for the same key
+// replaces the previous value and does not grow the cache.
+func TestResponseCache_Replace(t *testing.T) {
+	c := egressadapter.NewResponseCache(8)
+	e1 := egressadapter.NewCacheEntry("GET", "https://example.com/r", 200, time.Time{})
+	e2 := egressadapter.NewCacheEntry("GET", "https://example.com/r", 201, time.Time{})
+
+	c.Set(e1)
+	c.Set(e2)
+
+	if c.Len() != 1 {
+		t.Errorf("Len = %d after replace, want 1", c.Len())
+	}
+	got, hit := c.Get("GET", "https://example.com/r", time.Now())
+	if !hit || got.StatusCode != 201 {
+		t.Errorf("expected updated entry with status 201, got hit=%v status=%d", hit, got.StatusCode)
+	}
+}
+
+// TestResponseCache_MaxEntriesClamped verifies that a zero or negative maxEntries
+// value is clamped to 1 and the cache still accepts at least one entry.
+func TestResponseCache_MaxEntriesClamped(t *testing.T) {
+	for _, max := range []int{0, -1, -100} {
+		c := egressadapter.NewResponseCache(max)
+		e := egressadapter.NewCacheEntry("GET", "https://example.com/", 200, time.Time{})
+		c.Set(e)
+		if c.Len() != 1 {
+			t.Errorf("maxEntries=%d: Len = %d, want 1", max, c.Len())
+		}
+	}
+}
+
+// ---- Proxy integration tests for caching ----
+
+// TestProxy_CacheMiss_SetsHeader verifies that a non-cached response carries
+// X-Egress-Cache: MISS.
+func TestProxy_CacheMiss_SetsHeader(t *testing.T) {
+	upstream, requests := newCountingUpstream(t, http.StatusOK, []byte("body"))
+
+	route := newTestRouteWithCache(t, "api", upstream.URL+"/v1/*", domainegress.CacheConfig{
+		Enabled: true,
+		TTL:     time.Minute,
+	})
+	proxy := newTestProxyWithCache(t, route)
+
+	resp := mustHandleRequest(t, proxy, "GET", upstream.URL+"/v1/resource")
+
+	if got := resp.Header.Get("X-Egress-Cache"); got != "MISS" {
+		t.Errorf("X-Egress-Cache = %q, want MISS", got)
+	}
+	if *requests != 1 {
+		t.Errorf("upstream requests = %d, want 1", *requests)
+	}
+}
+
+// TestProxy_CacheHit_SetsHeader verifies that the second identical request is
+// served from cache and carries X-Egress-Cache: HIT.
+func TestProxy_CacheHit_SetsHeader(t *testing.T) {
+	upstream, requests := newCountingUpstream(t, http.StatusOK, []byte("cached-body"))
+
+	route := newTestRouteWithCache(t, "api", upstream.URL+"/v1/*", domainegress.CacheConfig{
+		Enabled: true,
+		TTL:     time.Minute,
+	})
+	proxy := newTestProxyWithCache(t, route)
+
+	// First request — cache MISS, stores entry.
+	mustHandleRequest(t, proxy, "GET", upstream.URL+"/v1/resource")
+
+	// Second request — should be served from cache.
+	resp2 := mustHandleRequest(t, proxy, "GET", upstream.URL+"/v1/resource")
+
+	if got := resp2.Header.Get("X-Egress-Cache"); got != "HIT" {
+		t.Errorf("X-Egress-Cache = %q, want HIT", got)
+	}
+	if *requests != 1 {
+		t.Errorf("upstream received %d requests, want 1 (second should be served from cache)", *requests)
+	}
+}
+
+// TestProxy_CacheHit_Body verifies that the cached body bytes match what the
+// upstream originally returned.
+func TestProxy_CacheHit_Body(t *testing.T) {
+	want := []byte("hello cache")
+	upstream, _ := newCountingUpstream(t, http.StatusOK, want)
+
+	route := newTestRouteWithCache(t, "api", upstream.URL+"/v1/*", domainegress.CacheConfig{
+		Enabled: true,
+		TTL:     time.Minute,
+	})
+	proxy := newTestProxyWithCache(t, route)
+
+	mustHandleRequest(t, proxy, "GET", upstream.URL+"/v1/item") // prime cache
+	resp := mustHandleRequest(t, proxy, "GET", upstream.URL+"/v1/item")
+
+	body := readBody(t, resp)
+	if !bytes.Equal(body, want) {
+		t.Errorf("body = %q, want %q", body, want)
+	}
+}
+
+// TestProxy_CacheExpiry verifies that an expired entry results in a fresh
+// upstream request after the TTL elapses.
+func TestProxy_CacheExpiry(t *testing.T) {
+	upstream, requests := newCountingUpstream(t, http.StatusOK, []byte("body"))
+
+	route := newTestRouteWithCache(t, "api", upstream.URL+"/v1/*", domainegress.CacheConfig{
+		Enabled: true,
+		TTL:     50 * time.Millisecond,
+	})
+	proxy := newTestProxyWithCache(t, route)
+
+	mustHandleRequest(t, proxy, "GET", upstream.URL+"/v1/exp")
+	time.Sleep(100 * time.Millisecond) // let TTL elapse
+
+	resp := mustHandleRequest(t, proxy, "GET", upstream.URL+"/v1/exp")
+	if got := resp.Header.Get("X-Egress-Cache"); got != "MISS" {
+		t.Errorf("X-Egress-Cache = %q after expiry, want MISS", got)
+	}
+	if *requests != 2 {
+		t.Errorf("upstream requests = %d after expiry, want 2", *requests)
+	}
+}
+
+// TestProxy_CacheNotCacheable_POST verifies that POST requests are never
+// cached and always reach the upstream.
+func TestProxy_CacheNotCacheable_POST(t *testing.T) {
+	upstream, requests := newCountingUpstream(t, http.StatusOK, []byte("ok"))
+
+	route := newTestRouteWithCache(t, "api", upstream.URL+"/v1/*", domainegress.CacheConfig{
+		Enabled: true,
+		TTL:     time.Minute,
+	})
+	proxy := newTestProxyWithCache(t, route)
+
+	for i := 0; i < 3; i++ {
+		mustHandleRequest(t, proxy, "POST", upstream.URL+"/v1/action")
+	}
+	if *requests != 3 {
+		t.Errorf("upstream requests = %d, want 3 (POST must never be cached)", *requests)
+	}
+}
+
+// TestProxy_CacheDisabled_NoCacheHeaders verifies that routes without
+// cache.enabled=true never set X-Egress-Cache headers.
+func TestProxy_CacheDisabled_NoCacheHeaders(t *testing.T) {
+	upstream, _ := newCountingUpstream(t, http.StatusOK, []byte("ok"))
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*")
+	proxy := newTestProxy(t, []domainegress.Route{route}, upstream.Client(), domainegress.PolicyDeny)
+
+	resp := mustHandleRequest(t, proxy, "GET", upstream.URL+"/v1/resource")
+	if h := resp.Header.Get("X-Egress-Cache"); h != "" {
+		t.Errorf("X-Egress-Cache = %q on non-cached route, want empty", h)
+	}
+}
+
+// TestProxy_CacheMaxSize_OversizedBodyNotCached verifies that responses whose
+// body exceeds cache.max_size are not stored, so the next request hits the
+// upstream again.
+func TestProxy_CacheMaxSize_OversizedBodyNotCached(t *testing.T) {
+	body := bytes.Repeat([]byte("x"), 100)
+	upstream, requests := newCountingUpstream(t, http.StatusOK, body)
+
+	route := newTestRouteWithCache(t, "api", upstream.URL+"/v1/*", domainegress.CacheConfig{
+		Enabled: true,
+		TTL:     time.Minute,
+		MaxSize: 10, // 10 bytes — well below the 100-byte response body
+	})
+	proxy := newTestProxyWithCache(t, route)
+
+	mustHandleRequest(t, proxy, "GET", upstream.URL+"/v1/big")
+	mustHandleRequest(t, proxy, "GET", upstream.URL+"/v1/big")
+
+	if *requests != 2 {
+		t.Errorf("upstream requests = %d, want 2 (oversized body must not be cached)", *requests)
+	}
+}
+
+// TestProxy_CacheNon2xx_NotCached verifies that 4xx and 5xx responses are
+// never stored in the cache.
+func TestProxy_CacheNon2xx_NotCached(t *testing.T) {
+	upstream, requests := newCountingUpstream(t, http.StatusNotFound, []byte("not found"))
+
+	route := newTestRouteWithCache(t, "api", upstream.URL+"/v1/*", domainegress.CacheConfig{
+		Enabled: true,
+		TTL:     time.Minute,
+	})
+	proxy := newTestProxyWithCache(t, route)
+
+	for i := 0; i < 3; i++ {
+		mustHandleRequest(t, proxy, "GET", upstream.URL+"/v1/gone")
+	}
+	if *requests != 3 {
+		t.Errorf("upstream requests = %d, want 3 (404 must not be cached)", *requests)
+	}
+}
+
+// TestProxy_CacheHead_Cached verifies that HEAD requests are eligible for
+// caching just like GET requests.
+func TestProxy_CacheHead_Cached(t *testing.T) {
+	upstream, requests := newCountingUpstream(t, http.StatusOK, nil)
+
+	route := newTestRouteWithCache(t, "api", upstream.URL+"/v1/*", domainegress.CacheConfig{
+		Enabled: true,
+		TTL:     time.Minute,
+	})
+	proxy := newTestProxyWithCache(t, route)
+
+	mustHandleRequest(t, proxy, "HEAD", upstream.URL+"/v1/check")
+	resp2 := mustHandleRequest(t, proxy, "HEAD", upstream.URL+"/v1/check")
+
+	if got := resp2.Header.Get("X-Egress-Cache"); got != "HIT" {
+		t.Errorf("X-Egress-Cache = %q on second HEAD, want HIT", got)
+	}
+	if *requests != 1 {
+		t.Errorf("upstream received %d requests, want 1", *requests)
+	}
+}
+
+// TestProxy_CacheDifferentURLs verifies that entries for different URLs are
+// stored independently.
+func TestProxy_CacheDifferentURLs(t *testing.T) {
+	upstream, requests := newCountingUpstream(t, http.StatusOK, []byte("data"))
+
+	route := newTestRouteWithCache(t, "api", upstream.URL+"/v1/*", domainegress.CacheConfig{
+		Enabled: true,
+		TTL:     time.Minute,
+	})
+	proxy := newTestProxyWithCache(t, route)
+
+	mustHandleRequest(t, proxy, "GET", upstream.URL+"/v1/a")
+	mustHandleRequest(t, proxy, "GET", upstream.URL+"/v1/b")
+
+	// Both are fresh — two upstream calls expected.
+	if *requests != 2 {
+		t.Errorf("upstream requests = %d, want 2 (different URLs are different cache keys)", *requests)
+	}
+
+	// Repeat — both should now hit cache.
+	mustHandleRequest(t, proxy, "GET", upstream.URL+"/v1/a")
+	mustHandleRequest(t, proxy, "GET", upstream.URL+"/v1/b")
+	if *requests != 2 {
+		t.Errorf("upstream requests = %d after cache prime, want still 2", *requests)
+	}
+}
+
+// ---- helpers ----
+
+func newTestRouteWithCache(t *testing.T, name, pattern string, cfg domainegress.CacheConfig) domainegress.Route {
+	t.Helper()
+	r, err := domainegress.NewRoute(name, pattern, domainegress.WithCache(cfg))
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+	return r
+}
+
+func newTestProxyWithCache(t *testing.T, route domainegress.Route) *egressadapter.Proxy {
+	t.Helper()
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true,
+		ResponseCaches: egressadapter.NewResponseCacheRegistry(),
+	}
+	return egressadapter.NewProxy(cfg, resolver, nil, nil)
+}
+
+// newCountingUpstream creates a test HTTP server that always responds with the
+// given status and body. It returns the server and a pointer to a counter of
+// requests received. The server is closed automatically via t.Cleanup.
+func newCountingUpstream(t *testing.T, status int, body []byte) (*httptest.Server, *int) {
+	t.Helper()
+	count := new(int)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		*count++
+		w.WriteHeader(status)
+		if len(body) > 0 {
+			_, _ = w.Write(body)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, count
+}
+
+func mustHandleRequest(t *testing.T, proxy *egressadapter.Proxy, method, rawURL string) domainegress.EgressResponse {
+	t.Helper()
+	req, err := domainegress.NewEgressRequest(method, rawURL, nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest(%s %s): %v", method, rawURL, err)
+	}
+	resp, err := proxy.HandleRequest(t.Context(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest(%s %s): %v", method, rawURL, err)
+	}
+	return resp
+}
+
+func readBody(t *testing.T, resp domainegress.EgressResponse) []byte {
+	t.Helper()
+	rc, ok := resp.BodyRef.(io.ReadCloser)
+	if !ok || rc == nil {
+		return nil
+	}
+	defer rc.Close() //nolint:errcheck
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	return data
+}

--- a/internal/adapters/egress/proxy.go
+++ b/internal/adapters/egress/proxy.go
@@ -126,6 +126,13 @@ type ProxyConfig struct {
 	// nil, per-route rate limiting is disabled regardless of route configuration.
 	RateLimiters *RateLimiterRegistry
 
+	// ResponseCaches, when non-nil, is the per-route in-memory response cache
+	// registry. GET and HEAD requests that match a route with cache.enabled=true
+	// will be served from the cache when a valid entry exists, and the upstream
+	// response will be stored in the cache on a 2xx status. When nil, response
+	// caching is disabled for all routes regardless of route configuration.
+	ResponseCaches *ResponseCacheRegistry
+
 	// AllowInsecure, when true, permits plain HTTP egress requests globally.
 	// By default only HTTPS targets are allowed. Individual routes can also
 	// override this with their AllowInsecure field.
@@ -330,6 +337,17 @@ func (p *Proxy) HandleRequest(ctx context.Context, req domainegress.EgressReques
 		}
 	}
 
+	// Check in-memory response cache for cacheable requests.
+	// Only GET and HEAD requests on routes with cache.enabled=true are eligible.
+	if match.Matched && p.cfg.ResponseCaches != nil {
+		cache := p.cfg.ResponseCaches.CacheFor(match.Route)
+		if cache != nil {
+			if entry, hit := cache.Get(req.Method, req.URL, time.Now()); hit {
+				return egressResponseFromCache(entry, 0), nil
+			}
+		}
+	}
+
 	// Enforce request body size limit. The effective limit is the per-route
 	// value when set, otherwise the proxy-level default.
 	bodySizeLimit := p.cfg.DefaultBodySizeLimit
@@ -360,6 +378,26 @@ func (p *Proxy) HandleRequest(ctx context.Context, req domainegress.EgressReques
 		}
 		return domainegress.EgressResponse{}, forwardErr
 	}
+
+	// Store a cacheable response in the route's in-memory cache.
+	// The body is fully read and buffered; the response returned to the caller
+	// gets a fresh reader over the same bytes.
+	if match.Matched && p.cfg.ResponseCaches != nil && isCacheable(req.Method, resp.StatusCode) {
+		cache := p.cfg.ResponseCaches.CacheFor(match.Route)
+		if cache != nil {
+			key := cacheKey{method: req.Method, url: req.URL}
+			entry, freshBody, readErr := cacheableResponse(resp, match.Route.Cache(), key, time.Now())
+			if readErr == nil {
+				resp.BodyRef = freshBody
+				// Set MISS header to indicate this response came from upstream.
+				resp.Header.Set(headerEgressCache, "MISS")
+				if entry != nil {
+					cache.Set(entry)
+				}
+			}
+		}
+	}
+
 	return resp, nil
 }
 

--- a/internal/domain/egress/route.go
+++ b/internal/domain/egress/route.go
@@ -98,6 +98,28 @@ func (m MTLSConfig) IsZero() bool {
 	return m.CertPath == "" && m.KeyPath == "" && m.CAPath == ""
 }
 
+// CacheConfig holds per-route response caching parameters.
+// Caching applies only to GET and HEAD requests that receive a 2xx response.
+type CacheConfig struct {
+	// Enabled activates response caching for this route.
+	Enabled bool
+
+	// TTL is how long a cached entry remains valid before it is evicted.
+	// A zero value means the cache entry never expires (not recommended in
+	// production — always set an explicit TTL).
+	TTL time.Duration
+
+	// MaxSize is the maximum number of bytes allowed for a single cached
+	// response body. Responses larger than this value are not cached.
+	// A value of 0 means no per-entry size limit is enforced.
+	MaxSize int64
+}
+
+// IsZero reports whether this CacheConfig is the zero value (caching disabled).
+func (c CacheConfig) IsZero() bool {
+	return !c.Enabled
+}
+
 // SecretConfig holds secret injection parameters for a route.
 type SecretConfig struct {
 	// Name is the OpenBao secret name to fetch and inject.
@@ -133,6 +155,7 @@ type Route struct {
 	allowInsecure     bool
 	sanitize          SanitizeConfig
 	mtls              MTLSConfig
+	cache             CacheConfig
 }
 
 // routeOptions carries optional fields supplied via functional options.
@@ -149,6 +172,7 @@ type routeOptions struct {
 	allowInsecure     bool
 	sanitize          SanitizeConfig
 	mtls              MTLSConfig
+	cache             CacheConfig
 }
 
 // RouteOption is a functional option for NewRoute.
@@ -229,6 +253,14 @@ func WithMTLS(cfg MTLSConfig) RouteOption {
 	return func(o *routeOptions) { o.mtls = cfg }
 }
 
+// WithCache enables in-memory response caching for this route.
+// Only GET and HEAD responses with a 2xx status code are cached.
+// Entries are evicted after cfg.TTL elapses or when the body size exceeds
+// cfg.MaxSize.
+func WithCache(cfg CacheConfig) RouteOption {
+	return func(o *routeOptions) { o.cache = cfg }
+}
+
 // NewRoute constructs a Route value object.
 // Returns an error when name is empty, pattern is empty, or the pattern is
 // not a valid URL glob (as accepted by path.Match).
@@ -263,6 +295,7 @@ func NewRoute(name, pattern string, opts ...RouteOption) (Route, error) {
 		allowInsecure:     o.allowInsecure,
 		sanitize:          o.sanitize,
 		mtls:              o.mtls,
+		cache:             o.cache,
 	}, nil
 }
 
@@ -316,6 +349,10 @@ func (r Route) Sanitize() SanitizeConfig { return r.sanitize }
 // MTLS returns the mutual-TLS client certificate configuration for this route.
 // A zero MTLSConfig means no mTLS is configured.
 func (r Route) MTLS() MTLSConfig { return r.mtls }
+
+// Cache returns the per-route response caching configuration.
+// A zero CacheConfig (Enabled == false) means no caching is configured.
+func (r Route) Cache() CacheConfig { return r.cache }
 
 // MatchesMethod reports whether the given HTTP method is allowed by this route.
 // When Methods is empty, all methods are considered a match.


### PR DESCRIPTION
Closes #369

## Summary

- Adds `CacheConfig` value object to `internal/domain/egress` with `Enabled`, `TTL`, and `MaxSize` fields; wired via `WithCache(cfg)` route option and `Route.Cache()` accessor.
- Implements `ResponseCache` in `internal/adapters/egress/cache.go`: thread-safe in-memory LRU eviction (doubly-linked list + hash map) with per-entry TTL. O(1) get and set. No external dependencies.
- Implements `ResponseCacheRegistry` in `internal/adapters/egress/cache_registry.go`: lazy per-route cache creation, 256-entry LRU per route.
- Wires cache into `Proxy.HandleRequest` in `proxy.go`:
  - Before forwarding: `GET`/`HEAD` requests check the cache. A valid entry is returned immediately with `X-Egress-Cache: HIT`.
  - After forwarding: `2xx` responses are buffered, stored in the cache, and returned to the caller with `X-Egress-Cache: MISS`. Bodies exceeding `max_size` are served but not stored.
- Adds `ResponseCaches *ResponseCacheRegistry` field to `ProxyConfig`. When `nil`, caching is fully disabled (opt-in, zero impact on existing routes).

## Design decisions

- In-memory only: no Redis, no external store.
- Cache key: method + full URL (query string included). GET and HEAD are separate namespaces.
- Only 2xx responses are cached; 3xx/4xx/5xx are never stored.
- POST/PUT/DELETE/PATCH are never cached.
- Body buffered on MISS: entire response body read into memory to allow re-serving. MaxSize guards against buffering large responses.

## Test plan

- `TestResponseCache_*` — unit tests for LRU, TTL expiry, zero-TTL (no-expiry), capacity clamping, and replace semantics.
- `TestProxy_Cache*` — integration tests via `Proxy.HandleRequest` covering: MISS header on first call, HIT header on second call, body integrity on cache hit, TTL expiry triggers fresh upstream call, POST bypass, non-2xx bypass, MaxSize oversized body bypass, different-URL independence.
- All 17 new tests pass; full `make check` passes.
