### PR TITLE
docs: set up MkDocs Material documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+name: Deploy docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs Material and dependencies
+        run: |
+          pip install \
+            mkdocs-material==9.5.* \
+            mkdocs-minify-plugin \
+            pymdown-extensions
+
+      - name: Configure git for gh-pages push
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,282 @@
+# Architecture
+
+VibeWarden is a local security sidecar built in Go. It embeds Caddy as a
+reverse-proxy engine and adds a middleware chain on top of it. This page describes
+the middleware stack, the plugin system, the hexagonal architecture that structures
+the codebase, and how Caddy is embedded.
+
+---
+
+## Sidecar model
+
+VibeWarden always runs **on the same machine as your app**. It is never hosted
+on a remote server.
+
+```
+[Internet]
+     │
+     │ :8080 (HTTP) or :443 (HTTPS)
+     ▼
+[VibeWarden]   ←── vibewarden.yaml
+     │
+     │ localhost (e.g., :3000)
+     ▼
+[Your App]
+```
+
+The sidecar intercepts all inbound traffic, applies the configured middleware
+chain, and forwards clean requests to the app. Outbound requests made by your
+app can optionally route through the egress proxy for SSRF protection and PII
+redaction.
+
+---
+
+## Middleware stack
+
+Every inbound request passes through the following ordered chain:
+
+```
+Request
+   │
+   ▼  1. IP filter
+   │     Allowlist or blocklist by IP/CIDR.
+   │
+   ▼  2. Body size limit
+   │     Global and per-path maximum request body sizes.
+   │
+   ▼  3. Rate limiter — per-IP
+   │     Token-bucket, in-memory or Redis-backed.
+   │
+   ▼  4. WAF
+   │     Pattern matching for SQLi, XSS, path traversal.
+   │     Modes: detect (log only) or block (return 403).
+   │
+   ▼  5. Content-Type validation
+   │     Rejects unexpected media types (optional).
+   │
+   ▼  6. Authentication
+   │     JWT/OIDC bearer token, Kratos session cookie,
+   │     or API key. Injects user identity headers.
+   │
+   ▼  7. Rate limiter — per-user
+   │     Applied only to authenticated requests.
+   │
+   ▼  8. Secret injection
+   │     Fetches secrets from OpenBao and injects them
+   │     as request headers before forwarding.
+   │
+   ▼  9. Reverse proxy (Caddy)
+   │     Forwards the request to the upstream app.
+   │
+   ▼ 10. Security headers
+   │     Added to the upstream response:
+   │     HSTS, CSP, X-Frame-Options, Referrer-Policy, etc.
+   │
+   ▼ 11. Audit log
+         Structured event emitted for every security-relevant action.
+
+Response
+```
+
+Plugins that are disabled in `vibewarden.yaml` are skipped entirely — no
+handler is registered.
+
+---
+
+## Plugin system
+
+All features in VibeWarden are implemented as plugins. Plugins are compiled into
+the binary and activated by configuration. There is no dynamic loading or external
+plugin API.
+
+### Plugin lifecycle
+
+1. **Registration**: each plugin registers itself with the plugin registry at
+   import time (via `init()`).
+2. **Configuration loading**: the config loader reads `vibewarden.yaml` and
+   populates the plugin's config struct.
+3. **Validation**: `Config.Validate()` checks the plugin's config for consistency.
+4. **Initialization**: `plugins.Start()` initializes each enabled plugin in
+   dependency order.
+5. **Shutdown**: `plugins.Stop()` gracefully shuts down each plugin in reverse
+   order.
+
+### Available plugins
+
+| Plugin | Config key | Description |
+|--------|-----------|-------------|
+| TLS | `tls` | Certificate provisioning via Caddy (Let's Encrypt, self-signed, external) |
+| Auth | `auth` | JWT/OIDC, Kratos session, or API key authentication |
+| Rate limiting | `rate_limit` | Token-bucket rate limiting (in-memory or Redis) |
+| WAF | `waf` | SQL injection, XSS, path traversal detection |
+| Security headers | `security_headers` | HSTS, CSP, X-Frame-Options, and more |
+| CORS | `cors` | Cross-Origin Resource Sharing headers |
+| Secrets | `secrets` | OpenBao integration — inject secrets as headers or env vars |
+| Egress proxy | `egress` | Outbound HTTP control with SSRF protection |
+| Observability | `observability` | Prometheus, Grafana, Loki, Promtail Compose stack |
+| Resilience | `resilience` | Circuit breaker, retry, and timeout middleware |
+| IP filter | `ip_filter` | IP address allowlist / blocklist |
+| Body size | `body_size` | Per-request body size enforcement |
+| Webhooks | `webhooks` | HMAC-signed audit event delivery |
+| Admin API | `admin` | User management endpoints |
+| Fleet | `fleet` | Pro tier telemetry bridge to `app.vibewarden.dev` |
+
+---
+
+## Hexagonal architecture
+
+VibeWarden's codebase is organized around the hexagonal architecture (ports and
+adapters) pattern combined with domain-driven design (DDD).
+
+```
+┌─────────────────────────────────────────────┐
+│                  Domain layer               │
+│  Pure Go — zero external dependencies       │
+│  Entities, value objects, domain events     │
+└────────────────────┬────────────────────────┘
+                     │
+      ┌──────────────▼──────────────┐
+      │         Ports layer         │
+      │  Interfaces (inbound +      │
+      │  outbound) — no impl here   │
+      └──────┬───────────────┬──────┘
+             │               │
+   ┌─────────▼──────┐  ┌─────▼─────────────┐
+   │ Application    │  │   Adapters         │
+   │ services       │  │   (implementations)│
+   │ (use cases)    │  │                    │
+   └────────────────┘  │ caddy/  postgres/  │
+                       │ kratos/ openbao/   │
+                       │ redis/  webhook/   │
+                       └───────────────────┘
+```
+
+### Directory layout
+
+```
+cmd/
+  vibewarden/         # CLI entrypoint (cobra commands)
+
+internal/
+  domain/             # Entities, value objects, domain events
+                      # Zero external dependencies — pure Go + stdlib only
+
+  ports/              # Interfaces (inbound + outbound)
+                      # Defined here, implemented in adapters/
+
+  adapters/
+    caddy/            # Caddy embedding adapter
+    kratos/           # Ory Kratos adapter
+    postgres/         # PostgreSQL adapter
+    log/              # Log sink adapters (stdout, file, webhook)
+    redis/            # Redis rate-limit store adapter
+    openbao/          # OpenBao secrets adapter
+
+  app/                # Application services (use cases)
+                      # Orchestrate domain + ports; no business logic
+
+  config/             # Config loading and validation (viper + mapstructure)
+  plugins/            # Plugin registry and lifecycle management
+
+migrations/           # SQL migration files (golang-migrate)
+
+docs/                 # Documentation
+```
+
+### Dependency rules
+
+1. **Domain layer** imports nothing outside the Go standard library and the
+   `internal/domain` package itself.
+2. **Ports layer** imports only the domain layer.
+3. **Application services** import domain and ports. They never import adapters
+   directly.
+4. **Adapters** import ports (the interfaces they implement) and external
+   libraries. They never import application services.
+5. **`cmd/vibewarden`** is the composition root. It is the only package allowed
+   to import everything and wire it together.
+
+---
+
+## Caddy embedding
+
+VibeWarden uses Caddy as its HTTP server and reverse-proxy engine. Caddy is
+embedded as a Go library — there is no `Caddyfile` and no Caddy process. All
+configuration is programmatic via Caddy's admin API data structures.
+
+### Why Caddy
+
+- Apache 2.0 license (compatible with VibeWarden's Apache 2.0 license)
+- Built-in ACME / Let's Encrypt support
+- Programmatic configuration without a config file
+- Mature TLS stack with automatic certificate renewal
+- High-performance HTTP/1.1, HTTP/2, and HTTP/3 support
+
+### How it is wired
+
+At startup:
+
+1. `internal/adapters/caddy/` builds a Caddy JSON config from `Config`.
+2. The config describes a single HTTP app with one route: forward all requests
+   to the upstream after passing through the middleware handlers.
+3. Middleware handlers are Go `http.Handler` chains registered programmatically.
+4. Caddy is started via `caddy.Run()` with the constructed config.
+
+On config reload (e.g., `vibew generate`):
+
+1. The new config is built from the updated `vibewarden.yaml`.
+2. Caddy's admin API receives the new config via `caddy.Load()` — no process
+   restart required.
+
+---
+
+## AI-readable structured logs
+
+Every security-relevant event produces a structured JSON log record:
+
+```json
+{
+  "schema_version": "v1",
+  "event_type": "request.completed",
+  "ai_summary": "GET /api/users 200 in 3ms",
+  "time": "2026-03-28T12:00:00Z",
+  "level": "INFO",
+  "payload": {
+    "method": "GET",
+    "path": "/api/users",
+    "status_code": 200,
+    "duration_ms": 3,
+    "user_id": "usr_abc123"
+  }
+}
+```
+
+The schema is published at `vibewarden.dev/schema/v1/event.json`. Schema
+stability is treated with the same care as a public API — breaking changes
+require a new `schema_version` value.
+
+### Event types
+
+| Event type | Description |
+|------------|-------------|
+| `request.completed` | HTTP request forwarded to upstream and response returned |
+| `auth.allowed` | Authentication passed; user identity established |
+| `auth.blocked` | Authentication failed; request rejected |
+| `rate_limit.blocked` | Request blocked by rate limiter |
+| `rate_limit.store_fallback` | Redis unavailable; falling back to in-memory |
+| `rate_limit.store_recovered` | Redis recovered after a fallback |
+| `waf.detected` | WAF detected a suspicious pattern |
+| `waf.blocked` | WAF blocked a request |
+| `secret.injected` | Secret successfully injected into request headers |
+| `secret.fetch_failed` | Failed to fetch secret from OpenBao |
+| `upstream.error` | Upstream returned an error or was unreachable |
+| `circuit_breaker.opened` | Circuit breaker tripped to open state |
+| `circuit_breaker.closed` | Circuit breaker recovered to closed state |
+
+### Log sinks
+
+| Sink | Config |
+|------|--------|
+| Standard output (JSON) | Always active — cannot be disabled |
+| File (JSONL) | `audit.output: /var/log/vibewarden/audit.jsonl` |
+| OTLP (Loki via OTel Collector) | `telemetry.logs.otlp: true` |
+| Webhook (HMAC-signed) | `webhooks.endpoints[].events` |

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1,0 +1,24 @@
+/* VibeWarden brand colors: purple #7C3AED -> cyan #06B6D4 */
+:root {
+  --vw-purple: #7C3AED;
+  --vw-cyan: #06B6D4;
+}
+
+/* Hero gradient on the landing page */
+.md-typeset .hero-gradient {
+  background: linear-gradient(135deg, var(--vw-purple) 0%, var(--vw-cyan) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* Make the primary color match our exact brand purple */
+[data-md-color-primary=deep-purple] {
+  --md-primary-fg-color: #7C3AED;
+  --md-primary-fg-color--light: #9D65F5;
+  --md-primary-fg-color--dark: #5B21B6;
+}
+
+[data-md-color-accent=cyan] {
+  --md-accent-fg-color: #06B6D4;
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,596 @@
+# Configuration Reference
+
+All VibeWarden configuration lives in `vibewarden.yaml` at the root of your
+project. Every field can also be set via an environment variable — the variable
+name is the YAML key path uppercased and prefixed with `VIBEWARDEN_`, with dots
+replaced by underscores. Example: `server.port` → `VIBEWARDEN_SERVER_PORT`.
+
+Environment variable substitution in YAML values is supported using `${VAR}`
+syntax. This is recommended for secrets:
+
+```yaml
+database:
+  external_url: "postgres://user:${DB_PASSWORD}@db.example.com:5432/vibewarden"
+```
+
+---
+
+## `profile`
+
+**Type:** string
+**Default:** `dev`
+**Accepted values:** `dev`, `tls`, `prod`
+
+Selects the deployment profile. Affects TLS settings, credential validation
+strictness, and which generated files are produced.
+
+```yaml
+profile: dev
+```
+
+---
+
+## `server`
+
+Settings for the VibeWarden HTTP listener.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `server.host` | string | `127.0.0.1` | Host/IP to bind to |
+| `server.port` | int | `8080` | Port to listen on |
+
+```yaml
+server:
+  host: 0.0.0.0
+  port: 8080
+```
+
+---
+
+## `upstream`
+
+Settings for the upstream application being protected.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `upstream.host` | string | `127.0.0.1` | Upstream host |
+| `upstream.port` | int | `3000` | Upstream port |
+| `upstream.health.enabled` | bool | `false` | Enable active upstream health checking |
+| `upstream.health.path` | string | `/health` | HTTP path to probe |
+| `upstream.health.interval` | duration | `10s` | Time between probes |
+| `upstream.health.timeout` | duration | `5s` | Per-probe timeout |
+| `upstream.health.unhealthy_threshold` | int | `3` | Consecutive failures to mark unhealthy |
+| `upstream.health.healthy_threshold` | int | `2` | Consecutive successes to mark healthy |
+
+```yaml
+upstream:
+  host: 127.0.0.1
+  port: 3000
+  health:
+    enabled: true
+    path: /health
+    interval: 10s
+    timeout: 5s
+```
+
+---
+
+## `app`
+
+Controls how your application is included in the generated Docker Compose file.
+When neither `build` nor `image` is set, no app service is rendered and
+VibeWarden falls back to `host.docker.internal`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `app.build` | string | `""` | Docker build context path (e.g., `.`) — used in dev/tls profiles |
+| `app.image` | string | `""` | Docker image reference (e.g., `ghcr.io/org/myapp:latest`) — used in prod profile |
+
+```yaml
+app:
+  build: .        # dev workflow: build from source
+  # image: ghcr.io/org/myapp:latest   # prod workflow: use pre-built image
+```
+
+---
+
+## `tls`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `tls.enabled` | bool | `false` | Enable TLS |
+| `tls.domain` | string | `""` | Domain for the TLS certificate. Required when `provider` is `letsencrypt` |
+| `tls.provider` | string | `""` | Certificate provider: `letsencrypt`, `self-signed`, or `external` |
+| `tls.cert_path` | string | `""` | Path to PEM certificate. Required when `provider` is `external` |
+| `tls.key_path` | string | `""` | Path to PEM private key. Required when `provider` is `external` |
+| `tls.storage_path` | string | `""` | Directory for ACME certificate storage. Applies to `letsencrypt` only |
+
+```yaml
+tls:
+  enabled: true
+  provider: letsencrypt
+  domain: myapp.example.com
+```
+
+---
+
+## `auth`
+
+### `auth` (top-level)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `auth.enabled` | bool | `false` | Enable the authentication middleware |
+| `auth.mode` | string | `none` | Auth strategy: `none`, `kratos`, `jwt`, or `api-key` |
+| `auth.public_paths` | list | `[]` | Glob patterns that bypass auth. `/_vibewarden/*` is always public |
+| `auth.session_cookie_name` | string | `ory_kratos_session` | Kratos session cookie name |
+| `auth.login_url` | string | `/self-service/login/browser` | Redirect for unauthenticated users |
+| `auth.on_kratos_unavailable` | string | `503` | Behavior when Kratos is unreachable: `503` or `allow_public` |
+| `auth.identity_schema` | string | `email_password` | Identity schema: `email_password`, `email_only`, `username_password`, `social`, or a file path |
+
+### `auth.jwt`
+
+Used when `auth.mode` is `jwt`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `auth.jwt.jwks_url` | string | `""` | Direct JWKS endpoint URL. Takes precedence over `issuer_url` |
+| `auth.jwt.issuer_url` | string | `""` | OIDC issuer base URL for auto-discovery |
+| `auth.jwt.issuer` | string | `""` | Expected `iss` claim value. Required |
+| `auth.jwt.audience` | string | `""` | Expected `aud` claim value. Required |
+| `auth.jwt.claims_to_headers` | map | see below | JWT claims injected as upstream request headers |
+| `auth.jwt.allowed_algorithms` | list | `[RS256, ES256]` | Accepted signing algorithms. Never include `none` or `HS256` in production |
+| `auth.jwt.cache_ttl` | duration | `1h` | How long the JWKS is cached locally |
+
+Default `claims_to_headers`:
+```yaml
+claims_to_headers:
+  sub: X-User-Id
+  email: X-User-Email
+  email_verified: X-User-Verified
+```
+
+### `auth.api_key`
+
+Used when `auth.mode` is `api-key`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `auth.api_key.header` | string | `X-API-Key` | Request header carrying the API key |
+| `auth.api_key.keys` | list | `[]` | Static key entries (see below) |
+| `auth.api_key.openbao_path` | string | `""` | KV path in OpenBao where key hashes are stored |
+| `auth.api_key.cache_ttl` | duration | `5m` | TTL for keys fetched from OpenBao |
+| `auth.api_key.scope_rules` | list | `[]` | Ordered path+method authorization rules |
+
+Each entry in `keys`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Human-readable label |
+| `hash` | string | Hex-encoded SHA-256 of the plaintext key |
+| `scopes` | list | Permission scopes granted to this key |
+
+Each entry in `scope_rules`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | string | Glob pattern matched against the request path |
+| `methods` | list | HTTP methods this rule applies to (empty = all methods) |
+| `required_scopes` | list | Scopes the key must possess |
+
+### `auth.social_providers`
+
+List of OAuth2/OIDC social login providers (used with `auth.mode: kratos`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `provider` | string | Provider name: `google`, `github`, `apple`, `facebook`, `microsoft`, `gitlab`, `discord`, `slack`, `spotify`, `oidc` |
+| `client_id` | string | OAuth2 client ID |
+| `client_secret` | string | OAuth2 client secret |
+| `scopes` | list | OAuth2 scopes to request (optional; provider defaults apply) |
+| `label` | string | Custom login button label (optional) |
+| `team_id` | string | Apple Developer Team ID (Apple only) |
+| `key_id` | string | Apple private key ID (Apple only) |
+| `id` | string | Unique identifier for OIDC entries |
+| `issuer_url` | string | OIDC issuer URL (OIDC provider only) |
+
+### `auth.ui`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `auth.ui.mode` | string | `built-in` | `built-in` or `custom` |
+| `auth.ui.app_name` | string | `""` | Application name on built-in login pages |
+| `auth.ui.logo_url` | string | `""` | Logo URL for built-in pages |
+| `auth.ui.primary_color` | string | `#7C3AED` | Accent color for built-in pages |
+| `auth.ui.background_color` | string | `#1a1a2e` | Background color for built-in pages |
+| `auth.ui.login_url` | string | `""` | Custom login page URL (when `mode: custom`) |
+| `auth.ui.registration_url` | string | `""` | Custom registration page URL |
+| `auth.ui.settings_url` | string | `""` | Custom account settings page URL |
+| `auth.ui.recovery_url` | string | `""` | Custom account recovery page URL |
+
+---
+
+## `kratos`
+
+Used when `auth.mode` is `kratos`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `kratos.public_url` | string | `http://127.0.0.1:4433` | Kratos public API URL |
+| `kratos.admin_url` | string | `http://127.0.0.1:4434` | Kratos admin API URL |
+| `kratos.dsn` | string | `""` | Kratos database DSN (postgres URL) |
+| `kratos.external` | bool | `false` | Connect to a user-managed Kratos instance instead of starting one |
+| `kratos.smtp.host` | string | `localhost` | SMTP server host |
+| `kratos.smtp.port` | int | `1025` | SMTP server port |
+| `kratos.smtp.from` | string | `no-reply@vibewarden.local` | Sender address for Kratos emails |
+
+---
+
+## `rate_limit`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rate_limit.enabled` | bool | `true` | Enable rate limiting |
+| `rate_limit.store` | string | `memory` | Backing store: `memory` or `redis` |
+| `rate_limit.trust_proxy_headers` | bool | `false` | Read `X-Forwarded-For` for client IP. Enable only behind a trusted proxy |
+| `rate_limit.exempt_paths` | list | `[]` | Glob patterns that bypass rate limiting. `/_vibewarden/*` is always exempt |
+
+### `rate_limit.per_ip` and `rate_limit.per_user`
+
+| Field | Type | Default (per_ip) | Default (per_user) | Description |
+|-------|------|------|------|-------------|
+| `requests_per_second` | float | `10` | `100` | Sustained token refill rate |
+| `burst` | int | `20` | `200` | Maximum tokens that can accumulate |
+
+### `rate_limit.redis`
+
+Only read when `store` is `redis`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `url` | string | `""` | Redis URL (`redis://` or `rediss://`). Takes precedence over all other fields |
+| `address` | string | `localhost:6379` | Redis address in `host:port` form |
+| `password` | string | `""` | Redis AUTH password |
+| `db` | int | `0` | Logical database index |
+| `pool_size` | int | `0` (auto) | Connection pool size (`0` = auto based on CPU count) |
+| `key_prefix` | string | `vibewarden` | Key namespace prefix |
+| `fallback` | bool | `true` | Fail-open on Redis failure (`true`) or fail-closed (`false`) |
+| `health_check_interval` | duration | `30s` | How often to probe Redis for recovery |
+
+---
+
+## `security_headers`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `security_headers.enabled` | bool | `true` | Enable security headers middleware |
+| `security_headers.hsts_max_age` | int | `31536000` | HSTS max-age in seconds (1 year) |
+| `security_headers.hsts_include_subdomains` | bool | `true` | Add `includeSubDomains` to HSTS |
+| `security_headers.hsts_preload` | bool | `false` | Add `preload` to HSTS |
+| `security_headers.content_type_nosniff` | bool | `true` | Set `X-Content-Type-Options: nosniff` |
+| `security_headers.frame_option` | string | `DENY` | `X-Frame-Options`: `DENY`, `SAMEORIGIN`, or `""` to disable |
+| `security_headers.content_security_policy` | string | `default-src 'self'` | `Content-Security-Policy` value |
+| `security_headers.referrer_policy` | string | `strict-origin-when-cross-origin` | `Referrer-Policy` value |
+| `security_headers.permissions_policy` | string | `""` | `Permissions-Policy` value |
+| `security_headers.cross_origin_opener_policy` | string | `same-origin` | `Cross-Origin-Opener-Policy` value |
+| `security_headers.cross_origin_resource_policy` | string | `same-origin` | `Cross-Origin-Resource-Policy` value |
+| `security_headers.permitted_cross_domain_policies` | string | `none` | `X-Permitted-Cross-Domain-Policies` value |
+| `security_headers.suppress_via_header` | bool | `true` | Remove `Via` header from proxied responses |
+
+---
+
+## `cors`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `cors.enabled` | bool | `false` | Enable CORS plugin |
+| `cors.allowed_origins` | list | `[]` | Permitted origins. Use `["*"]` for development only |
+| `cors.allowed_methods` | list | `[GET, POST, PUT, DELETE, OPTIONS]` | Permitted HTTP methods |
+| `cors.allowed_headers` | list | `[Content-Type, Authorization]` | Permitted request headers |
+| `cors.exposed_headers` | list | `[]` | Response headers exposed via `Access-Control-Expose-Headers` |
+| `cors.allow_credentials` | bool | `false` | Set `Access-Control-Allow-Credentials: true`. Must not be combined with `allowed_origins: ["*"]` |
+| `cors.max_age` | int | `0` | Preflight cache duration in seconds. `0` omits the header |
+
+---
+
+## `waf`
+
+### `waf.content_type_validation`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `waf.content_type_validation.enabled` | bool | `false` | Enable Content-Type validation on body-bearing requests |
+| `waf.content_type_validation.allowed` | list | `[application/json, application/x-www-form-urlencoded, multipart/form-data]` | Permitted media types. Requests with other types receive `415 Unsupported Media Type` |
+
+---
+
+## `body_size`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `body_size.max` | string | `""` | Global maximum body size (e.g., `1MB`, `512KB`). Empty means no limit |
+| `body_size.overrides` | list | `[]` | Per-path overrides |
+
+Each entry in `body_size.overrides`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | string | URL path prefix to match |
+| `max` | string | Maximum body size for this path |
+
+```yaml
+body_size:
+  max: 1MB
+  overrides:
+    - path: /api/upload
+      max: 50MB
+```
+
+---
+
+## `ip_filter`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ip_filter.enabled` | bool | `false` | Enable IP filter plugin |
+| `ip_filter.mode` | string | `blocklist` | `allowlist` or `blocklist` |
+| `ip_filter.addresses` | list | `[]` | IP addresses or CIDR ranges |
+| `ip_filter.trust_proxy_headers` | bool | `false` | Read `X-Forwarded-For` for client IP |
+
+```yaml
+ip_filter:
+  enabled: true
+  mode: allowlist
+  addresses:
+    - 10.0.0.0/8
+    - 192.168.1.100
+```
+
+---
+
+## `resilience`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `resilience.timeout` | duration | `30s` | Upstream response timeout. `0` disables the timeout |
+
+### `resilience.circuit_breaker`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `resilience.circuit_breaker.enabled` | bool | `false` | Enable circuit breaker |
+| `resilience.circuit_breaker.threshold` | int | `5` | Consecutive failures to trip the circuit |
+| `resilience.circuit_breaker.timeout` | duration | `60s` | How long the circuit stays open before probing |
+
+### `resilience.retry`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `resilience.retry.enabled` | bool | `false` | Enable retry with exponential backoff |
+| `resilience.retry.max_attempts` | int | `3` | Total attempts including the initial request |
+| `resilience.retry.backoff` | duration | `100ms` | Wait before the first retry |
+| `resilience.retry.max_backoff` | duration | `10s` | Upper bound on computed backoff |
+| `resilience.retry.retry_on` | list | `[502, 503, 504]` | HTTP status codes that trigger a retry |
+
+---
+
+## `telemetry`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `telemetry.enabled` | bool | `true` | Master switch for all telemetry |
+| `telemetry.path_patterns` | list | `[]` | URL path normalization patterns using `:param` syntax |
+| `telemetry.prometheus.enabled` | bool | `true` | Enable Prometheus pull-based exporter at `/_vibewarden/metrics` |
+| `telemetry.otlp.enabled` | bool | `false` | Enable OTLP push-based exporter |
+| `telemetry.otlp.endpoint` | string | `""` | OTLP HTTP endpoint URL. Required when `otlp.enabled` is `true` |
+| `telemetry.otlp.headers` | map | `{}` | HTTP headers for OTLP authentication |
+| `telemetry.otlp.interval` | duration | `30s` | Export interval |
+| `telemetry.otlp.protocol` | string | `http` | Transport protocol. Only `http` is supported |
+| `telemetry.logs.otlp` | bool | `false` | Export structured events via OTLP. Requires `otlp.endpoint` |
+| `telemetry.traces.enabled` | bool | `false` | Enable distributed tracing. Requires `otlp.enabled` |
+
+!!! note "Legacy `metrics:` section"
+    The `metrics:` config block is deprecated. Settings are automatically migrated
+    to `telemetry:` at startup with a deprecation warning. Migrate before the next
+    major version.
+
+---
+
+## `observability`
+
+Controls generation of the optional local observability stack (Grafana, Prometheus,
+Loki, Promtail).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `observability.enabled` | bool | `false` | Generate the observability stack |
+| `observability.grafana_port` | int | `3001` | Host port for Grafana |
+| `observability.prometheus_port` | int | `9090` | Host port for Prometheus |
+| `observability.loki_port` | int | `3100` | Host port for Loki |
+| `observability.retention_days` | int | `7` | Log retention period in Loki |
+
+---
+
+## `database`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `database.external_url` | string | `""` | Full `postgres://` connection URL. When set, the local Postgres container is omitted from the generated Compose file |
+| `database.tls_mode` | string | `require` | PostgreSQL SSL mode: `disable`, `require`, `verify-ca`, `verify-full` |
+| `database.pool.max_conns` | int | `10` | Maximum open connections |
+| `database.pool.min_conns` | int | `2` | Minimum idle connections |
+| `database.connect_timeout` | duration | `10s` | Connection establishment timeout |
+
+---
+
+## `secrets`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `secrets.enabled` | bool | `false` | Enable secrets management plugin |
+| `secrets.provider` | string | `openbao` | Secret store backend |
+| `secrets.cache_ttl` | duration | `5m` | How long fetched secrets are cached in memory |
+
+### `secrets.openbao`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `secrets.openbao.address` | string | `""` | OpenBao server URL (e.g., `http://openbao:8200`) |
+| `secrets.openbao.mount_path` | string | `secret` | KV v2 mount path |
+| `secrets.openbao.auth.method` | string | `""` | Auth method: `token` or `approle` |
+| `secrets.openbao.auth.token` | string | `""` | Static token (used when `method: token`) |
+| `secrets.openbao.auth.role_id` | string | `""` | AppRole role_id (used when `method: approle`) |
+| `secrets.openbao.auth.secret_id` | string | `""` | AppRole secret_id (used when `method: approle`) |
+
+### `secrets.inject`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `secrets.inject.headers` | list | Secrets injected as HTTP request headers |
+| `secrets.inject.env_file` | string | Path to write a `.env` file with secret values |
+| `secrets.inject.env` | list | Secrets written to the env file |
+
+Each entry in `secrets.inject.headers`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `secret_path` | string | KV path of the secret |
+| `secret_key` | string | Key within the secret map |
+| `header` | string | HTTP header name |
+
+### `secrets.dynamic`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `secrets.dynamic.postgres.enabled` | bool | `false` | Enable dynamic Postgres credential generation |
+| `secrets.dynamic.postgres.roles` | list | `[]` | OpenBao database roles to request credentials for |
+
+Each entry in `roles`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | OpenBao database role name |
+| `env_var_user` | string | Env var to write the generated username into |
+| `env_var_password` | string | Env var to write the generated password into |
+
+### `secrets.health`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `secrets.health.check_interval` | duration | `6h` | How often to run secret health checks |
+| `secrets.health.max_static_age` | duration | `2160h` | Maximum acceptable age of a static secret (90 days) |
+| `secrets.health.weak_patterns` | list | `[]` | Substrings that indicate a weak or default secret |
+
+---
+
+## `webhooks`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `webhooks.endpoints` | list | Webhook endpoints to deliver audit events to |
+
+Each entry in `webhooks.endpoints`:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `url` | string | — | HTTP(S) endpoint to POST events to. Required |
+| `events` | list | — | Event types to deliver. Use `["*"]` to subscribe to all |
+| `format` | string | `raw` | Payload format: `raw`, `slack`, or `discord` |
+| `timeout_seconds` | int | `10` | Per-request HTTP timeout in seconds |
+
+---
+
+## `audit`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `audit.enabled` | bool | `true` | Enable the audit log sink |
+| `audit.output` | string | `stdout` | Write destination: `stdout` or a file path |
+
+---
+
+## `log`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `log.level` | string | `info` | Log level: `debug`, `info`, `warn`, `error` |
+| `log.format` | string | `json` | Log format: `json` or `text` |
+
+---
+
+## `admin`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `admin.enabled` | bool | `false` | Enable the admin API at `/_vibewarden/admin/*` |
+| `admin.token` | string | `""` | Bearer token for admin API authentication |
+
+---
+
+## `overrides`
+
+Escape hatches for advanced users. All fields are optional.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `overrides.kratos_config` | string | Path to a custom `kratos.yml` file. When set, VibeWarden uses it instead of generating one |
+| `overrides.compose_file` | string | Path to a custom `docker-compose.yml` file |
+| `overrides.identity_schema` | string | Path to a custom Kratos identity schema JSON file |
+
+---
+
+## Full example `vibewarden.yaml`
+
+```yaml
+profile: dev
+
+server:
+  host: 0.0.0.0
+  port: 8080
+
+upstream:
+  host: 127.0.0.1
+  port: 3000
+
+auth:
+  enabled: true
+  mode: jwt
+  jwt:
+    jwks_url: "https://dev-abc123.us.auth0.com/.well-known/jwks.json"
+    issuer:   "https://dev-abc123.us.auth0.com/"
+    audience: "https://api.your-app.com"
+    claims_to_headers:
+      sub: X-User-Id
+      email: X-User-Email
+      email_verified: X-User-Verified
+  public_paths:
+    - /health
+    - /static/*
+
+rate_limit:
+  enabled: true
+  store: memory
+  per_ip:
+    requests_per_second: 10
+    burst: 20
+  per_user:
+    requests_per_second: 100
+    burst: 200
+
+security_headers:
+  enabled: true
+  hsts_max_age: 31536000
+  content_security_policy: "default-src 'self'"
+
+telemetry:
+  enabled: true
+  prometheus:
+    enabled: true
+  path_patterns:
+    - "/api/v1/users/:id"
+    - "/api/v1/orders/:order_id"
+
+log:
+  level: info
+  format: json
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,262 @@
+# Getting Started
+
+This guide walks you through adding VibeWarden to an existing app in three commands
+and explains what happens under the hood.
+
+---
+
+## Prerequisites
+
+- **Docker Engine 27+** and **Docker Compose v2+** installed and running.
+- Your app listening on a local port (e.g., `3000`).
+
+---
+
+## Step 1 — Install the `vibew` wrapper
+
+The `vibew` script is a thin shell wrapper that downloads the correct VibeWarden
+binary for your platform and delegates all commands to it. Commit it to your repo —
+it pins the version your team uses.
+
+=== "macOS / Linux"
+
+    ```bash
+    curl -fsSL https://vibewarden.dev/vibew > vibew && chmod +x vibew
+    ```
+
+=== "Windows (PowerShell)"
+
+    ```powershell
+    Invoke-WebRequest -Uri https://vibewarden.dev/vibew.ps1 -OutFile vibew.ps1
+    ```
+
+You can also install `vibew` globally:
+
+```bash
+sudo mv vibew /usr/local/bin/vibew
+```
+
+---
+
+## Step 2 — `vibew init`
+
+Run `vibew init` inside your project directory. Pass `--upstream` with the port
+your app listens on. Add feature flags for the security plugins you want enabled.
+
+```bash
+./vibew init --upstream 3000 --auth --rate-limit
+```
+
+Common flags:
+
+| Flag | Description |
+|------|-------------|
+| `--upstream <port>` | Port your app listens on (required) |
+| `--auth` | Enable authentication (defaults to JWT/OIDC mode) |
+| `--rate-limit` | Enable rate limiting |
+| `--tls --domain example.com` | Enable TLS with Let's Encrypt |
+| `--secrets` | Enable secrets management (OpenBao) |
+| `--observability` | Add Prometheus + Grafana |
+
+### What `init` generates
+
+```
+vibewarden.yaml          # Main config — commit this
+vibew / vibew.ps1        # Wrapper scripts (macOS/Linux/Windows)
+.vibewarden-version      # Pinned version
+.claude/CLAUDE.md        # AI agent context (Claude Code)
+.cursor/rules            # AI agent context (Cursor)
+AGENTS.md                # AI agent context (generic)
+```
+
+!!! tip "AI agent context"
+    `vibew init` generates context files for your AI coding assistant. When you
+    ask Claude or Cursor to "add a login page," the AI knows to use Kratos flows
+    instead of building auth from scratch. Regenerate after config changes with
+    `./vibew context refresh`.
+
+---
+
+## Step 3 — `vibew dev`
+
+Start the full local stack:
+
+```bash
+./vibew dev
+```
+
+This command:
+
+1. Runs `vibew generate` to produce `.vibewarden/generated/docker-compose.yml`
+   from your `vibewarden.yaml`.
+2. Starts the stack with `docker compose up`.
+
+Your app is now protected at `http://localhost:8080`.
+
+---
+
+## What just happened
+
+### The stack
+
+`vibew dev` starts several containers:
+
+| Container | Purpose |
+|-----------|---------|
+| `vibewarden` | The security sidecar — Caddy embedding all middleware |
+| `kratos` | Identity server (only when `auth.mode: kratos`) |
+| `kratos-db` | Postgres for Kratos (only when `auth.mode: kratos` and no external DB) |
+| `openbao` | Secrets manager (only when `secrets.enabled: true`) |
+
+Your app runs outside Docker and is reached from the container network via
+`host.docker.internal`. Alternatively, set `app.build` or `app.image` in
+`vibewarden.yaml` to include your app in the Compose stack.
+
+### The middleware chain
+
+Every inbound request passes through this ordered chain before reaching your app:
+
+```
+Request
+   │
+   ▼
+ IP filter (if enabled)
+   │
+   ▼
+ Rate limiter — per-IP token bucket
+   │
+   ▼
+ Body size limit
+   │
+   ▼
+ WAF — SQLi / XSS / path traversal detection
+   │
+   ▼
+ Authentication — JWT / Kratos / API key
+   │
+   ▼
+ Rate limiter — per-user token bucket
+   │
+   ▼
+ Secret injection into request headers
+   │
+   ▼
+ Upstream (your app)
+   │
+   ▼
+ Security headers added to response
+   │
+   ▼
+ Audit log event emitted
+   │
+   ▼
+Response
+```
+
+### Generated files
+
+Runtime files land under `.vibewarden/generated/` (add this to `.gitignore`):
+
+```
+.vibewarden/generated/
+  docker-compose.yml           # Full stack
+  kratos/kratos.yml            # Ory Kratos config
+  kratos/identity.schema.json  # Identity schema
+  observability/               # Grafana/Prometheus/Loki (when enabled)
+```
+
+Do not edit generated files. Re-run `vibew generate` after changing
+`vibewarden.yaml`.
+
+---
+
+## Next steps
+
+### Enable authentication
+
+The default JWT mode works with any OIDC provider. Edit `vibewarden.yaml`:
+
+```yaml
+auth:
+  mode: jwt
+  jwt:
+    jwks_url: "https://your-provider/.well-known/jwks.json"
+    issuer:   "https://your-provider/"
+    audience: "your-api-identifier"
+  public_paths:
+    - /static/*
+    - /health
+```
+
+See the [Identity Providers guide](identity-providers.md) for step-by-step
+examples with Auth0, Keycloak, Firebase, Cognito, Okta, Supabase, and Kratos.
+
+### Add observability
+
+```bash
+./vibew add observability
+./vibew dev
+```
+
+Open Grafana at `http://localhost:3001` to see request rate, latency percentiles,
+rate limit hits, and auth decisions in real time.
+
+See the [Observability guide](observability.md) for details.
+
+### Enable TLS for production
+
+```bash
+./vibew add tls --domain myapp.example.com
+```
+
+This sets `tls.provider: letsencrypt` and `tls.domain` in `vibewarden.yaml`.
+On the next `vibew generate` + `docker compose up`, Caddy obtains a certificate
+from Let's Encrypt automatically.
+
+See the [Production Deployment guide](production-deployment.md) for the full
+production checklist.
+
+### Validate your config
+
+```bash
+./vibew validate
+```
+
+Reports all validation errors in `vibewarden.yaml` before you start the stack.
+
+---
+
+## Troubleshooting
+
+### Port already in use
+
+VibeWarden defaults to port `8080`. Change it in `vibewarden.yaml`:
+
+```yaml
+server:
+  port: 8090
+```
+
+### App not reachable
+
+If your app does not run inside Docker, verify it is listening on `0.0.0.0`
+(not `127.0.0.1`), or override the upstream host:
+
+```yaml
+upstream:
+  host: host.docker.internal
+  port: 3000
+```
+
+### Containers not starting
+
+```bash
+# Check container health
+./vibew status
+
+# Show detailed logs for all containers
+./vibew logs
+
+# Diagnose common issues automatically
+./vibew doctor
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,156 @@
+# VibeWarden
+
+**Production-grade security for vibe-coded apps — zero config changes to your code.**
+
+You ship fast with AI coding tools. VibeWarden adds the security layer you skipped:
+TLS, authentication, rate limiting, WAF, secrets management, and AI-readable audit logs —
+all in a single binary that sits next to your app.
+
+---
+
+## Quick Start
+
+=== "macOS / Linux"
+
+    ```bash
+    # Download the vibew wrapper
+    curl -fsSL https://vibewarden.dev/vibew > vibew && chmod +x vibew
+
+    # Scaffold VibeWarden into your project (auth + rate limiting enabled)
+    ./vibew init --upstream 3000 --auth --rate-limit
+
+    # Start everything
+    ./vibew dev
+    ```
+
+=== "Windows"
+
+    ```powershell
+    Invoke-WebRequest -Uri https://vibewarden.dev/vibew.ps1 -OutFile vibew.ps1
+    .\vibew.ps1 init --upstream 3000 --auth --rate-limit
+    .\vibew.ps1 dev
+    ```
+
+Your app on port 3000 is now behind VibeWarden. Done.
+
+---
+
+## How It Works
+
+```
+             ┌────────────────────────────────┐
+Internet ────►│  VibeWarden  :8080             │
+             │                                │
+             │  TLS termination               │
+             │  Authentication (JWT / Kratos) │
+             │  Rate limiting (IP + user)     │
+             │  WAF (SQLi, XSS, traversal)    │
+             │  Security headers              │
+             │  Secret injection              │
+             │  AI-readable audit logs        │
+             └───────────────┬────────────────┘
+                             │ localhost
+                             ▼
+                    Your App  :3000
+```
+
+VibeWarden is a **local sidecar** — it always runs on the same machine as your app.
+It is never hosted remotely.
+
+---
+
+## Feature Matrix
+
+| Feature | Details |
+|---------|---------|
+| Reverse proxy | Embedded [Caddy](https://caddyserver.com/) — programmatic config, no Caddyfile |
+| TLS | Let's Encrypt (prod), self-signed (dev), or external (Cloudflare, ACM, …) |
+| Authentication | `none`, `jwt` (any OIDC provider), `kratos` (self-hosted), `api-key` |
+| Rate limiting | Token-bucket, per-IP and per-user; in-memory or Redis-backed |
+| WAF | Pattern detection for SQLi, XSS, path traversal; `block` or `detect` mode |
+| Security headers | HSTS, CSP, X-Frame-Options, Referrer-Policy, Permissions-Policy, CORS |
+| Secrets management | OpenBao (Apache 2.0 Vault fork) — inject secrets as headers or env vars |
+| Egress proxy | Outbound HTTP with mTLS, circuit breaker, retry, SSRF protection, PII redaction |
+| Resilience | Circuit breaker, retry with jitter, timeout middleware, aggregate health endpoint |
+| Observability | Prometheus metrics, OpenTelemetry traces + logs, Grafana dashboards, Jaeger/Tempo |
+| AI-readable logs | Versioned JSON schema: `schema_version`, `event_type`, `ai_summary`, `payload` |
+| Audit log sinks | JSON file, OTel logs, webhook (HMAC-signed) with retry |
+| Admin API | User management at `/_vibewarden/admin/*` (bearer-token protected) |
+| Docker Compose | Profile-based: `--profile observability`, `--profile demo` |
+
+---
+
+## Authentication Modes
+
+| Mode | When to use |
+|------|-------------|
+| `none` | Fully public apps |
+| `jwt` | Any OIDC provider — Auth0, Keycloak, Firebase, Cognito, Okta, Supabase, … |
+| `kratos` | Self-hosted identity with login / registration UI via Ory Kratos |
+| `api-key` | Machine-to-machine requests |
+
+The `jwt` mode works with any OIDC-compatible provider:
+
+```yaml
+auth:
+  mode: jwt
+  jwt:
+    jwks_url: "https://your-provider/.well-known/jwks.json"
+    issuer:   "https://your-provider/"
+    audience: "your-api-identifier"
+  public_paths:
+    - /static/*
+    - /health
+```
+
+Your app receives authenticated user info via headers:
+
+| Header | Source claim | Description |
+|--------|--------------|-------------|
+| `X-User-Id` | `sub` | Subject identifier |
+| `X-User-Email` | `email` | Primary email address |
+| `X-User-Verified` | `email_verified` | Email verification status (`true`/`false`) |
+
+---
+
+## Comparison with Alternatives
+
+| | VibeWarden | nginx | Traefik | Cloudflare Tunnel |
+|--|--|--|--|--|
+| Target user | Vibe coders / indie devs | Ops / sysadmin | Container-native teams | Any |
+| Setup time | 3 commands | Hours of config | Moderate | Minutes |
+| Auth out of the box | Yes (OIDC, Kratos, API key) | No | Partial (forward auth only) | No |
+| WAF | Yes | Paid (NGINX Plus) | No | Paid (Cloudflare WAF) |
+| Secrets management | Yes (OpenBao) | No | No | No |
+| AI-readable audit logs | Yes (versioned schema) | No | No | No |
+| Egress proxy + SSRF guard | Yes | No | No | No |
+| Self-hosted | Yes | Yes | Yes | No |
+| Open source | Apache 2.0 | BSD-2 core | Apache 2.0 | Proprietary |
+| Cost | Free (OSS core) | Free | Free | Free tier + paid |
+
+---
+
+## CLI Reference
+
+| Command | Description |
+|---------|-------------|
+| `vibew init` | Scaffold VibeWarden into a project |
+| `vibew add auth` | Enable authentication |
+| `vibew add rate-limit` | Enable rate limiting |
+| `vibew add tls --domain example.com` | Enable TLS |
+| `vibew add observability` | Add Prometheus + Grafana |
+| `vibew generate` | Regenerate `docker-compose.yml` from config |
+| `vibew dev` | Start local dev environment |
+| `vibew status` | Show health of all components |
+| `vibew doctor` | Diagnose common issues |
+| `vibew logs` | Pretty-print structured logs |
+| `vibew secret get <path>` | Read a secret from OpenBao |
+| `vibew secret list <path>` | List secrets at a path |
+| `vibew validate` | Validate configuration |
+| `vibew context refresh` | Regenerate AI agent context files |
+
+---
+
+## License
+
+Apache 2.0 — see [LICENSE](https://github.com/vibewarden/vibewarden/blob/main/LICENSE).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,88 @@
+site_name: VibeWarden
+site_description: Production-grade security for vibe-coded apps — zero config changes to your code.
+site_url: https://vibewarden.dev/docs
+repo_url: https://github.com/vibewarden/vibewarden
+repo_name: vibewarden/vibewarden
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  logo: assets/logo.svg
+  favicon: assets/favicon.png
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: cyan
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: cyan
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+    - toc.follow
+
+extra_css:
+  - assets/extra.css
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Configuration: configuration.md
+  - Architecture: architecture.md
+  - Guides:
+      - Identity Providers: identity-providers.md
+      - Rate Limiting: rate-limiting.md
+      - Postgres: postgres.md
+      - Observability: observability.md
+      - Secret Management: secret-management.md
+      - Performance: performance.md
+      - Social Login: social-login.md
+      - Production Deployment: production-deployment.md
+      - Production Hardening: production-hardening.md
+  - Framework Examples:
+      - Express (Node.js): examples/express.md
+      - Next.js: examples/nextjs.md
+      - Django: examples/django.md
+      - Rails: examples/rails.md
+  - Reference:
+      - Architectural Decisions: decisions.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/vibewarden/vibewarden
+  version:
+    provider: mike


### PR DESCRIPTION
## Summary

- Adds `mkdocs.yml` at repo root with Material theme (dark/light toggle, purple `#7C3AED` / cyan `#06B6D4` brand colors, search, repo link, full topic navigation)
- `docs/index.md` — landing page adapted from the README hero section
- `docs/getting-started.md` — step-by-step install → init → dev guide; explains the Docker stack, middleware chain, generated files, and next steps for auth / TLS / observability
- `docs/configuration.md` — complete `vibewarden.yaml` reference for every field, derived from the config struct godoc; organized by section with type/default/description tables
- `docs/architecture.md` — middleware stack diagram, plugin system table, hexagonal architecture layout, Caddy embedding rationale, AI-readable structured log schema and event types
- `docs/assets/extra.css` — brand color overrides to precisely match `#7C3AED` purple and `#06B6D4` cyan
- `.github/workflows/docs.yml` — deploys to GitHub Pages via `mkdocs gh-deploy` on every push to main that touches docs or config

All existing docs (`identity-providers.md`, `rate-limiting.md`, `postgres.md`, `observability.md`, `secret-management.md`, `performance.md`, `social-login.md`, `production-deployment.md`, `production-hardening.md`, `decisions.md`, and all four framework examples) are wired into the navigation without modification.

## Test plan

- [ ] `make check` passes locally (verified — pre-push hook ran all checks)
- [ ] Run `pip install mkdocs-material && mkdocs serve` locally and verify all nav links resolve
- [ ] Push to main and verify GitHub Pages deployment succeeds via the Actions tab
- [ ] Confirm dark/light mode toggle works in the rendered site
- [ ] Confirm search indexes all pages