### PR TITLE
feat(#418): add goreleaser config and GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write   # create GitHub Release and upload assets
+  packages: write   # push to ghcr.io
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # goreleaser needs the full history for changelog
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,162 @@
+# VibeWarden GoReleaser configuration.
+#
+# Produces:
+#   - Multi-platform static binaries (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64)
+#   - SHA-256 checksums file
+#   - Docker image pushed to ghcr.io/vibewarden/vibewarden
+#   - GitHub Release with changelog generated from conventional commits
+#
+# License: goreleaser is MIT — approved for this project.
+
+version: 2
+
+project_name: vibewarden
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+builds:
+  - id: vibewarden
+    main: ./cmd/vibewarden
+    binary: vibewarden
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+# ---------------------------------------------------------------------------
+# Archives
+# ---------------------------------------------------------------------------
+archives:
+  - id: vibewarden
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - LICENSE
+      - README.md
+      - vibewarden.example.yaml
+
+# ---------------------------------------------------------------------------
+# Checksums
+# ---------------------------------------------------------------------------
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+# ---------------------------------------------------------------------------
+# Docker images
+# ---------------------------------------------------------------------------
+dockers:
+  - id: vibewarden-amd64
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "ghcr.io/vibewarden/vibewarden:{{ .Version }}-amd64"
+      - "ghcr.io/vibewarden/vibewarden:latest-amd64"
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.description=Security sidecar for vibe-coded apps"
+      - "--label=org.opencontainers.image.url=https://vibewarden.dev"
+      - "--label=org.opencontainers.image.source=https://github.com/vibewarden/vibewarden"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+
+  - id: vibewarden-arm64
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "ghcr.io/vibewarden/vibewarden:{{ .Version }}-arm64"
+      - "ghcr.io/vibewarden/vibewarden:latest-arm64"
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.description=Security sidecar for vibe-coded apps"
+      - "--label=org.opencontainers.image.url=https://vibewarden.dev"
+      - "--label=org.opencontainers.image.source=https://github.com/vibewarden/vibewarden"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+
+# Multi-arch manifest lists so users can `docker pull` without specifying a
+# platform suffix.
+docker_manifests:
+  - name_template: "ghcr.io/vibewarden/vibewarden:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/vibewarden/vibewarden:{{ .Version }}-amd64"
+      - "ghcr.io/vibewarden/vibewarden:{{ .Version }}-arm64"
+
+  - name_template: "ghcr.io/vibewarden/vibewarden:latest"
+    image_templates:
+      - "ghcr.io/vibewarden/vibewarden:latest-amd64"
+      - "ghcr.io/vibewarden/vibewarden:latest-arm64"
+
+# ---------------------------------------------------------------------------
+# Changelog
+# ---------------------------------------------------------------------------
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "Merge pull request"
+      - "Merge branch"
+  groups:
+    - title: "Features"
+      regexp: "^feat"
+      order: 0
+    - title: "Bug fixes"
+      regexp: "^fix"
+      order: 1
+    - title: "Other"
+      order: 999
+
+# ---------------------------------------------------------------------------
+# GitHub Release
+# ---------------------------------------------------------------------------
+release:
+  github:
+    owner: vibewarden
+    name: vibewarden
+  draft: false
+  prerelease: auto
+  name_template: "{{ .ProjectName }} {{ .Version }}"
+  header: |
+    ## VibeWarden {{ .Version }}
+
+    Security sidecar for vibe-coded apps. Zero-to-secure in minutes.
+
+    ### Quick start
+
+    ```bash
+    # Docker (recommended)
+    docker pull ghcr.io/vibewarden/vibewarden:{{ .Version }}
+
+    # Binary install
+    curl -fsSL https://vibewarden.dev/install.sh | sh
+    ```
+  footer: |
+    **Full Changelog**: https://github.com/vibewarden/vibewarden/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,21 @@
+# VibeWarden — runtime-only Dockerfile for goreleaser.
+#
+# goreleaser builds the binary outside Docker (cross-compiled, CGO_ENABLED=0)
+# and copies it in here. This keeps the image lean and avoids a redundant
+# Go toolchain layer in the published image.
+#
+# The original Dockerfile (multi-stage, builds from source) is kept for the
+# local Docker Compose dev environment.
+
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates wget
+
+# goreleaser injects the binary into the Docker build context at this path.
+COPY vibewarden /vibewarden
+
+# VibeWarden listens on 8080 by default.
+EXPOSE 8080
+
+ENTRYPOINT ["/vibewarden"]
+CMD ["serve"]


### PR DESCRIPTION
Closes #418

## Summary

- `.goreleaser.yml` — multi-platform builds (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64), Docker image pushed to ghcr.io/vibewarden/vibewarden with versioned + `latest` manifest lists, SHA-256 checksums, GitHub Release with conventional-commit changelog grouped into Features / Bug fixes sections
- `Dockerfile.goreleaser` — runtime-only image that accepts the pre-built binary from goreleaser (keeps the published image lean; the original `Dockerfile` is unchanged for the local dev Docker Compose environment)
- `.github/workflows/release.yml` — triggered on `v*` tag push; sets up QEMU + Buildx for multi-arch Docker builds, logs in to GHCR with `GITHUB_TOKEN`, runs goreleaser with the `release --clean` command

## Design notes

- `Dockerfile.goreleaser` is a separate file so goreleaser injects its cross-compiled binary directly rather than re-running a Go build inside Docker. The original `Dockerfile` (builder stage + alpine runtime) is preserved for `make docker-up` / local dev.
- `docker_manifests` creates multi-arch manifest lists (`v*` and `latest`) so users can `docker pull ghcr.io/vibewarden/vibewarden` without specifying a platform suffix.
- `prerelease: auto` — goreleaser marks releases pre-release automatically when the tag contains a pre-release identifier (e.g. `v1.0.0-rc1`).

## Test plan

- [ ] Push a `v*` tag to a fork and verify the Actions workflow completes successfully
- [ ] Confirm GitHub Release is created with binaries, checksums, and changelog
- [ ] Confirm `ghcr.io/vibewarden/vibewarden:<tag>` and `latest` images are published
- [ ] Run `goreleaser check` locally to validate the config schema (requires goreleaser CLI)
