### PR TITLE
feat(#441): default to TLS with self-signed certificate on port 8443

### DIFF
--- a/internal/app/ops/dev.go
+++ b/internal/app/ops/dev.go
@@ -107,7 +107,7 @@ func printServiceURLs(cfg *config.Config, opts DevOptions, out io.Writer) {
 	}
 	proxyPort := cfg.Server.Port
 	if proxyPort == 0 {
-		proxyPort = 8080
+		proxyPort = 8443
 	}
 
 	fmt.Fprintln(out, "")

--- a/internal/app/ops/dev_test.go
+++ b/internal/app/ops/dev_test.go
@@ -58,9 +58,9 @@ func (f *fakeGenerator) Generate(_ context.Context, _ *config.Config, outputDir 
 
 func defaultConfig() *config.Config {
 	return &config.Config{
-		Server:   config.ServerConfig{Host: "127.0.0.1", Port: 8080},
+		Server:   config.ServerConfig{Host: "127.0.0.1", Port: 8443},
 		Upstream: config.UpstreamConfig{Host: "127.0.0.1", Port: 3000},
-		TLS:      config.TLSConfig{Enabled: false, Provider: "self-signed"},
+		TLS:      config.TLSConfig{Enabled: true, Provider: "self-signed"},
 		RateLimit: config.RateLimitConfig{
 			Enabled: true,
 			PerIP:   config.RateLimitRuleConfig{RequestsPerSecond: 10, Burst: 20},
@@ -86,7 +86,7 @@ func TestDevService_Run(t *testing.T) {
 			wantProfiles: nil,
 			wantOutputContains: []string{
 				"Proxy (VibeWarden):",
-				"http://localhost:8080",
+				"https://localhost:8443",
 				"vibewarden status",
 			},
 		},

--- a/internal/app/ops/doctor.go
+++ b/internal/app/ops/doctor.go
@@ -113,7 +113,7 @@ func (s *DoctorService) runChecks(ctx context.Context, cfg *config.Config, confi
 	// 4. Required ports available
 	proxyPort := cfg.Server.Port
 	if proxyPort == 0 {
-		proxyPort = 8080
+		proxyPort = 8443
 	}
 	proxyHost := cfg.Server.Host
 	if proxyHost == "" {

--- a/internal/app/ops/doctor_test.go
+++ b/internal/app/ops/doctor_test.go
@@ -84,7 +84,7 @@ func optsWithGeneratedFile(t *testing.T) ops.DoctorOptions {
 
 func TestDoctorService_Run_AllPassing(t *testing.T) {
 	fc := healthyContainersCompose()
-	pc := &fakePortChecker{available: map[int]bool{8080: true}}
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 
 	svc := ops.NewDoctorService(fc, pc, hc)
@@ -168,7 +168,7 @@ func TestDoctorService_Run_DockerComposeNotAvailable(t *testing.T) {
 
 func TestDoctorService_Run_PortInUse(t *testing.T) {
 	fc := noContainersCompose()
-	pc := &fakePortChecker{available: map[int]bool{8080: false}}
+	pc := &fakePortChecker{available: map[int]bool{8443: false}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
 	cfg := defaultConfig()
@@ -216,7 +216,7 @@ func TestDoctorService_ChecksAreIndependent(t *testing.T) {
 		versionErr: errors.New("compose not found"),
 		psErr:      errors.New("ps failed"),
 	}
-	pc := &fakePortChecker{available: map[int]bool{8080: false}}
+	pc := &fakePortChecker{available: map[int]bool{8443: false}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
 	cfg := defaultConfig()
@@ -244,7 +244,7 @@ func TestDoctorService_ChecksAreIndependent(t *testing.T) {
 
 func TestDoctorService_Run_GeneratedFileMissing_IsWarn(t *testing.T) {
 	fc := noContainersCompose()
-	pc := &fakePortChecker{available: map[int]bool{8080: true}}
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
 	cfg := defaultConfig()
@@ -276,7 +276,7 @@ func TestDoctorService_Run_UnhealthyContainer_IsFail(t *testing.T) {
 			{Name: "vibewarden-proxy-1", Service: "proxy", State: "running", Health: "unhealthy"},
 		},
 	}
-	pc := &fakePortChecker{available: map[int]bool{8080: true}}
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
 	cfg := defaultConfig()
@@ -298,7 +298,7 @@ func TestDoctorService_Run_UnhealthyContainer_IsFail(t *testing.T) {
 
 func TestDoctorService_Run_JSONOutput(t *testing.T) {
 	fc := noContainersCompose()
-	pc := &fakePortChecker{available: map[int]bool{8080: true}}
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
 	cfg := defaultConfig()
@@ -334,7 +334,7 @@ func TestDoctorService_Run_OKFAILBadgesInOutput(t *testing.T) {
 		infoErr:    errors.New("docker not running"),
 		versionStr: "Docker Compose version v2.35.1",
 	}
-	pc := &fakePortChecker{available: map[int]bool{8080: true}}
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
 	cfg := defaultConfig()
@@ -356,7 +356,7 @@ func TestDoctorService_Run_OKFAILBadgesInOutput(t *testing.T) {
 
 func TestDoctorService_Run_ContainersHealthy_AllOK(t *testing.T) {
 	fc := healthyContainersCompose()
-	pc := &fakePortChecker{available: map[int]bool{8080: true}}
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
 	cfg := defaultConfig()

--- a/internal/app/ops/status.go
+++ b/internal/app/ops/status.go
@@ -41,7 +41,7 @@ func (s *StatusService) Run(ctx context.Context, cfg *config.Config, out io.Writ
 	}
 	proxyPort := cfg.Server.Port
 	if proxyPort == 0 {
-		proxyPort = 8080
+		proxyPort = 8443
 	}
 	proxyBase := fmt.Sprintf("%s://localhost:%d", scheme, proxyPort)
 

--- a/internal/app/ops/status_test.go
+++ b/internal/app/ops/status_test.go
@@ -32,7 +32,7 @@ func (f *fakeHealthChecker) CheckHealth(_ context.Context, url string) (bool, in
 
 func TestStatusService_Run(t *testing.T) {
 	cfg := defaultConfig()
-	proxyBase := "http://localhost:8080"
+	proxyBase := "https://localhost:8443"
 
 	healthURL := proxyBase + "/_vibewarden/health"
 	metricsURL := proxyBase + "/_vibewarden/metrics"
@@ -118,7 +118,7 @@ func TestStatusService_RateLimitDisabled(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.RateLimit.Enabled = false
 
-	proxyBase := "http://localhost:8080"
+	proxyBase := "https://localhost:8443"
 	checker := &fakeHealthChecker{responses: map[string]healthResponse{
 		proxyBase + "/_vibewarden/health":          {ok: true, statusCode: 200},
 		proxyBase + "/_vibewarden/metrics":         {ok: true, statusCode: 200},
@@ -140,7 +140,7 @@ func TestStatusService_MetricsDisabled(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Metrics.Enabled = false
 
-	proxyBase := "http://localhost:8080"
+	proxyBase := "https://localhost:8443"
 	checker := &fakeHealthChecker{responses: map[string]healthResponse{
 		proxyBase + "/_vibewarden/health":          {ok: true, statusCode: 200},
 		"http://127.0.0.1:4434/admin/health/ready": {ok: true, statusCode: 200},
@@ -161,7 +161,7 @@ func TestStatusService_MetricsDisabled(t *testing.T) {
 func TestStatusService_PluginSectionShown(t *testing.T) {
 	cfg := defaultConfig()
 
-	proxyBase := "http://localhost:8080"
+	proxyBase := "https://localhost:8443"
 	checker := &fakeHealthChecker{responses: map[string]healthResponse{
 		proxyBase + "/_vibewarden/health":          {ok: true, statusCode: 200},
 		proxyBase + "/_vibewarden/metrics":         {ok: true, statusCode: 200},
@@ -196,8 +196,8 @@ func TestStatusService_TLSEnabled(t *testing.T) {
 	cfg.TLS.Domain = "example.com"
 
 	checker := &fakeHealthChecker{responses: map[string]healthResponse{
-		"https://localhost:8080/_vibewarden/health":  {ok: true, statusCode: 200},
-		"https://localhost:8080/_vibewarden/metrics": {ok: true, statusCode: 200},
+		"https://localhost:8443/_vibewarden/health":  {ok: true, statusCode: 200},
+		"https://localhost:8443/_vibewarden/metrics": {ok: true, statusCode: 200},
 		"http://127.0.0.1:4434/admin/health/ready":   {ok: true, statusCode: 200},
 	}}
 

--- a/internal/cli/cmd/dev.go
+++ b/internal/cli/cmd/dev.go
@@ -36,7 +36,7 @@ When vibewarden.yaml is present, VibeWarden generates runtime configuration
 files under .vibewarden/generated/ before starting the stack.
 
 The baseline stack includes:
-  - VibeWarden proxy (port 8080)
+  - VibeWarden proxy (port 8443, HTTPS with self-signed certificate)
   - Ory Kratos identity server (ports 4433, 4434)
   - PostgreSQL
   - Mailslurper (email sink)

--- a/internal/cli/cmd/init_test.go
+++ b/internal/cli/cmd/init_test.go
@@ -234,7 +234,12 @@ func TestNewInitCmd_RenderedYAMLValid(t *testing.T) {
 		{
 			name:       "default config contains server and upstream sections",
 			args:       []string{},
-			wantInYAML: []string{"server:", "upstream:", "port: 3000", "port: 8080"},
+			wantInYAML: []string{"server:", "upstream:", "port: 3000", "port: 8443"},
+		},
+		{
+			name:       "default config enables TLS with self-signed provider",
+			args:       []string{},
+			wantInYAML: []string{"tls:", "enabled: true", "self-signed"},
 		},
 		{
 			name:       "auth flag adds kratos and auth sections with new consolidated fields",

--- a/internal/cli/templates/vibewarden.yaml.tmpl
+++ b/internal/cli/templates/vibewarden.yaml.tmpl
@@ -4,7 +4,7 @@
 
 server:
   host: "127.0.0.1"
-  port: 8080
+  port: 8443
 
 upstream:
   host: "127.0.0.1"
@@ -41,7 +41,8 @@ tls:
 {{- else }}
 
 tls:
-  enabled: false
+  enabled: true
+  provider: "self-signed"
 {{- end }}
 {{- if .AuthEnabled }}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,7 +197,7 @@ func (d DatabaseConfig) BuildDSN() string {
 type ServerConfig struct {
 	// Host to bind to (default: "127.0.0.1")
 	Host string `mapstructure:"host"`
-	// Port to listen on (default: 8080)
+	// Port to listen on (default: 8443)
 	Port int `mapstructure:"port"`
 }
 
@@ -1673,10 +1673,10 @@ func Load(configPath string) (*Config, error) {
 	// Set defaults
 	v.SetDefault("profile", "dev")
 	v.SetDefault("server.host", "127.0.0.1")
-	v.SetDefault("server.port", 8080)
+	v.SetDefault("server.port", 8443)
 	v.SetDefault("upstream.host", "127.0.0.1")
 	v.SetDefault("upstream.port", 3000)
-	v.SetDefault("tls.enabled", false)
+	v.SetDefault("tls.enabled", true)
 	v.SetDefault("tls.provider", "self-signed")
 	v.SetDefault("kratos.public_url", "http://127.0.0.1:4433")
 	v.SetDefault("kratos.admin_url", "http://127.0.0.1:4434")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -239,10 +239,10 @@ func TestLoad_Defaults(t *testing.T) {
 		want interface{}
 	}{
 		{"server.host", cfg.Server.Host, "127.0.0.1"},
-		{"server.port", cfg.Server.Port, 8080},
+		{"server.port", cfg.Server.Port, 8443},
 		{"upstream.host", cfg.Upstream.Host, "127.0.0.1"},
 		{"upstream.port", cfg.Upstream.Port, 3000},
-		{"tls.enabled", cfg.TLS.Enabled, false},
+		{"tls.enabled", cfg.TLS.Enabled, true},
 		{"tls.provider", cfg.TLS.Provider, "self-signed"},
 		{"kratos.public_url", cfg.Kratos.PublicURL, "http://127.0.0.1:4433"},
 		{"kratos.admin_url", cfg.Kratos.AdminURL, "http://127.0.0.1:4434"},


### PR DESCRIPTION
Closes #441

## Summary

- `server.port` default changed from `8080` to `8443`
- `tls.enabled` default changed from `false` to `true`
- `tls.provider` default was already `"self-signed"` — no change needed
- `internal/cli/templates/vibewarden.yaml.tmpl`: port updated to `8443`; the `else` branch (no explicit `--tls` flag) now emits `enabled: true` + `provider: "self-signed"` instead of `enabled: false`
- `internal/app/ops/dev.go`, `doctor.go`, `status.go`: fallback port literal `8080` → `8443`
- `internal/cli/cmd/dev.go`: help text updated to mention port 8443 and HTTPS
- All test fixtures and assertions updated: `defaultConfig()` in `ops_test`, `status_test.go` URL strings, `doctor_test.go` port checker maps, `config_test.go` defaults assertions, `init_test.go` YAML content checks
- New `init_test.go` table-driven case added: verifies default scaffold emits `tls: enabled: true` + `self-signed`

## Test plan

- [ ] `make check` passes (all tests green, vet clean, race detector clean)
- [ ] `vibewarden init <dir>` produces a `vibewarden.yaml` with `port: 8443` and `tls: enabled: true` + `provider: "self-signed"`
- [ ] `vibewarden serve` (no config) binds to `:8443` with a self-signed cert
- [ ] Existing config files that explicitly set `port: 8080` still load correctly (backward-compat test covers this)
