### PR TITLE
feat(#444): implement vibew token — generate signed dev JWTs from CLI

### DIFF
--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -40,6 +40,7 @@ Zero-to-secure in minutes.`,
 	root.AddCommand(NewGenerateCmd())
 	root.AddCommand(NewPluginsCmd())
 	root.AddCommand(NewCertCmd())
+	root.AddCommand(NewTokenCmd())
 
 	return root
 }

--- a/internal/cli/cmd/token.go
+++ b/internal/cli/cmd/token.go
@@ -1,0 +1,182 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	"github.com/spf13/cobra"
+
+	jwtadapter "github.com/vibewarden/vibewarden/internal/adapters/jwt"
+)
+
+// devTokenClaims holds the custom claims written into the dev JWT.
+type devTokenClaims struct {
+	Email string `json:"email"`
+	Name  string `json:"name"`
+	Role  string `json:"role"`
+}
+
+// NewTokenCmd creates the "vibewarden token" subcommand.
+//
+// The command loads the dev RSA private key from .vibewarden/dev-keys/private.pem,
+// signs a JWT with the supplied claims, and writes the token to stdout. When
+// --json is given only the raw token string is printed, which makes the output
+// suitable for shell interpolation:
+//
+//	curl -H "Authorization: Bearer $(vibew token)" https://localhost:8443/api/me
+func NewTokenCmd() *cobra.Command {
+	var (
+		sub     string
+		email   string
+		name    string
+		role    string
+		expires string
+		jsonOut bool
+		keyDir  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "token",
+		Short: "Generate a signed dev JWT for local testing",
+		Long: `Generate a signed JWT using the local dev RSA private key.
+
+The key must exist at .vibewarden/dev-keys/private.pem. Run "vibewarden dev"
+or "vibewarden generate" first if the key is missing — VibeWarden creates the
+key pair automatically on first run.
+
+The generated token is signed with RS256, uses kid=` + jwtadapter.DevKID + `,
+iss=` + jwtadapter.DevIssuer + `, and aud=` + jwtadapter.DevAudience + `.
+
+Examples:
+  vibewarden token
+  vibewarden token --sub user-123 --email alice@test.com --role admin
+  vibewarden token --expires 24h
+  vibewarden token --json
+  curl https://localhost:8443/api/me \
+    -H "Authorization: Bearer $(vibewarden token --json)"`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runToken(cmd, keyDir, sub, email, name, role, expires, jsonOut)
+		},
+	}
+
+	cmd.Flags().StringVar(&sub, "sub", "dev-user", "Subject (user ID) claim")
+	cmd.Flags().StringVar(&email, "email", "dev@localhost", "Email claim")
+	cmd.Flags().StringVar(&name, "name", "Dev User", "Name claim")
+	cmd.Flags().StringVar(&role, "role", "user", "Role claim")
+	cmd.Flags().StringVar(&expires, "expires", "1h", "Token lifetime (Go duration, e.g. 1h, 30m, 24h)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Print raw token only (for shell interpolation)")
+	cmd.Flags().StringVar(&keyDir, "key-dir", "", "Directory containing the dev key pair (default: .vibewarden/dev-keys)")
+
+	return cmd
+}
+
+// runToken is the testable core of the token command. It is separated from the
+// cobra RunE closure so it can be exercised by unit tests without constructing
+// a cobra.Command.
+func runToken(cmd *cobra.Command, keyDir, sub, email, name, role, expires string, jsonOut bool) error {
+	dir, err := resolveKeyDir(keyDir)
+	if err != nil {
+		return err
+	}
+
+	privPath := filepath.Join(dir, jwtadapter.DevPrivateKeyFile)
+	if _, err := os.Stat(privPath); err != nil {
+		return fmt.Errorf(
+			"dev keys not found at %s: run \"vibewarden dev\" or \"vibewarden generate\" first",
+			privPath,
+		)
+	}
+
+	kp, err := jwtadapter.LoadOrGenerateDevKeys(dir)
+	if err != nil {
+		return fmt.Errorf("loading dev key pair: %w", err)
+	}
+
+	ttl, err := time.ParseDuration(expires)
+	if err != nil {
+		return fmt.Errorf("invalid --expires value %q: %w", expires, err)
+	}
+	if ttl <= 0 {
+		return fmt.Errorf("--expires must be a positive duration, got %q", expires)
+	}
+
+	token, err := SignDevToken(context.Background(), kp, sub, email, name, role, ttl)
+	if err != nil {
+		return fmt.Errorf("signing token: %w", err)
+	}
+
+	if jsonOut {
+		fmt.Fprintln(cmd.OutOrStdout(), token)
+		return nil
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), token)
+	fmt.Fprintln(cmd.OutOrStdout())
+	fmt.Fprintf(cmd.OutOrStdout(), "Hint: use this token with curl:\n")
+	fmt.Fprintf(cmd.OutOrStdout(), "  curl https://localhost:8443/api/me \\\n")
+	fmt.Fprintf(cmd.OutOrStdout(), "    -H \"Authorization: Bearer %s\"\n", token)
+	fmt.Fprintln(cmd.OutOrStdout())
+	fmt.Fprintf(cmd.OutOrStdout(), "Or inline via shell substitution:\n")
+	fmt.Fprintf(cmd.OutOrStdout(), "  curl https://localhost:8443/api/me \\\n")
+	fmt.Fprintf(cmd.OutOrStdout(), "    -H \"Authorization: Bearer $(vibewarden token --json)\"\n")
+
+	return nil
+}
+
+// SignDevToken signs a JWT with the dev RSA private key and returns the compact
+// serialisation. It is a pure function (aside from time.Now()) and is exposed
+// so package-level tests can call it directly with a pre-built key pair.
+func SignDevToken(_ context.Context, kp *jwtadapter.DevKeyPair, sub, email, name, role string, ttl time.Duration) (string, error) {
+	sig, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: kp.PrivateKey},
+		(&jose.SignerOptions{}).
+			WithType("JWT").
+			WithHeader("kid", jwtadapter.DevKID),
+	)
+	if err != nil {
+		return "", fmt.Errorf("creating signer: %w", err)
+	}
+
+	now := time.Now()
+	std := josejwt.Claims{
+		Issuer:   jwtadapter.DevIssuer,
+		Audience: josejwt.Audience{jwtadapter.DevAudience},
+		Subject:  sub,
+		IssuedAt: josejwt.NewNumericDate(now),
+		Expiry:   josejwt.NewNumericDate(now.Add(ttl)),
+	}
+
+	custom := devTokenClaims{
+		Email: email,
+		Name:  name,
+		Role:  role,
+	}
+
+	raw, err := josejwt.Signed(sig).Claims(std).Claims(custom).Serialize()
+	if err != nil {
+		return "", fmt.Errorf("serialising token: %w", err)
+	}
+
+	return raw, nil
+}
+
+// resolveKeyDir returns the absolute path to the dev key directory.
+// When override is non-empty it is used as-is. Otherwise the default
+// relative path ".vibewarden/dev-keys" is resolved against the working directory.
+func resolveKeyDir(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getting working directory: %w", err)
+	}
+
+	return filepath.Join(wd, jwtadapter.DevKeyDir), nil
+}

--- a/internal/cli/cmd/token_test.go
+++ b/internal/cli/cmd/token_test.go
@@ -1,0 +1,358 @@
+package cmd_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+
+	jwtadapter "github.com/vibewarden/vibewarden/internal/adapters/jwt"
+	"github.com/vibewarden/vibewarden/internal/cli/cmd"
+)
+
+// generateTestKeyPair creates a temporary directory with a 2048-bit RSA private
+// key written as a PEM-encoded PKCS#8 file. It returns the directory path and
+// a DevKeyPair suitable for use in tests.
+func generateTestKeyPair(t *testing.T) (dir string, kp *jwtadapter.DevKeyPair) {
+	t.Helper()
+
+	dir = t.TempDir()
+	var err error
+	kp, err = jwtadapter.LoadOrGenerateDevKeys(dir)
+	if err != nil {
+		t.Fatalf("generateTestKeyPair: %v", err)
+	}
+	return dir, kp
+}
+
+// writeRawPrivateKey writes the given RSA key as a PKCS#8 PEM file to path.
+func writeRawPrivateKey(t *testing.T, path string, key *rsa.PrivateKey) {
+	t.Helper()
+
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshalling key: %v", err)
+	}
+	block := &pem.Block{Type: "PRIVATE KEY", Bytes: der}
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("writing key: %v", err)
+	}
+}
+
+// ─── signDevToken (unit tests) ────────────────────────────────────────────────
+
+func TestSignDevToken_ValidToken(t *testing.T) {
+	_, kp := generateTestKeyPair(t)
+
+	raw, err := cmd.SignDevToken(context.Background(), kp, "sub-1", "user@test.com", "Test User", "admin", time.Hour)
+	if err != nil {
+		t.Fatalf("SignDevToken() unexpected error: %v", err)
+	}
+	if raw == "" {
+		t.Fatal("SignDevToken() returned empty token")
+	}
+
+	// Parse and validate the token against the public key.
+	tok, err := josejwt.ParseSigned(raw, []jose.SignatureAlgorithm{jose.RS256})
+	if err != nil {
+		t.Fatalf("ParseSigned() unexpected error: %v", err)
+	}
+
+	var stdClaims josejwt.Claims
+	var custom map[string]any
+	if err := tok.Claims(&kp.PrivateKey.PublicKey, &stdClaims, &custom); err != nil {
+		t.Fatalf("Claims() unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"issuer", stdClaims.Issuer, jwtadapter.DevIssuer},
+		{"subject", stdClaims.Subject, "sub-1"},
+		{"email", custom["email"], "user@test.com"},
+		{"name", custom["name"], "Test User"},
+		{"role", custom["role"], "admin"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("claim %s = %v, want %v", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+
+	// Audience slice must contain DevAudience.
+	found := false
+	for _, a := range stdClaims.Audience {
+		if a == jwtadapter.DevAudience {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("audience %v does not contain %q", stdClaims.Audience, jwtadapter.DevAudience)
+	}
+}
+
+func TestSignDevToken_KIDHeader(t *testing.T) {
+	_, kp := generateTestKeyPair(t)
+
+	raw, err := cmd.SignDevToken(context.Background(), kp, "u", "e@e.com", "N", "user", time.Minute)
+	if err != nil {
+		t.Fatalf("SignDevToken() unexpected error: %v", err)
+	}
+
+	tok, err := josejwt.ParseSigned(raw, []jose.SignatureAlgorithm{jose.RS256})
+	if err != nil {
+		t.Fatalf("ParseSigned() unexpected error: %v", err)
+	}
+
+	if len(tok.Headers) == 0 {
+		t.Fatal("no JWT headers")
+	}
+	if got := tok.Headers[0].KeyID; got != jwtadapter.DevKID {
+		t.Errorf("kid = %q, want %q", got, jwtadapter.DevKID)
+	}
+}
+
+func TestSignDevToken_Expiry(t *testing.T) {
+	_, kp := generateTestKeyPair(t)
+
+	ttl := 2 * time.Hour
+	before := time.Now()
+	raw, err := cmd.SignDevToken(context.Background(), kp, "u", "e@e.com", "N", "user", ttl)
+	after := time.Now()
+	if err != nil {
+		t.Fatalf("SignDevToken() unexpected error: %v", err)
+	}
+
+	tok, _ := josejwt.ParseSigned(raw, []jose.SignatureAlgorithm{jose.RS256})
+	var std josejwt.Claims
+	_ = tok.Claims(&kp.PrivateKey.PublicKey, &std)
+
+	expTime := std.Expiry.Time()
+	lo := before.Add(ttl).Add(-2 * time.Second)
+	hi := after.Add(ttl).Add(2 * time.Second)
+	if expTime.Before(lo) || expTime.After(hi) {
+		t.Errorf("expiry %v not in expected window [%v, %v]", expTime, lo, hi)
+	}
+}
+
+// ─── vibewarden token command (integration) ───────────────────────────────────
+
+func TestTokenCmd_DefaultOutput(t *testing.T) {
+	dir, _ := generateTestKeyPair(t)
+
+	root := cmd.NewRootCmd("test")
+	var outBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetArgs([]string{"token", "--key-dir", dir})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	out := outBuf.String()
+	// First line must be the JWT (starts with "ey").
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if !strings.HasPrefix(lines[0], "ey") {
+		t.Errorf("first output line does not look like a JWT: %q", lines[0])
+	}
+
+	// Non-JSON output must contain usage hints.
+	if !strings.Contains(out, "Hint:") {
+		t.Errorf("default output should contain a usage hint, got:\n%s", out)
+	}
+}
+
+func TestTokenCmd_JSONOutput(t *testing.T) {
+	dir, _ := generateTestKeyPair(t)
+
+	root := cmd.NewRootCmd("test")
+	var outBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetArgs([]string{"token", "--key-dir", dir, "--json"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	token := strings.TrimSpace(outBuf.String())
+	if !strings.HasPrefix(token, "ey") {
+		t.Errorf("--json output does not look like a JWT: %q", token)
+	}
+	// Must be a single line (no hints).
+	if strings.Contains(token, "\n") {
+		t.Errorf("--json output contains newlines: %q", token)
+	}
+}
+
+func TestTokenCmd_CustomClaims(t *testing.T) {
+	dir, kp := generateTestKeyPair(t)
+
+	root := cmd.NewRootCmd("test")
+	var outBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetArgs([]string{
+		"token", "--key-dir", dir, "--json",
+		"--sub", "user-42",
+		"--email", "alice@example.com",
+		"--name", "Alice",
+		"--role", "admin",
+		"--expires", "30m",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	raw := strings.TrimSpace(outBuf.String())
+	tok, err := josejwt.ParseSigned(raw, []jose.SignatureAlgorithm{jose.RS256})
+	if err != nil {
+		t.Fatalf("ParseSigned() unexpected error: %v", err)
+	}
+
+	var std josejwt.Claims
+	var custom map[string]any
+	if err := tok.Claims(&kp.PrivateKey.PublicKey, &std, &custom); err != nil {
+		t.Fatalf("Claims() unexpected error: %v", err)
+	}
+
+	checks := []struct {
+		field string
+		got   any
+		want  any
+	}{
+		{"sub", std.Subject, "user-42"},
+		{"email", custom["email"], "alice@example.com"},
+		{"name", custom["name"], "Alice"},
+		{"role", custom["role"], "admin"},
+	}
+	for _, c := range checks {
+		t.Run(c.field, func(t *testing.T) {
+			if c.got != c.want {
+				t.Errorf("claim %s = %v, want %v", c.field, c.got, c.want)
+			}
+		})
+	}
+}
+
+func TestTokenCmd_MissingKeys(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var errBuf bytes.Buffer
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"token", "--key-dir", "/nonexistent/path/dev-keys"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute() expected error for missing keys, got nil")
+	}
+}
+
+func TestTokenCmd_InvalidExpires(t *testing.T) {
+	dir, _ := generateTestKeyPair(t)
+
+	root := cmd.NewRootCmd("test")
+	var errBuf bytes.Buffer
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"token", "--key-dir", dir, "--expires", "notaduration"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute() expected error for invalid --expires, got nil")
+	}
+}
+
+func TestTokenCmd_ZeroExpires(t *testing.T) {
+	dir, _ := generateTestKeyPair(t)
+
+	root := cmd.NewRootCmd("test")
+	var errBuf bytes.Buffer
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"token", "--key-dir", dir, "--expires", "0s"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute() expected error for zero --expires, got nil")
+	}
+}
+
+func TestTokenCmd_NegativeExpires(t *testing.T) {
+	dir, _ := generateTestKeyPair(t)
+
+	root := cmd.NewRootCmd("test")
+	var errBuf bytes.Buffer
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"token", "--key-dir", dir, "--expires", "-1h"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute() expected error for negative --expires, got nil")
+	}
+}
+
+func TestTokenCmd_CorruptPrivateKey(t *testing.T) {
+	dir := t.TempDir()
+	// Write a syntactically invalid PEM file.
+	badPEM := "-----BEGIN PRIVATE KEY-----\nnotbase64\n-----END PRIVATE KEY-----\n"
+	if err := os.WriteFile(filepath.Join(dir, jwtadapter.DevPrivateKeyFile), []byte(badPEM), 0o600); err != nil {
+		t.Fatalf("writing corrupt key: %v", err)
+	}
+
+	root := cmd.NewRootCmd("test")
+	var errBuf bytes.Buffer
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"token", "--key-dir", dir})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute() expected error for corrupt key, got nil")
+	}
+}
+
+func TestTokenCmd_ValidatesAgainstPublicKey(t *testing.T) {
+	dir, kp := generateTestKeyPair(t)
+
+	root := cmd.NewRootCmd("test")
+	var outBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetArgs([]string{"token", "--key-dir", dir, "--json"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	raw := strings.TrimSpace(outBuf.String())
+
+	// Attempt to verify with a different (wrong) RSA public key — must fail.
+	wrongKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating wrong key: %v", err)
+	}
+
+	tok, err := josejwt.ParseSigned(raw, []jose.SignatureAlgorithm{jose.RS256})
+	if err != nil {
+		t.Fatalf("ParseSigned() unexpected error: %v", err)
+	}
+
+	var std josejwt.Claims
+	if err := tok.Claims(&wrongKey.PublicKey, &std); err == nil {
+		t.Error("Claims() with wrong key should have failed, but did not")
+	}
+
+	// Verify with the correct public key — must succeed.
+	if err := tok.Claims(&kp.PrivateKey.PublicKey, &std); err != nil {
+		t.Errorf("Claims() with correct key unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #444

## Summary

- Adds `vibewarden token` subcommand to `internal/cli/cmd/token.go` and registers it in `root.go`
- Loads the dev RSA private key from `.vibewarden/dev-keys/private.pem` (the same key pair created by `LoadOrGenerateDevKeys` used by the JWKS server)
- Signs RS256 JWTs with `kid=vibewarden-dev-1`, `iss=vibewarden-dev`, `aud=dev` and configurable claims via flags (`--sub`, `--email`, `--name`, `--role`, `--expires`)
- Default output prints the token followed by curl usage hints; `--json` emits the raw token only, enabling `$(vibewarden token --json)` in shell pipes
- `--key-dir` flag overrides the default `.vibewarden/dev-keys` path (used by tests)
- Returns a clear error message when keys are not found, directing the user to run `vibewarden dev` or `vibewarden generate` first
- No new dependencies — reuses `go-jose/v4` already in `go.mod`

## Test plan

- [ ] `go test -race ./internal/cli/cmd/...` — all 10 new table-driven test cases pass
- [ ] `TestSignDevToken_ValidToken` — token parses, signature verifies, all claims match
- [ ] `TestSignDevToken_KIDHeader` — `kid` header is `vibewarden-dev-1`
- [ ] `TestSignDevToken_Expiry` — expiry matches requested TTL within 2s tolerance
- [ ] `TestTokenCmd_DefaultOutput` — first line starts with `ey`, output contains `Hint:`
- [ ] `TestTokenCmd_JSONOutput` — single-line raw JWT, no hints
- [ ] `TestTokenCmd_CustomClaims` — all five flag values appear in verified claims
- [ ] `TestTokenCmd_MissingKeys` — returns error when key dir does not exist
- [ ] `TestTokenCmd_InvalidExpires` — returns error for non-duration string
- [ ] `TestTokenCmd_ZeroExpires` / `TestTokenCmd_NegativeExpires` — reject non-positive TTL
- [ ] `TestTokenCmd_CorruptPrivateKey` — returns error for malformed PEM
- [ ] `TestTokenCmd_ValidatesAgainstPublicKey` — token verifies with correct key, fails with a different key
