### PR TITLE
feat(#370): add per-route egress response validation

### DIFF
--- a/cmd/vibewarden/serve.go
+++ b/cmd/vibewarden/serve.go
@@ -704,6 +704,10 @@ func buildEgressPlugin(cfg *config.Config, eventLogger ports.EventLogger, logger
 				Methods: rc.Retries.Methods,
 				Backoff: rc.Retries.Backoff,
 			},
+			ValidateResponse: egressplugin.ResponseValidationConfig{
+				StatusCodes:  rc.ValidateResponse.StatusCodes,
+				ContentTypes: rc.ValidateResponse.ContentTypes,
+			},
 		})
 	}
 

--- a/internal/adapters/egress/errors.go
+++ b/internal/adapters/egress/errors.go
@@ -32,3 +32,9 @@ var ErrInsecureURL = errors.New("egress: plain HTTP is not allowed; use HTTPS or
 // to emit a structured egress.mtls_error event and log the failure with
 // additional context.
 var ErrMTLSHandshakeFailed = errors.New("egress: mTLS handshake failed")
+
+// ErrResponseValidationFailed is returned by Proxy.HandleRequest when the
+// upstream response fails the per-route validate_response rules (disallowed
+// status code or content type). The HTTP handler converts this into a 502 Bad
+// Gateway response.
+var ErrResponseValidationFailed = errors.New("egress: upstream response failed validation")

--- a/internal/adapters/egress/proxy.go
+++ b/internal/adapters/egress/proxy.go
@@ -379,6 +379,17 @@ func (p *Proxy) HandleRequest(ctx context.Context, req domainegress.EgressReques
 		return domainegress.EgressResponse{}, forwardErr
 	}
 
+	// Validate the upstream response against per-route rules when configured.
+	if match.Matched {
+		if err := p.validateResponse(ctx, req, match, resp); err != nil {
+			// Close the upstream body — we will not forward it.
+			if rc, ok := resp.BodyRef.(io.ReadCloser); ok && rc != nil {
+				rc.Close() //nolint:errcheck
+			}
+			return domainegress.EgressResponse{}, err
+		}
+	}
+
 	// Store a cacheable response in the route's in-memory cache.
 	// The body is fully read and buffered; the response returned to the caller
 	// gets a fresh reader over the same bytes.
@@ -416,6 +427,76 @@ func (p *Proxy) emitBlocked(ctx context.Context, match domainegress.RouteMatch, 
 	}
 	if p.cfg.Metrics != nil {
 		p.cfg.Metrics.IncEgressErrorTotal(routeNameOf(match))
+	}
+}
+
+// validateResponse checks the upstream response against the per-route
+// validate_response rules. It returns ErrResponseValidationFailed (with context)
+// when the status code or content type is not in the configured allowlists, and
+// emits an egress.response_invalid structured event. It returns nil when the
+// route has no validation config or the response passes all checks.
+func (p *Proxy) validateResponse(ctx context.Context, req domainegress.EgressRequest, match domainegress.RouteMatch, resp domainegress.EgressResponse) error {
+	valCfg := match.Route.ValidateResponse()
+	if valCfg.IsZero() {
+		return nil
+	}
+
+	routeName := routeNameOf(match)
+
+	// Check status code allowlist.
+	if !valCfg.MatchesStatusCode(resp.StatusCode) {
+		reason := fmt.Sprintf("status code %d not in allowed list", resp.StatusCode)
+		ct := resp.Header.Get("Content-Type")
+		p.logger.WarnContext(ctx, "egress.response_invalid",
+			slog.String("event_type", "egress.response_invalid"),
+			slog.String("route", routeName),
+			slog.String("url", req.URL),
+			slog.String("method", req.Method),
+			slog.Int("status_code", resp.StatusCode),
+			slog.String("content_type", ct),
+			slog.String("reason", reason),
+		)
+		p.emitResponseInvalid(ctx, req, routeName, resp.StatusCode, ct, reason)
+		return fmt.Errorf("%w: %s", ErrResponseValidationFailed, reason)
+	}
+
+	// Check content type allowlist.
+	ct := resp.Header.Get("Content-Type")
+	if !valCfg.MatchesContentType(ct) {
+		reason := fmt.Sprintf("content type %q not in allowed list", ct)
+		p.logger.WarnContext(ctx, "egress.response_invalid",
+			slog.String("event_type", "egress.response_invalid"),
+			slog.String("route", routeName),
+			slog.String("url", req.URL),
+			slog.String("method", req.Method),
+			slog.Int("status_code", resp.StatusCode),
+			slog.String("content_type", ct),
+			slog.String("reason", reason),
+		)
+		p.emitResponseInvalid(ctx, req, routeName, resp.StatusCode, ct, reason)
+		return fmt.Errorf("%w: %s", ErrResponseValidationFailed, reason)
+	}
+
+	return nil
+}
+
+// emitResponseInvalid emits an egress.response_invalid structured event and
+// increments the egress error metric.
+func (p *Proxy) emitResponseInvalid(ctx context.Context, req domainegress.EgressRequest, routeName string, statusCode int, contentType, reason string) {
+	if p.cfg.EventLogger != nil {
+		ev := events.NewEgressResponseInvalid(events.EgressResponseInvalidParams{
+			Route:       routeName,
+			Method:      req.Method,
+			URL:         req.URL,
+			StatusCode:  statusCode,
+			ContentType: contentType,
+			Reason:      reason,
+			TraceID:     traceIDFromContext(ctx),
+		})
+		_ = p.cfg.EventLogger.Log(ctx, ev)
+	}
+	if p.cfg.Metrics != nil {
+		p.cfg.Metrics.IncEgressErrorTotal(routeName)
 	}
 }
 
