### PR TITLE
feat(#426): implement vibew doctor diagnostic command

### DIFF
--- a/internal/adapters/ops/compose.go
+++ b/internal/adapters/ops/compose.go
@@ -2,9 +2,13 @@
 package ops
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
 // ComposeAdapter implements ports.ComposeRunner by shelling out to the
@@ -60,4 +64,46 @@ func (c *ComposeAdapter) Info(ctx context.Context) error {
 		return fmt.Errorf("docker info: %w", err)
 	}
 	return nil
+}
+
+// composeContainer is the JSON shape produced by "docker compose ps --format json".
+type composeContainer struct {
+	Name    string `json:"Name"`
+	Service string `json:"Service"`
+	State   string `json:"State"`
+	Health  string `json:"Health"`
+}
+
+// PS runs "docker compose [-f <composeFile>] ps --format json" and returns one
+// ContainerInfo per container.  An empty slice is returned when no containers
+// are running (not an error).
+func (c *ComposeAdapter) PS(ctx context.Context, composeFile string) ([]ports.ContainerInfo, error) {
+	args := []string{"compose"}
+	if composeFile != "" {
+		args = append(args, "-f", composeFile)
+	}
+	args = append(args, "ps", "--format", "json")
+
+	out, err := exec.CommandContext(ctx, "docker", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker compose ps: %w", err)
+	}
+
+	// "docker compose ps --format json" outputs one JSON object per line.
+	var results []ports.ContainerInfo
+	dec := json.NewDecoder(bytes.NewReader(out))
+	for dec.More() {
+		var ct composeContainer
+		if err := dec.Decode(&ct); err != nil {
+			// Ignore malformed lines; best-effort parsing.
+			continue
+		}
+		results = append(results, ports.ContainerInfo{
+			Name:    ct.Name,
+			Service: ct.Service,
+			State:   ct.State,
+			Health:  ct.Health,
+		})
+	}
+	return results, nil
 }

--- a/internal/adapters/ops/compose_test.go
+++ b/internal/adapters/ops/compose_test.go
@@ -108,6 +108,21 @@ func TestComposeAdapter_InfoReturnsErrorWhenDockerMissing(t *testing.T) {
 	}
 }
 
