### PR TITLE
fix: resolve all golangci-lint errors across the codebase

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,6 +53,27 @@ linters:
         - "fmt.Fprintln"
         - "fmt.Fprintf"
 
+  exclusions:
+    rules:
+      # Test helpers legitimately read/write temp files with path variables —
+      # these are not file inclusion vulnerabilities.
+      - path: "_test\\.go"
+        linters:
+          - gosec
+        text: "G304"
+      - path: "_test\\.go"
+        linters:
+          - gosec
+        text: "G306"
+      - path: "_test\\.go"
+        linters:
+          - gosec
+        text: "G301"
+      - path: "_test\\.go"
+        linters:
+          - gosec
+        text: "G115"
+
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,11 @@ clean:
 	rm -rf bin/
 
 # Run all quality checks (build, format, vet, tests)
-check: ## Run all quality checks (build, format, vet, tests)
+check: ## Run all quality checks (lint, build, tests)
 	@echo "==> Checking formatting (main module)..."
 	@test -z "$$(gofmt -l .)" || (echo "gofmt: these files need formatting:" && gofmt -l . && exit 1)
-	@echo "==> Running go vet (main module)..."
-	go vet ./...
+	@echo "==> Running golangci-lint (main module)..."
+	golangci-lint run ./...
 	@echo "==> Building (main module)..."
 	go build ./...
 	@echo "==> Running tests (main module)..."

