### PR TITLE
fix: only show kratos/observability in generate output when enabled

### DIFF
--- a/internal/cli/cmd/generate.go
+++ b/internal/cli/cmd/generate.go
@@ -66,9 +66,14 @@ Examples:
 				dir = ".vibewarden/generated"
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Generated runtime configuration files in %s\n", dir)
-			fmt.Fprintf(cmd.OutOrStdout(), "  %s/kratos/kratos.yml\n", dir)
-			fmt.Fprintf(cmd.OutOrStdout(), "  %s/kratos/identity.schema.json\n", dir)
 			fmt.Fprintf(cmd.OutOrStdout(), "  %s/docker-compose.yml\n", dir)
+			if cfg.Auth.Enabled && cfg.Auth.Mode == config.AuthModeKratos && !cfg.Kratos.External {
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s/kratos/kratos.yml\n", dir)
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s/kratos/identity.schema.json\n", dir)
+			}
+			if cfg.Observability.Enabled {
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s/observability/ (prometheus, grafana, loki, promtail, otel-collector)\n", dir)
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
## Summary
- Generate CLI unconditionally printed kratos file paths even when auth.mode was not "kratos"
- Now conditionally shows kratos and observability lines only when those features are enabled
- Actual file generation was already correct — only the CLI output was misleading

## Test plan
- [x] `make check` passes
- [x] Minimal config: only shows docker-compose.yml
- [x] Full config: shows docker-compose.yml + observability + kratos