@@ -552,6 +633,16 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 			)
 			w.Header().Set("Retry-After", retryAfter)
 			http.Error(w, "429 Too Many Requests: egress rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+		if errors.Is(err, ErrResponseValidationFailed) {
+			p.logger.WarnContext(r.Context(), "egress.response_invalid",
+				slog.String("event_type", "egress.response_invalid"),
+				slog.String("target", targetURL),
+				slog.String("method", r.Method),
+				slog.String("err", err.Error()),
+			)
+			http.Error(w, "502 Bad Gateway: "+err.Error(), http.StatusBadGateway)
 			return
 		}
 		if errors.Is(err, ErrMTLSHandshakeFailed) {

--- a/internal/adapters/egress/response_validation_test.go
+++ b/internal/adapters/egress/response_validation_test.go
@@ -1,0 +1,411 @@
+package egress_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	egressadapter "github.com/vibewarden/vibewarden/internal/adapters/egress"
+	domainegress "github.com/vibewarden/vibewarden/internal/domain/egress"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// newValidationProxy creates a Proxy with an EventLogger and MetricsCollector
+// wired in so tests can assert on emitted events and error metrics.
+func newValidationProxy(
+	t *testing.T,
+	routes []domainegress.Route,
+	client *http.Client,
+	logger ports.EventLogger,
+	metrics ports.MetricsCollector,
+) *egressadapter.Proxy {
+	t.Helper()
+	resolver := egressadapter.NewRouteResolver(routes)
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         routes,
+		AllowInsecure:  true,
+		EventLogger:    logger,
+		Metrics:        metrics,
+	}
+	return egressadapter.NewProxy(cfg, resolver, client, nil)
+}
+
+// TestValidateResponse_StatusCode_Pass verifies that a response whose status
+// code is in the allowlist is forwarded normally.
+func TestValidateResponse_StatusCode_Pass(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithValidateResponse(domainegress.ResponseValidationConfig{
+			StatusCodes: []string{"2xx"},
+		}),
+	)
+	proxy := newValidationProxy(t, []domainegress.Route{route}, upstream.Client(), nil, nil)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest returned unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+// TestValidateResponse_StatusCode_Fail verifies that a response whose status
+// code is NOT in the allowlist causes ErrResponseValidationFailed to be returned
+// and the upstream body to be dropped.
+func TestValidateResponse_StatusCode_Fail(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithValidateResponse(domainegress.ResponseValidationConfig{
+			StatusCodes: []string{"2xx"},
+		}),
+	)
+	el := &fakeObsEventLogger{}
+	mc := &fakeMetricsCollector{}
+	proxy := newValidationProxy(t, []domainegress.Route{route}, upstream.Client(), el, mc)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/resource", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+	_, err = proxy.HandleRequest(context.Background(), req)
+	if err == nil {
+		t.Fatal("HandleRequest should have returned an error")
+	}
+	if !errors.Is(err, egressadapter.ErrResponseValidationFailed) {
+		t.Errorf("error = %v, want errors.Is(ErrResponseValidationFailed)", err)
+	}
+
+	// An egress.response_invalid event should have been emitted.
+	evTypes := el.EventTypes()
+	found := false
+	for _, et := range evTypes {
+		if et == events.EventTypeEgressResponseInvalid {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected egress.response_invalid event, got event types: %v", evTypes)
+	}
+
+	// The error counter should have been incremented.
+	if len(mc.ErrorTotals()) == 0 {
+		t.Error("expected IncEgressErrorTotal to be called")
+	}
+}
+
+// TestValidateResponse_ContentType_Pass verifies that a response with a
+// content type in the allowlist is forwarded normally.
+func TestValidateResponse_ContentType_Pass(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithValidateResponse(domainegress.ResponseValidationConfig{
+			ContentTypes: []string{"application/json"},
+		}),
+	)
+	proxy := newValidationProxy(t, []domainegress.Route{route}, upstream.Client(), nil, nil)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/data", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest returned unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestValidateResponse_ContentType_Fail verifies that a response with a
+// content type NOT in the allowlist causes ErrResponseValidationFailed.
+func TestValidateResponse_ContentType_Fail(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<html>nope</html>`))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithValidateResponse(domainegress.ResponseValidationConfig{
+			ContentTypes: []string{"application/json"},
+		}),
+	)
+	el := &fakeObsEventLogger{}
+	proxy := newValidationProxy(t, []domainegress.Route{route}, upstream.Client(), el, nil)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/data", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+	_, err = proxy.HandleRequest(context.Background(), req)
+	if err == nil {
+		t.Fatal("HandleRequest should have returned an error")
+	}
+	if !errors.Is(err, egressadapter.ErrResponseValidationFailed) {
+		t.Errorf("error = %v, want errors.Is(ErrResponseValidationFailed)", err)
+	}
+
+	evTypes := el.EventTypes()
+	found := false
+	for _, et := range evTypes {
+		if et == events.EventTypeEgressResponseInvalid {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected egress.response_invalid event, got: %v", evTypes)
+	}
+}
+
+// TestValidateResponse_BothRules_Pass verifies that when both status code and
+// content type rules are configured, a response matching both rules passes.
+func TestValidateResponse_BothRules_Pass(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":1}`))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithValidateResponse(domainegress.ResponseValidationConfig{
+			StatusCodes:  []string{"2xx"},
+			ContentTypes: []string{"application/json"},
+		}),
+	)
+	proxy := newValidationProxy(t, []domainegress.Route{route}, upstream.Client(), nil, nil)
+
+	req, err := domainegress.NewEgressRequest("POST", upstream.URL+"/v1/items", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest returned unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("StatusCode = %d, want 201", resp.StatusCode)
+	}
+}
+
+// TestValidateResponse_BothRules_StatusFails verifies that when both rules are
+// configured, a bad status code triggers the error even when content type is
+// acceptable.
+func TestValidateResponse_BothRules_StatusFails(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":"down"}`))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithValidateResponse(domainegress.ResponseValidationConfig{
+			StatusCodes:  []string{"2xx"},
+			ContentTypes: []string{"application/json"},
+		}),
+	)
+	proxy := newValidationProxy(t, []domainegress.Route{route}, upstream.Client(), nil, nil)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/items", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+	_, err = proxy.HandleRequest(context.Background(), req)
+	if !errors.Is(err, egressadapter.ErrResponseValidationFailed) {
+		t.Errorf("error = %v, want ErrResponseValidationFailed", err)
+	}
+}
+
+// TestValidateResponse_NoConfig_AllowsAll verifies that a route with no
+// validate_response config does not block any upstream response.
+func TestValidateResponse_NoConfig_AllowsAll(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("error page"))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*")
+	proxy := newValidationProxy(t, []domainegress.Route{route}, upstream.Client(), nil, nil)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/page", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+	resp, err := proxy.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleRequest returned unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want 500", resp.StatusCode)
+	}
+}
+
+// TestHTTPHandler_ValidationFail_Returns502 verifies that the HTTP handler
+// writes 502 Bad Gateway when response validation fails.
+func TestHTTPHandler_ValidationFail_Returns502(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html>unexpected</html>"))
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "api", upstream.URL+"/v1/*",
+		domainegress.WithValidateResponse(domainegress.ResponseValidationConfig{
+			ContentTypes: []string{"application/json"},
+		}),
+	)
+	resolver := egressadapter.NewRouteResolver([]domainegress.Route{route})
+	cfg := egressadapter.ProxyConfig{
+		Listen:         "127.0.0.1:0",
+		DefaultPolicy:  domainegress.PolicyDeny,
+		DefaultTimeout: 5 * time.Second,
+		Routes:         []domainegress.Route{route},
+		AllowInsecure:  true,
+	}
+	proxy := egressadapter.NewProxy(cfg, resolver, upstream.Client(), nil)
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer proxy.Stop(context.Background()) //nolint:errcheck
+
+	proxyURL := "http://" + proxy.Addr() + "/"
+	httpReq, err := http.NewRequest(http.MethodGet, proxyURL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	httpReq.Header.Set("X-Egress-URL", upstream.URL+"/v1/resource")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusBadGateway {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("StatusCode = %d, want 502; body: %q", resp.StatusCode, string(body))
+	}
+}
+
+// TestValidateResponse_EventPayload verifies that the egress.response_invalid
+// event contains the expected fields.
+func TestValidateResponse_EventPayload(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer upstream.Close()
+
+	route := newTestRoute(t, "myroute", upstream.URL+"/v1/*",
+		domainegress.WithValidateResponse(domainegress.ResponseValidationConfig{
+			StatusCodes: []string{"2xx"},
+		}),
+	)
+	el := &fakeObsEventLogger{}
+	proxy := newValidationProxy(t, []domainegress.Route{route}, upstream.Client(), el, nil)
+
+	req, err := domainegress.NewEgressRequest("GET", upstream.URL+"/v1/item", nil, nil)
+	if err != nil {
+		t.Fatalf("NewEgressRequest: %v", err)
+	}
+	_, _ = proxy.HandleRequest(context.Background(), req)
+
+	evs := el.Snapshot()
+	var invalidEv *events.Event
+	for i := range evs {
+		if evs[i].EventType == events.EventTypeEgressResponseInvalid {
+			invalidEv = &evs[i]
+			break
+		}
+	}
+	if invalidEv == nil {
+		t.Fatal("no egress.response_invalid event emitted")
+	}
+
+	payload := invalidEv.Payload
+	assertPayloadString(t, payload, "route", "myroute")
+	assertPayloadString(t, payload, "method", "GET")
+	assertPayloadInt(t, payload, "status_code", http.StatusForbidden)
+	assertPayloadString(t, payload, "content_type", "text/plain")
+
+	if _, ok := payload["reason"]; !ok {
+		t.Error("event payload missing 'reason' field")
+	}
+}
+
+// assertPayloadString checks that payload[key] is a string equal to want.
+func assertPayloadString(t *testing.T, payload map[string]any, key, want string) {
+	t.Helper()
+	v, ok := payload[key]
+	if !ok {
+		t.Errorf("payload missing key %q", key)
+		return
+	}
+	s, ok := v.(string)
+	if !ok {
+		t.Errorf("payload[%q] = %T, want string", key, v)
+		return
+	}
+	if s != want {
+		t.Errorf("payload[%q] = %q, want %q", key, s, want)
+	}
+}
+
+// assertPayloadInt checks that payload[key] is an int equal to want.
+func assertPayloadInt(t *testing.T, payload map[string]any, key string, want int) {
+	t.Helper()
+	v, ok := payload[key]
+	if !ok {
+		t.Errorf("payload missing key %q", key)
+		return
+	}
+	n, ok := v.(int)
+	if !ok {
+		t.Errorf("payload[%q] = %T(%v), want int", key, v, v)
+		return
+	}
+	if n != want {
+		t.Errorf("payload[%q] = %d, want %d", key, n, want)
+	}
+}

