### PR TITLE
docs(#498): remove phantom CLI commands from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,14 +183,14 @@ If you need a general-purpose load balancer or a CDN edge, use the right tool fo
 | `vibew add auth` | Enable authentication |
 | `vibew add rate-limit` | Enable rate limiting |
 | `vibew add tls --domain example.com` | Enable TLS |
-| `vibew add observability` | Add Prometheus + Grafana |
+| `vibew add metrics` | Enable Prometheus metrics |
 | `vibew generate` | Regenerate `docker-compose.yml` from config |
 | `vibew dev` | Start local dev environment |
 | `vibew status` | Show health of all components |
 | `vibew doctor` | Diagnose common issues |
 | `vibew logs` | Pretty-print structured logs |
-| `vibew secret get <path>` | Read a secret from OpenBao |
-| `vibew secret list <path>` | List secrets at a path |
+| `vibew secret get <alias-or-path>` | Read a secret from OpenBao |
+| `vibew secret list` | List all managed secret paths |
 | `vibew token` | Generate a signed dev JWT for local testing |
 | `vibew cert export` | Export the local CA certificate (for curl, Postman, …) |
 | `vibew validate` | Validate configuration |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,12 +51,13 @@ Common flags:
 
 | Flag | Description |
 |------|-------------|
-| `--upstream <port>` | Port your app listens on (required) |
-| `--auth` | Enable authentication (defaults to JWT/OIDC mode) |
+| `--upstream <port>` | Port your app listens on (default: auto-detected or 3000) |
+| `--auth` | Enable authentication (Ory Kratos) |
 | `--rate-limit` | Enable rate limiting |
-| `--tls --domain example.com` | Enable TLS with Let's Encrypt |
-| `--secrets` | Enable secrets management (OpenBao) |
-| `--observability` | Add Prometheus + Grafana |
+| `--tls --domain example.com` | Enable TLS (requires `--domain`) |
+| `--force` | Overwrite existing files |
+| `--skip-wrapper` | Skip vibew wrapper script generation |
+| `--agent <type>` | Generate AI context files: `claude`, `cursor`, `generic`, `all`, or `none` |
 
 ### What `init` generates
 
@@ -205,7 +206,7 @@ examples with Auth0, Keycloak, Firebase, Cognito, Okta, Supabase, and Kratos.
 ### Add observability
 
 ```bash
-./vibew add observability
+./vibew add metrics
 ./vibew dev
 ```
 

--- a/docs/identity-providers.md
+++ b/docs/identity-providers.md
@@ -422,7 +422,7 @@ The KV secret at `auth/api-keys` must contain string fields where each key is
 the key name and each value is the SHA-256 hash:
 
 ```
-vibew secret store auth/api-keys ci-pipeline=e3b0c4...
+bao kv put secret/auth/api-keys ci-pipeline=e3b0c4...
 ```
 
 ### Scope-based authorization

--- a/docs/index.md
+++ b/docs/index.md
@@ -138,14 +138,14 @@ Your app receives authenticated user info via headers:
 | `vibew add auth` | Enable authentication |
 | `vibew add rate-limit` | Enable rate limiting |
 | `vibew add tls --domain example.com` | Enable TLS |
-| `vibew add observability` | Add Prometheus + Grafana |
+| `vibew add metrics` | Enable Prometheus metrics |
 | `vibew generate` | Regenerate `docker-compose.yml` from config |
 | `vibew dev` | Start local dev environment |
 | `vibew status` | Show health of all components |
 | `vibew doctor` | Diagnose common issues |
 | `vibew logs` | Pretty-print structured logs |
-| `vibew secret get <path>` | Read a secret from OpenBao |
-| `vibew secret list <path>` | List secrets at a path |
+| `vibew secret get <alias-or-path>` | Read a secret from OpenBao |
+| `vibew secret list` | List all managed secret paths |
 | `vibew token` | Generate a signed dev JWT for local testing |
 | `vibew cert export` | Export the local CA certificate (for curl, Postman, …) |
 | `vibew validate` | Validate configuration |

--- a/docs/secret-management.md
+++ b/docs/secret-management.md
@@ -53,14 +53,14 @@ Copy the printed `role_id` and `secret_id`.
 
 ### 2. Store a secret
 
-Use the VibeWarden CLI (or `curl` against OpenBao directly in dev):
+Use the OpenBao CLI (`bao`) or `curl` to write secrets directly to OpenBao:
 
 ```bash
 # Store your Stripe API key
-vibew secret store app/stripe api_key=sk_live_abc123
+bao kv put secret/app/stripe api_key=sk_live_abc123
 
 # Store your internal API token
-vibew secret store app/internal token=bearer-xyz
+bao kv put secret/app/internal token=bearer-xyz
 ```
 
 ### 3. Configure injection
@@ -106,13 +106,15 @@ Static secrets are key/value pairs stored in OpenBao KV v2 and refreshed on a co
 
 ### Storing secrets
 
+Use the OpenBao CLI (`bao`) to write secrets to OpenBao directly. VibeWarden reads
+them at runtime — it does not provide a write command.
+
 ```bash
-# CLI (reads from stdin if value is omitted)
-vibew secret store <path> <key>=<value>
-vibew secret store app/database password=s3cr3t!
+# Single key
+bao kv put secret/app/database password=s3cr3t!
 
 # Multiple keys at once
-vibew secret store app/stripe \
+bao kv put secret/app/stripe \
   api_key=sk_live_abc \
   webhook_secret=whsec_xyz
 ```
@@ -120,15 +122,15 @@ vibew secret store app/stripe \
 ### Listing secrets
 
 ```bash
-vibew secret list           # list all paths
-vibew secret list app/      # list paths under app/
+vibew secret list           # list all managed paths
 ```
 
 ### Viewing secrets
 
 ```bash
-vibew secret get app/stripe              # shows masked values: api_key=***
-vibew secret get app/stripe --reveal     # shows actual values
+vibew secret get app/stripe              # human-readable output
+vibew secret get app/stripe --json       # JSON output
+vibew secret get app/stripe --env        # export KEY=value lines
 ```
 
 ### Injection modes
@@ -347,15 +349,23 @@ Health events are also delivered to configured webhooks (Slack, Discord, etc.) w
 ## CLI Commands
 
 ```bash
-# Store a secret (key=value pairs)
-vibew secret store <path> <key>=<value> [<key>=<value>...]
+# Read a secret (human-readable, JSON, or shell-sourceable env output)
+vibew secret get <alias-or-path>
+vibew secret get <alias-or-path> --json
+vibew secret get <alias-or-path> --env
 
-# Read a secret (values masked by default)
-vibew secret get <path>
-vibew secret get <path> --reveal
+# List all managed secret paths
+vibew secret list
 
-# List secrets at a path prefix
-vibew secret list [<prefix>]
+# Generate a cryptographically secure random secret
+vibew secret generate
+vibew secret generate --length 64
+```
+
+To write secrets to OpenBao, use the `bao` CLI directly:
+
+```bash
+bao kv put secret/<path> <key>=<value> [<key>=<value>...]
 ```
 
 ---
@@ -463,10 +473,10 @@ EOF
 
 **Symptom:** `openbao: secret not found at "app/stripe"`
 
-**Fix:** The secret does not exist in OpenBao yet. Write it:
+**Fix:** The secret does not exist in OpenBao yet. Write it using the `bao` CLI:
 
 ```bash
-vibew secret store app/stripe api_key=your-api-key
+bao kv put secret/app/stripe api_key=your-api-key
 ```
 
 ---


### PR DESCRIPTION
Closes #498

## Summary

- `vibew add observability` does not exist — the real command is `vibew add metrics`. Fixed in `README.md`, `docs/index.md`, and `docs/getting-started.md`.
- `vibew secret store` does not exist — the CLI has no write command. Fixed in `docs/secret-management.md` and `docs/identity-providers.md` by replacing all occurrences with the correct `bao kv put` invocation and a note that VibeWarden reads but does not write secrets.
- `vibew secret list <path>` — the command accepts no path argument. Fixed in `README.md`, `docs/index.md`, and `docs/secret-management.md`.
- `vibew secret get --reveal` — this flag does not exist. The real flags are `--json` and `--env`. Fixed in `docs/secret-management.md`.
- `vibew init --observability` / `--secrets` flags — these were never added to `init.go`. Replaced the getting-started.md flag table with the actual flags from `init.go`.

No Go code was changed.

## Test plan

- `go build ./...` passes
- `go vet ./...` passes
- `go test -race ./...` passes (all cached, no code changes)
- Pre-push hook (`make check` including golangci-lint) passed