### PR TITLE
feat(#423): add structured event schema v1 and JSON Schema validation tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,6 +141,7 @@ require (
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.9.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.2 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -374,6 +374,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.9.0 h1:GbgQGNtTrEmddYDSAH9QLRyfAHY12md+8YFTqyMTC9k=
 github.com/sagikazarmark/locafero v0.9.0/go.mod h1:UBUyz37V+EdMS3hDF3QWIiVr/2dPrx49OMO0Bn0hJqk=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/schollz/jsonstore v1.1.0 h1:WZBDjgezFS34CHI+myb4s8GGpir3UMpy7vWoCeO0n6E=
 github.com/schollz/jsonstore v1.1.0/go.mod h1:15c6+9guw8vDRyozGjN3FoILt0wpruJk9Pi66vjaZfg=
 github.com/shirou/gopsutil/v4 v4.26.2 h1:X8i6sicvUFih4BmYIGT1m2wwgw2VG9YgrDTi7cIRGUI=

--- a/schema/v1/event.json
+++ b/schema/v1/event.json
@@ -1,0 +1,1434 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vibewarden.dev/schema/v1/event.json",
+  "title": "VibeWarden Event Schema v1",
+  "description": "Schema for all structured log events emitted by the VibeWarden security sidecar. Every event carries five top-level fields: schema_version, event_type, timestamp, ai_summary, and payload. Optional tracing fields (trace_id, span_id) are present when an active OTel span is associated with the event.",
+  "type": "object",
+  "required": ["schema_version", "event_type", "timestamp", "ai_summary", "payload"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "v1",
+      "description": "The schema version. Always 'v1' for events produced by this release."
+    },
+    "event_type": {
+      "type": "string",
+      "description": "Identifies the kind of event. Dot-separated namespace (e.g. 'auth.success').",
+      "enum": [
+        "proxy.started",
+        "proxy.kratos_flow",
+        "auth.success",
+        "auth.failed",
+        "auth.provider_unavailable",
+        "auth.provider_recovered",
+        "auth.api_key.success",
+        "auth.api_key.failed",
+        "auth.api_key.forbidden",
+        "auth.jwt_valid",
+        "auth.jwt_invalid",
+        "auth.jwt_expired",
+        "auth.jwks_refresh",
+        "auth.jwks_error",
+        "rate_limit.hit",
+        "rate_limit.unidentified_client",
+        "rate_limit.store_fallback",
+        "rate_limit.store_recovered",
+        "request.blocked",
+        "tls.certificate_issued",
+        "user.created",
+        "user.deleted",
+        "user.deactivated",
+        "audit.log_failure",
+        "ip_filter.blocked",
+        "secret.rotated",
+        "secret.rotation_failed",
+        "secret.health_check",
+        "upstream.timeout",
+        "upstream.retry",
+        "upstream.health_changed",
+        "circuit_breaker.opened",
+        "circuit_breaker.half_open",
+        "circuit_breaker.closed",
+        "egress.request",
+        "egress.response",
+        "egress.blocked",
+        "egress.error",
+        "egress.sanitized",
+        "egress.response_invalid",
+        "egress.rate_limit_hit",
+        "egress.circuit_breaker.opened",
+        "egress.circuit_breaker.closed"
+      ]
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC timestamp of when the event occurred, in RFC 3339 / ISO 8601 format."
+    },
+    "ai_summary": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "A concise human- and AI-readable sentence describing what happened. Includes the most relevant identifiers so an LLM can understand the event without reading the payload. Maximum 200 characters."
+    },
+    "payload": {
+      "type": "object",
+      "description": "Event-specific structured data. The set of keys is defined per event_type by the if/then constraints in this schema."
+    },
+    "trace_id": {
+      "type": "string",
+      "description": "OTel W3C trace ID (32 lowercase hex characters). Present only when the event is associated with an active tracing span.",
+      "pattern": "^[0-9a-f]{32}$"
+    },
+    "span_id": {
+      "type": "string",
+      "description": "OTel W3C span ID (16 lowercase hex characters). Present only when the event is associated with an active tracing span.",
+      "pattern": "^[0-9a-f]{16}$"
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "event_type": { "const": "proxy.started" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_proxy_started" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "proxy.kratos_flow" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_proxy_kratos_flow" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "auth.success" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_auth_success" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "auth.failed" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_auth_failed" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "auth.provider_unavailable" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_auth_provider_unavailable" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "auth.provider_recovered" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_auth_provider_recovered" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "auth.api_key.success" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_api_key_success" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "auth.api_key.failed" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_api_key_failed" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "auth.api_key.forbidden" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_api_key_forbidden" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "auth.jwt_valid" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_jwt_valid" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "auth.jwt_invalid" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_jwt_invalid" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "auth.jwt_expired" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_jwt_expired" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "auth.jwks_refresh" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_jwks_refresh" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "auth.jwks_error" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_jwks_error" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "rate_limit.hit" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_rate_limit_hit" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "rate_limit.unidentified_client" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_rate_limit_unidentified" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "rate_limit.store_fallback" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_rate_limit_store_fallback" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "rate_limit.store_recovered" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_rate_limit_store_recovered" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "request.blocked" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_request_blocked" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "tls.certificate_issued" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_tls_certificate_issued" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "user.created" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_user_created" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "user.deleted" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_user_deleted" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "user.deactivated" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_user_deactivated" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "audit.log_failure" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_audit_log_failure" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "ip_filter.blocked" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_ip_filter_blocked" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "secret.rotated" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_secret_rotated" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "secret.rotation_failed" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_secret_rotation_failed" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "secret.health_check" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_secret_health_check" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "upstream.timeout" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_upstream_timeout" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "upstream.retry" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_upstream_retry" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "upstream.health_changed" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_upstream_health_changed" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "circuit_breaker.opened" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_circuit_breaker_opened" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "circuit_breaker.half_open" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_circuit_breaker_half_open" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "circuit_breaker.closed" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_circuit_breaker_closed" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "egress.request" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_egress_request" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "egress.response" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_egress_response" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "egress.blocked" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_egress_blocked" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "egress.error" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_egress_error" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "egress.sanitized" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_egress_sanitized" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "egress.response_invalid" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_egress_response_invalid" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "egress.rate_limit_hit" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_egress_rate_limit_hit" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "egress.circuit_breaker.opened" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_egress_circuit_breaker_opened" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event_type": { "const": "egress.circuit_breaker.closed" } }, "required": ["event_type"] },
+      "then": {
+        "properties": {
+          "payload": { "$ref": "#/$defs/payload_egress_circuit_breaker_closed" }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "payload_proxy_started": {
+      "description": "Payload for proxy.started — emitted once when the reverse proxy is ready.",
+      "type": "object",
+      "required": ["listen", "upstream", "tls_enabled", "tls_provider", "security_headers_enabled", "version"],
+      "additionalProperties": false,
+      "properties": {
+        "listen": {
+          "type": "string",
+          "description": "Address the reverse proxy is listening on (e.g. ':443')."
+        },
+        "upstream": {
+          "type": "string",
+          "description": "Address requests are forwarded to (e.g. 'localhost:3000')."
+        },
+        "tls_enabled": {
+          "type": "boolean",
+          "description": "Whether TLS termination is active."
+        },
+        "tls_provider": {
+          "type": "string",
+          "description": "TLS certificate provider (e.g. 'letsencrypt', 'self-signed'). Empty string when tls_enabled is false."
+        },
+        "security_headers_enabled": {
+          "type": "boolean",
+          "description": "Whether the security headers middleware is active."
+        },
+        "version": {
+          "type": "string",
+          "description": "VibeWarden binary version string."
+        }
+      }
+    },
+    "payload_proxy_kratos_flow": {
+      "description": "Payload for proxy.kratos_flow — emitted when a request is routed to the Kratos self-service API.",
+      "type": "object",
+      "required": ["method", "path"],
+      "additionalProperties": false,
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the request (e.g. 'GET', 'POST')."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path of the request."
+        }
+      }
+    },
+    "payload_auth_success": {
+      "description": "Payload for auth.success — emitted when a Kratos session is validated.",
+      "type": "object",
+      "required": ["method", "path", "session_id", "identity_id", "email"],
+      "additionalProperties": false,
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the authenticated request."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path of the authenticated request."
+        },
+        "session_id": {
+          "type": "string",
+          "description": "Kratos session identifier."
+        },
+        "identity_id": {
+          "type": "string",
+          "description": "Kratos identity (user) identifier."
+        },
+        "email": {
+          "type": "string",
+          "description": "Email address of the authenticated identity."
+        }
+      }
+    },
+    "payload_auth_failed": {
+      "description": "Payload for auth.failed — emitted when a request is rejected due to missing or invalid session.",
+      "type": "object",
+      "required": ["method", "path", "reason", "detail"],
+      "additionalProperties": false,
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the rejected request."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path of the rejected request."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Short description of why the request was rejected."
+        },
+        "detail": {
+          "type": "string",
+          "description": "Optional additional detail (e.g. an error message). May be empty."
+        }
+      }
+    },
+    "payload_auth_provider_unavailable": {
+      "description": "Payload for auth.provider_unavailable — emitted when Ory Kratos cannot be reached.",
+      "type": "object",
+      "required": ["provider_url", "error", "affected_path"],
+      "additionalProperties": false,
+      "properties": {
+        "provider_url": {
+          "type": "string",
+          "description": "URL of the unavailable auth provider."
+        },
+        "error": {
+          "type": "string",
+          "description": "Short description of the connectivity failure."
+        },
+        "affected_path": {
+          "type": "string",
+          "description": "URL path of the request that triggered discovery. Empty string when emitted from a health probe."
+        }
+      }
+    },
+    "payload_auth_provider_recovered": {
+      "description": "Payload for auth.provider_recovered — emitted when Kratos is reachable again.",
+      "type": "object",
+      "required": ["provider_url"],
+      "additionalProperties": false,
+      "properties": {
+        "provider_url": {
+          "type": "string",
+          "description": "URL of the recovered auth provider."
+        }
+      }
+    },
+    "payload_api_key_success": {
+      "description": "Payload for auth.api_key.success — emitted when a request is authenticated via API key.",
+      "type": "object",
+      "required": ["method", "path", "key_name", "scopes"],
+      "additionalProperties": false,
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the authenticated request."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path of the authenticated request."
+        },
+        "key_name": {
+          "type": "string",
+          "description": "Human-readable name of the API key that was accepted."
+        },
+        "scopes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of scopes granted by the key."
+        }
+      }
+    },
+    "payload_api_key_failed": {
+      "description": "Payload for auth.api_key.failed — emitted when a request is rejected due to a missing or invalid API key.",
+      "type": "object",
+      "required": ["method", "path", "reason"],
+      "additionalProperties": false,
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the rejected request."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path of the rejected request."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Short description of why the request was rejected."
+        }
+      }
+    },
+    "payload_api_key_forbidden": {
+      "description": "Payload for auth.api_key.forbidden — emitted when a valid key lacks required scopes.",
+      "type": "object",
+      "required": ["method", "path", "key_name", "key_scopes", "required_scopes"],
+      "additionalProperties": false,
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the forbidden request."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path of the forbidden request."
+        },
+        "key_name": {
+          "type": "string",
+          "description": "Human-readable name of the API key that was presented."
+        },
+        "key_scopes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of scopes held by the key."
+        },
+        "required_scopes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of scopes required by the matching scope rule."
+        }
+      }
+    },
+    "payload_jwt_valid": {
+      "description": "Payload for auth.jwt_valid — emitted when a JWT token passes all validation checks.",
+      "type": "object",
+      "required": ["method", "path", "subject", "issuer", "audience"],
+      "additionalProperties": false,
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the authenticated request."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path of the authenticated request."
+        },
+        "subject": {
+          "type": "string",
+          "description": "The 'sub' claim value from the validated token."
+        },
+        "issuer": {
+          "type": "string",
+          "description": "The 'iss' claim value from the validated token."
+        },
+        "audience": {
+          "type": "string",
+          "description": "The 'aud' claim value that was validated against."
+        }
+      }
+    },
+    "payload_jwt_invalid": {
+      "description": "Payload for auth.jwt_invalid — emitted when a JWT token fails validation.",
+      "type": "object",
+      "required": ["method", "path", "reason", "detail"],
+      "additionalProperties": false,
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the rejected request."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path of the rejected request."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Machine-readable failure code (e.g. 'invalid_signature', 'invalid_issuer')."
+        },
+        "detail": {
+          "type": "string",
+          "description": "Optional additional detail. May be empty."
+        }
+      }
+    },
+    "payload_jwt_expired": {
+      "description": "Payload for auth.jwt_expired — emitted when a JWT token is structurally valid but past expiry.",
+      "type": "object",
+      "required": ["method", "path", "subject", "expired_at"],
+      "additionalProperties": false,
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the rejected request."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path of the rejected request."
+        },
+        "subject": {
+          "type": "string",
+          "description": "The 'sub' claim value from the expired token."
+        },
+        "expired_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which the token expired (value of the 'exp' claim), RFC 3339."
+        }
+      }
+    },
+    "payload_jwks_refresh": {
+      "description": "Payload for auth.jwks_refresh — emitted when the JWKS cache is successfully refreshed.",
+      "type": "object",
+      "required": ["jwks_url", "key_count"],
+      "additionalProperties": false,
+      "properties": {
+        "jwks_url": {
+          "type": "string",
+          "description": "URL from which the key set was fetched."
+        },
+        "key_count": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Number of keys in the refreshed key set."
+        }
+      }
+    },
+    "payload_jwks_error": {
+      "description": "Payload for auth.jwks_error — emitted when fetching or parsing the JWKS fails.",
+      "type": "object",
+      "required": ["jwks_url", "detail"],
+      "additionalProperties": false,
+      "properties": {
+        "jwks_url": {
+          "type": "string",
+          "description": "URL that could not be reached."
+        },
+        "detail": {
+          "type": "string",
+          "description": "Error message describing what went wrong."
+        }
+      }
+    },
+    "payload_rate_limit_hit": {
+      "description": "Payload for rate_limit.hit — emitted when a request is rejected for exceeding the rate limit.",
+      "type": "object",
+      "required": ["limit_type", "identifier", "requests_per_second", "burst", "retry_after_seconds", "path", "method"],
+      "additionalProperties": false,
+      "properties": {
+        "limit_type": {
+          "type": "string",
+          "enum": ["ip", "user"],
+          "description": "The kind of limit that was exceeded."
+        },
+        "identifier": {
+          "type": "string",
+          "description": "The value that was rate-limited: the client IP for type 'ip', or the user ID for type 'user'."
+        },
+        "requests_per_second": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Configured rate limit in tokens per second."
+        },
+        "burst": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Configured burst capacity."
+        },
+        "retry_after_seconds": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Seconds the caller must wait before retrying."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path of the rate-limited request."
+        },
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the rate-limited request."
+        },
+        "client_ip": {
+          "type": "string",
+          "description": "Client IP address. Present only when limit_type is 'user' and the IP is known."
+        }
+      }
+    },
+    "payload_rate_limit_unidentified": {
+      "description": "Payload for rate_limit.unidentified_client — emitted when the client IP cannot be determined.",
+      "type": "object",
+      "required": ["path", "method"],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "URL path of the rejected request."
+        },
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the rejected request."
+        }
+      }
+    },
+    "payload_rate_limit_store_fallback": {
+      "description": "Payload for rate_limit.store_fallback — emitted when Redis is unavailable and the limiter switches to in-memory.",
+      "type": "object",
+      "required": ["reason", "store"],
+      "additionalProperties": false,
+      "properties": {
+        "reason": {
+          "type": "string",
+          "description": "Short description of why the fallback was triggered."
+        },
+        "store": {
+          "type": "string",
+          "const": "memory",
+          "description": "The store now in use. Always 'memory' for this event type."
+        }
+      }
+    },
+    "payload_rate_limit_store_recovered": {
+      "description": "Payload for rate_limit.store_recovered — emitted when the Redis store is reachable again.",
+      "type": "object",
+      "required": ["store"],
+      "additionalProperties": false,
+      "properties": {
+        "store": {
+          "type": "string",
+          "const": "redis",
+          "description": "The store now in use. Always 'redis' for this event type."
+        }
+      }
+    },
+    "payload_request_blocked": {
+      "description": "Payload for request.blocked — emitted when a request is blocked by a security policy.",
+      "type": "object",
+      "required": ["method", "path", "reason", "blocked_by", "client_ip"],
+      "additionalProperties": false,
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the blocked request."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path of the blocked request."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Short description of why the request was blocked."
+        },
+        "blocked_by": {
+          "type": "string",
+          "description": "Middleware or policy that blocked the request (e.g. 'ip_blocklist', 'waf')."
+        },
+        "client_ip": {
+          "type": "string",
+          "description": "Client IP address. Empty string if it could not be determined."
+        }
+      }
+    },
+    "payload_tls_certificate_issued": {
+      "description": "Payload for tls.certificate_issued — emitted when a TLS certificate is obtained or renewed.",
+      "type": "object",
+      "required": ["domain", "provider", "expires_at"],
+      "additionalProperties": false,
+      "properties": {
+        "domain": {
+          "type": "string",
+          "description": "Domain name for which the certificate was issued."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Certificate authority or provider (e.g. 'letsencrypt', 'self-signed')."
+        },
+        "expires_at": {
+          "type": "string",
+          "description": "Certificate expiry time in RFC 3339 format."
+        }
+      }
+    },
+    "payload_user_created": {
+      "description": "Payload for user.created — emitted when a new user identity is created.",
+      "type": "object",
+      "required": ["identity_id", "email", "actor_id"],
+      "additionalProperties": false,
+      "properties": {
+        "identity_id": {
+          "type": "string",
+          "description": "Identity provider identifier for the new user."
+        },
+        "email": {
+          "type": "string",
+          "description": "Email address of the new user."
+        },
+        "actor_id": {
+          "type": "string",
+          "description": "Identifier of the admin who performed the action. Empty string when performed by the system."
+        }
+      }
+    },
+    "payload_user_deleted": {
+      "description": "Payload for user.deleted — emitted when a user identity is deleted.",
+      "type": "object",
+      "required": ["identity_id", "email", "actor_id", "reason"],
+      "additionalProperties": false,
+      "properties": {
+        "identity_id": {
+          "type": "string",
+          "description": "Identity provider identifier of the deleted user."
+        },
+        "email": {
+          "type": "string",
+          "description": "Email address of the deleted user."
+        },
+        "actor_id": {
+          "type": "string",
+          "description": "Identifier of the admin who performed the action. Empty string when performed by the system."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Optional human-readable explanation for the deletion. Empty string when not provided."
+        }
+      }
+    },
+    "payload_user_deactivated": {
+      "description": "Payload for user.deactivated — emitted when a user identity is deactivated.",
+      "type": "object",
+      "required": ["identity_id", "email", "actor_id", "reason"],
+      "additionalProperties": false,
+      "properties": {
+        "identity_id": {
+          "type": "string",
+          "description": "Identity provider identifier of the deactivated user."
+        },
+        "email": {
+          "type": "string",
+          "description": "Email address of the deactivated user."
+        },
+        "actor_id": {
+          "type": "string",
+          "description": "Identifier of the admin who performed the action. Empty string when performed by the system."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Optional human-readable explanation for the deactivation. Empty string when not provided."
+        }
+      }
+    },
+    "payload_audit_log_failure": {
+      "description": "Payload for audit.log_failure — emitted when an audit entry cannot be persisted.",
+      "type": "object",
+      "required": ["action", "user_id", "error"],
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "type": "string",
+          "description": "Audit action that failed to be persisted (e.g. 'user.created')."
+        },
+        "user_id": {
+          "type": "string",
+          "description": "User affected by the action that was not audited."
+        },
+        "error": {
+          "type": "string",
+          "description": "Short description of the persistence failure."
+        }
+      }
+    },
+    "payload_ip_filter_blocked": {
+      "description": "Payload for ip_filter.blocked — emitted when a request is rejected by the IP filter plugin.",
+      "type": "object",
+      "required": ["client_ip", "mode", "method", "path"],
+      "additionalProperties": false,
+      "properties": {
+        "client_ip": {
+          "type": "string",
+          "description": "IP address that was blocked."
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["allowlist", "blocklist"],
+          "description": "Filter mode in effect."
+        },
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the blocked request."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path of the blocked request."
+        }
+      }
+    },
+    "payload_secret_rotated": {
+      "description": "Payload for secret.rotated — emitted when a dynamic secret is successfully rotated.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "secret_name": {
+          "type": "string",
+          "description": "Human-readable name or identifier of the rotated secret."
+        },
+        "backend": {
+          "type": "string",
+          "description": "Secret backend that performed the rotation (e.g. 'openbao', 'vault')."
+        }
+      }
+    },
+    "payload_secret_rotation_failed": {
+      "description": "Payload for secret.rotation_failed — emitted when a dynamic secret rotation attempt fails.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "secret_name": {
+          "type": "string",
+          "description": "Human-readable name or identifier of the secret whose rotation failed."
+        },
+        "error": {
+          "type": "string",
+          "description": "Short description of the failure."
+        }
+      }
+    },
+    "payload_secret_health_check": {
+      "description": "Payload for secret.health_check — emitted on each scheduled secret health check run.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "findings": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of findings from the health check. Empty array when healthy."
+        }
+      }
+    },
+    "payload_upstream_timeout": {
+      "description": "Payload for upstream.timeout — emitted when the upstream does not respond within the configured timeout.",
+      "type": "object",
+      "required": ["method", "path", "timeout_seconds", "client_ip"],
+      "additionalProperties": false,
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the timed-out request."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path of the timed-out request."
+        },
+        "timeout_seconds": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Configured upstream timeout in seconds."
+        },
+        "client_ip": {
+          "type": "string",
+          "description": "Remote client IP address."
+        }
+      }
+    },
+    "payload_upstream_retry": {
+      "description": "Payload for upstream.retry — emitted each time the retry middleware re-sends a failed upstream request.",
+      "type": "object",
+      "required": ["method", "path", "attempt", "status_code", "client_ip"],
+      "additionalProperties": false,
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the retried request."
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path of the retried request."
+        },
+        "attempt": {
+          "type": "number",
+          "minimum": 1,
+          "description": "Retry attempt number (1 = first retry, 2 = second retry, ...)."
+        },
+        "status_code": {
+          "type": "number",
+          "minimum": 100,
+          "maximum": 599,
+          "description": "Upstream HTTP status code that triggered the retry."
+        },
+        "client_ip": {
+          "type": "string",
+          "description": "Remote client IP address."
+        }
+      }
+    },
+    "payload_upstream_health_changed": {
+      "description": "Payload for upstream.health_changed — emitted when the upstream health status transitions.",
+      "type": "object",
+      "required": ["previous_status", "new_status", "consecutive", "upstream_url"],
+      "additionalProperties": false,
+      "properties": {
+        "previous_status": {
+          "type": "string",
+          "enum": ["unknown", "healthy", "unhealthy"],
+          "description": "Health status before the transition."
+        },
+        "new_status": {
+          "type": "string",
+          "enum": ["unknown", "healthy", "unhealthy"],
+          "description": "Health status after the transition."
+        },
+        "consecutive": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Number of consecutive successes or failures that triggered the transition."
+        },
+        "upstream_url": {
+          "type": "string",
+          "description": "URL that was probed (host + path, no credentials)."
+        },
+        "last_error": {
+          "type": "string",
+          "description": "Error message from the most recent probe. Present only when new_status is 'unhealthy'."
+        }
+      }
+    },
+    "payload_circuit_breaker_opened": {
+      "description": "Payload for circuit_breaker.opened — emitted when the circuit breaker trips from Closed to Open.",
+      "type": "object",
+      "required": ["threshold", "timeout_seconds"],
+      "additionalProperties": false,
+      "properties": {
+        "threshold": {
+          "type": "number",
+          "minimum": 1,
+          "description": "Consecutive failure count that tripped the circuit."
+        },
+        "timeout_seconds": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Duration the circuit will remain open before allowing a probe, in seconds."
+        }
+      }
+    },
+    "payload_circuit_breaker_half_open": {
+      "description": "Payload for circuit_breaker.half_open — emitted when the circuit breaker enters HalfOpen state.",
+      "type": "object",
+      "required": ["timeout_seconds"],
+      "additionalProperties": false,
+      "properties": {
+        "timeout_seconds": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Open timeout that elapsed before the probe, in seconds."
+        }
+      }
+    },
+    "payload_circuit_breaker_closed": {
+      "description": "Payload for circuit_breaker.closed — emitted when the circuit breaker returns to Closed after a successful probe.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {}
+    },
+    "payload_egress_request": {
+      "description": "Payload for egress.request — emitted when the egress proxy begins forwarding an outbound request.",
+      "type": "object",
+      "required": ["route", "method", "url", "trace_id"],
+      "additionalProperties": false,
+      "properties": {
+        "route": {
+          "type": "string",
+          "description": "Matched egress route name. Empty string when unmatched."
+        },
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the outbound request."
+        },
+        "url": {
+          "type": "string",
+          "description": "Destination URL of the outbound request. Never includes bearer tokens or credentials."
+        },
+        "trace_id": {
+          "type": "string",
+          "description": "W3C trace-id of the inbound request. Empty string when no trace context is available."
+        }
+      }
+    },
+    "payload_egress_response": {
+      "description": "Payload for egress.response — emitted when the egress proxy receives a complete response.",
+      "type": "object",
+      "required": ["route", "method", "url", "status_code", "duration_seconds", "attempts", "trace_id"],
+      "additionalProperties": false,
+      "properties": {
+        "route": {
+          "type": "string",
+          "description": "Matched egress route name. Empty string when unmatched."
+        },
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the outbound request."
+        },
+        "url": {
+          "type": "string",
+          "description": "Destination URL of the outbound request."
+        },
+        "status_code": {
+          "type": "number",
+          "minimum": 100,
+          "maximum": 599,
+          "description": "HTTP status code returned by the external service."
+        },
+        "duration_seconds": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Complete round-trip duration in seconds."
+        },
+        "attempts": {
+          "type": "number",
+          "minimum": 1,
+          "description": "Total number of upstream attempts (1 = no retries)."
+        },
+        "trace_id": {
+          "type": "string",
+          "description": "W3C trace-id of the inbound request. Empty string when no trace context is available."
+        }
+      }
+    },
+    "payload_egress_blocked": {
+      "description": "Payload for egress.blocked — emitted when the egress proxy refuses to forward a request due to policy.",
+      "type": "object",
+      "required": ["route", "method", "url", "reason", "trace_id"],
+      "additionalProperties": false,
+      "properties": {
+        "route": {
+          "type": "string",
+          "description": "Matched route name. Empty string when no route matched."
+        },
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the blocked outbound request."
+        },
+        "url": {
+          "type": "string",
+          "description": "Destination URL of the blocked outbound request."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Short human-readable description of why the request was blocked."
+        },
+        "trace_id": {
+          "type": "string",
+          "description": "W3C trace-id of the inbound request. Empty string when no trace context is available."
+        }
+      }
+    },
+    "payload_egress_error": {
+      "description": "Payload for egress.error — emitted when the egress proxy encounters a transport-level error.",
+      "type": "object",
+      "required": ["route", "method", "url", "error", "attempts", "trace_id"],
+      "additionalProperties": false,
+      "properties": {
+        "route": {
+          "type": "string",
+          "description": "Matched egress route name. Empty string when unmatched."
+        },
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the failed outbound request."
+        },
+        "url": {
+          "type": "string",
+          "description": "Destination URL of the failed outbound request."
+        },
+        "error": {
+          "type": "string",
+          "description": "Human-readable error message. Never includes credentials."
+        },
+        "attempts": {
+          "type": "number",
+          "minimum": 1,
+          "description": "Total number of upstream attempts made before failing."
+        },
+        "trace_id": {
+          "type": "string",
+          "description": "W3C trace-id of the inbound request. Empty string when no trace context is available."
+        }
+      }
+    },
+    "payload_egress_sanitized": {
+      "description": "Payload for egress.sanitized — emitted after the egress proxy applies PII redaction rules.",
+      "type": "object",
+      "required": ["route", "method", "url", "redacted_headers", "stripped_query_params", "redacted_body_fields", "total_redacted", "trace_id"],
+      "additionalProperties": false,
+      "properties": {
+        "route": {
+          "type": "string",
+          "description": "Matched egress route name."
+        },
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the outbound request."
+        },
+        "url": {
+          "type": "string",
+          "description": "Destination URL of the outbound request."
+        },
+        "redacted_headers": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Count of request headers whose log values were replaced with '[REDACTED]'."
+        },
+        "stripped_query_params": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Count of query parameters removed from the request URL before forwarding."
+        },
+        "redacted_body_fields": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Count of JSON body fields replaced with '[REDACTED]' before the request was forwarded."
+        },
+        "total_redacted": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Total count of redacted fields (sum of the three categories above)."
+        },
+        "trace_id": {
+          "type": "string",
+          "description": "W3C trace-id of the inbound request. Empty string when no trace context is available."
+        }
+      }
+    },
+    "payload_egress_response_invalid": {
+      "description": "Payload for egress.response_invalid — emitted when the upstream response fails per-route validation.",
+      "type": "object",
+      "required": ["route", "method", "url", "status_code", "content_type", "reason", "trace_id"],
+      "additionalProperties": false,
+      "properties": {
+        "route": {
+          "type": "string",
+          "description": "Matched egress route name."
+        },
+        "method": {
+          "type": "string",
+          "description": "HTTP method of the outbound request."
+        },
+        "url": {
+          "type": "string",
+          "description": "Destination URL of the outbound request."
+        },
+        "status_code": {
+          "type": "number",
+          "minimum": 100,
+          "maximum": 599,
+          "description": "HTTP status code returned by the upstream."
+        },
+        "content_type": {
+          "type": "string",
+          "description": "Content-Type header value returned by the upstream."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Short human-readable description of why the response was considered invalid."
+        },
+        "trace_id": {
+          "type": "string",
+          "description": "W3C trace-id of the inbound request. Empty string when no trace context is available."
+        }
+      }
+    },
+    "payload_egress_rate_limit_hit": {
+      "description": "Payload for egress.rate_limit_hit — emitted when an outbound request is rejected by a per-route rate limit.",
+      "type": "object",
+      "required": ["route", "limit", "retry_after_seconds"],
+      "additionalProperties": false,
+      "properties": {
+        "route": {
+          "type": "string",
+          "description": "Egress route name whose rate limit was exceeded."
+        },
+        "limit": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Configured rate limit in requests per second."
+        },
+        "retry_after_seconds": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Seconds the caller should wait before retrying."
+        }
+      }
+    },
+    "payload_egress_circuit_breaker_opened": {
+      "description": "Payload for egress.circuit_breaker.opened — emitted when the per-route egress circuit breaker trips.",
+      "type": "object",
+      "required": ["route", "threshold", "timeout_seconds"],
+      "additionalProperties": false,
+      "properties": {
+        "route": {
+          "type": "string",
+          "description": "Egress route name whose circuit tripped."
+        },
+        "threshold": {
+          "type": "number",
+          "minimum": 1,
+          "description": "Consecutive failure count that tripped the circuit."
+        },
+        "timeout_seconds": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Duration the circuit will remain open before allowing a probe request, in seconds."
+        }
+      }
+    },
+    "payload_egress_circuit_breaker_closed": {
+      "description": "Payload for egress.circuit_breaker.closed — emitted when the per-route egress circuit breaker returns to Closed.",
+      "type": "object",
+      "required": ["route"],
+      "additionalProperties": false,
+      "properties": {
+        "route": {
+          "type": "string",
+          "description": "Egress route name whose circuit closed."
+        }
+      }
+    }
+  }
+}

