### PR TITLE
docs(#421): add SECURITY.md with supported versions, reporting channels, timelines, credit policy, and scope

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,13 +3,33 @@
 Thank you for helping keep VibeWarden and its users safe. We take security
 seriously and appreciate responsible disclosure.
 
+---
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| v0.1.x  | Yes       |
+
+Older releases are not patched once a newer minor version is available.
+We encourage all users to stay on the latest release.
+
+---
+
 ## Reporting a Vulnerability
 
-### Critical vulnerabilities
+### Preferred: GitHub Security Advisories
 
-For issues that could lead to remote code execution, privilege escalation,
-authentication bypass, or exposure of sensitive data, please report **privately**
-by email:
+Open a private advisory directly on GitHub:
+
+[https://github.com/vibewarden/vibewarden/security/advisories/new](https://github.com/vibewarden/vibewarden/security/advisories/new)
+
+This is our preferred channel. It keeps the full conversation in one place, is
+end-to-end encrypted, and lets us assign a CVE once a fix is ready.
+
+### Alternative: Email
+
+If you cannot use GitHub, email us at:
 
 **security@vibewarden.dev**
 
@@ -17,58 +37,91 @@ Include as much detail as possible:
 
 - A description of the vulnerability and its potential impact
 - Steps to reproduce or a proof-of-concept
-- Any affected versions you have identified
-- Suggested remediation if you have one
+- Affected versions (if known)
+- Suggested remediation (if any)
 
-Do not open a public GitHub issue for critical vulnerabilities until a fix has
-been released.
+**Do not open a public GitHub issue for security vulnerabilities** until a fix
+has been released.
 
-### Non-critical vulnerabilities
+---
 
-For lower-severity issues (hardening improvements, minor information leaks,
-dependency advisories), you may open a public GitHub issue or use
-[GitHub's private vulnerability reporting](https://github.com/vibewarden/vibewarden/security/advisories/new).
+## Response Timeline
 
-If you are unsure whether an issue is critical, default to the private email.
+| Milestone | Target |
+|-----------|--------|
+| Acknowledgement | Within 48 hours of receiving your report |
+| Initial assessment | Within 5 business days |
+| Fix released | Within 30 days for confirmed vulnerabilities |
+| Public disclosure | Within 90 days of the initial report |
 
-## Response Time
+We follow coordinated disclosure. If we need more time than the 90-day window
+allows, we will communicate that to you before the deadline and agree on an
+extension together.
 
-We aim to:
+---
 
-- **Acknowledge** your report within **48 hours**
-- Provide an initial assessment within 5 business days
-- Release a fix and publish a security advisory as quickly as the severity warrants
+## Disclosure Policy
 
-We will keep you informed throughout the process.
+1. Reporter notifies us privately via GitHub Security Advisories or email.
+2. We confirm the issue and develop a fix.
+3. We release a patch and publish a GitHub Security Advisory (CVE assigned where applicable).
+4. Reporter is credited (with permission) in `ACKNOWLEDGMENTS.md` and in the release notes.
 
-## Credit
+We will keep you informed throughout the process and aim to move quickly.
 
-We believe researchers who responsibly disclose vulnerabilities deserve public
-recognition. With your permission, we will credit you by name (or handle) in
-`ACKNOWLEDGMENTS.md` and in the release notes for the fix.
+---
 
-If you prefer to remain anonymous, just let us know and we will honour that
-preference.
+## Credit Policy
 
-## Bug Bounty
+Researchers who responsibly disclose vulnerabilities deserve public recognition.
+With your permission, we will credit you by name or handle in:
+
+- `ACKNOWLEDGMENTS.md`
+- The GitHub Security Advisory for the issue
+- The release notes for the fixing version
+
+If you prefer to remain anonymous, let us know and we will honour that
+preference without question.
 
 VibeWarden does not currently operate a paid bug bounty programme. We offer
 public credit and our sincere gratitude.
 
+---
+
+## What Qualifies as a Security Issue
+
+Report the following through our private disclosure process:
+
+- Authentication or authorisation bypass
+- Remote code execution or command injection
+- SQL injection or other injection attacks
+- Path traversal or directory traversal
+- Privilege escalation
+- Sensitive data exposure (credentials, secrets, PII)
+- Cryptographic weaknesses
+- Denial of service with low effort or no authentication required
+- Security misconfiguration in defaults that silently leaves users exposed
+
+The following are **not** security issues and should be filed as regular GitHub
+issues:
+
+- Bugs that do not have a security impact
+- Feature requests or UX improvements
+- Documentation errors
+- Performance regressions (unless exploitable for denial of service)
+- Dependency version bumps without a confirmed exploitable path
+
+If you are unsure whether something qualifies, default to private disclosure.
+We would rather investigate a non-issue than miss a real vulnerability.
+
+---
+
 ## Scope
 
-This policy covers the VibeWarden open-source sidecar binary and the code in
-this repository. It does not cover third-party dependencies (Caddy, Ory Kratos,
-etc.) — please report those vulnerabilities to their respective projects.
+This policy covers:
 
-## Disclosure Policy
+- The VibeWarden open-source sidecar binary and all code in this repository
+- The VibeWarden CLI (`vibew`)
 
-We follow a **coordinated disclosure** model:
-
-1. Reporter notifies us privately.
-2. We confirm the issue and develop a fix.
-3. Fix is released and a security advisory is published.
-4. Reporter is credited (with permission).
-
-We ask that you give us a reasonable amount of time to address the issue before
-any public disclosure.
+It does not cover third-party components (Caddy, Ory Kratos, OpenBao, etc.).
+Please report vulnerabilities in those projects to their respective maintainers.


### PR DESCRIPTION
Closes #421

## Summary

- Added a **Supported Versions** table (v0.1.x — supported)
- Set **GitHub Security Advisories** as the preferred reporting channel with a direct link; email (`security@vibewarden.dev`) listed as the alternative
- Added a **Response Timeline** table: acknowledge within 48 h, fix within 30 days, public disclosure within 90 days
- Added a **Disclosure Policy** section describing the coordinated disclosure steps
- Added a **Credit Policy** section: name/handle in `ACKNOWLEDGMENTS.md`, the advisory, and release notes; anonymous option honoured
- Added a **What Qualifies as a Security Issue** section listing examples that should go through private disclosure vs. examples that are regular bugs
- Added a **Scope** section clarifying that third-party components (Caddy, Ory Kratos, OpenBao) are out of scope
- README already contained a link to `SECURITY.md` — no change needed there

## Test plan

- [ ] Open `SECURITY.md` at the repo root and verify all sections are present
- [ ] Confirm the GitHub Security Advisories link resolves correctly
- [ ] Confirm `make check` passes (build, vet, tests all green — verified locally)