### PR TITLE
fix(#504): document WAF plugin in example config and configuration reference

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -295,12 +295,51 @@ Only read when `store` is `redis`.
 
 ## `waf`
 
+VibeWarden's built-in Web Application Firewall inspects every inbound request
+for common attack patterns in-process, with no external dependencies.
+
+### `waf` (top-level)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `waf.enabled` | bool | `false` | Enable the WAF middleware |
+| `waf.mode` | string | `block` | Detection mode: `block` (reject with 400) or `detect` (pass through and log) |
+
+### `waf.rules`
+
+Per-rule toggles. All rules are enabled by default when `waf.enabled` is `true`.
+Set a rule to `false` to disable that check while keeping all others active.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `waf.rules.sqli` | bool | `true` | Detect SQL injection patterns in query strings and request bodies |
+| `waf.rules.xss` | bool | `true` | Detect cross-site scripting payloads |
+| `waf.rules.path_traversal` | bool | `true` | Detect directory traversal sequences (e.g. `../../etc/passwd`) |
+| `waf.rules.command_injection` | bool | `true` | Detect shell command-injection metacharacters |
+
 ### `waf.content_type_validation`
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `waf.content_type_validation.enabled` | bool | `false` | Enable Content-Type validation on body-bearing requests |
 | `waf.content_type_validation.allowed` | list | `[application/json, application/x-www-form-urlencoded, multipart/form-data]` | Permitted media types. Requests with other types receive `415 Unsupported Media Type` |
+
+```yaml
+waf:
+  enabled: true
+  mode: block
+  rules:
+    sqli: true
+    xss: true
+    path_traversal: true
+    command_injection: true
+  content_type_validation:
+    enabled: true
+    allowed:
+      - application/json
+      - application/x-www-form-urlencoded
+      - multipart/form-data
+```
 
 ---
 

--- a/vibewarden.example.yaml
+++ b/vibewarden.example.yaml
@@ -538,6 +538,55 @@ cors:
   # Seconds to cache preflight response (0 omits Access-Control-Max-Age)
   max_age: 0
 
+# Web Application Firewall (WAF)
+# VibeWarden's built-in WAF inspects every inbound request for common attack
+# patterns before forwarding it to the upstream application.  No external
+# dependency is required — all detection runs in-process.
+#
+# Attack categories detected:
+#   sqli             — SQL injection payloads in query strings and request bodies
+#   xss              — Cross-site scripting payloads
+#   path_traversal   — Directory traversal sequences (e.g. "../..")
+#   command_injection — Shell metacharacters and command-chaining patterns
+#
+# When a request matches an active rule, VibeWarden responds immediately with:
+#   HTTP 400 Bad Request   (mode: block, default)
+#   HTTP 200 forwarded     (mode: detect  — request passes through, attack is logged)
+#
+waf:
+  # Enable the WAF middleware (default: false).
+  enabled: false
+
+  # Detection mode controls what happens when a rule fires.
+  # "block"  — reject the request with 400 Bad Request (recommended for production).
+  # "detect" — pass the request through but emit a structured log event.
+  #            Use detect mode to audit traffic before switching to block mode.
+  mode: block
+
+  # Content-Type validation — rejects requests whose Content-Type is not in the
+  # allowed list with 415 Unsupported Media Type.
+  content_type_validation:
+    # Enable Content-Type validation on body-bearing requests (default: false).
+    enabled: false
+    # Media types accepted for request bodies. Requests with any other
+    # Content-Type receive 415 Unsupported Media Type.
+    allowed:
+      - application/json
+      - application/x-www-form-urlencoded
+      - multipart/form-data
+
+  # Per-rule toggles. Each rule is enabled by default when waf.enabled is true.
+  # Set a rule to false to skip that check while keeping all others active.
+  rules:
+    # Detect SQL injection patterns in query strings and request bodies.
+    sqli: true
+    # Detect cross-site scripting payloads.
+    xss: true
+    # Detect directory traversal sequences (e.g. ../../etc/passwd).
+    path_traversal: true
+    # Detect shell command-injection metacharacters.
+    command_injection: true
+
 # Security headers added to all proxied responses
 security_headers:
   # Enable security headers middleware (recommended: true)


### PR DESCRIPTION
Closes #504

## Summary

- Added a fully-commented `waf:` section to `vibewarden.example.yaml` directly before `security_headers:`, covering every configurable field: `enabled`, `mode`, `content_type_validation` (with its `allowed` list), and the four per-rule toggles (`sqli`, `xss`, `path_traversal`, `command_injection`).
- Expanded the `## waf` section in `docs/configuration.md` with three field-reference tables (`waf` top-level, `waf.rules`, `waf.content_type_validation`) and an inline YAML example showing a complete WAF block.

No code changes — docs and example config only.

## Test plan

- [ ] `make check` passes locally (verified before push; pre-push hook also ran it).
- [ ] Open `vibewarden.example.yaml` and confirm the `waf:` section appears between `cors:` and `security_headers:` with all fields commented.
- [ ] Open `docs/configuration.md` and confirm the `## waf` section has tables for top-level fields, `waf.rules`, and `waf.content_type_validation`, plus a YAML example.