--- a/schema/v1/schema_validate_test.go
+++ b/schema/v1/schema_validate_test.go
@@ -1,0 +1,524 @@
+// Package schema_test validates that sample events produced by the domain layer
+// conform to the published VibeWarden v1 event JSON Schema.
+//
+// The test round-trips each event constructor through the SlogEventLogger (JSON
+// serialisation) and then validates the resulting JSON object against
+// schema/v1/event.json using santhosh-tekuri/jsonschema v6 (Apache 2.0).
+package schema_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	jsschema "github.com/santhosh-tekuri/jsonschema/v6"
+
+	"github.com/vibewarden/vibewarden/internal/adapters/log"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+)
+
+// schemaPath returns the absolute path to schema/v1/event.json relative to
+// this test file so the test works regardless of the working directory.
+func schemaPath() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(file), "event.json")
+}
+
+// compileSchema compiles the event.json schema and returns it.
+func compileSchema(t *testing.T) *jsschema.Schema {
+	t.Helper()
+	c := jsschema.NewCompiler()
+	// Enable format assertions (date-time, etc.)
+	c.AssertFormat()
+	sch, err := c.Compile(schemaPath())
+	if err != nil {
+		t.Fatalf("compile schema: %v", err)
+	}
+	return sch
+}
+
+// marshalEvent serialises an event to a JSON object via SlogEventLogger so that
+// the test exercises the exact same serialisation path as production code.
+func marshalEvent(t *testing.T, event events.Event) any {
+	t.Helper()
+	var buf bytes.Buffer
+	logger := log.NewSlogEventLogger(&buf)
+	if err := logger.Log(context.Background(), event); err != nil {
+		t.Fatalf("log event: %v", err)
+	}
+	inst, err := jsschema.UnmarshalJSON(strings.NewReader(buf.String()))
+	if err != nil {
+		t.Fatalf("unmarshal logged JSON: %v\nraw: %s", err, buf.String())
+	}
+	return inst
+}
+
+// assertValid validates inst against sch, failing the test on schema violations.
+func assertValid(t *testing.T, sch *jsschema.Schema, inst any) {
+	t.Helper()
+	if err := sch.Validate(inst); err != nil {
+		// Pretty-print the raw event for debugging.
+		raw, _ := json.MarshalIndent(inst, "", "  ")
+		t.Errorf("schema validation failed:\n%v\nevent JSON:\n%s", err, raw)
+	}
+}
+
+// TestSchemaValidation generates one sample event per event_type and validates
+// each against schema/v1/event.json. The test fails when any generated event
+// does not conform to the schema.
+func TestSchemaValidation(t *testing.T) {
+	sch := compileSchema(t)
+
+	// sampleTime is a fixed UTC time used where a time.Time field is needed.
+	sampleTime := time.Date(2026, 3, 28, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		event events.Event
+	}{
+		// --- proxy ---
+		{
+			name: "proxy.started",
+			event: events.NewProxyStarted(events.ProxyStartedParams{
+				ListenAddr:             ":443",
+				UpstreamAddr:           "localhost:3000",
+				TLSEnabled:             true,
+				TLSProvider:            "letsencrypt",
+				SecurityHeadersEnabled: true,
+				Version:                "1.0.0",
+			}),
+		},
+		{
+			name: "proxy.kratos_flow",
+			event: events.NewProxyKratosFlow(events.ProxyKratosFlowParams{
+				Method: "GET",
+				Path:   "/self-service/login/browser",
+			}),
+		},
+		// --- auth ---
+		{
+			name: "auth.success",
+			event: events.NewAuthSuccess(events.AuthSuccessParams{
+				Method:     "GET",
+				Path:       "/api/data",
+				SessionID:  "sess-abc123",
+				IdentityID: "id-xyz456",
+				Email:      "alice@example.com",
+			}),
+		},
+		{
+			name: "auth.failed",
+			event: events.NewAuthFailed(events.AuthFailedParams{
+				Method: "GET",
+				Path:   "/dashboard",
+				Reason: "missing session cookie",
+				Detail: "",
+			}),
+		},
+		{
+			name: "auth.provider_unavailable",
+			event: events.NewAuthProviderUnavailable(events.AuthProviderUnavailableParams{
+				ProviderURL:  "http://kratos:4433",
+				Error:        "connection refused",
+				AffectedPath: "/api/data",
+			}),
+		},
+		{
+			name: "auth.provider_recovered",
+			event: events.NewAuthProviderRecovered(events.AuthProviderRecoveredParams{
+				ProviderURL: "http://kratos:4433",
+			}),
+		},
+		// --- api key ---
+		{
+			name: "auth.api_key.success",
+			event: events.NewAPIKeySuccess(events.APIKeySuccessParams{
+				Method:  "GET",
+				Path:    "/api/resource",
+				KeyName: "my-key",
+				Scopes:  []string{"read", "write"},
+			}),
+		},
+		{
+			name: "auth.api_key.failed",
+			event: events.NewAPIKeyFailed(events.APIKeyFailedParams{
+				Method: "GET",
+				Path:   "/api/resource",
+				Reason: "missing api key",
+			}),
+		},
+		{
+			name: "auth.api_key.forbidden",
+			event: events.NewAPIKeyForbidden(events.APIKeyForbiddenParams{
+				Method:         "POST",
+				Path:           "/admin/users",
+				KeyName:        "readonly-key",
+				KeyScopes:      []string{"read"},
+				RequiredScopes: []string{"admin"},
+			}),
+		},
+		// --- jwt ---
+		{
+			name: "auth.jwt_valid",
+			event: events.NewJWTValid(events.JWTValidParams{
+				Method:   "GET",
+				Path:     "/api/data",
+				Subject:  "user-123",
+				Issuer:   "https://idp.example.com",
+				Audience: "api.example.com",
+			}),
+		},
+		{
+			name: "auth.jwt_invalid",
+			event: events.NewJWTInvalid(events.JWTInvalidParams{
+				Method: "GET",
+				Path:   "/api/data",
+				Reason: "invalid_signature",
+				Detail: "signature verification failed",
+			}),
+		},
+		{
+			name: "auth.jwt_expired",
+			event: events.NewJWTExpired(events.JWTExpiredParams{
+				Method:    "GET",
+				Path:      "/api/data",
+				Subject:   "user-123",
+				ExpiredAt: sampleTime.Add(-1 * time.Hour),
+			}),
+		},
+		{
+			name: "auth.jwks_refresh",
+			event: events.NewJWKSRefresh(events.JWKSRefreshParams{
+				JWKSURL:  "https://idp.example.com/.well-known/jwks.json",
+				KeyCount: 3,
+			}),
+		},
+		{
+			name: "auth.jwks_error",
+			event: events.NewJWKSError(events.JWKSErrorParams{
+				JWKSURL: "https://idp.example.com/.well-known/jwks.json",
+				Detail:  "connection timeout",
+			}),
+		},
+		// --- rate limit ---
+		{
+			name: "rate_limit.hit (ip)",
+			event: events.NewRateLimitHit(events.RateLimitHitParams{
+				LimitType:         "ip",
+				Identifier:        "192.168.1.1",
+				RequestsPerSecond: 10,
+				Burst:             20,
+				RetryAfterSeconds: 3,
+				Path:              "/api/data",
+				Method:            "GET",
+			}),
+		},
+		{
+			name: "rate_limit.hit (user)",
+			event: events.NewRateLimitHit(events.RateLimitHitParams{
+				LimitType:         "user",
+				Identifier:        "user-123",
+				RequestsPerSecond: 100,
+				Burst:             200,
+				RetryAfterSeconds: 1,
+				Path:              "/api/data",
+				Method:            "GET",
+				ClientIP:          "10.0.0.5",
+			}),
+		},
+		{
+			name: "rate_limit.unidentified_client",
+			event: events.NewRateLimitUnidentified(events.RateLimitUnidentifiedParams{
+				Path:   "/api/resource",
+				Method: "GET",
+			}),
+		},
+		{
+			name: "rate_limit.store_fallback",
+			event: events.NewRateLimitStoreFallback(events.RateLimitStoreFallbackParams{
+				Reason: "redis: connection refused",
+			}),
+		},
+		{
+			name:  "rate_limit.store_recovered",
+			event: events.NewRateLimitStoreRecovered(),
+		},
+		// --- request ---
+		{
+			name: "request.blocked",
+			event: events.NewRequestBlocked(events.RequestBlockedParams{
+				Method:    "GET",
+				Path:      "/admin",
+				Reason:    "IP blocklist match",
+				BlockedBy: "ip_blocklist",
+				ClientIP:  "1.2.3.4",
+			}),
+		},
+		// --- tls ---
+		{
+			name: "tls.certificate_issued",
+			event: events.NewTLSCertificateIssued(events.TLSCertificateIssuedParams{
+				Domain:    "example.com",
+				Provider:  "letsencrypt",
+				ExpiresAt: "2026-06-26T00:00:00Z",
+			}),
+		},
+		// --- user ---
+		{
+			name: "user.created",
+			event: events.NewUserCreated(events.UserCreatedParams{
+				IdentityID: "id-newuser001",
+				Email:      "newuser@example.com",
+				ActorID:    "admin-001",
+			}),
+		},
+		{
+			name: "user.deleted",
+			event: events.NewUserDeleted(events.UserDeletedParams{
+				IdentityID: "id-olduser007",
+				Email:      "leavinguser@example.com",
+				ActorID:    "admin-001",
+				Reason:     "account requested",
+			}),
+		},
+		{
+			name: "user.deactivated",
+			event: events.NewUserDeactivated(events.UserDeactivatedParams{
+				IdentityID: "id-user001",
+				Email:      "user@example.com",
+				ActorID:    "admin-001",
+				Reason:     "policy violation",
+			}),
+		},
+		// --- audit ---
+		{
+			name: "audit.log_failure",
+			event: events.NewAuditLogFailure(events.AuditLogFailureParams{
+				Action: "user.created",
+				UserID: "id-xyz",
+				Error:  "postgres: connection refused",
+			}),
+		},
+		// --- ip filter ---
+		{
+			name: "ip_filter.blocked",
+			event: events.NewIPFilterBlocked(events.IPFilterBlockedParams{
+				ClientIP: "192.168.1.100",
+				Mode:     "allowlist",
+				Method:   "GET",
+				Path:     "/api/data",
+			}),
+		},
+		// --- upstream ---
+		{
+			name: "upstream.timeout",
+			event: events.NewUpstreamTimeout(events.UpstreamTimeoutParams{
+				Method:         "GET",
+				Path:           "/slow",
+				TimeoutSeconds: 30,
+				ClientIP:       "10.0.0.1",
+			}),
+		},
+		{
+			name: "upstream.retry",
+			event: events.NewUpstreamRetry(events.UpstreamRetryParams{
+				Method:     "GET",
+				Path:       "/api/data",
+				Attempt:    1,
+				StatusCode: 503,
+				ClientIP:   "10.0.0.1",
+			}),
+		},
+		{
+			name: "upstream.health_changed (healthy)",
+			event: events.NewUpstreamHealthChanged(events.UpstreamHealthChangedParams{
+				PreviousStatus:   "unknown",
+				NewStatus:        "healthy",
+				ConsecutiveCount: 3,
+				UpstreamURL:      "http://localhost:3000/health",
+			}),
+		},
+		{
+			name: "upstream.health_changed (unhealthy)",
+			event: events.NewUpstreamHealthChanged(events.UpstreamHealthChangedParams{
+				PreviousStatus:   "healthy",
+				NewStatus:        "unhealthy",
+				ConsecutiveCount: 5,
+				UpstreamURL:      "http://localhost:3000/health",
+				LastError:        "connection refused",
+			}),
+		},
+		// --- circuit breaker ---
+		{
+			name: "circuit_breaker.opened",
+			event: events.NewCircuitBreakerOpened(events.CircuitBreakerOpenedParams{
+				Threshold:      5,
+				TimeoutSeconds: 30,
+			}),
+		},
+		{
+			name: "circuit_breaker.half_open",
+			event: events.NewCircuitBreakerHalfOpen(events.CircuitBreakerHalfOpenParams{
+				TimeoutSeconds: 30,
+			}),
+		},
+		{
+			name:  "circuit_breaker.closed",
+			event: events.NewCircuitBreakerClosed(),
+		},
+		// --- egress ---
+		{
+			name: "egress.request",
+			event: events.NewEgressRequest(events.EgressRequestParams{
+				Route:   "payments",
+				Method:  "POST",
+				URL:     "https://api.stripe.com/v1/charges",
+				TraceID: "",
+			}),
+		},
+		{
+			name: "egress.response",
+			event: events.NewEgressResponse(events.EgressResponseParams{
+				Route:           "payments",
+				Method:          "POST",
+				URL:             "https://api.stripe.com/v1/charges",
+				StatusCode:      200,
+				DurationSeconds: 0.342,
+				Attempts:        1,
+				TraceID:         "",
+			}),
+		},
+		{
+			name: "egress.blocked",
+			event: events.NewEgressBlocked(events.EgressBlockedParams{
+				Route:   "",
+				Method:  "GET",
+				URL:     "http://internal.corp/secrets",
+				Reason:  "no route matched default deny policy",
+				TraceID: "",
+			}),
+		},
+		{
+			name: "egress.error",
+			event: events.NewEgressError(events.EgressErrorParams{
+				Route:    "payments",
+				Method:   "POST",
+				URL:      "https://api.stripe.com/v1/charges",
+				Error:    "connection refused",
+				Attempts: 3,
+				TraceID:  "",
+			}),
+		},
+		{
+			name: "egress.sanitized",
+			event: events.NewEgressSanitized(events.EgressSanitizedParams{
+				Route:               "analytics",
+				Method:              "POST",
+				URL:                 "https://analytics.example.com/track",
+				RedactedHeaders:     1,
+				StrippedQueryParams: 2,
+				RedactedBodyFields:  3,
+				TraceID:             "",
+			}),
+		},
+		{
+			name: "egress.response_invalid",
+			event: events.NewEgressResponseInvalid(events.EgressResponseInvalidParams{
+				Route:       "api",
+				Method:      "GET",
+				URL:         "https://api.example.com/data",
+				StatusCode:  500,
+				ContentType: "text/html",
+				Reason:      "status code not allowed",
+				TraceID:     "",
+			}),
+		},
+		{
+			name: "egress.rate_limit_hit",
+			event: events.NewEgressRateLimitHit(events.EgressRateLimitHitParams{
+				Route:             "payments",
+				Limit:             10.0,
+				RetryAfterSeconds: 5.0,
+			}),
+		},
+		{
+			name: "egress.circuit_breaker.opened",
+			event: events.NewEgressCircuitBreakerOpened(events.EgressCircuitBreakerOpenedParams{
+				Route:          "payments",
+				Threshold:      3,
+				TimeoutSeconds: 60,
+			}),
+		},
+		{
+			name: "egress.circuit_breaker.closed",
+			event: events.NewEgressCircuitBreakerClosed(events.EgressCircuitBreakerClosedParams{
+				Route: "payments",
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inst := marshalEvent(t, tt.event)
+			assertValid(t, sch, inst)
+		})
+	}
+}
+
+// TestSchemaRejectsInvalidEvents verifies that the schema correctly rejects
+// documents that violate structural constraints.
+func TestSchemaRejectsInvalidEvents(t *testing.T) {
+	sch := compileSchema(t)
+
+	tests := []struct {
+		name    string
+		jsonStr string
+	}{
+		{
+			name:    "missing schema_version",
+			jsonStr: `{"event_type":"auth.success","timestamp":"2026-03-28T12:00:00Z","ai_summary":"ok","payload":{}}`,
+		},
+		{
+			name:    "wrong schema_version",
+			jsonStr: `{"schema_version":"v2","event_type":"auth.success","timestamp":"2026-03-28T12:00:00Z","ai_summary":"ok","payload":{}}`,
+		},
+		{
+			name:    "unknown event_type",
+			jsonStr: `{"schema_version":"v1","event_type":"unknown.type","timestamp":"2026-03-28T12:00:00Z","ai_summary":"ok","payload":{}}`,
+		},
+		{
+			name:    "missing required field payload",
+			jsonStr: `{"schema_version":"v1","event_type":"auth.success","timestamp":"2026-03-28T12:00:00Z","ai_summary":"ok"}`,
+		},
+		{
+			name:    "ai_summary exceeds 200 chars",
+			jsonStr: fmt.Sprintf(`{"schema_version":"v1","event_type":"auth.success","timestamp":"2026-03-28T12:00:00Z","ai_summary":%q,"payload":{}}`, strings.Repeat("x", 201)),
+		},
+		{
+			name:    "invalid timestamp format",
+			jsonStr: `{"schema_version":"v1","event_type":"auth.success","timestamp":"not-a-date","ai_summary":"ok","payload":{}}`,
+		},
+		{
+			name:    "additional top-level property",
+			jsonStr: `{"schema_version":"v1","event_type":"auth.success","timestamp":"2026-03-28T12:00:00Z","ai_summary":"ok","payload":{},"extra_field":"bad"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inst, err := jsschema.UnmarshalJSON(strings.NewReader(tt.jsonStr))
+			if err != nil {
+				t.Fatalf("unmarshal test JSON: %v", err)
+			}
+			if err := sch.Validate(inst); err == nil {
+				t.Errorf("expected schema validation to fail for %q, but it passed", tt.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #423

## Summary

- Adds `schema/v1/event.json` — the VibeWarden v1 event JSON Schema using JSON Schema draft 2020-12
- Schema covers all 43 event types with typed payload field constraints (required fields, types, enums, minimum/maximum) via `if/then` dispatching on `event_type`
- Top-level structure enforces `schema_version: "v1"`, `event_type` (enum), RFC 3339 `timestamp`, `ai_summary` (max 200 chars), `payload`, and optional `trace_id`/`span_id` OTel fields
- Adds `schema/v1/schema_validate_test.go` with two test functions:
  - `TestSchemaValidation`: generates a sample event for all 43 event types via their constructor functions, round-trips through `SlogEventLogger` (real JSON serialisation), and validates each against the schema
  - `TestSchemaRejectsInvalidEvents`: confirms the schema correctly rejects malformed events (wrong schema_version, unknown event_type, missing required fields, oversized ai_summary, invalid timestamp, extra top-level properties)
- Adds `github.com/santhosh-tekuri/jsonschema/v6` (Apache 2.0) as a test dependency

## Test plan

- [ ] `make check` passes (all 50 new subtests pass, full test suite clean)
- [ ] `schema/v1/event.json` is valid JSON Schema draft 2020-12
- [ ] Every event type from `internal/domain/events/` has a corresponding test case
- [ ] `TestSchemaRejectsInvalidEvents` confirms constraint enforcement