--- a/cmd/vibewarden/serve_test.go
+++ b/cmd/vibewarden/serve_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 
@@ -51,13 +52,13 @@ func TestBuildLogger_Level(t *testing.T) {
 			if logger == nil {
 				t.Fatal("buildLogger() returned nil logger")
 			}
-			if !logger.Enabled(nil, tt.wantLevel) {
+			if !logger.Enabled(context.TODO(), tt.wantLevel) {
 				t.Errorf("buildLogger(%q) logger does not enable level %v", tt.cfg.Level, tt.wantLevel)
 			}
 			// Verify that one level below is disabled (except for debug which has nothing below)
 			if tt.wantLevel > slog.LevelDebug {
 				lowerLevel := tt.wantLevel - 4
-				if logger.Enabled(nil, lowerLevel) {
+				if logger.Enabled(context.TODO(), lowerLevel) {
 					t.Errorf("buildLogger(%q) unexpectedly enables level %v (below minimum %v)", tt.cfg.Level, lowerLevel, tt.wantLevel)
 				}
 			}

--- a/internal/adapters/audit/json_writer.go
+++ b/internal/adapters/audit/json_writer.go
@@ -67,7 +67,7 @@ func NewJSONWriter(w io.Writer) *JSONWriter {
 // The returned closer must be called when the writer is no longer needed.
 // Returns an error if the file cannot be opened or created.
 func NewJSONWriterToFile(path string) (*JSONWriter, io.Closer, error) {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644) //nolint:gosec // path is caller-supplied audit log destination, not user input
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening audit log file %q: %w", path, err)
 	}

--- a/internal/adapters/authui/handler.go
+++ b/internal/adapters/authui/handler.go
@@ -31,6 +31,8 @@ var templateFS embed.FS
 
 // AuthUIConfig holds the theming and behavioural configuration for the
 // built-in auth UI pages.
+//
+//nolint:revive // AuthUIConfig name is intentional to distinguish from other Config types in the codebase
 type AuthUIConfig struct {
 	// Mode selects the UI serving strategy.
 	// "built-in" (default) — VibeWarden serves its own pages.

--- a/internal/adapters/authui/handler_test.go
+++ b/internal/adapters/authui/handler_test.go
@@ -1,6 +1,7 @@
 package authui_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -69,7 +70,7 @@ func TestHandler_StartAndAddr(t *testing.T) {
 	if err := h.Start(); err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
-	defer h.Stop(nil) //nolint: errcheck
+	defer h.Stop(context.TODO()) //nolint:errcheck
 
 	addr := h.Addr()
 	if addr == "" {
@@ -152,7 +153,7 @@ func TestHandler_Pages(t *testing.T) {
 			if err := h.Start(); err != nil {
 				t.Fatalf("Start() error: %v", err)
 			}
-			defer h.Stop(nil) //nolint: errcheck
+			defer h.Stop(context.TODO()) //nolint:errcheck
 
 			resp, err := http.Get("http://" + h.Addr() + tt.path)
 			if err != nil {
@@ -200,7 +201,7 @@ func TestHandler_ThemeColorsInjected(t *testing.T) {
 	if err := h.Start(); err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
-	defer h.Stop(nil) //nolint: errcheck
+	defer h.Stop(context.TODO()) //nolint:errcheck
 
 	pages := []string{
 		"/_vibewarden/login",
@@ -239,7 +240,7 @@ func TestHandler_ReturnToQueryPropagated(t *testing.T) {
 	if err := h.Start(); err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
-	defer h.Stop(nil) //nolint: errcheck
+	defer h.Stop(context.TODO()) //nolint:errcheck
 
 	// The login page should include the return_to value in registration link.
 	resp, err := http.Get(fmt.Sprintf("http://%s/_vibewarden/login?return_to=%%2Fdashboard", h.Addr()))
@@ -263,7 +264,7 @@ func TestHandler_DefaultColorsApplied(t *testing.T) {
 	if err := h.Start(); err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
-	defer h.Stop(nil) //nolint: errcheck
+	defer h.Stop(context.TODO()) //nolint:errcheck
 
 	resp, err := http.Get("http://" + h.Addr() + "/_vibewarden/login")
 	if err != nil {
@@ -323,7 +324,7 @@ func TestHandler_ServeHTTP_ViaRecorder(t *testing.T) {
 	if err := realH.Start(); err != nil {
 		t.Fatalf("Start(): %v", err)
 	}
-	defer realH.Stop(nil) //nolint: errcheck
+	defer realH.Stop(context.TODO()) //nolint:errcheck
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/adapters/caddy/retry_handler.go
+++ b/internal/adapters/caddy/retry_handler.go
@@ -184,7 +184,7 @@ func (h *RetryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next ca
 	// All attempts exhausted — add Retry-After hint and flush the last response.
 	if lastBuf != nil {
 		if lastBuf.status == http.StatusServiceUnavailable {
-			backoffMs := h.Config.InitialBackoffMs * float64(int(1)<<uint(h.Config.MaxAttempts-1))
+			backoffMs := h.Config.InitialBackoffMs * float64(int(1)<<uint(h.Config.MaxAttempts-1)) //nolint:gosec // MaxAttempts is validated to be small (≤10) during config parsing
 			if backoffMs > h.Config.MaxBackoffMs {
 				backoffMs = h.Config.MaxBackoffMs
 			}

--- a/internal/adapters/caddy/timeout_handler_test.go
+++ b/internal/adapters/caddy/timeout_handler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+
 	"github.com/vibewarden/vibewarden/internal/middleware"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )

--- a/internal/adapters/caddy/waf_engine_handler.go
+++ b/internal/adapters/caddy/waf_engine_handler.go
@@ -2,7 +2,6 @@
 package caddy
 
 import (
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -158,20 +157,6 @@ func buildEnabledCategories(cfg WAFEngineHandlerRulesConfig) map[domainwaf.Categ
 		domainwaf.CategoryPathTraversal:    cfg.PathTraversal,
 		domainwaf.CategoryCommandInjection: cfg.CmdInjection,
 	}
-}
-
-// buildWAFEngineHandlerJSON serialises a WAFEngineHandlerConfig into the Caddy
-// handler JSON fragment used in BuildCaddyConfig.
-func buildWAFEngineHandlerJSON(cfg WAFEngineHandlerConfig) (map[string]any, error) {
-	cfgBytes, err := json.Marshal(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling WAF engine handler config: %w", err)
-	}
-
-	return map[string]any{
-		"handler": "vibewarden_waf_engine",
-		"config":  json.RawMessage(cfgBytes),
-	}, nil
 }
 
 // Interface guards — ensure WAFEngineHandler satisfies required Caddy

--- a/internal/adapters/credentials/store.go
+++ b/internal/adapters/credentials/store.go
@@ -60,7 +60,7 @@ OPENBAO_DEV_ROOT_TOKEN=%s
 func (s *Store) Read(_ context.Context, outputDir string) (*generate.GeneratedCredentials, error) {
 	path := filepath.Join(outputDir, credentialsFileName)
 
-	file, err := os.Open(path)
+	file, err := os.Open(path) //nolint:gosec // path is constructed from trusted config-provided outputDir via filepath.Join
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapters/egress/body_size_test.go
+++ b/internal/adapters/egress/body_size_test.go
@@ -476,7 +476,7 @@ func TestHTTPHandler_NoSizeLimits(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, _ := io.ReadAll(r.Body)
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(fmt.Sprintf("received %d bytes; response: %s", len(b), body)))
+		_, _ = fmt.Fprintf(w, "received %d bytes; response: %s", len(b), body)
 	}))
 	defer upstream.Close()
 

--- a/internal/adapters/egress/circuit_breakers_test.go
+++ b/internal/adapters/egress/circuit_breakers_test.go
@@ -268,11 +268,9 @@ func TestCircuitBreakerRegistry_ClosesAfterReset(t *testing.T) {
 		return err
 	}
 
-	// Trip the circuit.
+	// Trip the circuit — transport/upstream errors are acceptable here.
 	for i := 0; i < 2; i++ {
-		if err := doRequest(); err != nil && err != egressadapter.ErrCircuitOpen {
-			// Transport or upstream failure — acceptable here.
-		}
+		_ = doRequest()
 	}
 
 	// Circuit should now be open.

--- a/internal/adapters/egress/mtls.go
+++ b/internal/adapters/egress/mtls.go
@@ -94,11 +94,11 @@ func loadClientCert(certPath, keyPath string) (tls.Certificate, error) {
 		return tls.Certificate{}, fmt.Errorf("key_path is required for mTLS")
 	}
 
-	certPEM, err := os.ReadFile(certPath)
+	certPEM, err := os.ReadFile(certPath) //nolint:gosec // path comes from operator-controlled mTLS config, not user input
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("reading client cert %q: %w", certPath, err)
 	}
-	keyPEM, err := os.ReadFile(keyPath)
+	keyPEM, err := os.ReadFile(keyPath) //nolint:gosec // path comes from operator-controlled mTLS config, not user input
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("reading client key %q: %w", keyPath, err)
 	}
@@ -114,7 +114,7 @@ func loadClientCert(certPath, keyPath string) (tls.Certificate, error) {
 // given file path and returns a populated *x509.CertPool. Returns an error
 // when the file cannot be read or contains no valid PEM certificates.
 func loadCACert(caPath string) (*x509.CertPool, error) {
-	caPEM, err := os.ReadFile(caPath)
+	caPEM, err := os.ReadFile(caPath) //nolint:gosec // path comes from operator-controlled mTLS config, not user input
 	if err != nil {
 		return nil, fmt.Errorf("reading CA cert %q: %w", caPath, err)
 	}

--- a/internal/adapters/egress/proxy.go
+++ b/internal/adapters/egress/proxy.go
@@ -879,7 +879,7 @@ func (p *Proxy) forward(ctx context.Context, req domainegress.EgressRequest, mat
 	defer cancel()
 
 	// Apply per-route request header manipulation when a route was matched.
-	outHeaders := req.Header
+	var outHeaders http.Header
 	if match.Matched {
 		outHeaders = match.Route.Headers().ApplyToRequest(req.Header)
 	} else {
@@ -1334,13 +1334,9 @@ func routeNameOf(match domainegress.RouteMatch) string {
 
 // traceIDFromContext extracts the W3C trace-id string from ctx as a hex string.
 // Returns an empty string when no span is active in ctx or tracing is disabled.
+// The trace-id is stored in the context via a key when a span is started, avoiding
+// a hard dependency on the OTel SDK in this package.
 func traceIDFromContext(ctx context.Context) string {
-	type traceIDer interface {
-		TraceID() [16]byte
-		IsValid() bool
-	}
-	// Use OTel SDK directly would create a hard dependency on the SDK here.
-	// Instead we store the trace-id in the context via a key when we start a span.
 	if id, ok := ctx.Value(ctxKeyTraceID{}).(string); ok {
 		return id
 	}

--- a/internal/adapters/jwt/adapter_test.go
+++ b/internal/adapters/jwt/adapter_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	josejwt "github.com/go-jose/go-jose/v4/jwt"
+
 	domjwks "github.com/vibewarden/vibewarden/internal/domain/jwks"
 )
 

--- a/internal/adapters/jwt/jwks_fetcher.go
+++ b/internal/adapters/jwt/jwks_fetcher.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
+
 	domjwks "github.com/vibewarden/vibewarden/internal/domain/jwks"
 )
 

--- a/internal/adapters/jwt/keygen.go
+++ b/internal/adapters/jwt/keygen.go
@@ -78,7 +78,7 @@ func LoadOrGenerateDevKeys(dir string) (*DevKeyPair, error) {
 // loadPrivateKey reads an RSA private key from a PEM-encoded PKCS#8 or
 // PKCS#1 file at path.
 func loadPrivateKey(path string) (*rsa.PrivateKey, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // path is an internal dev-key directory constructed by LoadOrGenerateDevKeys
 	if err != nil {
 		return nil, fmt.Errorf("reading %q: %w", path, err)
 	}

--- a/internal/adapters/log/slog_adapter_test.go
+++ b/internal/adapters/log/slog_adapter_test.go
@@ -475,7 +475,7 @@ func traceEvent() events.Event {
 
 // logAndDecodeWithCtx writes a single event using the given context and decodes
 // the JSON output. It fails the test if the output is not valid JSON.
-func logAndDecodeWithCtx(t *testing.T, ctx context.Context, event events.Event) map[string]any {
+func logAndDecodeWithCtx(t *testing.T, ctx context.Context, event events.Event) map[string]any { //nolint:revive // t must precede ctx in test helpers by Go testing convention
 	t.Helper()
 	var buf bytes.Buffer
 	logger := log.NewSlogEventLogger(&buf)

--- a/internal/adapters/otel/meter.go
+++ b/internal/adapters/otel/meter.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/vibewarden/vibewarden/internal/ports"
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
 // meterAdapter wraps an OTel metric.Meter to implement ports.Meter.

--- a/internal/adapters/otel/meter_test.go
+++ b/internal/adapters/otel/meter_test.go
@@ -131,5 +131,5 @@ func TestMeter_Int64UpDownCounter_Add_DoesNotPanic(t *testing.T) {
 
 func TestMeter_ImplementsPorts(t *testing.T) {
 	p := newInitializedProvider(t)
-	var _ ports.Meter = p.Meter()
+	var _ = p.Meter()
 }

--- a/internal/adapters/otel/provider.go
+++ b/internal/adapters/otel/provider.go
@@ -26,7 +26,6 @@ import (
 
 	prometheusclient "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/vibewarden/vibewarden/internal/ports"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -38,6 +37,8 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
 // Provider implements ports.OTelProvider using the OTel Go SDK.

--- a/internal/adapters/otel/tracer.go
+++ b/internal/adapters/otel/tracer.go
@@ -4,11 +4,12 @@ package otel
 import (
 	"context"
 
-	"github.com/vibewarden/vibewarden/internal/ports"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
 // tracerAdapter wraps an OTel trace.Tracer to implement ports.Tracer.

--- a/internal/adapters/otel/tracer_test.go
+++ b/internal/adapters/otel/tracer_test.go
@@ -5,10 +5,11 @@ import (
 	"errors"
 	"testing"
 
-	oteladapter "github.com/vibewarden/vibewarden/internal/adapters/otel"
-	"github.com/vibewarden/vibewarden/internal/ports"
 	"net/http"
 	"net/http/httptest"
+
+	oteladapter "github.com/vibewarden/vibewarden/internal/adapters/otel"
+	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
 // newTracerProvider creates a Provider with a fake OTLP endpoint for tracing tests.
@@ -247,7 +248,7 @@ func TestProvider_Propagator_ImplementsPort(t *testing.T) {
 	p, cleanup := newTracerProvider(t)
 	defer cleanup()
 
-	var _ ports.TextMapPropagator = p.Propagator()
+	var _ = p.Propagator()
 }
 
 func TestProvider_Propagator_Extract_ReturnsContext(t *testing.T) {

--- a/internal/adapters/ratelimit/fallback_store_test.go
+++ b/internal/adapters/ratelimit/fallback_store_test.go
@@ -32,11 +32,6 @@ func (f *fakeStore) Close() error {
 	return nil
 }
 
-// fakeErrorStore.Close returns an error for error-path tests.
-type fakeErrorStore struct{ fakeStore }
-
-func (f *fakeErrorStore) Close() error { return errors.New("close error") }
-
 // discardSlogLogger returns an slog.Logger that discards all output.
 func discardSlogLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(noopSlogWriter{}, nil))

--- a/internal/adapters/ratelimit/memory_test.go
+++ b/internal/adapters/ratelimit/memory_test.go
@@ -295,8 +295,7 @@ func TestMemoryFactory_NewLimiter_ImplementsInterface(t *testing.T) {
 		t.Fatal("NewLimiter returned nil")
 	}
 
-	// Verify it satisfies the interface at compile time — the cast below panics if not.
-	_ = limiter.(ports.RateLimiter)
+	// limiter is typed as ports.RateLimiter by NewLimiter's return type; no runtime cast needed.
 
 	_ = limiter.Close()
 }

--- a/internal/adapters/scaffold/detector.go
+++ b/internal/adapters/scaffold/detector.go
@@ -53,7 +53,7 @@ func (d *Detector) Detect(dir string) (*scaffold.ProjectConfig, error) {
 // detectNodePort tries to read the PORT from the package.json scripts section.
 // It looks for patterns like "PORT=3000" in start/dev/serve scripts.
 func detectNodePort(pkgPath string) (int, error) {
-	data, err := os.ReadFile(pkgPath)
+	data, err := os.ReadFile(pkgPath) //nolint:gosec // pkgPath is resolved from the project root via filepath.Abs, not user input
 	if err != nil {
 		return 0, fmt.Errorf("reading package.json: %w", err)
 	}

--- a/internal/adapters/yamlmod/toggler.go
+++ b/internal/adapters/yamlmod/toggler.go
@@ -113,7 +113,7 @@ func (t *Toggler) EnableFeature(_ context.Context, path string, feature scaffold
 // readNode reads the YAML file at path and returns its document root mapping
 // node. Returns scaffold.ErrConfigNotFound when the file does not exist.
 func readNode(path string) (*yaml.Node, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // path is the vibewarden.yaml config file resolved from project root
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("%w: %s", scaffold.ErrConfigNotFound, path)

--- a/internal/app/generate/service.go
+++ b/internal/app/generate/service.go
@@ -192,7 +192,7 @@ func (s *Service) Generate(ctx context.Context, cfg *config.Config, outputDir st
 		if err := s.renderer.RenderToFile("seed-secrets.sh.tmpl", cfg, seedPath, true); err != nil {
 			return fmt.Errorf("rendering seed-secrets.sh: %w", err)
 		}
-		if err := os.Chmod(seedPath, 0o750); err != nil {
+		if err := os.Chmod(seedPath, 0o750); err != nil { //nolint:gosec // seed-secrets.sh must be executable; 0o750 is intentional for a shell script
 			return fmt.Errorf("setting seed-secrets.sh permissions: %w", err)
 		}
 	}

--- a/internal/app/ops/dev_test.go
+++ b/internal/app/ops/dev_test.go
@@ -65,8 +65,8 @@ func defaultConfig() *config.Config {
 			Enabled: true,
 			PerIP:   config.RateLimitRuleConfig{RequestsPerSecond: 10, Burst: 20},
 		},
-		Metrics: config.MetricsConfig{Enabled: true},
-		Kratos:  config.KratosConfig{PublicURL: "http://127.0.0.1:4433", AdminURL: "http://127.0.0.1:4434"},
+		Telemetry: config.TelemetryConfig{Prometheus: config.PrometheusExporterConfig{Enabled: true}},
+		Kratos:    config.KratosConfig{PublicURL: "http://127.0.0.1:4433", AdminURL: "http://127.0.0.1:4434"},
 	}
 }
 

--- a/internal/app/scaffold/service.go
+++ b/internal/app/scaffold/service.go
@@ -192,7 +192,7 @@ func (s *Service) renderWrappers(dir string, data domainscaffold.TemplateData, f
 func (s *Service) ensureGitIgnore(dir string) error {
 	gitignorePath := filepath.Join(dir, gitIgnoreFile)
 
-	existing, err := os.ReadFile(gitignorePath)
+	existing, err := os.ReadFile(gitignorePath) //nolint:gosec // gitignorePath is constructed from the project root via filepath.Join, not user input
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("reading .gitignore: %w", err)
 	}

--- a/internal/cli/cmd/cert.go
+++ b/internal/cli/cmd/cert.go
@@ -91,7 +91,7 @@ Examples:
 				return nil
 			}
 
-			pem, err := os.ReadFile(certPath)
+			pem, err := os.ReadFile(certPath) //nolint:gosec // certPath comes from the vibewarden.yaml config, not direct user input
 			if err != nil {
 				return fmt.Errorf("reading certificate at %s: %w", certPath, err)
 			}

--- a/internal/cli/cmd/init.go
+++ b/internal/cli/cmd/init.go
@@ -87,7 +87,7 @@ Examples:
 
 			if err := svc.Init(context.Background(), dir, opts); err != nil {
 				if errors.Is(err, os.ErrExist) {
-					return fmt.Errorf("%w\n\nRun with --force to overwrite existing files.", err)
+					return fmt.Errorf("%w\n\nRun with --force to overwrite existing files.", err) //nolint:revive,staticcheck // user-facing CLI hint: intentional newline and trailing period
 				}
 				return err
 			}
@@ -97,7 +97,7 @@ Examples:
 				agentFiles, err = agentSvc.GenerateAgentContext(context.Background(), dir, agentType, opts)
 				if err != nil {
 					if errors.Is(err, os.ErrExist) {
-						return fmt.Errorf("%w\n\nRun with --force to overwrite existing files.", err)
+						return fmt.Errorf("%w\n\nRun with --force to overwrite existing files.", err) //nolint:revive,staticcheck // user-facing CLI hint: intentional newline and trailing period
 					}
 					return fmt.Errorf("generating agent context: %w", err)
 				}

--- a/internal/cli/cmd/secret_get.go
+++ b/internal/cli/cmd/secret_get.go
@@ -128,14 +128,11 @@ func buildSecretService(configPath, outputDir string) (*appsecret.Service, error
 func formatSecretGetError(err error, aliasOrPath string) error {
 	switch {
 	case isErrNoSourceAvailable(err):
-		return fmt.Errorf(
-			"No secret source available. Run 'vibewarden generate' to create credentials, or start the stack with 'vibewarden dev'.",
-		)
+		//nolint:revive,staticcheck // user-facing CLI hint: intentionally capitalised with trailing period
+		return fmt.Errorf("No secret source available. Run 'vibewarden generate' to create credentials, or start the stack with 'vibewarden dev'.") //nolint:revive,staticcheck
 	case isErrSecretNotFound(err):
-		return fmt.Errorf(
-			"Secret %q not found. Use 'vibew secret list' to see available secrets.",
-			aliasOrPath,
-		)
+		//nolint:revive,staticcheck // user-facing CLI hint: intentionally capitalised with trailing period
+		return fmt.Errorf("Secret %q not found. Use 'vibew secret list' to see available secrets.", aliasOrPath) //nolint:revive,staticcheck
 	default:
 		return err
 	}

--- a/internal/cli/cmd/token_test.go
+++ b/internal/cli/cmd/token_test.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,20 +31,6 @@ func generateTestKeyPair(t *testing.T) (dir string, kp *jwtadapter.DevKeyPair) {
 		t.Fatalf("generateTestKeyPair: %v", err)
 	}
 	return dir, kp
-}
-
-// writeRawPrivateKey writes the given RSA key as a PKCS#8 PEM file to path.
-func writeRawPrivateKey(t *testing.T, path string, key *rsa.PrivateKey) {
-	t.Helper()
-
-	der, err := x509.MarshalPKCS8PrivateKey(key)
-	if err != nil {
-		t.Fatalf("marshalling key: %v", err)
-	}
-	block := &pem.Block{Type: "PRIVATE KEY", Bytes: der}
-	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
-		t.Fatalf("writing key: %v", err)
-	}
 }
 
 // ─── signDevToken (unit tests) ────────────────────────────────────────────────

--- a/internal/config/presets/presets.go
+++ b/internal/config/presets/presets.go
@@ -54,7 +54,7 @@ func Resolve(name string) ([]byte, error) {
 		return nil, fmt.Errorf("identity schema name must not be empty")
 	default:
 		// Treat as a filesystem path to a custom schema.
-		data, err := os.ReadFile(name)
+		data, err := os.ReadFile(name) //nolint:gosec // name is a file path from operator config for a custom identity schema, not user input
 		if err != nil {
 			return nil, fmt.Errorf("reading custom identity schema %q: %w", name, err)
 		}

--- a/internal/domain/audit/audit.go
+++ b/internal/domain/audit/audit.go
@@ -150,6 +150,8 @@ type Target struct {
 //
 // AuditEvent equality is by value: two events are equal if all fields are equal.
 // Callers must not mutate the Details map after construction.
+//
+//nolint:revive // AuditEvent name is intentional to avoid confusion with the events package's Event type
 type AuditEvent struct {
 	// Timestamp is when the event occurred, always in UTC.
 	Timestamp time.Time

--- a/internal/domain/egress/headers_test.go
+++ b/internal/domain/egress/headers_test.go
@@ -84,13 +84,7 @@ func TestHeadersConfig_ApplyToRequest_InjectHeaders(t *testing.T) {
 
 			got := tt.cfg.ApplyToRequest(tt.incoming)
 
-			// Verify original is untouched.
-			for k, v := range original {
-				if got, ok := tt.incoming[k]; !ok || got[0] != v[0] {
-					// only check first value for simplicity
-				}
-			}
-			// Simpler: check that X-Inject-Secret was not deleted from original.
+			// Verify original is untouched — check that X-Inject-Secret was not deleted from original.
 			if tt.incoming.Get("X-Inject-Secret") != original.Get("X-Inject-Secret") {
 				t.Error("ApplyToRequest mutated the original header map")
 			}

--- a/internal/domain/egress/request.go
+++ b/internal/domain/egress/request.go
@@ -8,6 +8,8 @@ import (
 // EgressRequest is a value object that carries the details of an outbound
 // HTTP request intercepted by the egress proxy. The body is referenced by an
 // opaque handle rather than held in memory to avoid large allocations.
+//
+//nolint:revive // EgressRequest name is intentional to distinguish from inbound request types
 type EgressRequest struct {
 	// Method is the HTTP method of the outbound request (e.g. "GET", "POST").
 	Method string

--- a/internal/domain/egress/response.go
+++ b/internal/domain/egress/response.go
@@ -10,6 +10,8 @@ import (
 // HTTP response received from an upstream service and forwarded back to the
 // wrapped application. The body is referenced by an opaque handle rather than
 // held in memory to avoid large allocations.
+//
+//nolint:revive // EgressResponse name is intentional to distinguish from inbound response types
 type EgressResponse struct {
 	// StatusCode is the HTTP status code returned by the upstream service.
 	StatusCode int

--- a/internal/domain/events/egress_response_invalid_test.go
+++ b/internal/domain/events/egress_response_invalid_test.go
@@ -1,7 +1,6 @@
 package events_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/vibewarden/vibewarden/internal/domain/events"
@@ -24,13 +23,6 @@ func requirePayloadInt(t *testing.T, payload map[string]any, key string, want in
 	if got != want {
 		t.Errorf("Payload[%q] = %d, want %d", key, got, want)
 	}
-}
-
-// requireSummaryContainsInt is a helper that asserts the summary contains the
-// string representation of n.
-func requireSummaryContainsInt(t *testing.T, summary string, n int) {
-	t.Helper()
-	requireSummaryContains(t, summary, fmt.Sprintf("%d", n))
 }
 
 // TestNewEgressResponseInvalid verifies the egress.response_invalid event

--- a/internal/domain/plugin/types.go
+++ b/internal/domain/plugin/types.go
@@ -3,6 +3,8 @@ package plugin
 // PluginConfig holds the configuration block for a single plugin as loaded
 // from vibewarden.yaml under plugins.<name>. It is intentionally generic so
 // that each plugin can define its own settings structure and unmarshal into it.
+//
+//nolint:revive // PluginConfig is the established public API name used across all plugin implementations
 type PluginConfig struct {
 	// Enabled controls whether the plugin is active. Disabled plugins are
 	// never initialised or started.

--- a/internal/domain/scaffold/types.go
+++ b/internal/domain/scaffold/types.go
@@ -36,6 +36,8 @@ type ProjectConfig struct {
 
 // ScaffoldOptions holds the user-supplied options that drive file generation.
 // It is a value object — all fields set at construction.
+//
+//nolint:revive // ScaffoldOptions is the established public API name used across the scaffold package
 type ScaffoldOptions struct {
 	// UpstreamPort is the port that the user's application listens on.
 	UpstreamPort int

--- a/internal/domain/secret/secret.go
+++ b/internal/domain/secret/secret.go
@@ -3,6 +3,8 @@
 package secret
 
 // SecretSource indicates the origin of a retrieved secret.
+//
+//nolint:revive // SecretSource is the established public API type name used by secret retrieval adapters
 type SecretSource string
 
 const (

--- a/internal/domain/sync/sync.go
+++ b/internal/domain/sync/sync.go
@@ -166,6 +166,8 @@ func (u StateUpdate) Validate() error {
 
 // SyncMessage wraps a StateUpdate with routing metadata so that subscribers
 // can quickly filter messages without deserialising the full payload.
+//
+//nolint:revive // SyncMessage is the established public API name in the sync package
 type SyncMessage struct {
 	// Type mirrors Update.Type for fast routing without unpacking Update.
 	Type StateType

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -269,7 +269,7 @@ func emitAuditAuthFailure(r *http.Request, auditLogger ports.AuditEventLogger, u
 //
 // Deprecated: Remove once all callers use IdentityProvider directly.
 type sessionCheckerAdapter struct {
-	checker    ports.SessionChecker
+	checker    ports.SessionChecker //nolint:staticcheck // intentional: this adapter bridges the deprecated SessionChecker to IdentityProvider during migration
 	cookieName string
 }
 

--- a/internal/plugins/bodysize/plugin.go
+++ b/internal/plugins/bodysize/plugin.go
@@ -129,10 +129,7 @@ func buildBodySizeHandlerJSON(cfg Config) (map[string]any, error) {
 		MaxBytes: cfg.MaxBytes,
 	}
 	for _, ov := range cfg.Overrides {
-		hcfg.Overrides = append(hcfg.Overrides, bodySizeOverrideJSONItem{
-			Path:     ov.Path,
-			MaxBytes: ov.MaxBytes,
-		})
+		hcfg.Overrides = append(hcfg.Overrides, bodySizeOverrideJSONItem(ov))
 	}
 
 	cfgBytes, err := json.Marshal(hcfg)

--- a/internal/plugins/cors/plugin.go
+++ b/internal/plugins/cors/plugin.go
@@ -197,34 +197,6 @@ func buildCORSHeaders(cfg Config) corsHeaders {
 	return h
 }
 
-// headerSet builds the map[string][]string of response headers to set.
-func headerSet(cfg Config, h corsHeaders) map[string][]string {
-	set := map[string][]string{}
-
-	set["Access-Control-Allow-Origin"] = []string{h.allowOrigin}
-
-	if h.allowMethods != "" {
-		set["Access-Control-Allow-Methods"] = []string{h.allowMethods}
-	}
-	if h.allowHeaders != "" {
-		set["Access-Control-Allow-Headers"] = []string{h.allowHeaders}
-	}
-	if h.exposeHeaders != "" {
-		set["Access-Control-Expose-Headers"] = []string{h.exposeHeaders}
-	}
-	if h.allowCredentials {
-		set["Access-Control-Allow-Credentials"] = []string{"true"}
-	}
-	if h.maxAge != "" {
-		set["Access-Control-Max-Age"] = []string{h.maxAge}
-	}
-	if h.varyOrigin {
-		set["Vary"] = []string{"Origin"}
-	}
-
-	return set
-}
-
 // buildPreflightHandler creates a Caddy handler that responds to OPTIONS
 // preflight requests with 204 No Content and the full set of CORS headers.
 //
@@ -271,8 +243,6 @@ func buildPreflightHandler(h corsHeaders) map[string]any {
 // response headers on all responses (non-OPTIONS requests that pass through
 // the preflight handler).
 func buildResponseHeadersHandler(h corsHeaders) map[string]any {
-	// We need a Config to call headerSet; reconstruct minimal needed fields.
-	// Since we have the corsHeaders struct we can build directly.
 	set := map[string][]string{
 		"Access-Control-Allow-Origin": {h.allowOrigin},
 	}

--- a/internal/plugins/registry_test.go
+++ b/internal/plugins/registry_test.go
@@ -59,13 +59,13 @@ func (f *fakeCaddyPlugin) ContributeCaddyHandlers() []ports.CaddyHandler { retur
 // ----------------------------------------------------------------------------
 
 func discardLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(nil_writer{}, nil))
+	return slog.New(slog.NewTextHandler(nilWriter{}, nil))
 }
 
-// nil_writer discards all log output so tests stay quiet.
-type nil_writer struct{}
+// nilWriter discards all log output so tests stay quiet.
+type nilWriter struct{}
 
-func (nil_writer) Write(p []byte) (int, error) { return len(p), nil }
+func (nilWriter) Write(p []byte) (int, error) { return len(p), nil }
 
 func newOrder() *[]string { s := []string{}; return &s }
 

--- a/internal/plugins/secrets/plugin.go
+++ b/internal/plugins/secrets/plugin.go
@@ -541,7 +541,8 @@ func (p *Plugin) rotateDynamicCredentialsIfNeeded(ctx context.Context) {
 		}
 
 		// Revoke the old lease after a short grace period.
-		go func(old *openbao.DynamicCredentials) {
+		// context.Background is intentional: revocation must outlive the request context.
+		go func(old *openbao.DynamicCredentials) { //nolint:gosec // G118: background context is correct — revocation runs after the request completes
 			time.Sleep(5 * time.Second)
 			revokeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()

--- a/internal/plugins/waf/config.go
+++ b/internal/plugins/waf/config.go
@@ -39,6 +39,8 @@ type RulesConfig struct {
 }
 
 // WAFEngineConfig holds settings for the built-in WAF rule engine.
+//
+//nolint:revive // WAFEngineConfig distinguishes the engine config from the WAF plugin's top-level Config type
 type WAFEngineConfig struct {
 	// Enabled toggles the WAF rule engine. Default: false.
 	Enabled bool

--- a/internal/ports/circuit_breaker.go
+++ b/internal/ports/circuit_breaker.go
@@ -46,12 +46,12 @@ type CircuitBreakerConfig struct {
 	Timeout time.Duration
 }
 
+// MetricsCollectorWithCircuitBreaker extends MetricsCollector with a circuit
+// breaker state gauge. Adapters that expose this gauge implement this interface;
+// others embed a no-op to satisfy MetricsCollector without the extra method.
+//
 // SetCircuitBreakerState sets the vibewarden_circuit_breaker_state gauge.
 // The state values match the schema: 0=closed, 1=open, 2=half_open.
-//
-// This method is defined on MetricsCollector via an extension interface so that
-// existing implementations that do not expose this gauge can embed a no-op.
-// Adapters that support it implement MetricsCollectorWithCircuitBreaker.
 type MetricsCollectorWithCircuitBreaker interface {
 	MetricsCollector
 


### PR DESCRIPTION
## Summary

- **goimports**: Fixed import group ordering (stdlib / third-party / local) in 6 files across the `otel`, `jwt`, and `caddy` packages using `goimports -w -local github.com/vibewarden/vibewarden`
- **gosec (G304/G306/G301/G115 in tests)**: Added `.golangci.yml` exclusion rules for test files — these are legitimate temp-file operations in test helpers, not file inclusion vulnerabilities
- **gosec (production code)**: Added targeted `//nolint:gosec` comments with explanatory reasons on 10 production callsites reading config-supplied paths (cert files, YAML config, audit log, etc.)
- **unused**: Removed 6 dead code items: `buildWAFEngineHandlerJSON`, `traceIDer` interface, `fakeErrorStore`, `writeRawPrivateKey`, `requireSummaryContainsInt`, `headerSet`
- **staticcheck**: Fixed SA1012 (nil context → `context.TODO()`), SA4006 (unused variable initial assignment), SA9003 (empty branches), QF1011/QF1012 (style simplifications), S1040 (redundant type assertion), S1016 (struct literal → type conversion), SA1019 (deprecated `MetricsConfig` → `TelemetryConfig` in test)
- **revive**: Fixed `nil_writer` → `nilWriter` naming, fixed godoc comment format on `MetricsCollectorWithCircuitBreaker`; suppressed stutter warnings on established public API type names with `//nolint:revive` and justification comments; suppressed `context-as-argument` in test helper where `t *testing.T` must precede `ctx` by Go testing convention

## Test plan

- `golangci-lint run ./...` reports `0 issues.`
- `go build ./...` succeeds
- `go test -race ./...` — all packages pass
- `make check` passes end-to-end including the demo-app sub-module