--- a/internal/config/egress.go
+++ b/internal/config/egress.go
@@ -110,6 +110,28 @@ type EgressRouteConfig struct {
 	// specific route, overriding the global egress.allow_insecure setting.
 	// When false (default), only HTTPS targets are accepted.
 	AllowInsecure bool `mapstructure:"allow_insecure"`
+
+	// ValidateResponse holds per-route upstream response validation settings.
+	// When non-zero, each upstream response is checked against the configured
+	// allowed status code ranges and content types. Responses that fail
+	// validation are dropped and the caller receives a 502 Bad Gateway.
+	ValidateResponse EgressResponseValidationConfig `mapstructure:"validate_response"`
+}
+
+// EgressResponseValidationConfig holds per-route upstream response validation
+// parameters, as parsed from vibewarden.yaml.
+type EgressResponseValidationConfig struct {
+	// StatusCodes is a list of allowed HTTP status code range expressions.
+	// Supported formats: exact code ("200"), class wildcard ("2xx", "3xx", "4xx",
+	// "5xx"). When empty, no status code validation is performed.
+	// Example: ["2xx", "301", "302"]
+	StatusCodes []string `mapstructure:"status_codes"`
+
+	// ContentTypes is a list of allowed MIME type prefixes for the upstream
+	// response Content-Type header (parameters such as charset are ignored).
+	// When empty, no Content-Type validation is performed.
+	// Example: ["application/json", "text/plain"]
+	ContentTypes []string `mapstructure:"content_types"`
 }
 
 // EgressCircuitBreakerConfig holds circuit breaker parameters for an egress route.