+func TestComposeAdapter_PS_CancelledContext(t *testing.T) {
+	if !dockerAvailable() {
+		t.Skip("docker binary not available")
+	}
+
+	adapter := opsadapter.NewComposeAdapter()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := adapter.PS(ctx, "")
+	if err == nil {
+		t.Fatal("expected an error because context was cancelled")
+	}
+}
+
 // commandArgs is a helper used in table-driven tests to verify the args slice
 // that would be passed to docker compose up for a given composeFile and profiles.
 func commandArgs(composeFile string, profiles []string) []string {

--- a/internal/app/ops/dev_test.go
+++ b/internal/app/ops/dev_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/vibewarden/vibewarden/internal/app/ops"
 	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
 // fakeCompose is a test double for ports.ComposeRunner.
@@ -17,6 +18,8 @@ type fakeCompose struct {
 	versionStr string
 	versionErr error
 	infoErr    error
+	psResult   []ports.ContainerInfo
+	psErr      error
 
 	capturedComposeFile string
 	capturedProfiles    []string
@@ -34,6 +37,10 @@ func (f *fakeCompose) Version(_ context.Context) (string, error) {
 
 func (f *fakeCompose) Info(_ context.Context) error {
 	return f.infoErr
+}
+
+func (f *fakeCompose) PS(_ context.Context, _ string) ([]ports.ContainerInfo, error) {
+	return f.psResult, f.psErr
 }
 
 // fakeGenerator is a test double for ports.ConfigGenerator.

--- a/internal/app/ops/doctor.go
+++ b/internal/app/ops/doctor.go
@@ -2,8 +2,11 @@ package ops
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/fatih/color"
@@ -12,15 +15,30 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
+// Severity classifies the outcome of a single doctor check.
+type Severity string
+
+const (
+	// SeverityOK means the check passed.
+	SeverityOK Severity = "OK"
+	// SeverityWarn means the check found something worth noting but not critical.
+	SeverityWarn Severity = "WARN"
+	// SeverityFail means the check found a critical problem.
+	SeverityFail Severity = "FAIL"
+)
+
 // CheckResult holds the result of a single doctor check.
 type CheckResult struct {
 	// Name is a short human-readable label for the check.
-	Name string
-	// OK is true when the check passed.
-	OK bool
+	Name string `json:"name"`
+	// Severity is the outcome classification: OK, WARN, or FAIL.
+	Severity Severity `json:"severity"`
 	// Detail is an optional explanation (shown on success and failure).
-	Detail string
+	Detail string `json:"detail,omitempty"`
 }
+
+// OK returns true when the check severity is OK.
+func (c CheckResult) OK() bool { return c.Severity == SeverityOK }
 
 // DoctorService orchestrates the "vibewarden doctor" use case.
 // Every check runs independently — a failing check does not stop subsequent ones.
@@ -39,16 +57,39 @@ func NewDoctorService(compose ports.ComposeRunner, portChecker ports.PortChecker
 	}
 }
 
+// DoctorOptions controls how Run behaves.
+type DoctorOptions struct {
+	// ConfigPath is the path to the vibewarden.yaml file (used in the report label).
+	ConfigPath string
+	// WorkDir is the working directory used to resolve relative paths such as
+	// .vibewarden/generated/docker-compose.yml.  Defaults to the current directory.
+	WorkDir string
+	// JSON requests machine-readable JSON output instead of the human-readable table.
+	JSON bool
+}
+
 // Run executes all diagnostics and writes the report to out.
 // It never returns an error just because individual checks fail; the exit
 // behaviour is determined by the CLI command inspecting the results.
-func (s *DoctorService) Run(ctx context.Context, cfg *config.Config, configPath string, out io.Writer) (allOK bool, err error) {
-	checks := s.runChecks(ctx, cfg, configPath)
-	printDoctorReport(checks, out)
+func (s *DoctorService) Run(ctx context.Context, cfg *config.Config, opts DoctorOptions, out io.Writer) (allOK bool, err error) {
+	workDir := opts.WorkDir
+	if workDir == "" {
+		workDir = "."
+	}
+
+	checks := s.runChecks(ctx, cfg, opts.ConfigPath, workDir)
+
+	if opts.JSON {
+		if err := printDoctorJSON(checks, out); err != nil {
+			return false, fmt.Errorf("encoding JSON output: %w", err)
+		}
+	} else {
+		printDoctorReport(checks, out)
+	}
 
 	allOK = true
 	for _, c := range checks {
-		if !c.OK {
+		if c.Severity == SeverityFail {
 			allOK = false
 			break
 		}
@@ -57,35 +98,35 @@ func (s *DoctorService) Run(ctx context.Context, cfg *config.Config, configPath 
 }
 
 // runChecks executes every diagnostic check and returns the aggregated results.
-func (s *DoctorService) runChecks(ctx context.Context, cfg *config.Config, configPath string) []CheckResult {
+func (s *DoctorService) runChecks(ctx context.Context, cfg *config.Config, configPath, workDir string) []CheckResult {
 	var results []CheckResult
 
-	// 1. Is Docker running?
+	// 1. vibewarden.yaml present and valid
+	results = append(results, checkConfigFile(cfg, configPath))
+
+	// 2. Is Docker running?
 	results = append(results, s.checkDockerRunning(ctx))
 
-	// 2. Is Docker Compose available?
+	// 3. Is Docker Compose v2 available?
 	results = append(results, s.checkDockerCompose(ctx))
-
-	// 3. vibewarden.yaml present and valid
-	results = append(results, checkConfigFile(cfg, configPath))
 
 	// 4. Required ports available
 	proxyPort := cfg.Server.Port
 	if proxyPort == 0 {
 		proxyPort = 8080
 	}
-	results = append(results, s.checkPort(ctx, "Proxy port", cfg.Server.Host, proxyPort))
+	proxyHost := cfg.Server.Host
+	if proxyHost == "" {
+		proxyHost = "127.0.0.1"
+	}
+	results = append(results, s.checkPort(ctx, "Proxy port", proxyHost, proxyPort))
 
-	// 5. Can reach upstream app?
-	upstreamHost := cfg.Upstream.Host
-	if upstreamHost == "" {
-		upstreamHost = "127.0.0.1"
-	}
-	upstreamPort := cfg.Upstream.Port
-	if upstreamPort == 0 {
-		upstreamPort = 3000
-	}
-	results = append(results, s.checkUpstream(ctx, upstreamHost, upstreamPort))
+	// 5. Generated files present
+	generatedCompose := filepath.Join(workDir, ".vibewarden", "generated", "docker-compose.yml")
+	results = append(results, checkGeneratedFiles(generatedCompose))
+
+	// 6. If stack is running: container health
+	results = append(results, s.checkContainerHealth(ctx, generatedCompose))
 
 	return results
 }
@@ -96,15 +137,15 @@ func (s *DoctorService) checkDockerRunning(ctx context.Context) CheckResult {
 
 	if err := s.compose.Info(checkCtx); err != nil {
 		return CheckResult{
-			Name:   "Docker daemon",
-			OK:     false,
-			Detail: "not running — start Docker Desktop or the Docker service",
+			Name:     "Docker daemon",
+			Severity: SeverityFail,
+			Detail:   "not running — start Docker Desktop or the Docker service",
 		}
 	}
 	return CheckResult{
-		Name:   "Docker daemon",
-		OK:     true,
-		Detail: "running",
+		Name:     "Docker daemon",
+		Severity: SeverityOK,
+		Detail:   "running",
 	}
 }
 
@@ -115,15 +156,15 @@ func (s *DoctorService) checkDockerCompose(ctx context.Context) CheckResult {
 	version, err := s.compose.Version(checkCtx)
 	if err != nil {
 		return CheckResult{
-			Name:   "Docker Compose",
-			OK:     false,
-			Detail: "not available — install Docker Compose v2",
+			Name:     "Docker Compose",
+			Severity: SeverityFail,
+			Detail:   "not available — install Docker Compose v2",
 		}
 	}
 	return CheckResult{
-		Name:   "Docker Compose",
-		OK:     true,
-		Detail: sanitizeOneLine(version),
+		Name:     "Docker Compose",
+		Severity: SeverityOK,
+		Detail:   sanitizeOneLine(version),
 	}
 }
 
@@ -136,15 +177,15 @@ func checkConfigFile(cfg *config.Config, configPath string) CheckResult {
 
 	if cfg == nil {
 		return CheckResult{
-			Name:   "Config file",
-			OK:     false,
-			Detail: fmt.Sprintf("%s not found or invalid", label),
+			Name:     "Config file",
+			Severity: SeverityFail,
+			Detail:   fmt.Sprintf("%s not found or invalid", label),
 		}
 	}
 	return CheckResult{
-		Name:   "Config file",
-		OK:     true,
-		Detail: fmt.Sprintf("%s — valid", label),
+		Name:     "Config file",
+		Severity: SeverityOK,
+		Detail:   fmt.Sprintf("%s — valid", label),
 	}
 }
 
@@ -155,49 +196,89 @@ func (s *DoctorService) checkPort(ctx context.Context, label, host string, port 
 	available, err := s.portChecker.IsPortAvailable(checkCtx, host, port)
 	if err != nil {
 		return CheckResult{
-			Name:   label,
-			OK:     false,
-			Detail: fmt.Sprintf("port %d check failed: %v", port, err),
+			Name:     label,
+			Severity: SeverityFail,
+			Detail:   fmt.Sprintf("port %d check failed: %v", port, err),
 		}
 	}
 	if !available {
 		return CheckResult{
-			Name:   label,
-			OK:     false,
-			Detail: fmt.Sprintf("port %d is already in use", port),
+			Name:     label,
+			Severity: SeverityFail,
+			Detail:   fmt.Sprintf("port %d is already in use", port),
 		}
 	}
 	return CheckResult{
-		Name:   label,
-		OK:     true,
-		Detail: fmt.Sprintf("port %d is available", port),
+		Name:     label,
+		Severity: SeverityOK,
+		Detail:   fmt.Sprintf("port %d is available", port),
 	}
 }
 
-func (s *DoctorService) checkUpstream(ctx context.Context, host string, port int) CheckResult {
-	checkCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-
-	url := fmt.Sprintf("http://%s:%d", host, port)
-	ok, statusCode, err := s.healthChecker.CheckHealth(checkCtx, url)
+// checkGeneratedFiles verifies that the generated docker-compose.yml exists.
+func checkGeneratedFiles(composePath string) CheckResult {
+	_, err := os.Stat(composePath)
 	if err != nil {
 		return CheckResult{
-			Name:   "Upstream app",
-			OK:     false,
-			Detail: fmt.Sprintf("not reachable at %s", url),
+			Name:     "Generated files",
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("%s not found — run 'vibewarden generate' first", composePath),
 		}
 	}
-
 	return CheckResult{
-		Name:   "Upstream app",
-		OK:     ok,
-		Detail: fmt.Sprintf("reachable at %s (HTTP %d)", url, statusCode),
+		Name:     "Generated files",
+		Severity: SeverityOK,
+		Detail:   composePath,
 	}
 }
 
-// printDoctorReport renders the check results to out.
+// checkContainerHealth runs "docker compose ps" and reports the health of each
+// container.  When no containers are running it is treated as a warning.
+func (s *DoctorService) checkContainerHealth(ctx context.Context, composePath string) CheckResult {
+	checkCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	containers, err := s.compose.PS(checkCtx, composePath)
+	if err != nil {
+		// PS failing is not catastrophic — the stack may not have been started.
+		return CheckResult{
+			Name:     "Container health",
+			Severity: SeverityWarn,
+			Detail:   "could not query containers — stack may not be running",
+		}
+	}
+	if len(containers) == 0 {
+		return CheckResult{
+			Name:     "Container health",
+			Severity: SeverityWarn,
+			Detail:   "no containers found — run 'vibewarden dev' to start the stack",
+		}
+	}
+
+	var unhealthy []string
+	for _, c := range containers {
+		if c.State != "running" || (c.Health != "" && c.Health != "healthy") {
+			unhealthy = append(unhealthy, fmt.Sprintf("%s (%s/%s)", c.Service, c.State, c.Health))
+		}
+	}
+	if len(unhealthy) > 0 {
+		return CheckResult{
+			Name:     "Container health",
+			Severity: SeverityFail,
+			Detail:   fmt.Sprintf("unhealthy containers: %v", unhealthy),
+		}
+	}
+	return CheckResult{
+		Name:     "Container health",
+		Severity: SeverityOK,
+		Detail:   fmt.Sprintf("%d container(s) running", len(containers)),
+	}
+}
+
+// printDoctorReport renders the check results to out using ANSI colour codes.
 func printDoctorReport(results []CheckResult, out io.Writer) {
 	green := color.New(color.FgGreen).SprintFunc()
+	yellow := color.New(color.FgYellow).SprintFunc()
 	red := color.New(color.FgRed).SprintFunc()
 
 	fmt.Fprintln(out, "")
@@ -205,17 +286,29 @@ func printDoctorReport(results []CheckResult, out io.Writer) {
 	fmt.Fprintln(out, "─────────────────────────────────────────")
 
 	for _, r := range results {
-		mark := green("✓")
-		if !r.OK {
-			mark = red("✗")
+		var badge string
+		switch r.Severity {
+		case SeverityOK:
+			badge = green("[OK]")
+		case SeverityWarn:
+			badge = yellow("[WARN]")
+		default:
+			badge = red("[FAIL]")
 		}
 		if r.Detail != "" {
-			fmt.Fprintf(out, "  %s  %-22s  %s\n", mark, r.Name, r.Detail)
+			fmt.Fprintf(out, "  %-14s  %-22s  %s\n", badge, r.Name, r.Detail)
 		} else {
-			fmt.Fprintf(out, "  %s  %s\n", mark, r.Name)
+			fmt.Fprintf(out, "  %-14s  %s\n", badge, r.Name)
 		}
 	}
 	fmt.Fprintln(out, "")
+}
+
+// printDoctorJSON encodes results as a JSON array to out.
+func printDoctorJSON(results []CheckResult, out io.Writer) error {
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(results)
 }
 
 // sanitizeOneLine trims a multiline string to its first non-empty line.

--- a/internal/app/ops/doctor_test.go
+++ b/internal/app/ops/doctor_test.go
@@ -3,11 +3,15 @@ package ops_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
 // fakePortChecker is a test double for ports.PortChecker.
@@ -32,20 +36,54 @@ func reachableHealthChecker() *fakeHealthChecker {
 	}
 }
 
-// unreachableHealthChecker is a fakeHealthChecker that reports upstream as unreachable.
-func unreachableHealthChecker() *fakeHealthChecker {
-	return &fakeHealthChecker{
-		responses: map[string]healthResponse{
-			"http://127.0.0.1:3000": {ok: false, err: errors.New("connection refused")},
+// noContainersCompose returns a fakeCompose whose PS returns an empty slice.
+func noContainersCompose() *fakeCompose {
+	return &fakeCompose{
+		versionStr: "Docker Compose version v2.35.1",
+		psResult:   nil,
+	}
+}
+
+// healthyContainersCompose returns a fakeCompose with one healthy running container.
+func healthyContainersCompose() *fakeCompose {
+	return &fakeCompose{
+		versionStr: "Docker Compose version v2.35.1",
+		psResult: []ports.ContainerInfo{
+			{Name: "vibewarden-proxy-1", Service: "proxy", State: "running", Health: "healthy"},
 		},
 	}
 }
 
-func TestDoctorService_Run_AllPassing(t *testing.T) {
-	fc := &fakeCompose{
-		versionStr: "Docker Compose version v2.35.1",
-		infoErr:    nil,
+// defaultOpts returns a DoctorOptions with a temp workDir so generated-file checks
+// do not depend on the actual filesystem.
+func defaultOpts(t *testing.T) ops.DoctorOptions {
+	t.Helper()
+	return ops.DoctorOptions{
+		ConfigPath: "vibewarden.yaml",
+		WorkDir:    t.TempDir(), // no generated files present by default
 	}
+}
+
+// optsWithGeneratedFile creates a DoctorOptions whose workDir contains the
+// expected generated docker-compose.yml so that check passes.
+func optsWithGeneratedFile(t *testing.T) ops.DoctorOptions {
+	t.Helper()
+	dir := t.TempDir()
+	genDir := filepath.Join(dir, ".vibewarden", "generated")
+	if err := os.MkdirAll(genDir, 0o755); err != nil {
+		t.Fatalf("create generated dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(genDir, "docker-compose.yml"), []byte("version: '3'"), 0o644); err != nil {
+		t.Fatalf("create docker-compose.yml: %v", err)
+	}
+	return ops.DoctorOptions{
+		ConfigPath: "vibewarden.yaml",
+		WorkDir:    dir,
+	}
+}
+
+func TestDoctorService_Run_AllPassing(t *testing.T) {
+	fc := healthyContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8080: true}}
 	hc := reachableHealthChecker()
 
@@ -53,7 +91,8 @@ func TestDoctorService_Run_AllPassing(t *testing.T) {
 	cfg := defaultConfig()
 	var buf bytes.Buffer
 
-	allOK, err := svc.Run(context.Background(), cfg, "vibewarden.yaml", &buf)
+	opts := optsWithGeneratedFile(t)
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
 	if err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
@@ -68,7 +107,8 @@ func TestDoctorService_Run_AllPassing(t *testing.T) {
 		"Docker Compose",
 		"Config file",
 		"Proxy port",
-		"Upstream app",
+		"Generated files",
+		"Container health",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q\ngot:\n%s", want, out)
@@ -87,7 +127,7 @@ func TestDoctorService_Run_DockerNotRunning(t *testing.T) {
 	cfg := defaultConfig()
 	var buf bytes.Buffer
 
-	allOK, err := svc.Run(context.Background(), cfg, "", &buf)
+	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -112,7 +152,7 @@ func TestDoctorService_Run_DockerComposeNotAvailable(t *testing.T) {
 	cfg := defaultConfig()
 	var buf bytes.Buffer
 
-	allOK, err := svc.Run(context.Background(), cfg, "", &buf)
+	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -127,16 +167,14 @@ func TestDoctorService_Run_DockerComposeNotAvailable(t *testing.T) {
 }
 
 func TestDoctorService_Run_PortInUse(t *testing.T) {
-	fc := &fakeCompose{
-		versionStr: "Docker Compose version v2.35.1",
-	}
+	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8080: false}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
 	cfg := defaultConfig()
 	var buf bytes.Buffer
 
-	allOK, err := svc.Run(context.Background(), cfg, "", &buf)
+	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -150,42 +188,17 @@ func TestDoctorService_Run_PortInUse(t *testing.T) {
 	}
 }
 
-func TestDoctorService_Run_UpstreamUnreachable(t *testing.T) {
-	fc := &fakeCompose{
-		versionStr: "Docker Compose version v2.35.1",
-	}
-	pc := &fakePortChecker{available: map[int]bool{8080: true}}
-	hc := unreachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
-	var buf bytes.Buffer
-
-	allOK, err := svc.Run(context.Background(), cfg, "", &buf)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if allOK {
-		t.Error("expected allOK = false when upstream is unreachable")
-	}
-
-	out := buf.String()
-	if !strings.Contains(out, "not reachable") {
-		t.Errorf("expected 'not reachable' in output, got:\n%s", out)
-	}
-}
-
-func TestDoctorService_Run_NilConfig(t *testing.T) {
-	fc := &fakeCompose{versionStr: "Docker Compose version v2.35.1"}
+func TestDoctorService_Run_ConfigPathInOutput(t *testing.T) {
+	fc := noContainersCompose()
 	pc := &fakePortChecker{}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-
-	// nil cfg should not panic — checkConfigFile handles it
-	// We pass a defaultConfig but test the label path
 	cfg := defaultConfig()
 	var buf bytes.Buffer
 
-	_, err := svc.Run(context.Background(), cfg, "custom.yaml", &buf)
+	opts := defaultOpts(t)
+	opts.ConfigPath = "custom.yaml"
+	_, err := svc.Run(context.Background(), cfg, opts, &buf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -201,14 +214,15 @@ func TestDoctorService_ChecksAreIndependent(t *testing.T) {
 	fc := &fakeCompose{
 		infoErr:    errors.New("docker not running"),
 		versionErr: errors.New("compose not found"),
+		psErr:      errors.New("ps failed"),
 	}
 	pc := &fakePortChecker{available: map[int]bool{8080: false}}
-	hc := unreachableHealthChecker()
+	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
 	cfg := defaultConfig()
 	var buf bytes.Buffer
 
-	_, err := svc.Run(context.Background(), cfg, "", &buf)
+	_, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -219,10 +233,149 @@ func TestDoctorService_ChecksAreIndependent(t *testing.T) {
 		"Docker Compose",
 		"Config file",
 		"Proxy port",
-		"Upstream app",
+		"Generated files",
+		"Container health",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("check %q missing from output\ngot:\n%s", want, out)
 		}
+	}
+}
+
+func TestDoctorService_Run_GeneratedFileMissing_IsWarn(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8080: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	// defaultOpts uses an empty temp dir — no generated file present.
+	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// WARN does not cause allOK=false.
+	if !allOK {
+		t.Error("expected allOK = true because generated-file absence is WARN, not FAIL")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "[WARN]") {
+		t.Errorf("expected [WARN] badge in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Generated files") {
+		t.Errorf("expected 'Generated files' check name in output, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_UnhealthyContainer_IsFail(t *testing.T) {
+	fc := &fakeCompose{
+		versionStr: "Docker Compose version v2.35.1",
+		psResult: []ports.ContainerInfo{
+			{Name: "vibewarden-proxy-1", Service: "proxy", State: "running", Health: "unhealthy"},
+		},
+	}
+	pc := &fakePortChecker{available: map[int]bool{8080: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	allOK, err := svc.Run(context.Background(), cfg, optsWithGeneratedFile(t), &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allOK {
+		t.Error("expected allOK = false when a container is unhealthy")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "unhealthy") {
+		t.Errorf("expected 'unhealthy' in output, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_JSONOutput(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8080: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	opts := optsWithGeneratedFile(t)
+	opts.JSON = true
+	_, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var results []ops.CheckResult
+	if err := json.Unmarshal(buf.Bytes(), &results); err != nil {
+		t.Fatalf("output is not valid JSON: %v\ngot:\n%s", err, buf.String())
+	}
+	if len(results) == 0 {
+		t.Error("expected at least one check result in JSON output")
+	}
+	for _, r := range results {
+		if r.Name == "" {
+			t.Errorf("check result has empty name: %+v", r)
+		}
+		if r.Severity == "" {
+			t.Errorf("check result has empty severity: %+v", r)
+		}
+	}
+}
+
+func TestDoctorService_Run_OKFAILBadgesInOutput(t *testing.T) {
+	// Docker daemon failure should produce a [FAIL] badge in human output.
+	fc := &fakeCompose{
+		infoErr:    errors.New("docker not running"),
+		versionStr: "Docker Compose version v2.35.1",
+	}
+	pc := &fakePortChecker{available: map[int]bool{8080: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	_, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "[FAIL]") {
+		t.Errorf("expected [FAIL] badge in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[OK]") {
+		t.Errorf("expected [OK] badge in output, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_ContainersHealthy_AllOK(t *testing.T) {
+	fc := healthyContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8080: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	opts := optsWithGeneratedFile(t)
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allOK {
+		t.Errorf("expected allOK = true when containers are healthy\noutput:\n%s", buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Container health") {
+		t.Errorf("expected 'Container health' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "running") {
+		t.Errorf("expected 'running' in container health detail, got:\n%s", out)
 	}
 }

--- a/internal/cli/cmd/doctor.go
+++ b/internal/cli/cmd/doctor.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -18,26 +19,31 @@ import (
 // The command runs a series of independent diagnostics and reports problems.
 // It exits with status 1 when any check fails so it can be used in scripts.
 func NewDoctorCmd() *cobra.Command {
-	var configPath string
+	var (
+		configPath string
+		jsonOutput bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Diagnose common configuration and environment issues",
 		Long: `Run a series of independent diagnostics and report any issues found.
 
-Checks performed:
-  - Is Docker running?
-  - Is Docker Compose (v2) available?
-  - Is vibewarden.yaml present and valid?
-  - Are required ports available?
-  - Can VibeWarden reach the upstream app?
+Checks performed (in order):
+  - vibewarden.yaml is present and parses without errors
+  - Docker daemon is reachable (docker info)
+  - Docker Compose v2+ is available (docker compose version)
+  - Required ports are available (proxy port)
+  - Generated files are present (.vibewarden/generated/docker-compose.yml)
+  - If the stack is running: containers are healthy (docker compose ps)
 
 Each check runs independently — a failure does not stop subsequent checks.
 Exit code is 1 when any check fails.
 
 Examples:
   vibewarden doctor
-  vibewarden doctor --config ./my-vibewarden.yaml`,
+  vibewarden doctor --config ./my-vibewarden.yaml
+  vibewarden doctor --json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Load config — pass nil-safe; doctor will report missing config.
 			cfg, loadErr := config.Load(configPath)
@@ -52,6 +58,11 @@ Examples:
 				cfg = &config.Config{}
 			}
 
+			workDir, err := os.Getwd()
+			if err != nil {
+				workDir = "."
+			}
+
 			compose := opsadapter.NewComposeAdapter()
 			portChecker := opsadapter.NewNetPortChecker()
 			httpClient := &http.Client{Timeout: 5 * time.Second}
@@ -63,7 +74,13 @@ Examples:
 				label = "vibewarden.yaml"
 			}
 
-			allOK, err := svc.Run(cmd.Context(), cfg, label, cmd.OutOrStdout())
+			opts := opsapp.DoctorOptions{
+				ConfigPath: label,
+				WorkDir:    workDir,
+				JSON:       jsonOutput,
+			}
+
+			allOK, err := svc.Run(cmd.Context(), cfg, opts, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}
@@ -76,6 +93,7 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&configPath, "config", "", "path to vibewarden.yaml (default: ./vibewarden.yaml)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output results as JSON")
 
 	return cmd
 }

--- a/internal/ports/ops.go
+++ b/internal/ports/ops.go
@@ -3,6 +3,18 @@ package ports
 
 import "context"
 
+// ContainerInfo holds the status of a single container reported by docker compose ps.
+type ContainerInfo struct {
+	// Name is the container name.
+	Name string
+	// Service is the Compose service name.
+	Service string
+	// State is the raw container state string (e.g. "running", "exited").
+	State string
+	// Health is the Docker health-check status ("healthy", "unhealthy", "starting", or empty).
+	Health string
+}
+
 // ComposeRunner runs Docker Compose commands.
 // Implementations shell out to the docker compose CLI.
 type ComposeRunner interface {
@@ -20,6 +32,11 @@ type ComposeRunner interface {
 	// Info returns the docker info output.
 	// Returns an error when Docker is not running.
 	Info(ctx context.Context) error
+
+	// PS returns the list of containers for the compose project.
+	// composeFile is the path to the docker-compose.yml; when empty the default
+	// discovery logic applies.  Returns an empty slice when no containers exist.
+	PS(ctx context.Context, composeFile string) ([]ContainerInfo, error)
 }
 
 // HealthChecker performs HTTP health checks against VibeWarden endpoints.


### PR DESCRIPTION
Closes #426

## Summary

- Replaces the existing `✓`/`✗` output with `[OK]` (green), `[WARN]` (yellow), `[FAIL]` (red) ANSI-coloured badges as required by the issue
- Adds `--json` flag to emit a JSON array of check results for machine-readable consumption
- Introduces a `Severity` type (`OK`/`WARN`/`FAIL`) on `CheckResult`; exit code 1 is triggered only by `FAIL` results, so `WARN` checks do not fail scripts
- Adds a **Generated files** check that looks for `.vibewarden/generated/docker-compose.yml` (reported as `WARN` when absent, not `FAIL`, since the stack may not have been initialised yet)
- Adds a **Container health** check that calls `docker compose ps --format json`; reports `WARN` when no containers exist, `FAIL` when any container is not running or is unhealthy
- Introduces `DoctorOptions` struct (`ConfigPath`, `WorkDir`, `JSON`) to replace the loose `configPath string` argument, making the API easier to extend
- Extends `ports.ComposeRunner` with `PS(ctx, composeFile) ([]ContainerInfo, error)` and implements it in `ComposeAdapter`
- Adds `ContainerInfo` value type to the `ports` package
- Updates `fakeCompose` test double to satisfy the extended interface

## Test plan

- `go test ./internal/app/ops/... ./internal/adapters/ops/... ./internal/cli/cmd/...` — all green
- `make check` — all checks pass including formatting, vet, build, tests, demo-app
