### PR TITLE
fix(#505): change default CSP to empty string — opt-in instead of opt-out

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -269,7 +269,7 @@ Only read when `store` is `redis`.
 | `security_headers.hsts_preload` | bool | `false` | Add `preload` to HSTS |
 | `security_headers.content_type_nosniff` | bool | `true` | Set `X-Content-Type-Options: nosniff` |
 | `security_headers.frame_option` | string | `DENY` | `X-Frame-Options`: `DENY`, `SAMEORIGIN`, or `""` to disable |
-| `security_headers.content_security_policy` | string | `default-src 'self'` | `Content-Security-Policy` value |
+| `security_headers.content_security_policy` | string | `""` (disabled) | `Content-Security-Policy` value — empty by default; set explicitly to opt in |
 | `security_headers.referrer_policy` | string | `strict-origin-when-cross-origin` | `Referrer-Policy` value |
 | `security_headers.permissions_policy` | string | `""` | `Permissions-Policy` value |
 | `security_headers.cross_origin_opener_policy` | string | `same-origin` | `Cross-Origin-Opener-Policy` value |
@@ -712,7 +712,7 @@ rate_limit:
 security_headers:
   enabled: true
   hsts_max_age: 31536000
-  content_security_policy: "default-src 'self'"
+  content_security_policy: ""
 
 telemetry:
   enabled: true

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -254,7 +254,7 @@ security_headers:
   hsts_preload: false
   content_type_nosniff: true
   frame_option: "DENY"
-  content_security_policy: "default-src 'self'"
+  content_security_policy: "default-src 'self'; style-src 'self' 'unsafe-inline'"
   referrer_policy: "strict-origin-when-cross-origin"
   permissions_policy: ""
   cross_origin_opener_policy: "same-origin"

--- a/docs/production-hardening.md
+++ b/docs/production-hardening.md
@@ -57,7 +57,9 @@ Each item is a concrete action, not a vague recommendation.
 
 - [ ] `security_headers.enabled: true`.
 - [ ] `content_security_policy` is set to the strictest policy your app supports.
-  At minimum use `"default-src 'self'"`. Tighten per-app after testing:
+  The default is empty (no CSP header) so that VibeWarden works with any app out
+  of the box. For production, start with `"default-src 'self'"` and tighten from
+  there after testing with your actual app:
   ```yaml
   content_security_policy: >-
     default-src 'self';

--- a/examples/demo-app/main.go
+++ b/examples/demo-app/main.go
@@ -304,9 +304,10 @@ func handleVulnLab(w http.ResponseWriter, r *http.Request) {
 // response without any escaping.  This lets an attacker craft a URL that
 // executes arbitrary JavaScript in the victim's browser.
 //
-// VibeWarden mitigation: the CSP header "default-src 'self'" set by the
-// sidecar prevents inline scripts from executing, so the injected payload
-// is blocked even though the app itself does nothing to stop it.
+// VibeWarden mitigation: a CSP header set by the sidecar (e.g.
+// "default-src 'self'", configured in vibewarden.yaml) prevents inline
+// scripts from executing, so the injected payload is blocked even though
+// the app itself does nothing to stop it.
 //
 // INTENTIONALLY VULNERABLE — do not sanitise this endpoint.
 func handleXSSReflected(w http.ResponseWriter, r *http.Request) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -704,7 +704,9 @@ type SecurityHeadersConfig struct {
 	// FrameOption sets X-Frame-Options value: "DENY", "SAMEORIGIN", or "" to disable (default: "DENY")
 	FrameOption string `mapstructure:"frame_option"`
 
-	// ContentSecurityPolicy sets Content-Security-Policy value (default: "default-src 'self'")
+	// ContentSecurityPolicy sets Content-Security-Policy value.
+	// An empty string (the default) disables the header entirely; users opt in
+	// by setting an explicit policy in vibewarden.yaml.
 	ContentSecurityPolicy string `mapstructure:"content_security_policy"`
 
 	// ReferrerPolicy sets Referrer-Policy value (default: "strict-origin-when-cross-origin")
@@ -1738,7 +1740,7 @@ func Load(configPath string) (*Config, error) {
 	v.SetDefault("security_headers.hsts_preload", false)
 	v.SetDefault("security_headers.content_type_nosniff", true)
 	v.SetDefault("security_headers.frame_option", "DENY")
-	v.SetDefault("security_headers.content_security_policy", "default-src 'self'")
+	v.SetDefault("security_headers.content_security_policy", "")
 	v.SetDefault("security_headers.referrer_policy", "strict-origin-when-cross-origin")
 	v.SetDefault("security_headers.permissions_policy", "")
 	v.SetDefault("security_headers.cross_origin_opener_policy", "same-origin")

--- a/internal/middleware/security_headers.go
+++ b/internal/middleware/security_headers.go
@@ -69,7 +69,7 @@ func DefaultSecurityHeadersConfig() ports.SecurityHeadersConfig {
 		HSTSPreload:           false, // Preload requires manual submission to browser lists
 		ContentTypeNosniff:    true,
 		FrameOption:           "DENY",
-		ContentSecurityPolicy: "default-src 'self'",
+		ContentSecurityPolicy: "", // disabled by default — users opt in via config
 		ReferrerPolicy:        "strict-origin-when-cross-origin",
 		PermissionsPolicy:     "",
 	}

--- a/internal/middleware/security_headers_test.go
+++ b/internal/middleware/security_headers_test.go
@@ -309,8 +309,8 @@ func TestDefaultSecurityHeadersConfig(t *testing.T) {
 	if cfg.FrameOption != "DENY" {
 		t.Errorf("FrameOption = %q, want %q", cfg.FrameOption, "DENY")
 	}
-	if cfg.ContentSecurityPolicy == "" {
-		t.Error("expected ContentSecurityPolicy to be non-empty")
+	if cfg.ContentSecurityPolicy != "" {
+		t.Errorf("expected ContentSecurityPolicy to be empty (opt-in), got %q", cfg.ContentSecurityPolicy)
 	}
 	if cfg.ReferrerPolicy == "" {
 		t.Error("expected ReferrerPolicy to be non-empty")

--- a/internal/plugins/catalog.go
+++ b/internal/plugins/catalog.go
@@ -102,14 +102,15 @@ var Catalog = []PluginDescriptor{
 			"hsts_preload":            "Append preload to HSTS header (default: false)",
 			"content_type_nosniff":    "Set X-Content-Type-Options: nosniff (default: true)",
 			"frame_option":            "X-Frame-Options value: DENY, SAMEORIGIN, or empty (default: DENY)",
-			"content_security_policy": "Content-Security-Policy header value (default: default-src 'self')",
+			"content_security_policy": "Content-Security-Policy header value (default: empty — header not sent; set explicitly to opt in)",
 			"referrer_policy":         "Referrer-Policy header value (default: strict-origin-when-cross-origin)",
 			"permissions_policy":      "Permissions-Policy header value (default: empty/disabled)",
 		},
 		Example: `  security-headers:
     enabled: true
     frame_option: DENY
-    content_security_policy: "default-src 'self'"`,
+    # content_security_policy is empty by default (header not sent).
+    # Set explicitly to opt in, e.g.: content_security_policy: "default-src 'self'"`,
 	},
 	{
 		Name:        "body-size",

--- a/internal/plugins/securityheaders/config.go
+++ b/internal/plugins/securityheaders/config.go
@@ -39,8 +39,8 @@ type Config struct {
 	FrameOption string
 
 	// ContentSecurityPolicy sets the Content-Security-Policy response header
-	// value. An empty string disables the header.
-	// Default: "default-src 'self'".
+	// value. An empty string (the default) disables the header; users opt in
+	// by setting an explicit policy in vibewarden.yaml.
 	ContentSecurityPolicy string
 
 	// ReferrerPolicy sets the Referrer-Policy response header value.

--- a/internal/plugins/securityheaders/meta.go
+++ b/internal/plugins/securityheaders/meta.go
@@ -14,7 +14,7 @@ func (p *Plugin) ConfigSchema() map[string]string {
 		"hsts_preload":            "Append preload to HSTS header (default: false)",
 		"content_type_nosniff":    "Set X-Content-Type-Options: nosniff (default: true)",
 		"frame_option":            "X-Frame-Options value: DENY, SAMEORIGIN, or empty to disable (default: DENY)",
-		"content_security_policy": "Content-Security-Policy header value (default: default-src 'self')",
+		"content_security_policy": "Content-Security-Policy header value (default: empty — header not sent; set explicitly to opt in)",
 		"referrer_policy":         "Referrer-Policy header value (default: strict-origin-when-cross-origin)",
 		"permissions_policy":      "Permissions-Policy header value (default: empty/disabled)",
 	}
@@ -25,5 +25,7 @@ func (p *Plugin) Example() string {
 	return `  security-headers:
     enabled: true
     frame_option: DENY
-    content_security_policy: "default-src 'self'"`
+    # content_security_policy is empty by default (header not sent).
+    # Uncomment and customise once you know your app's requirements:
+    # content_security_policy: "default-src 'self'"`
 }

--- a/vibewarden.example.yaml
+++ b/vibewarden.example.yaml
@@ -553,8 +553,12 @@ security_headers:
   content_type_nosniff: true
   # Set X-Frame-Options: "DENY", "SAMEORIGIN", or "" to disable
   frame_option: "DENY"
-  # Content-Security-Policy value (empty string disables the header)
-  content_security_policy: "default-src 'self'"
+  # Content-Security-Policy value (empty string disables the header — the default).
+  # CSP is disabled by default because "default-src 'self'" breaks most real apps
+  # (inline styles, external fonts, CDN scripts, etc.).  Set an explicit policy
+  # once you know your app's requirements, e.g.:
+  #   content_security_policy: "default-src 'self'; style-src 'self' 'unsafe-inline'"
+  content_security_policy: ""
   # Referrer-Policy value (empty string disables the header)
   referrer_policy: "strict-origin-when-cross-origin"
   # Permissions-Policy value (empty string disables the header)


### PR DESCRIPTION
Closes #505

## Summary

- The default `Content-Security-Policy` value was `"default-src 'self'"`, which blocks inline styles, external fonts, CDN scripts, and many other common patterns used by real apps.
- Changed the default to `""` (empty string). When empty, no `Content-Security-Policy` header is sent. Users opt in by setting an explicit policy in `vibewarden.yaml`.
- All other security headers (`X-Frame-Options`, `X-Content-Type-Options`, HSTS, `Referrer-Policy`) retain their defaults — those rarely break apps.

## Test plan

- [x] `make check` passes (lint + build + all unit tests)
- [x] `TestDefaultSecurityHeadersConfig` asserts `ContentSecurityPolicy == ""`
- [x] Existing `TestSecurityHeaders_CSP` continues to verify CSP is emitted when explicitly configured
- [x] Existing `TestPlugin_ContributeCaddyHandlers_CSP` covers both `"" — no header` and `"default-src 'self'" — header present`