### PR TITLE
fix: resolve errcheck CI failures and update Go version badge

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,14 @@ linters:
       severity: medium
       confidence: medium
 
+    errcheck:
+      # fmt.Fprint* writes to user-facing output (os.Stdout/Stderr or io.Writer);
+      # write errors on these streams are not recoverable and can be ignored.
+      exclude-functions:
+        - "fmt.Fprint"
+        - "fmt.Fprintln"
+        - "fmt.Fprintf"
+
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # VibeWarden
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)][license]
-[![Go Version](https://img.shields.io/badge/go-1.24-00ADD8.svg)][go]
+[![Go Version](https://img.shields.io/badge/go-1.26-00ADD8.svg)][go]
 [![CI](https://github.com/vibewarden/vibewarden/actions/workflows/ci.yml/badge.svg)][ci]
 [![Release](https://img.shields.io/github/v/release/vibewarden/vibewarden)][releases]
 

--- a/internal/adapters/authui/handler_test.go
+++ b/internal/adapters/authui/handler_test.go
@@ -158,7 +158,7 @@ func TestHandler_Pages(t *testing.T) {
 			if err != nil {
 				t.Fatalf("GET %s: %v", tt.path, err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
 			if resp.StatusCode != tt.wantStatus {
 				t.Errorf("status = %d, want %d", resp.StatusCode, tt.wantStatus)
@@ -216,7 +216,7 @@ func TestHandler_ThemeColorsInjected(t *testing.T) {
 			if err != nil {
 				t.Fatalf("GET %s: %v", path, err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
 			body, _ := io.ReadAll(resp.Body)
 			bodyStr := string(body)
@@ -246,7 +246,7 @@ func TestHandler_ReturnToQueryPropagated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET login with return_to: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
 	body, _ := io.ReadAll(resp.Body)
 	if !strings.Contains(string(body), "return_to") {
@@ -269,7 +269,7 @@ func TestHandler_DefaultColorsApplied(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET login: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
 	body, _ := io.ReadAll(resp.Body)
 	bodyStr := string(body)
@@ -331,7 +331,7 @@ func TestHandler_ServeHTTP_ViaRecorder(t *testing.T) {
 			if err != nil {
 				t.Fatalf("GET %s: %v", tt.path, err)
 			}
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
 			if tt.wantOK && resp.StatusCode != http.StatusOK {
 				t.Errorf("status = %d, want 200", resp.StatusCode)

--- a/internal/adapters/caddy/timeout_handler_test.go
+++ b/internal/adapters/caddy/timeout_handler_test.go
@@ -151,7 +151,7 @@ func TestTimeoutHandler_ServeHTTP_SlowUpstream(t *testing.T) {
 	_ = err // error handling is internal
 
 	resp := rec.Result()
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusGatewayTimeout {
 		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusGatewayTimeout)

--- a/internal/adapters/credentials/store.go
+++ b/internal/adapters/credentials/store.go
@@ -64,7 +64,7 @@ func (s *Store) Read(_ context.Context, outputDir string) (*generate.GeneratedCr
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }() //nolint:errcheck // read-only file close error is not actionable
 
 	values := make(map[string]string)
 	scanner := bufio.NewScanner(file)

--- a/internal/adapters/credentials/store_test.go
+++ b/internal/adapters/credentials/store_test.go
@@ -75,7 +75,7 @@ func TestStore_Write_DotenvFormat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open(%q): %v", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() //nolint:errcheck
 
 	wantKeys := map[string]string{
 		"POSTGRES_PASSWORD":      creds.PostgresPassword,

--- a/internal/adapters/health/checker.go
+++ b/internal/adapters/health/checker.go
@@ -159,7 +159,7 @@ func (c *HTTPChecker) probe(ctx context.Context) {
 		c.recordFailure(err.Error())
 		return
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close() //nolint:errcheck // body close error on health probe is not actionable
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		c.recordSuccess()

--- a/internal/adapters/http/admin_server_test.go
+++ b/internal/adapters/http/admin_server_test.go
@@ -43,7 +43,7 @@ func TestAdminServer_StartAndStop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /_vibewarden/admin/users: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("status = %d, want 200", resp.StatusCode)
@@ -98,7 +98,7 @@ func TestAdminServer_RespondsWithJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /_vibewarden/admin/users: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
 	ct := resp.Header.Get("Content-Type")
 	if ct != "application/json" {

--- a/internal/adapters/jwt/dev_server_test.go
+++ b/internal/adapters/jwt/dev_server_test.go
@@ -52,7 +52,7 @@ func TestDevServer_ServesValidJWKS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET %s: %v", srv.LocalJWKSURL(), err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)

--- a/internal/adapters/jwt/discovery.go
+++ b/internal/adapters/jwt/discovery.go
@@ -51,7 +51,7 @@ func DiscoverJWKSURL(ctx context.Context, issuerURL string, timeout time.Duratio
 	if err != nil {
 		return "", fmt.Errorf("oidc discovery: fetching %s: %w", discoveryURL, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // response body close error is not actionable
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("oidc discovery: endpoint returned %d", resp.StatusCode)

--- a/internal/adapters/jwt/jwks_fetcher.go
+++ b/internal/adapters/jwt/jwks_fetcher.go
@@ -147,7 +147,7 @@ func (f *HTTPJWKSFetcher) doFetch(ctx context.Context) (*domjwks.KeySet, error) 
 	if err != nil {
 		return nil, fmt.Errorf("jwks: fetching %s: %w", f.jwksURL, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // response body close error is not actionable
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("jwks: endpoint returned %d", resp.StatusCode)

--- a/internal/adapters/kratos/adapter.go
+++ b/internal/adapters/kratos/adapter.go
@@ -169,7 +169,7 @@ func (a *Adapter) CheckSession(ctx context.Context, sessionCookie string) (*port
 		}
 		return nil, fmt.Errorf("kratos unreachable: %w", ports.ErrAuthProviderUnavailable)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // response body close error is not actionable
 
 	switch {
 	case resp.StatusCode == http.StatusOK:

--- a/internal/adapters/kratos/adapter_test.go
+++ b/internal/adapters/kratos/adapter_test.go
@@ -282,7 +282,7 @@ func TestCheckSession_NetworkError(t *testing.T) {
 		t.Fatalf("failed to listen: %v", err)
 	}
 	addr := ln.Addr().String()
-	ln.Close()
+	_ = ln.Close() //nolint:errcheck
 
 	adapter := kratos.NewAdapter("http://"+addr, 0, newTestLogger())
 	_, checkErr := adapter.CheckSession(context.Background(), "ory_kratos_session=abc")

--- a/internal/adapters/kratos/admin.go
+++ b/internal/adapters/kratos/admin.go
@@ -90,7 +90,7 @@ func (a *AdminAdapter) ListUsers(ctx context.Context, pagination ports.Paginatio
 	if err != nil {
 		return nil, a.wrapNetworkError(ctx, "list identities", endpoint, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // response body close error is not actionable
 
 	if err := a.checkAdminError(ctx, resp, "list identities"); err != nil {
 		return nil, err
@@ -127,7 +127,7 @@ func (a *AdminAdapter) GetUser(ctx context.Context, id string) (*user.User, erro
 	if err != nil {
 		return nil, a.wrapNetworkError(ctx, "get identity", endpoint, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // response body close error is not actionable
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, ports.ErrUserNotFound
@@ -172,7 +172,7 @@ func (a *AdminAdapter) InviteUser(ctx context.Context, email string) (*ports.Inv
 	if err != nil {
 		return nil, a.wrapNetworkError(ctx, "create identity", createEndpoint, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // response body close error is not actionable
 
 	if resp.StatusCode == http.StatusConflict {
 		return nil, ports.ErrUserAlreadyExists
@@ -227,7 +227,7 @@ func (a *AdminAdapter) DeactivateUser(ctx context.Context, id string) error {
 	if err != nil {
 		return a.wrapNetworkError(ctx, "deactivate identity", endpoint, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // response body close error is not actionable
 
 	if resp.StatusCode == http.StatusNotFound {
 		return ports.ErrUserNotFound
@@ -261,7 +261,7 @@ func (a *AdminAdapter) generateRecoveryLink(ctx context.Context, identityID stri
 	if err != nil {
 		return "", a.wrapNetworkError(ctx, "recovery link", endpoint, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // response body close error is not actionable
 
 	if err := a.checkAdminError(ctx, resp, "recovery link"); err != nil {
 		return "", err

--- a/internal/adapters/kratos/admin_test.go
+++ b/internal/adapters/kratos/admin_test.go
@@ -107,7 +107,7 @@ func TestAdminAdapter_ListUsers_NetworkError(t *testing.T) {
 		t.Fatalf("listen: %v", err)
 	}
 	addr := ln.Addr().String()
-	ln.Close()
+	_ = ln.Close() //nolint:errcheck
 
 	adapter := kratos.NewAdminAdapter("http://"+addr, 0, newTestLogger())
 	_, err = adapter.ListUsers(context.Background(), ports.Pagination{Page: 1, PerPage: 10})
@@ -390,7 +390,7 @@ func TestAdminAdapter_DeactivateUser_NetworkError(t *testing.T) {
 		t.Fatalf("listen: %v", err)
 	}
 	addr := ln.Addr().String()
-	ln.Close()
+	_ = ln.Close() //nolint:errcheck
 
 	adapter := kratos.NewAdminAdapter("http://"+addr, 0, newTestLogger())
 	err = adapter.DeactivateUser(context.Background(), identityID)

--- a/internal/adapters/metrics/server_test.go
+++ b/internal/adapters/metrics/server_test.go
@@ -45,7 +45,7 @@ func TestServer_StartAndStop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /metrics: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("status = %d, want 200", resp.StatusCode)
@@ -90,7 +90,7 @@ func TestServer_UnknownPathReturns404(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /unknown: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", resp.StatusCode)

--- a/internal/adapters/otel/log_provider_integration_test.go
+++ b/internal/adapters/otel/log_provider_integration_test.go
@@ -66,14 +66,14 @@ func TestLogProvider_Integration_FullRoundtrip(t *testing.T) {
 // readBody reads and optionally decompresses the request body.
 func readBody(r *http.Request) ([]byte, error) {
 	var reader io.Reader = r.Body
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }() //nolint:errcheck
 
 	if r.Header.Get("Content-Encoding") == "gzip" {
 		gr, err := gzip.NewReader(r.Body)
 		if err != nil {
 			return nil, err
 		}
-		defer gr.Close()
+		defer func() { _ = gr.Close() }() //nolint:errcheck
 		reader = gr
 	}
 

--- a/internal/adapters/otel/testing.go
+++ b/internal/adapters/otel/testing.go
@@ -50,7 +50,7 @@ func NewTestLogProvider(ctx context.Context) (*LogProvider, func() [][]byte, fun
 	var received [][]byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := func() ([]byte, error) {
-			defer r.Body.Close()
+			defer func() { _ = r.Body.Close() }() //nolint:errcheck // test helper body close error is not actionable
 			var buf []byte
 			b := make([]byte, 4096)
 			for {

--- a/internal/adapters/ratelimit/redis_adapter_integration_test.go
+++ b/internal/adapters/ratelimit/redis_adapter_integration_test.go
@@ -43,7 +43,7 @@ func startRedisContainer(t *testing.T) *redis.Options {
 func TestRedisStore_Integration_AllowWithinBurst(t *testing.T) {
 	opts := startRedisContainer(t)
 	client := redis.NewClient(opts)
-	t.Cleanup(func() { client.Close() })
+	t.Cleanup(func() { _ = client.Close() }) //nolint:errcheck
 
 	ctx := context.Background()
 	prefix := fmt.Sprintf("vw:rl:int:%d", time.Now().UnixNano())
@@ -65,7 +65,7 @@ func TestRedisStore_Integration_AllowWithinBurst(t *testing.T) {
 func TestRedisStore_Integration_BurstExhaustion(t *testing.T) {
 	opts := startRedisContainer(t)
 	client := redis.NewClient(opts)
-	t.Cleanup(func() { client.Close() })
+	t.Cleanup(func() { _ = client.Close() }) //nolint:errcheck
 
 	ctx := context.Background()
 	prefix := fmt.Sprintf("vw:rl:int:%d", time.Now().UnixNano())
@@ -96,7 +96,7 @@ func TestRedisStore_Integration_BurstExhaustion(t *testing.T) {
 func TestRedisStore_Integration_IndependentKeys(t *testing.T) {
 	opts := startRedisContainer(t)
 	client := redis.NewClient(opts)
-	t.Cleanup(func() { client.Close() })
+	t.Cleanup(func() { _ = client.Close() }) //nolint:errcheck
 
 	ctx := context.Background()
 	prefix := fmt.Sprintf("vw:rl:int:%d", time.Now().UnixNano())
@@ -120,7 +120,7 @@ func TestRedisStore_Integration_IndependentKeys(t *testing.T) {
 func TestRedisStore_Integration_KeyTTL(t *testing.T) {
 	opts := startRedisContainer(t)
 	client := redis.NewClient(opts)
-	t.Cleanup(func() { client.Close() })
+	t.Cleanup(func() { _ = client.Close() }) //nolint:errcheck
 
 	ctx := context.Background()
 	prefix := fmt.Sprintf("vw:rl:int:%d", time.Now().UnixNano())
@@ -172,7 +172,7 @@ func TestFallbackStore_Integration_FallbackOnRedisFailure(t *testing.T) {
 	}
 
 	// Close the client to simulate Redis going away.
-	client.Close()
+	_ = client.Close() //nolint:errcheck
 
 	// Wait for at least two health check cycles.
 	time.Sleep(5 * interval)

--- a/internal/adapters/ratelimit/redis_adapter_test.go
+++ b/internal/adapters/ratelimit/redis_adapter_test.go
@@ -32,7 +32,7 @@ func newTestRedisStore(t *testing.T, rps float64, burst int, prefix string) (*Re
 		if len(keys) > 0 {
 			client.Del(ctx, keys...)
 		}
-		client.Close()
+		_ = client.Close() //nolint:errcheck
 	})
 
 	rule := ports.RateLimitRule{RequestsPerSecond: rps, Burst: burst}
@@ -49,7 +49,7 @@ func redisTestAddr(t *testing.T) string {
 	addr := "localhost:6379"
 
 	client := redis.NewClient(&redis.Options{Addr: addr})
-	defer client.Close()
+	defer func() { _ = client.Close() }() //nolint:errcheck
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -204,7 +204,7 @@ func TestRedisStore_Allow_ResultFields(t *testing.T) {
 func TestRedisFactory_NewLimiter(t *testing.T) {
 	addr := redisTestAddr(t)
 	client := redis.NewClient(&redis.Options{Addr: addr})
-	t.Cleanup(func() { client.Close() })
+	t.Cleanup(func() { _ = client.Close() }) //nolint:errcheck
 
 	factory := NewRedisFactory(client, "vw:rl")
 	rule := ports.RateLimitRule{RequestsPerSecond: 5, Burst: 10}
@@ -218,7 +218,7 @@ func TestRedisFactory_NewLimiter(t *testing.T) {
 func TestRedisFactory_NewLimiter_UniqueKeyPrefixes(t *testing.T) {
 	addr := redisTestAddr(t)
 	client := redis.NewClient(&redis.Options{Addr: addr})
-	t.Cleanup(func() { client.Close() })
+	t.Cleanup(func() { _ = client.Close() }) //nolint:errcheck
 
 	factory := NewRedisFactory(client, "vw:rl")
 	rule := ports.RateLimitRule{RequestsPerSecond: 100, Burst: 100}

--- a/internal/plugins/auth/plugin.go
+++ b/internal/plugins/auth/plugin.go
@@ -340,7 +340,7 @@ func (p *Plugin) HealthCheck(ctx context.Context) ports.HealthStatus {
 		p.healthMsg = fmt.Sprintf("auth: kratos unreachable: %s", err)
 		return ports.HealthStatus{Healthy: false, Message: p.healthMsg}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // response body close error is not actionable
 
 	if resp.StatusCode >= 500 {
 		p.healthy = false
@@ -399,7 +399,7 @@ func (p *Plugin) CheckDependency(ctx context.Context) ports.DependencyStatus {
 			Error:     fmt.Sprintf("kratos unreachable: %s", err),
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // response body close error is not actionable
 
 	if resp.StatusCode >= 500 {
 		return ports.DependencyStatus{
@@ -708,7 +708,7 @@ func (c *kratosHTTPChecker) Authenticate(ctx context.Context, r *http.Request) i
 	if err != nil {
 		return identity.Failure("provider_unavailable", fmt.Sprintf("kratos unreachable: %s", err))
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // response body close error is not actionable
 
 	switch {
 	case resp.StatusCode == http.StatusOK:

--- a/internal/plugins/usermgmt/plugin.go
+++ b/internal/plugins/usermgmt/plugin.go
@@ -274,7 +274,7 @@ func (p *Plugin) HealthCheck(ctx context.Context) ports.HealthStatus {
 		p.healthMsg = fmt.Sprintf("user-management: kratos admin unreachable: %s", err)
 		return ports.HealthStatus{Healthy: false, Message: p.healthMsg}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // response body close error is not actionable
 
 	if resp.StatusCode >= 500 {
 		p.healthy = false


### PR DESCRIPTION
## Summary

- Fixed all 142 errcheck lint violations across the codebase
- Updated README Go version badge from 1.24 to 1.26

### Approach

**Production code** (`resp.Body.Close`, `file.Close`): replaced bare `defer x.Close()` with `defer func() { _ = x.Close() }()` and an explanatory comment. Affected files: `health/checker.go`, `jwt/discovery.go`, `jwt/jwks_fetcher.go`, `kratos/adapter.go`, `kratos/admin.go`, `plugins/auth/plugin.go`, `plugins/usermgmt/plugin.go`, `credentials/store.go`, `otel/testing.go`.

**Test files** (`resp.Body.Close`, `client.Close`, `ln.Close`, `f.Close`): same `_ = x.Close()` pattern with `//nolint:errcheck`. Affected files: `authui/handler_test.go`, `caddy/timeout_handler_test.go`, `credentials/store_test.go`, `http/admin_server_test.go`, `jwt/dev_server_test.go`, `kratos/adapter_test.go`, `kratos/admin_test.go`, `metrics/server_test.go`, `otel/log_provider_integration_test.go`, `ratelimit/redis_adapter_test.go`, `ratelimit/redis_adapter_integration_test.go`.

**CLI/ops `fmt.Fprint*` calls**: added `errcheck.exclude-functions` to `.golangci.yml` for `fmt.Fprint`, `fmt.Fprintln`, and `fmt.Fprintf`. These write to user-facing `io.Writer` output; write errors on stdout/stderr are not recoverable and should not clutter the code with impossible-to-handle error checks.

**`TestHandler_Pages/recovery_page`**: the test was passing locally. The CI failure was caused by the linter blocking the test run, not a real test bug. Verified all `TestHandler_Pages` subtests pass after the lint fixes.

## Test plan

- `go build ./...` passes
- `go vet ./...` passes
- `go test -race ./...` passes (all tests including `TestHandler_Pages/recovery_page`)
- `golangci-lint run ./...` reports zero errcheck violations
- Pre-push hook (`make check`) passed before push