### PR TITLE
feat(#422): add quick start end-to-end validation script

### DIFF
--- a/test/quickstart/README.md
+++ b/test/quickstart/README.md
@@ -1,0 +1,111 @@
+# Quick start end-to-end validation
+
+This directory contains the automated validation script for the
+`vibew init → vibewarden generate` quick start flow (issue #422).
+
+## Purpose
+
+The quick start flow is the primary user-facing experience for VibeWarden.
+This script validates the entire flow without requiring Docker, a network
+connection, or any external services.  It exercises:
+
+1. `vibewarden init --upstream 3000` — scaffold vibewarden.yaml and wrappers
+2. `vibewarden generate` — generate runtime config from vibewarden.yaml
+3. Structural validation of the generated docker-compose.yml
+
+## Running the test
+
+From the repository root:
+
+```sh
+./test/quickstart/test.sh
+```
+
+The script builds a fresh binary automatically.  To skip the build step and
+use a pre-installed binary:
+
+```sh
+VIBEWARDEN_BIN=/usr/local/bin/vibewarden ./test/quickstart/test.sh
+```
+
+Exit code is `0` on success and `1` if any check fails.
+
+## Checks performed
+
+### Step 1: vibewarden init
+
+| Check | Expected result |
+|---|---|
+| vibewarden.yaml exists | present |
+| vibew (shell) exists | present |
+| vibew.ps1 exists | present |
+| vibew.cmd exists | present |
+| .vibewarden-version exists | present |
+| .gitignore exists | present |
+| vibew shell wrapper is executable | +x permission set |
+| vibewarden.yaml contains upstream port 3000 | `port: 3000` present |
+| vibewarden.yaml contains server port 8080 | `port: 8080` present |
+| vibewarden.yaml contains app.build section | `build:` present |
+| vibewarden.yaml contains security_headers section | `security_headers:` present |
+| .gitignore excludes .vibewarden/ | `.vibewarden/` entry present |
+| docker-compose.yml NOT generated at init time | file absent at project root |
+
+### Step 2: vibewarden generate
+
+| Check | Expected result |
+|---|---|
+| .vibewarden/generated/docker-compose.yml exists | present |
+| .vibewarden/generated/.env.template exists | present |
+| kratos/kratos.yml NOT generated (auth disabled) | file absent |
+
+### Step 3: docker-compose.yml structure
+
+| Check | Expected result |
+|---|---|
+| vibewarden service present | `vibewarden:` in services block |
+| app service present (app.build is set) | `app:` in services block |
+| proxy port 8080 exposed | `"8080:8080"` in ports |
+| vibewarden depends_on app with healthcheck | `service_healthy` condition |
+| upstream port 3000 propagated via env var | `VIBEWARDEN_UPSTREAM_PORT=3000` |
+| kratos service absent (auth disabled) | no `kratos:` service |
+| redis service absent (default memory store) | no `redis:` service |
+| networks section present | `networks:` block present |
+| vibewarden network defined | `vibewarden:` under networks |
+| docker-compose.yml is valid YAML | python3 parse succeeds |
+
+## vibew dev flow (manual validation)
+
+The `vibew dev` command wraps `vibewarden generate` + `docker compose up`.
+It requires Docker to be running and is not automated here because it pulls
+images and starts containers.  To validate manually:
+
+```sh
+# In a fresh directory
+vibewarden init --upstream 3000
+./vibew dev
+```
+
+Expected outcome:
+
+- VibeWarden proxy starts on http://localhost:8080
+- `/_vibewarden/health` returns `200 OK`
+- Security headers are present on all responses (`X-Content-Type-Options`,
+  `X-Frame-Options`, `Referrer-Policy`)
+- Rate limiting returns `429 Too Many Requests` when the burst is exceeded
+
+To stop the environment:
+
+```sh
+docker compose -f .vibewarden/generated/docker-compose.yml down
+```
+
+## Known issues found during validation
+
+None at time of writing (issue #422).  Any issues discovered during manual
+`vibew dev` testing should be documented here and tracked as follow-up issues.
+
+## Test coverage
+
+This script is a black-box integration test that complements the unit and
+integration tests in `internal/`.  It is the canonical smoke test to run
+before any release that touches the `init` or `generate` commands.

--- a/test/quickstart/test.sh
+++ b/test/quickstart/test.sh
@@ -1,0 +1,260 @@
+#!/bin/sh
+# test/quickstart/test.sh — Quick start end-to-end validation
+#
+# Validates the vibew init → vibewarden generate flow without requiring
+# Docker, a running network, or any external services.
+#
+# What is checked:
+#   1. vibewarden init --upstream 3000 scaffolds the expected files
+#   2. Generated vibewarden.yaml contains the correct upstream port
+#   3. vibew wrapper script is executable
+#   4. .gitignore contains the .vibewarden/ exclusion
+#   5. vibewarden generate produces docker-compose.yml and .env.template
+#   6. Generated docker-compose.yml references the correct service names
+#   7. Generated docker-compose.yml references the correct upstream port
+#   8. Generated docker-compose.yml is syntactically valid YAML (via python3
+#      or python, both of which ship by default on macOS and most Linux distros)
+#
+# Usage:
+#   ./test/quickstart/test.sh              # auto-builds the binary
+#   VIBEWARDEN_BIN=/usr/local/bin/vibewarden ./test/quickstart/test.sh
+#
+# Exit code:
+#   0 — all checks passed
+#   1 — one or more checks failed (failures are printed before exit)
+
+set -e
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+PASS=0
+FAIL=0
+
+pass() {
+    printf "  [PASS] %s\n" "$1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    printf "  [FAIL] %s\n" "$1"
+    FAIL=$((FAIL + 1))
+}
+
+check_file_exists() {
+    label="$1"
+    path="$2"
+    if [ -f "$path" ]; then
+        pass "$label exists"
+    else
+        fail "$label missing: $path"
+    fi
+}
+
+check_file_contains() {
+    label="$1"
+    path="$2"
+    pattern="$3"
+    if grep -q "$pattern" "$path" 2>/dev/null; then
+        pass "$label"
+    else
+        fail "$label  (pattern: '$pattern' not found in $path)"
+    fi
+}
+
+check_file_executable() {
+    label="$1"
+    path="$2"
+    if [ -x "$path" ]; then
+        pass "$label is executable"
+    else
+        fail "$label is not executable: $path"
+    fi
+}
+
+check_yaml_valid() {
+    label="$1"
+    path="$2"
+    dir="$(dirname "$path")"
+    file="$(basename "$path")"
+
+    # Prefer `docker compose config` — it fully parses and resolves the
+    # compose file and is available wherever Docker is installed.
+    if command -v docker >/dev/null 2>&1; then
+        # Run from the directory that contains the compose file so that
+        # docker compose resolves relative paths (e.g. ./.credentials)
+        # correctly.  Suppress output — we only care about exit code.
+        if (cd "$dir" && docker compose -f "$file" config --quiet 2>/dev/null); then
+            pass "$label is valid (docker compose config)"
+            return
+        else
+            fail "$label failed docker compose config validation"
+            return
+        fi
+    fi
+
+    # Fallback: python3 with PyYAML.  PyYAML is not part of the stdlib but is
+    # present on many developer machines.
+    if command -v python3 >/dev/null 2>&1; then
+        if python3 -c "import yaml; yaml.safe_load(open('$path'))" 2>/dev/null; then
+            pass "$label is valid YAML (python3 + PyYAML)"
+            return
+        else
+            # python3 found but PyYAML not available — do not fail the check.
+            printf "  [SKIP] %s — PyYAML not installed (run: pip3 install pyyaml)\n" "$label"
+            return
+        fi
+    fi
+
+    # No suitable tool found — skip the check rather than fail on a missing
+    # optional dependency.
+    printf "  [SKIP] %s — neither docker nor python3+PyYAML available\n" "$label"
+}
+
+# ── locate or build the binary ────────────────────────────────────────────────
+
+# Resolve the repo root relative to this script's location, then resolve to
+# an absolute path so subsequent cd calls do not break $REPO_ROOT.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+if [ -n "$VIBEWARDEN_BIN" ]; then
+    BIN="$VIBEWARDEN_BIN"
+else
+    BIN="$REPO_ROOT/bin/vibewarden-quickstart-test"
+    printf "Building vibewarden binary...\n"
+    cd "$REPO_ROOT"
+    go build -o "$BIN" ./cmd/vibewarden
+    printf "Built: %s\n" "$BIN"
+fi
+
+if [ ! -x "$BIN" ]; then
+    printf "error: binary not found or not executable: %s\n" "$BIN" >&2
+    exit 1
+fi
+
+# ── create temp work directory ────────────────────────────────────────────────
+
+WORKDIR="$(mktemp -d)"
+# Ensure cleanup on exit regardless of pass/fail.
+trap 'rm -rf "$WORKDIR"; [ -z "$VIBEWARDEN_BIN" ] && rm -f "$BIN"' EXIT
+
+printf "\nWork directory: %s\n\n" "$WORKDIR"
+
+# ── step 1: vibewarden init ───────────────────────────────────────────────────
+
+printf "==> Step 1: vibewarden init --upstream 3000\n"
+
+# Run init without agent files to keep the output minimal.
+"$BIN" init --upstream 3000 --agent none "$WORKDIR" >/dev/null
+
+check_file_exists  "vibewarden.yaml"          "$WORKDIR/vibewarden.yaml"
+check_file_exists  "vibew wrapper (shell)"    "$WORKDIR/vibew"
+check_file_exists  "vibew wrapper (ps1)"      "$WORKDIR/vibew.ps1"
+check_file_exists  "vibew wrapper (cmd)"      "$WORKDIR/vibew.cmd"
+check_file_exists  ".vibewarden-version"      "$WORKDIR/.vibewarden-version"
+check_file_exists  ".gitignore"               "$WORKDIR/.gitignore"
+
+check_file_executable "vibew shell wrapper"  "$WORKDIR/vibew"
+
+check_file_contains "vibewarden.yaml has upstream port 3000" \
+    "$WORKDIR/vibewarden.yaml" "port: 3000"
+
+check_file_contains "vibewarden.yaml has server port 8080" \
+    "$WORKDIR/vibewarden.yaml" "port: 8080"
+
+check_file_contains "vibewarden.yaml has app.build section" \
+    "$WORKDIR/vibewarden.yaml" "build:"
+
+check_file_contains "vibewarden.yaml has security_headers section" \
+    "$WORKDIR/vibewarden.yaml" "security_headers:"
+
+check_file_contains ".gitignore excludes .vibewarden/" \
+    "$WORKDIR/.gitignore" ".vibewarden/"
+
+# Confirm docker-compose.yml is NOT generated at init time.
+if [ -f "$WORKDIR/docker-compose.yml" ]; then
+    fail "docker-compose.yml must NOT be generated by init (found at root)"
+else
+    pass "docker-compose.yml correctly absent after init"
+fi
+
+printf "\n"
+
+# ── step 2: vibewarden generate ───────────────────────────────────────────────
+
+printf "==> Step 2: vibewarden generate\n"
+
+cd "$WORKDIR"
+"$BIN" generate >/dev/null
+
+GENDIR="$WORKDIR/.vibewarden/generated"
+
+check_file_exists "generated docker-compose.yml"  "$GENDIR/docker-compose.yml"
+check_file_exists "generated .env.template"       "$GENDIR/.env.template"
+
+# Auth is disabled in the default config, so Kratos files should be absent.
+if [ -f "$GENDIR/kratos/kratos.yml" ]; then
+    fail "kratos.yml must NOT be generated when auth is disabled"
+else
+    pass "kratos/kratos.yml correctly absent (auth disabled)"
+fi
+
+printf "\n"
+
+# ── step 3: validate docker-compose.yml structure ────────────────────────────
+
+printf "==> Step 3: validate docker-compose.yml structure\n"
+
+COMPOSE="$GENDIR/docker-compose.yml"
+
+# Required service: vibewarden
+check_file_contains "compose has 'vibewarden' service"       "$COMPOSE" "^  vibewarden:"
+
+# Required service: app (because vibewarden.yaml has app.build: .)
+check_file_contains "compose has 'app' service"              "$COMPOSE" "^  app:"
+
+# vibewarden service must expose the proxy port
+check_file_contains "compose exposes port 8080"              "$COMPOSE" '"8080:8080"'
+
+# The app service depends_on app healthcheck
+check_file_contains "vibewarden depends_on app"              "$COMPOSE" "service_healthy"
+
+# Upstream port propagated from vibewarden.yaml
+check_file_contains "compose references upstream port 3000"  "$COMPOSE" "VIBEWARDEN_UPSTREAM_PORT=3000"
+
+# No auth → no kratos service
+if grep -q "^  kratos:" "$COMPOSE" 2>/dev/null; then
+    fail "kratos service must NOT appear in compose when auth is disabled"
+else
+    pass "kratos service correctly absent in compose (auth disabled)"
+fi
+
+# No redis → redis service should be absent (default store is memory)
+if grep -q "^  redis:" "$COMPOSE" 2>/dev/null; then
+    fail "redis service must NOT appear in compose when rate_limit.store != redis"
+else
+    pass "redis service correctly absent in compose (default memory store)"
+fi
+
+# Network section must be present
+check_file_contains "compose has networks section"           "$COMPOSE" "^networks:"
+check_file_contains "compose has vibewarden network"        "$COMPOSE" "vibewarden:"
+
+# YAML validity
+check_yaml_valid "generated docker-compose.yml" "$COMPOSE"
+
+printf "\n"
+
+# ── summary ───────────────────────────────────────────────────────────────────
+
+printf "==> Results\n"
+printf "    Passed: %d\n" "$PASS"
+printf "    Failed: %d\n" "$FAIL"
+printf "\n"
+
+if [ "$FAIL" -gt 0 ]; then
+    printf "FAIL — %d check(s) failed.\n" "$FAIL"
+    exit 1
+fi
+
+printf "PASS — all checks passed.\n"


### PR DESCRIPTION
Closes #422

## Summary

- Adds `test/quickstart/test.sh` — a POSIX shell script that automates the `vibew init → vibewarden generate` validation flow without requiring Docker, a network connection, or any running services.
- The script runs 26 checks across three steps: init file scaffolding, generate output, and docker-compose.yml structural validation.
- YAML validity is verified using `docker compose config` (preferred, resolves variables) with a fallback to `python3 + PyYAML` and a graceful skip when neither is available.
- Adds `test/quickstart/README.md` documenting the automated checks, the manual `vibew dev` validation steps, and a known-issues section.
- No issues were found: the full `vibew init → vibewarden generate` flow is working correctly.

## Test plan

- [ ] Run `./test/quickstart/test.sh` — should print `PASS — all checks passed.`
- [ ] Run `make check` — all Go tests pass
- [ ] Verify `test/quickstart/test.sh` is executable (`-rwxr-xr-x`)
- [ ] Run with `VIBEWARDEN_BIN=/path/to/binary ./test/quickstart/test.sh` to confirm the skip-build path works