### PR TITLE
docs(#445): update docs, quick start, and examples for secure-by-default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ curl -fsSL https://vibewarden.dev/vibew > vibew && chmod +x vibew
 ./vibew dev
 ```
 
-Your app on port 3000 is now behind VibeWarden. Done.
+Your app on port 3000 is now behind VibeWarden at `https://localhost:8443`. Done.
 
 **Windows:**
 
@@ -67,7 +67,7 @@ Do not edit generated files — re-run `vibew generate` after changing `vibeward
 
 ```
                  ┌────────────────────────────────┐
-  Internet ─────►│  VibeWarden  :8080             │
+  Internet ─────►│  VibeWarden  :8443 (HTTPS)     │
                  │                                │
                  │  TLS termination               │
                  │  Authentication (JWT / Kratos) │
@@ -180,6 +180,8 @@ If you need a general-purpose load balancer or a CDN edge, use the right tool fo
 | `vibew logs` | Pretty-print structured logs |
 | `vibew secret get <path>` | Read a secret from OpenBao |
 | `vibew secret list <path>` | List secrets at a path |
+| `vibew token` | Generate a signed dev JWT for local testing |
+| `vibew cert export` | Export the local CA certificate (for curl, Postman, …) |
 | `vibew validate` | Validate configuration |
 | `vibew context refresh` | Regenerate AI agent context files |
 
@@ -206,7 +208,7 @@ Regenerate after config changes:
 ```bash
 cd examples/demo-app
 docker compose up -d
-# Open http://localhost:8080
+# Open https://localhost:8443
 ```
 
 The demo includes a Vulnerability Lab with live SQLi, XSS, and path traversal

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,12 +37,12 @@ Settings for the VibeWarden HTTP listener.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `server.host` | string | `127.0.0.1` | Host/IP to bind to |
-| `server.port` | int | `8080` | Port to listen on |
+| `server.port` | int | `8443` | Port to listen on |
 
 ```yaml
 server:
   host: 0.0.0.0
-  port: 8080
+  port: 8443
 ```
 
 ---
@@ -98,7 +98,7 @@ app:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `tls.enabled` | bool | `false` | Enable TLS |
+| `tls.enabled` | bool | `true` | Enable TLS |
 | `tls.domain` | string | `""` | Domain for the TLS certificate. Required when `provider` is `letsencrypt` |
 | `tls.provider` | string | `""` | Certificate provider: `letsencrypt`, `self-signed`, or `external` |
 | `tls.cert_path` | string | `""` | Path to PEM certificate. Required when `provider` is `external` |
@@ -546,7 +546,11 @@ profile: dev
 
 server:
   host: 0.0.0.0
-  port: 8080
+  port: 8443
+
+tls:
+  enabled: true
+  provider: self-signed
 
 upstream:
   host: 127.0.0.1

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -91,7 +91,18 @@ This command:
    from your `vibewarden.yaml`.
 2. Starts the stack with `docker compose up`.
 
-Your app is now protected at `http://localhost:8080`.
+Your app is now protected at `https://localhost:8443`.
+
+!!! tip "Trust the self-signed certificate"
+    On first run, VibeWarden generates a self-signed CA certificate so your browser
+    can open `https://localhost:8443` without TLS errors. Export and trust it with:
+
+    ```bash
+    ./vibew cert export > vibewarden-ca.pem
+    ```
+
+    Then import `vibewarden-ca.pem` into your browser's or OS's trusted certificate
+    store (or pass `--cacert vibewarden-ca.pem` to `curl`).
 
 ---
 
@@ -201,6 +212,16 @@ examples with Auth0, Keycloak, Firebase, Cognito, Okta, Supabase, and Kratos.
 Open Grafana at `http://localhost:3001` to see request rate, latency percentiles,
 rate limit hits, and auth decisions in real time.
 
+!!! tip "Generate a dev JWT"
+    Use `vibew token` to mint a signed JWT for local testing without an external
+    OIDC provider:
+
+    ```bash
+    curl https://localhost:8443/api/me \
+      --cacert vibewarden-ca.pem \
+      -H "Authorization: Bearer $(./vibew token --json)"
+    ```
+
 See the [Observability guide](observability.md) for details.
 
 ### Enable TLS for production
@@ -230,11 +251,11 @@ Reports all validation errors in `vibewarden.yaml` before you start the stack.
 
 ### Port already in use
 
-VibeWarden defaults to port `8080`. Change it in `vibewarden.yaml`:
+VibeWarden defaults to port `8443`. Change it in `vibewarden.yaml`:
 
 ```yaml
 server:
-  port: 8090
+  port: 9443
 ```
 
 ### App not reachable

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ all in a single binary that sits next to your app.
     .\vibew.ps1 dev
     ```
 
-Your app on port 3000 is now behind VibeWarden. Done.
+Your app on port 3000 is now behind VibeWarden at `https://localhost:8443`. Done.
 
 ---
 
@@ -39,7 +39,7 @@ Your app on port 3000 is now behind VibeWarden. Done.
 
 ```
              ┌────────────────────────────────┐
-Internet ────►│  VibeWarden  :8080             │
+Internet ────►│  VibeWarden  :8443 (HTTPS)     │
              │                                │
              │  TLS termination               │
              │  Authentication (JWT / Kratos) │
@@ -146,6 +146,8 @@ Your app receives authenticated user info via headers:
 | `vibew logs` | Pretty-print structured logs |
 | `vibew secret get <path>` | Read a secret from OpenBao |
 | `vibew secret list <path>` | List secrets at a path |
+| `vibew token` | Generate a signed dev JWT for local testing |
+| `vibew cert export` | Export the local CA certificate (for curl, Postman, …) |
 | `vibew validate` | Validate configuration |
 | `vibew context refresh` | Regenerate AI agent context files |
 

--- a/examples/demo-app/.env.example
+++ b/examples/demo-app/.env.example
@@ -26,15 +26,12 @@ VIBEWARDEN_PROFILE=dev
 # Sidecar port overrides (change when VIBEWARDEN_PROFILE != dev)
 # --------------------------------------------------------------------------
 
-# HTTP port exposed to the host for the dev profile.
-# Default: 8080
-# VIBEWARDEN_HTTP_PORT=8080
-
-# For tls profile: override the port to 8443 and enable TLS.
-# VIBEWARDEN_HTTP_PORT=8443
+# HTTPS port exposed to the host. Default: 8443 (TLS enabled by default).
 # VIBEWARDEN_SERVER_PORT=8443
-# VIBEWARDEN_TLS_ENABLED=true
-# VIBEWARDEN_TLS_PROVIDER=self-signed
+
+# To disable TLS and revert to plain HTTP on port 8080 (not recommended):
+# VIBEWARDEN_TLS_ENABLED=false
+# VIBEWARDEN_SERVER_PORT=8080
 
 # For prod profile: standard HTTP+HTTPS ports and Let's Encrypt.
 # VIBEWARDEN_HTTP_PORT=443

--- a/examples/demo-app/CHALLENGE.md
+++ b/examples/demo-app/CHALLENGE.md
@@ -67,7 +67,7 @@ The safest way to probe VibeWarden is against your own local instance:
 ```bash
 cd examples/demo-app
 docker compose up -d
-# VibeWarden is now listening on http://localhost:8080
+# VibeWarden is now listening on https://localhost:8443
 ```
 
 See [`README.md`](README.md) for the full list of endpoints and what each one

--- a/examples/demo-app/README.md
+++ b/examples/demo-app/README.md
@@ -19,14 +19,14 @@ Generated files are written to `.vibewarden/generated/` which is gitignored.
 ```bash
 cd examples/demo-app
 make demo
-# Visit http://localhost:8080
+# Visit https://localhost:8443
 ```
 
 Wait ~30 seconds for the full stack to be healthy.
 
 | Service | URL | Credentials |
 |---|---|---|
-| Demo app (via VibeWarden) | http://localhost:8080 | see Demo credentials below |
+| Demo app (via VibeWarden) | https://localhost:8443 | see Demo credentials below |
 | Grafana | http://localhost:3001 | admin / admin |
 | Prometheus | http://localhost:9090 | — |
 | Kratos public API | http://localhost:4433 | — |
@@ -107,7 +107,7 @@ for a clean, classless style with zero build tooling.
 ```
 Browser / curl
     |
-    | :8080 (dev) or :8443 (tls)
+    | :8443 (HTTPS)
     v
 +-------------------+
 |    VibeWarden      |  <-- auth check (Kratos), rate limiting, security headers, secrets injection
@@ -142,7 +142,7 @@ Returns a personalised greeting when logged in, or a generic welcome when not.
 from the validated Kratos session.
 
 ```bash
-curl http://localhost:8080/
+curl https://localhost:8443/
 # {"authenticated":false,"message":"Welcome! Please log in."}
 ```
 
@@ -151,7 +151,7 @@ curl http://localhost:8080/
 Returns the active demo profile and which feature sets are available.
 
 ```bash
-curl http://localhost:8080/profile
+curl https://localhost:8443/profile
 # {"observability_enabled":false,"profile":"dev","tls_enabled":false}
 ```
 
@@ -162,7 +162,7 @@ Always returns a timestamp. VibeWarden skips auth for this path.
 **Demonstrates:** `public_paths` configuration — no Kratos check, no redirect.
 
 ```bash
-curl http://localhost:8080/public
+curl https://localhost:8443/public
 # {"message":"This is a public endpoint","timestamp":"2025-01-15T12:00:00Z"}
 ```
 
@@ -172,7 +172,7 @@ Returns the authenticated user's ID, email, and email-verification status.
 Returns 401 if the request did not pass through VibeWarden (no session cookie).
 
 ```bash
-curl -b cookies.txt http://localhost:8080/me
+curl -b cookies.txt https://localhost:8443/me
 # {"email":"alice@example.com","user_id":"...","verified":"true"}
 ```
 
@@ -185,7 +185,7 @@ Returns all incoming request headers as a JSON object.
 security response headers visible in the response.
 
 ```bash
-curl http://localhost:8080/headers
+curl https://localhost:8443/headers
 ```
 
 ### `POST /spam` — Rate-limit trigger
@@ -195,7 +195,7 @@ VibeWarden's rate limiter.
 
 ```bash
 for i in $(seq 1 20); do
-  curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:8080/spam
+  curl -s -o /dev/null -w "%{http_code}\n" -X POST https://localhost:8443/spam
 done
 # 200 x 10, then 429 x 10
 ```
@@ -205,7 +205,7 @@ done
 Returns `{"status":"ok"}`.
 
 ```bash
-curl http://localhost:8080/health
+curl https://localhost:8443/health
 # {"status":"ok"}
 ```
 
@@ -225,14 +225,14 @@ access protected endpoints without completing a verification flow.
 ## Registration and login
 
 VibeWarden proxies Kratos self-service flows, so you can register and log in
-through the same `:8080` port:
+through the same `:8443` port:
 
 ```bash
 # Start a browser login flow
-open http://localhost:8080/self-service/login/browser
+open https://localhost:8443/self-service/login/browser
 
 # Start a browser registration flow
-open http://localhost:8080/self-service/registration/browser
+open https://localhost:8443/self-service/registration/browser
 ```
 
 Verification emails are captured by Mailslurper at http://localhost:4437 —
@@ -251,5 +251,5 @@ Every response from VibeWarden includes:
 Inspect them with:
 
 ```bash
-curl -I http://localhost:8080/public
+curl -I https://localhost:8443/public
 ```

--- a/examples/demo-app/vibewarden.yaml
+++ b/examples/demo-app/vibewarden.yaml
@@ -19,17 +19,15 @@ app:
 
 server:
   host: "0.0.0.0"
-  port: 8080
+  port: 8443
 
 upstream:
   host: app
   port: 3000
 
 tls:
-  enabled: false
-  # For TLS profile, set via env vars:
-  # VIBEWARDEN_TLS_ENABLED=true
-  # VIBEWARDEN_TLS_PROVIDER=self-signed
+  enabled: true
+  provider: self-signed
 
 kratos:
   public_url: "http://kratos:4433"

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -27,7 +27,15 @@ Step 3 — start everything:
 vibew dev
 ```
 
-Visit http://localhost:8080. VibeWarden is now protecting your Next.js app.
+Visit https://localhost:8443. VibeWarden is now protecting your Next.js app over HTTPS.
+
+To trust the self-signed certificate:
+
+```bash
+vibew cert export > vibewarden-ca.pem
+# Then import vibewarden-ca.pem into your browser or OS trust store,
+# or pass --cacert vibewarden-ca.pem to curl.
+```
 
 ## Endpoints
 
@@ -42,10 +50,10 @@ Visit http://localhost:8080. VibeWarden is now protecting your Next.js app.
 ```
 curl / browser
       |
-      | :8080
+      | :8443 (HTTPS)
       v
 +------------------+
-|   VibeWarden     |  rate limiting, security headers, optional auth
+|   VibeWarden     |  TLS termination, rate limiting, security headers, optional auth
 +------------------+
       |
       | :3000 (internal)

--- a/examples/nextjs/vibewarden.yaml
+++ b/examples/nextjs/vibewarden.yaml
@@ -11,14 +11,15 @@ app:
 
 server:
   host: "0.0.0.0"
-  port: 8080
+  port: 8443
 
 upstream:
   host: app
   port: 3000
 
 tls:
-  enabled: false
+  enabled: true
+  provider: self-signed
 
 auth:
   mode: none

--- a/examples/node-express/README.md
+++ b/examples/node-express/README.md
@@ -27,7 +27,15 @@ Step 3 — start everything:
 vibew dev
 ```
 
-Visit http://localhost:8080. VibeWarden is now protecting your Express app.
+Visit https://localhost:8443. VibeWarden is now protecting your Express app over HTTPS.
+
+To trust the self-signed certificate:
+
+```bash
+vibew cert export > vibewarden-ca.pem
+# Then import vibewarden-ca.pem into your browser or OS trust store,
+# or pass --cacert vibewarden-ca.pem to curl.
+```
 
 ## Endpoints
 
@@ -42,10 +50,10 @@ Visit http://localhost:8080. VibeWarden is now protecting your Express app.
 ```
 curl / browser
       |
-      | :8080
+      | :8443 (HTTPS)
       v
 +------------------+
-|   VibeWarden     |  rate limiting, security headers, optional auth
+|   VibeWarden     |  TLS termination, rate limiting, security headers, optional auth
 +------------------+
       |
       | :3000 (internal)

--- a/examples/node-express/vibewarden.yaml
+++ b/examples/node-express/vibewarden.yaml
@@ -11,14 +11,15 @@ app:
 
 server:
   host: "0.0.0.0"
-  port: 8080
+  port: 8443
 
 upstream:
   host: app
   port: 3000
 
 tls:
-  enabled: false
+  enabled: true
+  provider: self-signed
 
 auth:
   mode: none

--- a/examples/python-flask/README.md
+++ b/examples/python-flask/README.md
@@ -27,7 +27,15 @@ Step 3 — start everything:
 vibew dev
 ```
 
-Visit http://localhost:8080. VibeWarden is now protecting your Flask app.
+Visit https://localhost:8443. VibeWarden is now protecting your Flask app over HTTPS.
+
+To trust the self-signed certificate:
+
+```bash
+vibew cert export > vibewarden-ca.pem
+# Then import vibewarden-ca.pem into your browser or OS trust store,
+# or pass --cacert vibewarden-ca.pem to curl.
+```
 
 ## Endpoints
 
@@ -42,10 +50,10 @@ Visit http://localhost:8080. VibeWarden is now protecting your Flask app.
 ```
 curl / browser
       |
-      | :8080
+      | :8443 (HTTPS)
       v
 +------------------+
-|   VibeWarden     |  rate limiting, security headers, optional auth
+|   VibeWarden     |  TLS termination, rate limiting, security headers, optional auth
 +------------------+
       |
       | :5000 (internal)

--- a/examples/python-flask/vibewarden.yaml
+++ b/examples/python-flask/vibewarden.yaml
@@ -11,14 +11,15 @@ app:
 
 server:
   host: "0.0.0.0"
-  port: 8080
+  port: 8443
 
 upstream:
   host: app
   port: 5000
 
 tls:
-  enabled: false
+  enabled: true
+  provider: self-signed
 
 auth:
   mode: none

--- a/vibewarden.example.yaml
+++ b/vibewarden.example.yaml
@@ -57,7 +57,7 @@ server:
   # Host to bind to (use 0.0.0.0 to expose externally)
   host: "127.0.0.1"
   # Port to listen on
-  port: 8080
+  port: 8443
 
 # Upstream application being protected
 upstream:
@@ -68,9 +68,9 @@ upstream:
 
 # TLS configuration
 tls:
-  # Enable TLS termination (set to true in production).
+  # Enable TLS termination. Enabled by default — VibeWarden is secure by default.
   # When enabled, HTTP requests on port 80 are automatically redirected to HTTPS.
-  enabled: false
+  enabled: true
 
   # Provider selects how TLS certificates are obtained. Valid values:
   #


### PR DESCRIPTION
Closes #445

## Summary

- Replace all `http://localhost:8080` references with `https://localhost:8443` across `docs/`, example `README.md` files, and `README.md`
- Set `tls.enabled: true` and `provider: self-signed` in all four example `vibewarden.yaml` files (`node-express`, `python-flask`, `nextjs`, `demo-app`) and in `vibewarden.example.yaml`
- Update `server.port` default from `8080` to `8443` in `docs/configuration.md` and `vibewarden.example.yaml`
- Add `vibew token` and `vibew cert export` rows to the CLI reference tables in `README.md` and `docs/index.md`
- Add a "Trust the self-signed certificate" admonition (with `vibew cert export` instructions) and a "Generate a dev JWT" tip (with `vibew token` usage) to `docs/getting-started.md`
- Update the "Port already in use" troubleshooting section in `docs/getting-started.md` to reference port `8443`
- Update `examples/demo-app/.env.example` to reflect that `8443`/TLS is the new default

## Test plan

- [x] `make check` passes (build, vet, all tests)
- [x] Pre-push hook ran the full suite — green
- [ ] Manually visit `https://localhost:8443` after `vibew dev` and confirm the browser hits HTTPS
- [ ] Run `vibew cert export > ca.pem` and `curl --cacert ca.pem https://localhost:8443/health` — expect `{"status":"ok"}`
- [ ] Run `curl --cacert ca.pem https://localhost:8443/api/me -H "Authorization: Bearer $(vibew token --json)"` — expect a user-info response