--- a/internal/domain/egress/response_validation_test.go
+++ b/internal/domain/egress/response_validation_test.go
@@ -1,0 +1,297 @@
+package egress_test
+
+import (
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/domain/egress"
+)
+
+// TestResponseValidationConfig_IsZero verifies the zero-value detection.
+func TestResponseValidationConfig_IsZero(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  egress.ResponseValidationConfig
+		want bool
+	}{
+		{
+			name: "empty config is zero",
+			cfg:  egress.ResponseValidationConfig{},
+			want: true,
+		},
+		{
+			name: "status codes set — not zero",
+			cfg:  egress.ResponseValidationConfig{StatusCodes: []string{"2xx"}},
+			want: false,
+		},
+		{
+			name: "content types set — not zero",
+			cfg:  egress.ResponseValidationConfig{ContentTypes: []string{"application/json"}},
+			want: false,
+		},
+		{
+			name: "both set — not zero",
+			cfg: egress.ResponseValidationConfig{
+				StatusCodes:  []string{"2xx"},
+				ContentTypes: []string{"application/json"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.IsZero()
+			if got != tt.want {
+				t.Errorf("IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResponseValidationConfig_MatchesStatusCode verifies status code matching.
+func TestResponseValidationConfig_MatchesStatusCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        egress.ResponseValidationConfig
+		statusCode int
+		want       bool
+	}{
+		// Empty allowlist — everything passes.
+		{
+			name:       "empty allowlist allows any code",
+			cfg:        egress.ResponseValidationConfig{},
+			statusCode: 500,
+			want:       true,
+		},
+		// Class wildcards.
+		{
+			name:       "2xx matches 200",
+			cfg:        egress.ResponseValidationConfig{StatusCodes: []string{"2xx"}},
+			statusCode: 200,
+			want:       true,
+		},
+		{
+			name:       "2xx matches 201",
+			cfg:        egress.ResponseValidationConfig{StatusCodes: []string{"2xx"}},
+			statusCode: 201,
+			want:       true,
+		},
+		{
+			name:       "2xx matches 299",
+			cfg:        egress.ResponseValidationConfig{StatusCodes: []string{"2xx"}},
+			statusCode: 299,
+			want:       true,
+		},
+		{
+			name:       "2xx does not match 300",
+			cfg:        egress.ResponseValidationConfig{StatusCodes: []string{"2xx"}},
+			statusCode: 300,
+			want:       false,
+		},
+		{
+			name:       "3xx matches 301",
+			cfg:        egress.ResponseValidationConfig{StatusCodes: []string{"3xx"}},
+			statusCode: 301,
+			want:       true,
+		},
+		{
+			name:       "3xx does not match 200",
+			cfg:        egress.ResponseValidationConfig{StatusCodes: []string{"3xx"}},
+			statusCode: 200,
+			want:       false,
+		},
+		{
+			name:       "4xx matches 404",
+			cfg:        egress.ResponseValidationConfig{StatusCodes: []string{"4xx"}},
+			statusCode: 404,
+			want:       true,
+		},
+		{
+			name:       "5xx matches 500",
+			cfg:        egress.ResponseValidationConfig{StatusCodes: []string{"5xx"}},
+			statusCode: 500,
+			want:       true,
+		},
+		{
+			name:       "5xx does not match 200",
+			cfg:        egress.ResponseValidationConfig{StatusCodes: []string{"5xx"}},
+			statusCode: 200,
+			want:       false,
+		},
+		// Exact codes.
+		{
+			name:       "exact 200 matches 200",
+			cfg:        egress.ResponseValidationConfig{StatusCodes: []string{"200"}},
+			statusCode: 200,
+			want:       true,
+		},
+		{
+			name:       "exact 200 does not match 201",
+			cfg:        egress.ResponseValidationConfig{StatusCodes: []string{"200"}},
+			statusCode: 201,
+			want:       false,
+		},
+		// Multiple entries — OR semantics.
+		{
+			name:       "2xx or 301 — matches 200",
+			cfg:        egress.ResponseValidationConfig{StatusCodes: []string{"2xx", "301"}},
+			statusCode: 200,
+			want:       true,
+		},
+		{
+			name:       "2xx or 301 — matches 301",
+			cfg:        egress.ResponseValidationConfig{StatusCodes: []string{"2xx", "301"}},
+			statusCode: 301,
+			want:       true,
+		},
+		{
+			name:       "2xx or 301 — does not match 302",
+			cfg:        egress.ResponseValidationConfig{StatusCodes: []string{"2xx", "301"}},
+			statusCode: 302,
+			want:       false,
+		},
+		// Unknown / garbage expression does not match.
+		{
+			name:       "unknown expression does not match",
+			cfg:        egress.ResponseValidationConfig{StatusCodes: []string{"not-a-code"}},
+			statusCode: 200,
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.MatchesStatusCode(tt.statusCode)
+			if got != tt.want {
+				t.Errorf("MatchesStatusCode(%d) = %v, want %v", tt.statusCode, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResponseValidationConfig_MatchesContentType verifies content-type matching.
+func TestResponseValidationConfig_MatchesContentType(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         egress.ResponseValidationConfig
+		contentType string
+		want        bool
+	}{
+		// Empty allowlist — everything passes.
+		{
+			name:        "empty allowlist allows any content type",
+			cfg:         egress.ResponseValidationConfig{},
+			contentType: "text/html",
+			want:        true,
+		},
+		// Exact match.
+		{
+			name:        "exact match application/json",
+			cfg:         egress.ResponseValidationConfig{ContentTypes: []string{"application/json"}},
+			contentType: "application/json",
+			want:        true,
+		},
+		// Parameters are stripped.
+		{
+			name:        "match ignores charset parameter",
+			cfg:         egress.ResponseValidationConfig{ContentTypes: []string{"application/json"}},
+			contentType: "application/json; charset=utf-8",
+			want:        true,
+		},
+		{
+			name:        "match ignores boundary parameter",
+			cfg:         egress.ResponseValidationConfig{ContentTypes: []string{"multipart/form-data"}},
+			contentType: "multipart/form-data; boundary=----WebKitFormBoundary",
+			want:        true,
+		},
+		// Case-insensitive.
+		{
+			name:        "case-insensitive match",
+			cfg:         egress.ResponseValidationConfig{ContentTypes: []string{"application/json"}},
+			contentType: "Application/JSON",
+			want:        true,
+		},
+		// Mismatch.
+		{
+			name:        "text/html not in json allowlist",
+			cfg:         egress.ResponseValidationConfig{ContentTypes: []string{"application/json"}},
+			contentType: "text/html",
+			want:        false,
+		},
+		// Empty content type — only matches when empty string is in allowlist.
+		{
+			name:        "empty content type does not match non-empty allowlist",
+			cfg:         egress.ResponseValidationConfig{ContentTypes: []string{"application/json"}},
+			contentType: "",
+			want:        false,
+		},
+		// Multiple allowed types — OR semantics.
+		{
+			name: "json or text/plain — matches json",
+			cfg: egress.ResponseValidationConfig{
+				ContentTypes: []string{"application/json", "text/plain"},
+			},
+			contentType: "application/json",
+			want:        true,
+		},
+		{
+			name: "json or text/plain — matches text/plain",
+			cfg: egress.ResponseValidationConfig{
+				ContentTypes: []string{"application/json", "text/plain"},
+			},
+			contentType: "text/plain; charset=utf-8",
+			want:        true,
+		},
+		{
+			name: "json or text/plain — does not match text/html",
+			cfg: egress.ResponseValidationConfig{
+				ContentTypes: []string{"application/json", "text/plain"},
+			},
+			contentType: "text/html",
+			want:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.MatchesContentType(tt.contentType)
+			if got != tt.want {
+				t.Errorf("MatchesContentType(%q) = %v, want %v", tt.contentType, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRoute_ValidateResponse verifies that WithValidateResponse is wired
+// through NewRoute and returned by ValidateResponse.
+func TestRoute_ValidateResponse(t *testing.T) {
+	cfg := egress.ResponseValidationConfig{
+		StatusCodes:  []string{"2xx", "301"},
+		ContentTypes: []string{"application/json"},
+	}
+	route, err := egress.NewRoute("api", "https://api.example.com/*",
+		egress.WithValidateResponse(cfg),
+	)
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+	got := route.ValidateResponse()
+	if got.IsZero() {
+		t.Error("ValidateResponse() should not be zero after WithValidateResponse")
+	}
+	if len(got.StatusCodes) != 2 {
+		t.Errorf("StatusCodes len = %d, want 2", len(got.StatusCodes))
+	}
+	if len(got.ContentTypes) != 1 {
+		t.Errorf("ContentTypes len = %d, want 1", len(got.ContentTypes))
+	}
+}
+
+// TestRoute_ValidateResponse_Zero verifies that a route without the option
+// returns the zero value.
+func TestRoute_ValidateResponse_Zero(t *testing.T) {
+	route, err := egress.NewRoute("api", "https://api.example.com/*")
+	if err != nil {
+		t.Fatalf("NewRoute: %v", err)
+	}
+	if !route.ValidateResponse().IsZero() {
+		t.Error("ValidateResponse() should be zero when not set")
+	}
+}

--- a/internal/domain/egress/route.go
+++ b/internal/domain/egress/route.go
@@ -98,6 +98,89 @@ func (m MTLSConfig) IsZero() bool {
 	return m.CertPath == "" && m.KeyPath == "" && m.CAPath == ""
 }
 
+// ResponseValidationConfig holds per-route response validation parameters.
+// When non-zero, the egress proxy validates each upstream response against the
+// configured rules and returns 502 Bad Gateway if the response does not match.
+type ResponseValidationConfig struct {
+	// StatusCodes is a list of allowed HTTP status code range expressions.
+	// Supported formats: exact code ("200"), class wildcard ("2xx", "3xx"),
+	// or both together. When empty, no status code validation is performed.
+	// Example: ["2xx", "301", "302"]
+	StatusCodes []string
+
+	// ContentTypes is a list of allowed MIME type prefixes for the upstream
+	// response Content-Type header. The comparison ignores parameters (e.g.
+	// "application/json" matches "application/json; charset=utf-8").
+	// When empty, no Content-Type validation is performed.
+	// Example: ["application/json", "text/plain"]
+	ContentTypes []string
+}
+
+// IsZero reports whether this ResponseValidationConfig is the zero value
+// (no validation configured).
+func (v ResponseValidationConfig) IsZero() bool {
+	return len(v.StatusCodes) == 0 && len(v.ContentTypes) == 0
+}
+
+// MatchesStatusCode reports whether statusCode satisfies at least one entry
+// in the StatusCodes allowlist. Returns true when StatusCodes is empty.
+func (v ResponseValidationConfig) MatchesStatusCode(statusCode int) bool {
+	if len(v.StatusCodes) == 0 {
+		return true
+	}
+	for _, expr := range v.StatusCodes {
+		if matchStatusCodeExpr(expr, statusCode) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchesContentType reports whether the given Content-Type header value
+// satisfies at least one entry in the ContentTypes allowlist. The comparison
+// is case-insensitive and ignores parameters (charset, boundary, etc.).
+// Returns true when ContentTypes is empty.
+func (v ResponseValidationConfig) MatchesContentType(contentType string) bool {
+	if len(v.ContentTypes) == 0 {
+		return true
+	}
+	// Strip parameters: "application/json; charset=utf-8" → "application/json"
+	mediaType := strings.ToLower(strings.TrimSpace(contentType))
+	if idx := strings.IndexByte(mediaType, ';'); idx >= 0 {
+		mediaType = strings.TrimSpace(mediaType[:idx])
+	}
+	for _, allowed := range v.ContentTypes {
+		if strings.ToLower(strings.TrimSpace(allowed)) == mediaType {
+			return true
+		}
+	}
+	return false
+}
+
+// matchStatusCodeExpr returns true when statusCode matches the expression expr.
+// Supported expressions: "2xx" / "3xx" / "4xx" / "5xx" class wildcards, or any
+// three-digit decimal string representing an exact status code.
+func matchStatusCodeExpr(expr string, statusCode int) bool {
+	if len(expr) == 3 {
+		switch expr {
+		case "2xx":
+			return statusCode >= 200 && statusCode < 300
+		case "3xx":
+			return statusCode >= 300 && statusCode < 400
+		case "4xx":
+			return statusCode >= 400 && statusCode < 500
+		case "5xx":
+			return statusCode >= 500 && statusCode < 600
+		}
+	}
+	// Try exact match.
+	var code int
+	if _, err := fmt.Sscanf(expr, "%d", &code); err == nil {
+		return code == statusCode
+	}
+	return false
+}
+
 // CacheConfig holds per-route response caching parameters.
 // Caching applies only to GET and HEAD requests that receive a 2xx response.
 type CacheConfig struct {
@@ -156,6 +239,7 @@ type Route struct {
 	sanitize          SanitizeConfig
 	mtls              MTLSConfig
 	cache             CacheConfig
+	validateResponse  ResponseValidationConfig
 }
 
 // routeOptions carries optional fields supplied via functional options.
@@ -173,6 +257,7 @@ type routeOptions struct {
 	sanitize          SanitizeConfig
 	mtls              MTLSConfig
 	cache             CacheConfig
+	validateResponse  ResponseValidationConfig
 }
 
 // RouteOption is a functional option for NewRoute.
@@ -261,6 +346,14 @@ func WithCache(cfg CacheConfig) RouteOption {
 	return func(o *routeOptions) { o.cache = cfg }
 }
 
+// WithValidateResponse configures per-route upstream response validation.
+// When non-zero, each upstream response is checked against the allowed status
+// code ranges and content types. Responses that fail validation are dropped and
+// the caller receives a 502 Bad Gateway instead of the upstream body.
+func WithValidateResponse(cfg ResponseValidationConfig) RouteOption {
+	return func(o *routeOptions) { o.validateResponse = cfg }
+}
+
 // NewRoute constructs a Route value object.
 // Returns an error when name is empty, pattern is empty, or the pattern is
 // not a valid URL glob (as accepted by path.Match).
@@ -296,6 +389,7 @@ func NewRoute(name, pattern string, opts ...RouteOption) (Route, error) {
 		sanitize:          o.sanitize,
 		mtls:              o.mtls,
 		cache:             o.cache,
+		validateResponse:  o.validateResponse,
 	}, nil
 }
 
@@ -353,6 +447,10 @@ func (r Route) MTLS() MTLSConfig { return r.mtls }
 // Cache returns the per-route response caching configuration.
 // A zero CacheConfig (Enabled == false) means no caching is configured.
 func (r Route) Cache() CacheConfig { return r.cache }
+
+// ValidateResponse returns the per-route upstream response validation
+// configuration. A zero ResponseValidationConfig means no validation is applied.
+func (r Route) ValidateResponse() ResponseValidationConfig { return r.validateResponse }
 
 // MatchesMethod reports whether the given HTTP method is allowed by this route.
 // When Methods is empty, all methods are considered a match.

--- a/internal/domain/events/egress.go
+++ b/internal/domain/events/egress.go
@@ -274,6 +274,63 @@ func NewEgressCircuitBreakerClosed(params EgressCircuitBreakerClosedParams) Even
 	}
 }
 
+// EventTypeEgressResponseInvalid is emitted when the upstream response for an
+// egress request fails the per-route validate_response rules (disallowed status
+// code or content type). The egress proxy drops the upstream response and returns
+// 502 Bad Gateway to the caller.
+const EventTypeEgressResponseInvalid = "egress.response_invalid"
+
+// EgressResponseInvalidParams contains the parameters needed to construct an
+// egress.response_invalid event.
+type EgressResponseInvalidParams struct {
+	// Route is the matched egress route name.
+	Route string
+
+	// Method is the HTTP method of the outbound request.
+	Method string
+
+	// URL is the destination URL of the outbound request.
+	URL string
+
+	// StatusCode is the HTTP status code returned by the upstream.
+	StatusCode int
+
+	// ContentType is the Content-Type header value returned by the upstream.
+	ContentType string
+
+	// Reason is a short human-readable description of why the response was
+	// considered invalid (e.g. "status code not allowed", "content type not allowed").
+	Reason string
+
+	// TraceID is the W3C trace-id of the inbound request that triggered this
+	// egress call. Empty when no inbound trace context is available.
+	TraceID string
+}
+
+// NewEgressResponseInvalid creates an egress.response_invalid event indicating
+// that the upstream response failed per-route validation and was dropped.
+func NewEgressResponseInvalid(params EgressResponseInvalidParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeEgressResponseInvalid,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"Egress response invalid: %s %s via route %q — status %d content-type %q — %s",
+			params.Method, params.URL, params.Route,
+			params.StatusCode, params.ContentType, params.Reason,
+		),
+		Payload: map[string]any{
+			"route":        params.Route,
+			"method":       params.Method,
+			"url":          params.URL,
+			"status_code":  params.StatusCode,
+			"content_type": params.ContentType,
+			"reason":       params.Reason,
+			"trace_id":     params.TraceID,
+		},
+	}
+}
+
 // EventTypeEgressRateLimitHit is emitted when an outbound request to a named
 // egress route is rejected because the per-route rate limit has been exceeded.
 const EventTypeEgressRateLimitHit = "egress.rate_limit_hit"

--- a/internal/domain/events/egress_response_invalid_test.go
+++ b/internal/domain/events/egress_response_invalid_test.go
@@ -1,0 +1,106 @@
+package events_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+)
+
+// requirePayloadInt asserts that the payload map contains key with the
+// expected int value.
+func requirePayloadInt(t *testing.T, payload map[string]any, key string, want int) {
+	t.Helper()
+	v, ok := payload[key]
+	if !ok {
+		t.Errorf("Payload missing key %q", key)
+		return
+	}
+	got, ok := v.(int)
+	if !ok {
+		t.Errorf("Payload[%q] type = %T (%v), want int", key, v, v)
+		return
+	}
+	if got != want {
+		t.Errorf("Payload[%q] = %d, want %d", key, got, want)
+	}
+}
+
+// requireSummaryContainsInt is a helper that asserts the summary contains the
+// string representation of n.
+func requireSummaryContainsInt(t *testing.T, summary string, n int) {
+	t.Helper()
+	requireSummaryContains(t, summary, fmt.Sprintf("%d", n))
+}
+
+// TestNewEgressResponseInvalid verifies the egress.response_invalid event
+// constructor produces a well-formed event with all required payload fields.
+func TestNewEgressResponseInvalid(t *testing.T) {
+	tests := []struct {
+		name        string
+		params      events.EgressResponseInvalidParams
+		wantRoute   string
+		wantMethod  string
+		wantURL     string
+		wantStatus  int
+		wantCT      string
+		wantReason  string
+		wantTraceID string
+	}{
+		{
+			name: "status code not allowed",
+			params: events.EgressResponseInvalidParams{
+				Route:       "stripe",
+				Method:      "GET",
+				URL:         "https://api.stripe.com/v1/charges",
+				StatusCode:  500,
+				ContentType: "application/json",
+				Reason:      "status code 500 not in allowed list",
+				TraceID:     "abc123",
+			},
+			wantRoute:   "stripe",
+			wantMethod:  "GET",
+			wantURL:     "https://api.stripe.com/v1/charges",
+			wantStatus:  500,
+			wantCT:      "application/json",
+			wantReason:  "status code 500 not in allowed list",
+			wantTraceID: "abc123",
+		},
+		{
+			name: "content type not allowed",
+			params: events.EgressResponseInvalidParams{
+				Route:       "github",
+				Method:      "POST",
+				URL:         "https://api.github.com/repos",
+				StatusCode:  200,
+				ContentType: "text/html",
+				Reason:      `content type "text/html" not in allowed list`,
+				TraceID:     "",
+			},
+			wantRoute:  "github",
+			wantMethod: "POST",
+			wantURL:    "https://api.github.com/repos",
+			wantStatus: 200,
+			wantCT:     "text/html",
+			wantReason: `content type "text/html" not in allowed list`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := events.NewEgressResponseInvalid(tt.params)
+
+			assertEvent(t, e, events.EventTypeEgressResponseInvalid)
+			requireSummaryContains(t, e.AISummary, tt.wantRoute)
+			requireSummaryContains(t, e.AISummary, tt.wantMethod)
+
+			requirePayloadString(t, e.Payload, "route", tt.wantRoute)
+			requirePayloadString(t, e.Payload, "method", tt.wantMethod)
+			requirePayloadString(t, e.Payload, "url", tt.wantURL)
+			requirePayloadInt(t, e.Payload, "status_code", tt.wantStatus)
+			requirePayloadString(t, e.Payload, "content_type", tt.wantCT)
+			requirePayloadString(t, e.Payload, "reason", tt.wantReason)
+			requirePayloadString(t, e.Payload, "trace_id", tt.wantTraceID)
+		})
+	}
+}

--- a/internal/plugins/egress/config.go
+++ b/internal/plugins/egress/config.go
@@ -86,6 +86,28 @@ type RouteConfig struct {
 
 	// AllowInsecure permits plain HTTP for this specific route.
 	AllowInsecure bool
+
+	// ValidateResponse holds per-route upstream response validation settings.
+	// When non-zero, each upstream response is checked against the configured
+	// allowed status code ranges and content types. Responses that fail
+	// validation are dropped and the caller receives a 502 Bad Gateway.
+	ValidateResponse ResponseValidationConfig
+}
+
+// ResponseValidationConfig holds per-route upstream response validation
+// parameters for the egress proxy.
+type ResponseValidationConfig struct {
+	// StatusCodes is a list of allowed HTTP status code range expressions.
+	// Supported formats: exact code ("200"), class wildcard ("2xx", "3xx", "4xx",
+	// "5xx"). When empty, no status code validation is performed.
+	// Example: ["2xx", "301", "302"]
+	StatusCodes []string
+
+	// ContentTypes is a list of allowed MIME type prefixes for the upstream
+	// response Content-Type header (parameters are ignored).
+	// When empty, no Content-Type validation is performed.
+	// Example: ["application/json", "text/plain"]
+	ContentTypes []string
 }
 
 // CircuitBreakerConfig holds circuit breaker parameters for a route.

--- a/internal/plugins/egress/plugin.go
+++ b/internal/plugins/egress/plugin.go
@@ -259,6 +259,13 @@ func routeOptions(rc RouteConfig) ([]domainegress.RouteOption, error) {
 		opts = append(opts, domainegress.WithAllowInsecure(true))
 	}
 
+	if len(rc.ValidateResponse.StatusCodes) > 0 || len(rc.ValidateResponse.ContentTypes) > 0 {
+		opts = append(opts, domainegress.WithValidateResponse(domainegress.ResponseValidationConfig{
+			StatusCodes:  rc.ValidateResponse.StatusCodes,
+			ContentTypes: rc.ValidateResponse.ContentTypes,
+		}))
+	}
+
 	return opts, nil
 }
 


### PR DESCRIPTION
Closes #370

## Summary

- `internal/domain/egress/route.go` — new `ResponseValidationConfig` value object with `MatchesStatusCode` and `MatchesContentType` methods; `WithValidateResponse` route option; `ValidateResponse()` accessor on `Route`
- `internal/domain/events/egress.go` — new `EventTypeEgressResponseInvalid` constant and `NewEgressResponseInvalid` constructor
- `internal/adapters/egress/errors.go` — new `ErrResponseValidationFailed` sentinel
- `internal/adapters/egress/proxy.go` — `validateResponse` and `emitResponseInvalid` methods wired into `HandleRequest` after the upstream response arrives; `handleRequest` HTTP handler maps `ErrResponseValidationFailed` to 502 Bad Gateway
- `internal/plugins/egress/config.go` — `ResponseValidationConfig` type and `ValidateResponse` field on `RouteConfig`
- `internal/plugins/egress/plugin.go` — wires `ValidateResponse` from `RouteConfig` to domain `WithValidateResponse` option
- `internal/config/egress.go` — `EgressResponseValidationConfig` type and `ValidateResponse` field on `EgressRouteConfig`
- `cmd/vibewarden/serve.go` — passes `ValidateResponse` through `buildEgressPlugin`

## Config example

```yaml
plugins:
  egress:
    enabled: true
    routes:
      - name: payments-api
        pattern: "https://api.stripe.com/**"
        validate_response:
          status_codes: ["2xx", "301", "302"]
          content_types: ["application/json"]
```

## Test plan

- `internal/domain/egress/response_validation_test.go` — table-driven unit tests for `IsZero`, `MatchesStatusCode` (class wildcards, exact codes, multiple entries), `MatchesContentType` (parameter stripping, case-insensitivity), and `WithValidateResponse` route option round-trip
- `internal/domain/events/egress_response_invalid_test.go` — verifies schema version, event type, non-empty AI summary, and all payload fields
- `internal/adapters/egress/response_validation_test.go` — integration tests via `HandleRequest` and the full HTTP handler: pass/fail for status codes, pass/fail for content types, both rules together, no-config passthrough, 502 response from HTTP handler, event payload field assertions