### PR TITLE
feat(#460,#461): add Semgrep SAST and Trivy vulnerability scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: semgrep/semgrep:latest
+      image: semgrep/semgrep:1.121.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy filesystem scan (dependencies)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.31.0
         with:
           scan-type: fs
           scan-ref: .
@@ -80,7 +80,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy image scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.31.0
         with:
           scan-type: image
           image-ref: vibewarden:scan


### PR DESCRIPTION
Closes #460
Closes #461

## Summary

- Adds `.github/workflows/security.yml` with two independent security scanning jobs triggered on push to `main` and on PRs to `main`.
- **semgrep** job: runs `semgrep/semgrep:latest` container, scans with `p/golang`, `p/owasp-top-ten`, and `p/secrets` rulesets, fails on error-severity findings (`--error` flag), uploads SARIF to the GitHub Security tab via `github/codeql-action/upload-sarif@v3`. Respects the optional `SEMGREP_APP_TOKEN` secret for dashboard integration. Timeout: 10 minutes.
- **trivy** job: runs `aquasecurity/trivy-action@master` twice — first a filesystem scan of the repo (catches vulnerable Go dependencies via `go.sum`), then builds the Docker image locally and scans it. Both scans threshold at `HIGH,CRITICAL` and exit non-zero on findings. Both upload SARIF to the GitHub Security tab under distinct categories (`trivy-fs`, `trivy-image`). Uses `docker/build-push-action@v6` with GHA layer cache for fast image builds. Timeout: 10 minutes.
- The `security-events: write` permission is set at the workflow level (required for SARIF upload). `contents: read` is set for principle of least privilege.
- SARIF upload steps use `if: always()` so findings are visible in the Security tab even when the scan job fails.

## Test plan

- [ ] Confirm the `Security` workflow appears in the Actions tab after merge.
- [ ] Verify both jobs complete without error on the initial main push.
- [ ] Open a test PR and confirm both jobs run and their results appear in the GitHub Security / Code scanning tab.
- [ ] Introduce a deliberate `p/secrets` finding in a test branch and confirm the semgrep job fails and surfaces it in the Security tab.
- [ ] Confirm Trivy image scan results appear under the `trivy-image` category in the Security tab.
