### PR TITLE
feat(#417): add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Build
+        run: go build ./...
+
+      - name: Build demo-app
+        run: cd examples/demo-app && go build ./...
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Run tests
+        run: go test -race ./...
+
+      - name: Run demo-app tests
+        run: cd examples/demo-app && go test -race ./...


### PR DESCRIPTION
Closes #417

## Summary

- Adds `.github/workflows/ci.yml` with three jobs: **lint**, **build**, and **test**
- Triggers on push to `main` and on pull requests targeting `main`
- Uses Go 1.26 (matches `go.mod`) on `ubuntu-latest`
- Module and build cache enabled via `actions/setup-go@v5` built-in cache
- Each job has a 10-minute timeout
- Lint job delegates to `golangci/golangci-lint-action@v8` (uses the existing `.golangci.yml`)
- Build and test jobs cover both the main module and `examples/demo-app`, matching what `make check` does locally
- No secrets required

## Test plan

- [ ] Confirm the workflow file parses correctly in GitHub Actions UI
- [ ] Verify lint job picks up `.golangci.yml` config (gofmt, govet, errcheck, staticcheck, revive, gosec)
- [ ] Verify build job compiles main module and demo-app
- [ ] Verify test job runs `go test -race ./...` on both modules
- [ ] Push a branch with a deliberate formatting error and confirm lint job fails
- [ ] Push a branch with a failing test and confirm test job fails