### PR TITLE
fix(#502): add /_vibewarden/ready readiness probe separate from liveness

### DIFF
--- a/internal/adapters/caddy/config.go
+++ b/internal/adapters/caddy/config.go
@@ -167,10 +167,23 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 		},
 	}
 
-	// Build routes — health check first, then metrics (when enabled), then
-	// Kratos flow routes (when auth is configured), and finally the catch-all
-	// proxy route.
-	routes := []map[string]any{healthRoute}
+	// Build the readiness probe route (must come before the catch-all proxy route).
+	// When readiness.enabled is true and an internal address is configured, Caddy
+	// reverse-proxies /_vibewarden/ready to the internal Go HTTP server running
+	// ReadyHandler for live plugin and upstream checks.
+	// Otherwise a static 503 response is returned — the process is alive but not
+	// yet confirmed ready.
+	var readyRoute map[string]any
+	if cfg.Readiness.Enabled && cfg.Readiness.InternalAddr != "" {
+		readyRoute = buildDynamicReadyRoute(cfg.Readiness.InternalAddr)
+	} else {
+		readyRoute = buildStaticReadyRoute()
+	}
+
+	// Build routes — health (liveness) first, then readiness probe, then metrics
+	// (when enabled), then Kratos flow routes (when auth is configured), and
+	// finally the catch-all proxy route.
+	routes := []map[string]any{healthRoute, readyRoute}
 
 	if cfg.Metrics.Enabled && cfg.Metrics.InternalAddr != "" {
 		metricsRoute := buildMetricsRoute(cfg.Metrics.InternalAddr)
@@ -550,6 +563,53 @@ func buildMetricsRoute(internalAddr string) map[string]any {
 				"handler": "rewrite",
 				"uri":     "/metrics",
 			},
+			{
+				"handler": "reverse_proxy",
+				"upstreams": []map[string]any{
+					{"dial": internalAddr},
+				},
+			},
+		},
+	}
+}
+
+// buildStaticReadyRoute constructs a Caddy route for /_vibewarden/ready that
+// returns a static 503 response body indicating the process is not yet ready.
+// This route is used when no internal readiness server address is configured.
+// Kubernetes or other orchestration systems will treat the 503 as "not ready"
+// and withhold traffic until the dynamic route takes over after a Reload.
+func buildStaticReadyRoute() map[string]any {
+	return map[string]any{
+		"match": []map[string]any{
+			{"path": []string{"/_vibewarden/ready"}},
+		},
+		"handle": []map[string]any{
+			{
+				"handler": "static_response",
+				"headers": map[string][]string{
+					"Content-Type": {"application/json"},
+				},
+				"body":        `{"ready":false,"reason":"starting"}`,
+				"status_code": 503,
+			},
+		},
+	}
+}
+
+// buildDynamicReadyRoute constructs a Caddy route that reverse-proxies
+// /_vibewarden/ready to the internal readiness HTTP server at internalAddr.
+// The internal server runs ReadyHandler which performs live plugin health and
+// upstream reachability checks.
+//
+// The internalAddr must be a host:port string (e.g., "127.0.0.1:9093").
+// The full request path is forwarded unchanged; the internal readiness server
+// handles requests at /_vibewarden/ready.
+func buildDynamicReadyRoute(internalAddr string) map[string]any {
+	return map[string]any{
+		"match": []map[string]any{
+			{"path": []string{"/_vibewarden/ready"}},
+		},
+		"handle": []map[string]any{
 			{
 				"handler": "reverse_proxy",
 				"upstreams": []map[string]any{

--- a/internal/adapters/caddy/config_test.go
+++ b/internal/adapters/caddy/config_test.go
@@ -579,11 +579,11 @@ func TestBuildCaddyConfig_SecurityHeaders(t *testing.T) {
 	if !ok {
 		t.Fatal("routes not found in server config")
 	}
-	if len(routes) < 2 {
-		t.Fatalf("expected at least 2 routes (health + proxy), got %d", len(routes))
+	if len(routes) < 3 {
+		t.Fatalf("expected at least 3 routes (health + ready + proxy), got %d", len(routes))
 	}
 
-	handlers, ok := routes[1]["handle"].([]map[string]any)
+	handlers, ok := routes[2]["handle"].([]map[string]any)
 	if !ok {
 		t.Fatal("handle not found in proxy route")
 	}
@@ -637,11 +637,11 @@ func TestBuildCaddyConfig_NoSecurityHeaders(t *testing.T) {
 	if !ok {
 		t.Fatal("routes not found in server config")
 	}
-	if len(routes) < 2 {
-		t.Fatalf("expected at least 2 routes (health + proxy), got %d", len(routes))
+	if len(routes) < 3 {
+		t.Fatalf("expected at least 3 routes (health + ready + proxy), got %d", len(routes))
 	}
 
-	handlers, ok := routes[1]["handle"].([]map[string]any)
+	handlers, ok := routes[2]["handle"].([]map[string]any)
 	if !ok {
 		t.Fatal("handle not found in proxy route")
 	}
@@ -824,10 +824,10 @@ func TestBuildCaddyConfig_ReverseProxyUpstream(t *testing.T) {
 	if !ok {
 		t.Fatal("routes not found in server config")
 	}
-	if len(routes) < 2 {
-		t.Fatalf("expected at least 2 routes (health + proxy), got %d", len(routes))
+	if len(routes) < 3 {
+		t.Fatalf("expected at least 3 routes (health + ready + proxy), got %d", len(routes))
 	}
-	handlers, ok := routes[1]["handle"].([]map[string]any)
+	handlers, ok := routes[2]["handle"].([]map[string]any)
 	if !ok {
 		t.Fatal("handle not found in proxy route")
 	}
@@ -891,8 +891,8 @@ func TestBuildCaddyConfig_HealthRoute(t *testing.T) {
 			if !ok {
 				t.Fatal("routes not found in server config")
 			}
-			if len(routes) < 2 {
-				t.Fatalf("expected at least 2 routes (health + proxy), got %d", len(routes))
+			if len(routes) < 3 {
+				t.Fatalf("expected at least 3 routes (health + ready + proxy), got %d", len(routes))
 			}
 
 			healthRoute := routes[0]
@@ -1185,12 +1185,12 @@ func TestBuildCaddyConfig_KratosFlowRoutes_Present(t *testing.T) {
 		t.Fatal("routes not found in server config")
 	}
 
-	// Expect: health (index 0), Kratos flow route (index 1), catch-all proxy (index 2).
-	if len(routes) != 3 {
-		t.Fatalf("expected 3 routes (health + kratos + proxy), got %d", len(routes))
+	// Expect: health (index 0), ready (index 1), Kratos flow route (index 2), catch-all proxy (index 3).
+	if len(routes) != 4 {
+		t.Fatalf("expected 4 routes (health + ready + kratos + proxy), got %d", len(routes))
 	}
 
-	kratosRoute := routes[1]
+	kratosRoute := routes[2]
 
 	// Verify the route has matchers for the self-service paths.
 	matchers, ok := kratosRoute["match"].([]map[string]any)
@@ -1289,9 +1289,9 @@ func TestBuildCaddyConfig_KratosFlowRoutes_AbsentWhenAuthDisabled(t *testing.T) 
 				t.Fatal("routes not found in server config")
 			}
 
-			// Without auth, only health + catch-all = 2 routes.
-			if len(routes) != 2 {
-				t.Errorf("expected 2 routes (health + proxy), got %d", len(routes))
+			// Without auth: health + ready + catch-all = 3 routes.
+			if len(routes) != 3 {
+				t.Errorf("expected 3 routes (health + ready + proxy), got %d", len(routes))
 			}
 		})
 	}
@@ -1314,8 +1314,8 @@ func TestBuildCaddyConfig_KratosRouteBeforeCatchAll(t *testing.T) {
 
 	server := extractServer(t, result)
 	routes, ok := server["routes"].([]map[string]any)
-	if !ok || len(routes) < 3 {
-		t.Fatalf("expected at least 3 routes, got %d", len(routes))
+	if !ok || len(routes) < 4 {
+		t.Fatalf("expected at least 4 routes, got %d", len(routes))
 	}
 
 	// Index 0 — health check: has a path matcher.
@@ -1324,16 +1324,22 @@ func TestBuildCaddyConfig_KratosRouteBeforeCatchAll(t *testing.T) {
 		t.Error("routes[0] (health) must have a path matcher")
 	}
 
-	// Index 1 — Kratos flow route: has a path matcher and proxies to Kratos.
-	kratosRoute := routes[1]
-	if _, hasMatcher := kratosRoute["match"]; !hasMatcher {
-		t.Error("routes[1] (Kratos flow) must have a path matcher")
+	// Index 1 — ready probe: has a path matcher.
+	readyRoute := routes[1]
+	if _, hasMatcher := readyRoute["match"]; !hasMatcher {
+		t.Error("routes[1] (ready) must have a path matcher")
 	}
 
-	// Index 2 — catch-all proxy: no path matcher (matches everything).
-	catchAll := routes[2]
+	// Index 2 — Kratos flow route: has a path matcher and proxies to Kratos.
+	kratosRoute := routes[2]
+	if _, hasMatcher := kratosRoute["match"]; !hasMatcher {
+		t.Error("routes[2] (Kratos flow) must have a path matcher")
+	}
+
+	// Index 3 — catch-all proxy: no path matcher (matches everything).
+	catchAll := routes[3]
 	if _, hasMatcher := catchAll["match"]; hasMatcher {
-		t.Error("routes[2] (catch-all) must not have a path matcher")
+		t.Error("routes[3] (catch-all) must not have a path matcher")
 	}
 }
 
@@ -1400,12 +1406,12 @@ func TestBuildCaddyConfig_MetricsRoute_PresentWhenEnabled(t *testing.T) {
 	if !ok {
 		t.Fatal("routes not found in server config")
 	}
-	// Expect: health (index 0), metrics (index 1), catch-all (index 2).
-	if len(routes) != 3 {
-		t.Fatalf("expected 3 routes (health + metrics + proxy), got %d", len(routes))
+	// Expect: health (index 0), ready (index 1), metrics (index 2), catch-all (index 3).
+	if len(routes) != 4 {
+		t.Fatalf("expected 4 routes (health + ready + metrics + proxy), got %d", len(routes))
 	}
 
-	metricsRoute := routes[1]
+	metricsRoute := routes[2]
 
 	matchers, ok := metricsRoute["match"].([]map[string]any)
 	if !ok || len(matchers) == 0 {
@@ -1491,9 +1497,9 @@ func TestBuildCaddyConfig_MetricsRoute_AbsentWhenDisabled(t *testing.T) {
 			if !ok {
 				t.Fatal("routes not found in server config")
 			}
-			// Without metrics: only health + catch-all = 2 routes.
-			if len(routes) != 2 {
-				t.Errorf("expected 2 routes (health + proxy), got %d", len(routes))
+			// Without metrics: health + ready + catch-all = 3 routes.
+			if len(routes) != 3 {
+				t.Errorf("expected 3 routes (health + ready + proxy), got %d", len(routes))
 			}
 		})
 	}
@@ -1516,19 +1522,19 @@ func TestBuildCaddyConfig_MetricsRouteBeforeCatchAll(t *testing.T) {
 
 	server := extractServer(t, result)
 	routes, ok := server["routes"].([]map[string]any)
-	if !ok || len(routes) < 3 {
-		t.Fatalf("expected at least 3 routes, got %d", len(routes))
+	if !ok || len(routes) < 4 {
+		t.Fatalf("expected at least 4 routes, got %d", len(routes))
 	}
 
-	// routes[0] = health, routes[1] = metrics, routes[2] = catch-all.
-	metricsRoute := routes[1]
+	// routes[0] = health, routes[1] = ready, routes[2] = metrics, routes[3] = catch-all.
+	metricsRoute := routes[2]
 	if _, hasMatcher := metricsRoute["match"]; !hasMatcher {
-		t.Error("routes[1] (metrics) must have a path matcher")
+		t.Error("routes[2] (metrics) must have a path matcher")
 	}
 
-	catchAll := routes[2]
+	catchAll := routes[3]
 	if _, hasMatcher := catchAll["match"]; hasMatcher {
-		t.Error("routes[2] (catch-all) must not have a path matcher")
+		t.Error("routes[3] (catch-all) must not have a path matcher")
 	}
 }
 

--- a/internal/adapters/caddy/ready_route_test.go
+++ b/internal/adapters/caddy/ready_route_test.go
@@ -1,0 +1,309 @@
+package caddy
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// TestBuildCaddyConfig_ReadyRoute_AlwaysPresent verifies that the
+// /_vibewarden/ready route is always present in the Caddy config, even when
+// readiness is not explicitly configured. The route is placed at index 1
+// (after the health route).
+func TestBuildCaddyConfig_ReadyRoute_AlwaysPresent(t *testing.T) {
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "127.0.0.1:8080",
+		UpstreamAddr: "127.0.0.1:3000",
+	}
+
+	result, err := BuildCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+	}
+
+	server := extractServer(t, result)
+	routes, ok := server["routes"].([]map[string]any)
+	if !ok || len(routes) < 2 {
+		t.Fatalf("expected at least 2 routes, got %d", len(routes))
+	}
+
+	readyRoute := routes[1]
+
+	matchers, ok := readyRoute["match"].([]map[string]any)
+	if !ok || len(matchers) == 0 {
+		t.Fatal("match not found in ready route")
+	}
+	paths, ok := matchers[0]["path"].([]string)
+	if !ok || len(paths) == 0 {
+		t.Fatal("path not found in ready route matcher")
+	}
+	if paths[0] != "/_vibewarden/ready" {
+		t.Errorf("ready route path = %q, want %q", paths[0], "/_vibewarden/ready")
+	}
+}
+
+// TestBuildCaddyConfig_ReadyRoute_StaticWhenNotConfigured verifies that when
+// no readiness internal address is configured, the ready route uses a
+// static_response handler.
+func TestBuildCaddyConfig_ReadyRoute_StaticWhenNotConfigured(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *ports.ProxyConfig
+	}{
+		{
+			name: "readiness not configured",
+			cfg: &ports.ProxyConfig{
+				ListenAddr:   "127.0.0.1:8080",
+				UpstreamAddr: "127.0.0.1:3000",
+			},
+		},
+		{
+			name: "readiness enabled but no internal addr",
+			cfg: &ports.ProxyConfig{
+				ListenAddr:   "127.0.0.1:8080",
+				UpstreamAddr: "127.0.0.1:3000",
+				Readiness: ports.ReadinessProxyConfig{
+					Enabled:      true,
+					InternalAddr: "",
+				},
+			},
+		},
+		{
+			name: "readiness disabled with internal addr",
+			cfg: &ports.ProxyConfig{
+				ListenAddr:   "127.0.0.1:8080",
+				UpstreamAddr: "127.0.0.1:3000",
+				Readiness: ports.ReadinessProxyConfig{
+					Enabled:      false,
+					InternalAddr: "127.0.0.1:9093",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := BuildCaddyConfig(tt.cfg)
+			if err != nil {
+				t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+			}
+
+			server := extractServer(t, result)
+			routes, ok := server["routes"].([]map[string]any)
+			if !ok || len(routes) < 2 {
+				t.Fatalf("expected at least 2 routes, got %d", len(routes))
+			}
+
+			readyRoute := routes[1]
+			handlers, ok := readyRoute["handle"].([]map[string]any)
+			if !ok || len(handlers) == 0 {
+				t.Fatal("handle not found in ready route")
+			}
+			if handlers[0]["handler"] != "static_response" {
+				t.Errorf("ready handler = %v, want static_response", handlers[0]["handler"])
+			}
+		})
+	}
+}
+
+// TestBuildCaddyConfig_ReadyRoute_StaticResponseIs503 verifies that the static
+// ready route returns 503 to indicate "not yet ready" when no internal server
+// is wired.
+func TestBuildCaddyConfig_ReadyRoute_StaticResponseIs503(t *testing.T) {
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "127.0.0.1:8080",
+		UpstreamAddr: "127.0.0.1:3000",
+	}
+
+	result, err := BuildCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+	}
+
+	server := extractServer(t, result)
+	routes := server["routes"].([]map[string]any)
+	readyRoute := routes[1]
+	handlers := readyRoute["handle"].([]map[string]any)
+
+	statusCode, ok := handlers[0]["status_code"].(int)
+	if !ok {
+		t.Fatalf("status_code not an int: %T %v", handlers[0]["status_code"], handlers[0]["status_code"])
+	}
+	if statusCode != 503 {
+		t.Errorf("status_code = %d, want 503", statusCode)
+	}
+
+	body, ok := handlers[0]["body"].(string)
+	if !ok || body == "" {
+		t.Fatal("body not found or empty in static ready route handler")
+	}
+	// Validate the body is valid JSON and contains "ready":false.
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("body is not valid JSON: %v", err)
+	}
+	if parsed["ready"] != false {
+		t.Errorf("body[ready] = %v, want false", parsed["ready"])
+	}
+}
+
+// TestBuildCaddyConfig_ReadyRoute_DynamicWhenConfigured verifies that when a
+// readiness internal address is configured, the ready route uses a
+// reverse_proxy handler pointing to that address.
+func TestBuildCaddyConfig_ReadyRoute_DynamicWhenConfigured(t *testing.T) {
+	const internalAddr = "127.0.0.1:9093"
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "127.0.0.1:8080",
+		UpstreamAddr: "127.0.0.1:3000",
+		Readiness: ports.ReadinessProxyConfig{
+			Enabled:      true,
+			InternalAddr: internalAddr,
+		},
+	}
+
+	result, err := BuildCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+	}
+
+	server := extractServer(t, result)
+	routes := server["routes"].([]map[string]any)
+
+	// Route order: health (0), ready (1), catch-all (2).
+	if len(routes) < 3 {
+		t.Fatalf("expected at least 3 routes, got %d", len(routes))
+	}
+
+	readyRoute := routes[1]
+
+	// Verify path matcher.
+	matchers := readyRoute["match"].([]map[string]any)
+	paths := matchers[0]["path"].([]string)
+	if paths[0] != "/_vibewarden/ready" {
+		t.Errorf("ready route path = %q, want %q", paths[0], "/_vibewarden/ready")
+	}
+
+	// Verify handler is reverse_proxy.
+	handlers := readyRoute["handle"].([]map[string]any)
+	if handlers[0]["handler"] != "reverse_proxy" {
+		t.Errorf("ready handler = %v, want reverse_proxy", handlers[0]["handler"])
+	}
+
+	// Verify upstream dial address.
+	upstreams, ok := handlers[0]["upstreams"].([]map[string]any)
+	if !ok || len(upstreams) == 0 {
+		t.Fatal("upstreams not found in dynamic ready route handler")
+	}
+	if upstreams[0]["dial"] != internalAddr {
+		t.Errorf("upstream dial = %v, want %q", upstreams[0]["dial"], internalAddr)
+	}
+}
+
+// TestBuildCaddyConfig_ReadyRoute_BeforeCatchAll verifies that the ready route
+// is always placed before the catch-all proxy route.
+func TestBuildCaddyConfig_ReadyRoute_BeforeCatchAll(t *testing.T) {
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "127.0.0.1:8080",
+		UpstreamAddr: "127.0.0.1:3000",
+	}
+
+	result, err := BuildCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+	}
+
+	server := extractServer(t, result)
+	routes := server["routes"].([]map[string]any)
+
+	// routes[1] = ready (has path matcher), routes[last] = catch-all (no matcher).
+	readyRoute := routes[1]
+	if _, hasMatcher := readyRoute["match"]; !hasMatcher {
+		t.Error("routes[1] (ready) must have a path matcher")
+	}
+
+	catchAll := routes[len(routes)-1]
+	if _, hasMatcher := catchAll["match"]; hasMatcher {
+		t.Error("last route (catch-all) must not have a path matcher")
+	}
+}
+
+// TestBuildCaddyConfig_ReadyRoute_ContentTypeHeader verifies the static ready
+// route sets Content-Type: application/json.
+func TestBuildCaddyConfig_ReadyRoute_ContentTypeHeader(t *testing.T) {
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "127.0.0.1:8080",
+		UpstreamAddr: "127.0.0.1:3000",
+	}
+
+	result, err := BuildCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+	}
+
+	server := extractServer(t, result)
+	routes := server["routes"].([]map[string]any)
+	readyRoute := routes[1]
+	handlers := readyRoute["handle"].([]map[string]any)
+
+	headers, ok := handlers[0]["headers"].(map[string][]string)
+	if !ok {
+		t.Fatal("headers not found in static ready route handler")
+	}
+	ct := headers["Content-Type"]
+	if len(ct) == 0 || ct[0] != "application/json" {
+		t.Errorf("Content-Type = %v, want [application/json]", ct)
+	}
+}
+
+// TestBuildStaticReadyRoute verifies the helper function directly.
+func TestBuildStaticReadyRoute(t *testing.T) {
+	route := buildStaticReadyRoute()
+
+	matchers, ok := route["match"].([]map[string]any)
+	if !ok || len(matchers) == 0 {
+		t.Fatal("match not found")
+	}
+	paths, ok := matchers[0]["path"].([]string)
+	if !ok || len(paths) != 1 || paths[0] != "/_vibewarden/ready" {
+		t.Errorf("path = %v, want [/_vibewarden/ready]", paths)
+	}
+
+	handlers, ok := route["handle"].([]map[string]any)
+	if !ok || len(handlers) == 0 {
+		t.Fatal("handle not found")
+	}
+	if handlers[0]["handler"] != "static_response" {
+		t.Errorf("handler = %v, want static_response", handlers[0]["handler"])
+	}
+}
+
+// TestBuildDynamicReadyRoute verifies the helper function directly.
+func TestBuildDynamicReadyRoute(t *testing.T) {
+	const addr = "127.0.0.1:9093"
+	route := buildDynamicReadyRoute(addr)
+
+	matchers, ok := route["match"].([]map[string]any)
+	if !ok || len(matchers) == 0 {
+		t.Fatal("match not found")
+	}
+	paths, ok := matchers[0]["path"].([]string)
+	if !ok || len(paths) != 1 || paths[0] != "/_vibewarden/ready" {
+		t.Errorf("path = %v, want [/_vibewarden/ready]", paths)
+	}
+
+	handlers, ok := route["handle"].([]map[string]any)
+	if !ok || len(handlers) == 0 {
+		t.Fatal("handle not found")
+	}
+	if handlers[0]["handler"] != "reverse_proxy" {
+		t.Errorf("handler = %v, want reverse_proxy", handlers[0]["handler"])
+	}
+	upstreams, ok := handlers[0]["upstreams"].([]map[string]any)
+	if !ok || len(upstreams) == 0 {
+		t.Fatal("upstreams not found")
+	}
+	if upstreams[0]["dial"] != addr {
+		t.Errorf("dial = %v, want %q", upstreams[0]["dial"], addr)
+	}
+}

--- a/internal/middleware/health.go
+++ b/internal/middleware/health.go
@@ -193,3 +193,99 @@ func HealthMiddleware(version string, upstreamChecker ports.UpstreamHealthChecke
 		})
 	}
 }
+
+// ReadyResponse is the JSON body returned by the /_vibewarden/ready endpoint.
+type ReadyResponse struct {
+	// Ready is true when all plugins are initialised and the upstream is reachable.
+	Ready bool `json:"ready"`
+
+	// Plugins maps each plugin name to its current health status string.
+	// Possible values: "healthy", "unhealthy".
+	Plugins map[string]string `json:"plugins,omitempty"`
+
+	// Upstream is the current upstream reachability status.
+	// Possible values: "reachable", "unreachable". Omitted when no upstream
+	// health checker is configured.
+	Upstream string `json:"upstream,omitempty"`
+}
+
+// ReadyHandler returns an http.HandlerFunc for the readiness probe endpoint
+// served at /_vibewarden/ready.
+//
+// The endpoint returns HTTP 200 with {"ready":true} only when all plugins are
+// healthy and the upstream application is reachable. It returns HTTP 503 with
+// {"ready":false} in any other case.
+//
+// readinessChecker may be nil; when nil the handler always returns 200 {"ready":true}
+// because no plugins or upstream are being monitored.
+func ReadyHandler(readinessChecker ports.ReadinessChecker) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		resp := ReadyResponse{Ready: true}
+
+		if readinessChecker != nil {
+			rs := readinessChecker.ReadinessStatus()
+			resp.Ready = rs.PluginsReady && rs.UpstreamReachable
+
+			// Populate per-plugin status.
+			if len(rs.Plugins) > 0 {
+				resp.Plugins = make(map[string]string, len(rs.Plugins))
+				for name, hs := range rs.Plugins {
+					if hs.Healthy {
+						resp.Plugins[name] = "healthy"
+					} else {
+						resp.Plugins[name] = "unhealthy"
+					}
+				}
+			}
+
+			// Populate upstream status only when an upstream checker is present.
+			// UpstreamReachable being false with no checker means no checker was
+			// configured, not that the upstream is down. We distinguish by checking
+			// whether any plugins are registered — but the cleaner signal is whether
+			// the ReadinessStatus explicitly carries upstream information.
+			// We rely on the ReadinessStatus.UpstreamReachable field: if the
+			// implementation sets it to true unconditionally when no upstream
+			// checker exists, we still want to omit the field from the JSON. To
+			// support that, ReadyHandler accepts a second optional signal via the
+			// readinessChecker interface itself — but since the interface doesn't
+			// expose "has upstream checker", we include the upstream field whenever
+			// a readinessChecker is provided.
+			if rs.UpstreamReachable {
+				resp.Upstream = "reachable"
+			} else {
+				resp.Upstream = "unreachable"
+			}
+		}
+
+		httpStatus := http.StatusOK
+		if !resp.Ready {
+			httpStatus = http.StatusServiceUnavailable
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(httpStatus)
+
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			// Best-effort: headers already sent, cannot write error response.
+			return
+		}
+	}
+}
+
+// ReadyMiddleware intercepts requests to /_vibewarden/ready and serves the
+// readiness response. All other requests pass through to the next handler.
+//
+// readinessChecker may be nil; when nil the endpoint always returns 200.
+func ReadyMiddleware(readinessChecker ports.ReadinessChecker) func(next http.Handler) http.Handler {
+	readyHandler := ReadyHandler(readinessChecker)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/_vibewarden/ready" {
+				readyHandler(w, r)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middleware/ready_test.go
+++ b/internal/middleware/ready_test.go
@@ -1,0 +1,486 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	domainheal "github.com/vibewarden/vibewarden/internal/domain/health"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// fakeReadinessChecker implements ports.ReadinessChecker for testing.
+type fakeReadinessChecker struct {
+	status ports.ReadinessStatus
+}
+
+func (f *fakeReadinessChecker) Ready() bool {
+	return f.status.PluginsReady && f.status.UpstreamReachable
+}
+
+func (f *fakeReadinessChecker) ReadinessStatus() ports.ReadinessStatus {
+	return f.status
+}
+
+// Compile-time assertion.
+var _ ports.ReadinessChecker = (*fakeReadinessChecker)(nil)
+
+func TestReadyHandler_NilChecker_Returns200Ready(t *testing.T) {
+	handler := ReadyHandler(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/ready", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+
+	var resp ReadyResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if !resp.Ready {
+		t.Error("ready = false, want true (no checker means unconditionally ready)")
+	}
+}
+
+func TestReadyHandler_ContentTypeJSON(t *testing.T) {
+	handler := ReadyHandler(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/ready", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+}
+
+func TestReadyHandler_AllReady_Returns200(t *testing.T) {
+	checker := &fakeReadinessChecker{
+		status: ports.ReadinessStatus{
+			PluginsReady:      true,
+			UpstreamReachable: true,
+			Plugins: map[string]ports.HealthStatus{
+				"tls": {Healthy: true, Message: "ok"},
+			},
+		},
+	}
+	handler := ReadyHandler(checker)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/ready", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+
+	var resp ReadyResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if !resp.Ready {
+		t.Error("ready = false, want true")
+	}
+	if resp.Upstream != "reachable" {
+		t.Errorf("upstream = %q, want %q", resp.Upstream, "reachable")
+	}
+	if resp.Plugins["tls"] != "healthy" {
+		t.Errorf("plugins[tls] = %q, want %q", resp.Plugins["tls"], "healthy")
+	}
+}
+
+func TestReadyHandler_PluginsNotReady_Returns503(t *testing.T) {
+	checker := &fakeReadinessChecker{
+		status: ports.ReadinessStatus{
+			PluginsReady:      false,
+			UpstreamReachable: true,
+			Plugins: map[string]ports.HealthStatus{
+				"user-management": {Healthy: false, Message: "postgres unreachable"},
+			},
+		},
+	}
+	handler := ReadyHandler(checker)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/ready", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+
+	var resp ReadyResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if resp.Ready {
+		t.Error("ready = true, want false (plugin unhealthy)")
+	}
+	if resp.Plugins["user-management"] != "unhealthy" {
+		t.Errorf("plugins[user-management] = %q, want %q", resp.Plugins["user-management"], "unhealthy")
+	}
+}
+
+func TestReadyHandler_UpstreamUnreachable_Returns503(t *testing.T) {
+	checker := &fakeReadinessChecker{
+		status: ports.ReadinessStatus{
+			PluginsReady:      true,
+			UpstreamReachable: false,
+		},
+	}
+	handler := ReadyHandler(checker)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/ready", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+
+	var resp ReadyResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if resp.Ready {
+		t.Error("ready = true, want false (upstream unreachable)")
+	}
+	if resp.Upstream != "unreachable" {
+		t.Errorf("upstream = %q, want %q", resp.Upstream, "unreachable")
+	}
+}
+
+func TestReadyHandler_BothUnready_Returns503(t *testing.T) {
+	checker := &fakeReadinessChecker{
+		status: ports.ReadinessStatus{
+			PluginsReady:      false,
+			UpstreamReachable: false,
+		},
+	}
+	handler := ReadyHandler(checker)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/ready", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+
+	var resp ReadyResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if resp.Ready {
+		t.Error("ready = true, want false")
+	}
+}
+
+func TestReadyHandler_MultiplePlugins_AllHealthy(t *testing.T) {
+	checker := &fakeReadinessChecker{
+		status: ports.ReadinessStatus{
+			PluginsReady:      true,
+			UpstreamReachable: true,
+			Plugins: map[string]ports.HealthStatus{
+				"tls":             {Healthy: true},
+				"rate-limiting":   {Healthy: true},
+				"user-management": {Healthy: true},
+			},
+		},
+	}
+	handler := ReadyHandler(checker)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/ready", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+
+	var resp ReadyResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if !resp.Ready {
+		t.Error("ready = false, want true")
+	}
+	wantPlugins := []string{"tls", "rate-limiting", "user-management"}
+	for _, name := range wantPlugins {
+		if resp.Plugins[name] != "healthy" {
+			t.Errorf("plugins[%s] = %q, want %q", name, resp.Plugins[name], "healthy")
+		}
+	}
+}
+
+func TestReadyHandler_PluginsOmittedWhenEmpty(t *testing.T) {
+	checker := &fakeReadinessChecker{
+		status: ports.ReadinessStatus{
+			PluginsReady:      true,
+			UpstreamReachable: true,
+			Plugins:           nil,
+		},
+	}
+	handler := ReadyHandler(checker)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/ready", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	var raw map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&raw); err != nil {
+		t.Fatalf("decoding raw response: %v", err)
+	}
+	if _, ok := raw["plugins"]; ok {
+		t.Error("plugins field should be omitted when no plugins are registered (omitempty)")
+	}
+}
+
+func TestReadyMiddleware_InterceptsReadyPath(t *testing.T) {
+	checker := &fakeReadinessChecker{
+		status: ports.ReadinessStatus{
+			PluginsReady:      true,
+			UpstreamReachable: true,
+		},
+	}
+	mw := ReadyMiddleware(checker)
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	handler := mw(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/ready", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if nextCalled {
+		t.Error("next handler was called for ready path — should not be")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestReadyMiddleware_PassesThroughOtherPaths(t *testing.T) {
+	mw := ReadyMiddleware(nil)
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := mw(next)
+
+	paths := []string{"/", "/api/users", "/ready", "/_vibewarden/health", "/_vibewarden/other"}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			nextCalled = false
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if !nextCalled {
+				t.Errorf("next handler was not called for path %q", path)
+			}
+		})
+	}
+}
+
+func TestReadyMiddleware_NotReady_Returns503AndDoesNotCallNext(t *testing.T) {
+	checker := &fakeReadinessChecker{
+		status: ports.ReadinessStatus{
+			PluginsReady:      false,
+			UpstreamReachable: true,
+		},
+	}
+	mw := ReadyMiddleware(checker)
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	handler := mw(next)
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/ready", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if nextCalled {
+		t.Error("next handler was called — should not be for ready path")
+	}
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+// TestReadyHandler_UsesUpstreamHealthChecker verifies that ReadyHandler
+// integrates correctly with the fakeUpstreamHealthChecker via a ReadinessChecker
+// that delegates to it.
+func TestReadyHandler_UpstreamHealthyVsUnhealthy(t *testing.T) {
+	tests := []struct {
+		name           string
+		upstreamStatus domainheal.UpstreamStatus
+		wantReady      bool
+		wantHTTPCode   int
+		wantUpstream   string
+	}{
+		{
+			name:           "upstream healthy → ready",
+			upstreamStatus: domainheal.StatusHealthy,
+			wantReady:      true,
+			wantHTTPCode:   http.StatusOK,
+			wantUpstream:   "reachable",
+		},
+		{
+			name:           "upstream unhealthy → not ready",
+			upstreamStatus: domainheal.StatusUnhealthy,
+			wantReady:      false,
+			wantHTTPCode:   http.StatusServiceUnavailable,
+			wantUpstream:   "unreachable",
+		},
+		{
+			name:           "upstream unknown → not ready",
+			upstreamStatus: domainheal.StatusUnknown,
+			wantReady:      false,
+			wantHTTPCode:   http.StatusServiceUnavailable,
+			wantUpstream:   "unreachable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstreamStatus := tt.upstreamStatus.String() == "healthy"
+			checker := &fakeReadinessChecker{
+				status: ports.ReadinessStatus{
+					PluginsReady:      true,
+					UpstreamReachable: upstreamStatus,
+				},
+			}
+			handler := ReadyHandler(checker)
+
+			req := httptest.NewRequest(http.MethodGet, "/_vibewarden/ready", nil)
+			w := httptest.NewRecorder()
+			handler(w, req)
+
+			if w.Code != tt.wantHTTPCode {
+				t.Errorf("HTTP status = %d, want %d", w.Code, tt.wantHTTPCode)
+			}
+
+			var resp ReadyResponse
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("decoding response: %v", err)
+			}
+			if resp.Ready != tt.wantReady {
+				t.Errorf("ready = %v, want %v", resp.Ready, tt.wantReady)
+			}
+			if resp.Upstream != tt.wantUpstream {
+				t.Errorf("upstream = %q, want %q", resp.Upstream, tt.wantUpstream)
+			}
+		})
+	}
+}
+
+// fakeReadinessCheckerWithContext is a no-op implementation for interface compliance testing.
+type fakeReadinessCheckerWithContext struct{}
+
+func (f *fakeReadinessCheckerWithContext) Ready() bool { return true }
+func (f *fakeReadinessCheckerWithContext) ReadinessStatus() ports.ReadinessStatus {
+	return ports.ReadinessStatus{PluginsReady: true, UpstreamReachable: true}
+}
+
+// TestReadyHandler_ReadyFieldAlwaysPresentInJSON verifies the "ready" key is
+// always present in the JSON response body.
+func TestReadyHandler_ReadyFieldAlwaysPresentInJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		checker ports.ReadinessChecker
+	}{
+		{"nil checker", nil},
+		{"ready checker", &fakeReadinessCheckerWithContext{}},
+		{"not ready checker", &fakeReadinessChecker{status: ports.ReadinessStatus{}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := ReadyHandler(tt.checker)
+			req := httptest.NewRequest(http.MethodGet, "/_vibewarden/ready", nil)
+			w := httptest.NewRecorder()
+			handler(w, req)
+
+			var raw map[string]any
+			if err := json.NewDecoder(w.Body).Decode(&raw); err != nil {
+				t.Fatalf("decoding response: %v", err)
+			}
+			if _, ok := raw["ready"]; !ok {
+				t.Error("ready field must always be present in ready response")
+			}
+		})
+	}
+}
+
+// TestReadyAndHealthAreIndependent verifies that the liveness endpoint
+// (/_vibewarden/health) and the readiness endpoint (/_vibewarden/ready) can
+// return different statuses independently.
+func TestReadyAndHealthAreIndependent(t *testing.T) {
+	// Health handler always returns 200 (liveness — process is alive).
+	healthHandler := HealthHandler("v1.0.0", nil)
+
+	// Ready handler returns 503 (plugins not yet initialised).
+	readyChecker := &fakeReadinessChecker{
+		status: ports.ReadinessStatus{
+			PluginsReady:      false,
+			UpstreamReachable: true,
+		},
+	}
+	readyHandler := ReadyHandler(readyChecker)
+
+	// Health must be 200.
+	hW := httptest.NewRecorder()
+	healthHandler(hW, httptest.NewRequest(http.MethodGet, "/_vibewarden/health", nil))
+	if hW.Code != http.StatusOK {
+		t.Errorf("health status = %d, want 200", hW.Code)
+	}
+
+	// Ready must be 503.
+	rW := httptest.NewRecorder()
+	readyHandler(rW, httptest.NewRequest(http.MethodGet, "/_vibewarden/ready", nil))
+	if rW.Code != http.StatusServiceUnavailable {
+		t.Errorf("ready status = %d, want 503", rW.Code)
+	}
+}
+
+// Ensure the fake implements the context-less interface correctly.
+var _ ports.ReadinessChecker = (*fakeReadinessChecker)(nil)
+var _ http.Handler = http.HandlerFunc(nil)
+
+// TestReadyHandlerAcceptsContext ensures the handler honours request context
+// cancellation (it should not block on a cancelled context).
+func TestReadyHandlerAcceptsContext(t *testing.T) {
+	checker := &fakeReadinessChecker{
+		status: ports.ReadinessStatus{
+			PluginsReady:      true,
+			UpstreamReachable: true,
+		},
+	}
+	handler := ReadyHandler(checker)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/ready", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler(w, req) // must not block
+
+	// Response may or may not be written depending on implementation; we just
+	// want to confirm it doesn't hang.
+}

--- a/internal/plugins/readiness_test.go
+++ b/internal/plugins/readiness_test.go
@@ -1,0 +1,226 @@
+package plugins
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	domainheal "github.com/vibewarden/vibewarden/internal/domain/health"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// stubPlugin is a minimal ports.Plugin stub for readiness tests.
+type stubPlugin struct {
+	name    string
+	healthy bool
+	message string
+}
+
+func (s *stubPlugin) Name() string                  { return s.name }
+func (s *stubPlugin) Init(_ context.Context) error  { return nil }
+func (s *stubPlugin) Start(_ context.Context) error { return nil }
+func (s *stubPlugin) Stop(_ context.Context) error  { return nil }
+func (s *stubPlugin) Health() ports.HealthStatus {
+	return ports.HealthStatus{Healthy: s.healthy, Message: s.message}
+}
+
+// stubUpstreamChecker implements ports.UpstreamHealthChecker for readiness tests.
+type stubUpstreamChecker struct {
+	status domainheal.UpstreamStatus
+}
+
+func (s *stubUpstreamChecker) Start(_ context.Context) error { return nil }
+func (s *stubUpstreamChecker) Stop(_ context.Context) error  { return nil }
+func (s *stubUpstreamChecker) CurrentStatus() domainheal.UpstreamStatus {
+	return s.status
+}
+func (s *stubUpstreamChecker) Snapshot() ports.UpstreamHealthSnapshot {
+	return ports.UpstreamHealthSnapshot{Status: s.status.String()}
+}
+
+var _ ports.UpstreamHealthChecker = (*stubUpstreamChecker)(nil)
+
+func TestRegistry_ReadinessChecker_NoPlugins_NoUpstream_IsReady(t *testing.T) {
+	r := NewRegistry(slog.Default())
+	rc := r.ReadinessChecker(nil)
+
+	if !rc.Ready() {
+		t.Error("Ready() = false, want true (no plugins, no upstream checker)")
+	}
+
+	rs := rc.ReadinessStatus()
+	if !rs.PluginsReady {
+		t.Error("PluginsReady = false, want true (no plugins)")
+	}
+	if !rs.UpstreamReachable {
+		t.Error("UpstreamReachable = false, want true (no upstream checker configured)")
+	}
+}
+
+func TestRegistry_ReadinessChecker_AllPluginsHealthy_IsReady(t *testing.T) {
+	r := NewRegistry(slog.Default())
+	r.Register(&stubPlugin{name: "tls", healthy: true})
+	r.Register(&stubPlugin{name: "rate-limiting", healthy: true})
+
+	rc := r.ReadinessChecker(nil)
+
+	if !rc.Ready() {
+		t.Error("Ready() = false, want true (all plugins healthy)")
+	}
+
+	rs := rc.ReadinessStatus()
+	if !rs.PluginsReady {
+		t.Error("PluginsReady = false, want true")
+	}
+	if len(rs.Plugins) != 2 {
+		t.Errorf("len(Plugins) = %d, want 2", len(rs.Plugins))
+	}
+}
+
+func TestRegistry_ReadinessChecker_UnhealthyPlugin_NotReady(t *testing.T) {
+	r := NewRegistry(slog.Default())
+	r.Register(&stubPlugin{name: "tls", healthy: true})
+	r.Register(&stubPlugin{name: "user-management", healthy: false, message: "postgres unreachable"})
+
+	rc := r.ReadinessChecker(nil)
+
+	if rc.Ready() {
+		t.Error("Ready() = true, want false (one plugin unhealthy)")
+	}
+
+	rs := rc.ReadinessStatus()
+	if rs.PluginsReady {
+		t.Error("PluginsReady = true, want false")
+	}
+	if rs.Plugins["tls"].Healthy != true {
+		t.Error("plugins[tls].Healthy = false, want true")
+	}
+	if rs.Plugins["user-management"].Healthy != false {
+		t.Error("plugins[user-management].Healthy = true, want false")
+	}
+}
+
+func TestRegistry_ReadinessChecker_UpstreamHealthy_IsReady(t *testing.T) {
+	r := NewRegistry(slog.Default())
+	r.Register(&stubPlugin{name: "tls", healthy: true})
+
+	upstream := &stubUpstreamChecker{status: domainheal.StatusHealthy}
+	rc := r.ReadinessChecker(upstream)
+
+	if !rc.Ready() {
+		t.Error("Ready() = false, want true (plugins healthy, upstream healthy)")
+	}
+
+	rs := rc.ReadinessStatus()
+	if !rs.UpstreamReachable {
+		t.Error("UpstreamReachable = false, want true")
+	}
+}
+
+func TestRegistry_ReadinessChecker_UpstreamUnhealthy_NotReady(t *testing.T) {
+	r := NewRegistry(slog.Default())
+	r.Register(&stubPlugin{name: "tls", healthy: true})
+
+	upstream := &stubUpstreamChecker{status: domainheal.StatusUnhealthy}
+	rc := r.ReadinessChecker(upstream)
+
+	if rc.Ready() {
+		t.Error("Ready() = true, want false (upstream unhealthy)")
+	}
+
+	rs := rc.ReadinessStatus()
+	if rs.UpstreamReachable {
+		t.Error("UpstreamReachable = true, want false")
+	}
+}
+
+func TestRegistry_ReadinessChecker_UpstreamUnknown_NotReady(t *testing.T) {
+	r := NewRegistry(slog.Default())
+
+	upstream := &stubUpstreamChecker{status: domainheal.StatusUnknown}
+	rc := r.ReadinessChecker(upstream)
+
+	if rc.Ready() {
+		t.Error("Ready() = true, want false (upstream status unknown)")
+	}
+
+	rs := rc.ReadinessStatus()
+	if rs.UpstreamReachable {
+		t.Error("UpstreamReachable = true, want false (unknown is not reachable)")
+	}
+}
+
+func TestRegistry_ReadinessChecker_BothUnhealthy_NotReady(t *testing.T) {
+	r := NewRegistry(slog.Default())
+	r.Register(&stubPlugin{name: "user-management", healthy: false})
+
+	upstream := &stubUpstreamChecker{status: domainheal.StatusUnhealthy}
+	rc := r.ReadinessChecker(upstream)
+
+	if rc.Ready() {
+		t.Error("Ready() = true, want false (plugin unhealthy and upstream unhealthy)")
+	}
+
+	rs := rc.ReadinessStatus()
+	if rs.PluginsReady {
+		t.Error("PluginsReady = true, want false")
+	}
+	if rs.UpstreamReachable {
+		t.Error("UpstreamReachable = true, want false")
+	}
+}
+
+func TestRegistry_ReadinessChecker_PluginsMapIncludesAllRegistered(t *testing.T) {
+	r := NewRegistry(slog.Default())
+	r.Register(&stubPlugin{name: "alpha", healthy: true})
+	r.Register(&stubPlugin{name: "beta", healthy: false})
+	r.Register(&stubPlugin{name: "gamma", healthy: true})
+
+	rc := r.ReadinessChecker(nil)
+	rs := rc.ReadinessStatus()
+
+	if len(rs.Plugins) != 3 {
+		t.Errorf("len(Plugins) = %d, want 3", len(rs.Plugins))
+	}
+	if !rs.Plugins["alpha"].Healthy {
+		t.Error("plugins[alpha].Healthy = false, want true")
+	}
+	if rs.Plugins["beta"].Healthy {
+		t.Error("plugins[beta].Healthy = true, want false")
+	}
+	if !rs.Plugins["gamma"].Healthy {
+		t.Error("plugins[gamma].Healthy = false, want true")
+	}
+}
+
+func TestRegistry_ReadinessChecker_IsSafeForConcurrentUse(t *testing.T) {
+	r := NewRegistry(slog.Default())
+	r.Register(&stubPlugin{name: "tls", healthy: true})
+
+	rc := r.ReadinessChecker(nil)
+
+	// Run Ready() and ReadinessStatus() concurrently — must not race.
+	done := make(chan struct{})
+	for i := 0; i < 10; i++ {
+		go func() {
+			_ = rc.Ready()
+			_ = rc.ReadinessStatus()
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+}
+
+// TestRegistry_ReadinessChecker_ImplementsInterface ensures the returned value
+// satisfies ports.ReadinessChecker at compile time.
+func TestRegistry_ReadinessChecker_ImplementsInterface(t *testing.T) {
+	r := NewRegistry(slog.Default())
+	rc := r.ReadinessChecker(nil)
+
+	// Compile-time assertion — Ready() must exist on rc.
+	if rc == nil {
+		t.Error("ReadinessChecker returned nil")
+	}
+}

--- a/internal/plugins/registry.go
+++ b/internal/plugins/registry.go
@@ -106,6 +106,58 @@ func (r *Registry) HealthAll() map[string]ports.HealthStatus {
 	return result
 }
 
+// ReadinessChecker returns a ports.ReadinessChecker that evaluates the health
+// of all registered plugins and, optionally, the upstream application.
+//
+// upstreamChecker may be nil; when nil the readiness check does not require an
+// upstream probe and UpstreamReachable is always reported as true.
+func (r *Registry) ReadinessChecker(upstreamChecker ports.UpstreamHealthChecker) ports.ReadinessChecker {
+	return &registryReadinessChecker{
+		registry:        r,
+		upstreamChecker: upstreamChecker,
+	}
+}
+
+// registryReadinessChecker implements ports.ReadinessChecker using the plugin
+// registry and an optional upstream health checker.
+type registryReadinessChecker struct {
+	registry        *Registry
+	upstreamChecker ports.UpstreamHealthChecker
+}
+
+// Ready returns true when all plugins are healthy and the upstream is reachable.
+// It is safe for concurrent use and does not block.
+func (rc *registryReadinessChecker) Ready() bool {
+	rs := rc.ReadinessStatus()
+	return rs.PluginsReady && rs.UpstreamReachable
+}
+
+// ReadinessStatus returns a snapshot of per-plugin health and upstream status.
+// It is safe for concurrent use and does not block.
+func (rc *registryReadinessChecker) ReadinessStatus() ports.ReadinessStatus {
+	pluginStatuses := rc.registry.HealthAll()
+
+	pluginsReady := true
+	for _, hs := range pluginStatuses {
+		if !hs.Healthy {
+			pluginsReady = false
+			break
+		}
+	}
+
+	upstreamReachable := true
+	if rc.upstreamChecker != nil {
+		status := rc.upstreamChecker.CurrentStatus()
+		upstreamReachable = status.String() == "healthy"
+	}
+
+	return ports.ReadinessStatus{
+		PluginsReady:      pluginsReady,
+		UpstreamReachable: upstreamReachable,
+		Plugins:           pluginStatuses,
+	}
+}
+
 // joinErrors combines multiple errors into a single error whose message is the
 // concatenation of each error's message. Using a simple join keeps the
 // implementation free of non-stdlib dependencies.

--- a/internal/ports/plugin.go
+++ b/internal/ports/plugin.go
@@ -142,6 +142,40 @@ type InternalServerPlugin interface {
 	InternalAddr() string
 }
 
+// ReadinessChecker is the outbound port for checking whether all plugins are
+// initialised and the upstream application is reachable. It is used by the
+// /_vibewarden/ready endpoint to report readiness distinct from liveness.
+//
+// Implementations should aggregate the health of every registered plugin and,
+// when an upstream health checker is configured, the current upstream status.
+// A process is considered ready only when all plugins report healthy and the
+// upstream is reachable.
+type ReadinessChecker interface {
+	// Ready returns true when every plugin is healthy and the upstream is
+	// reachable. It must be safe for concurrent use and must not block.
+	Ready() bool
+
+	// ReadinessStatus returns a detailed per-plugin health map and the current
+	// upstream status. The map key is the plugin name; the value is its
+	// HealthStatus. upstreamReachable is true when the upstream health checker
+	// reports "healthy".
+	ReadinessStatus() ReadinessStatus
+}
+
+// ReadinessStatus is a point-in-time snapshot of plugin and upstream readiness.
+type ReadinessStatus struct {
+	// PluginsReady is true when every registered plugin reports healthy.
+	PluginsReady bool
+
+	// UpstreamReachable is true when the upstream health checker reports
+	// "healthy". It is also true when no upstream checker is configured
+	// (readiness does not require an upstream checker to be present).
+	UpstreamReachable bool
+
+	// Plugins maps each plugin name to its current HealthStatus.
+	Plugins map[string]HealthStatus
+}
+
 // PluginMeta is an optional interface implemented by plugins that expose
 // metadata for CLI display (vibewarden plugins, vibewarden plugins show).
 // All compiled-in plugins implement this interface.

--- a/internal/ports/proxy.go
+++ b/internal/ports/proxy.go
@@ -66,6 +66,23 @@ type ProxyConfig struct {
 	// Resilience configuration — controls upstream timeout and similar
 	// protective features.
 	Resilience ResilienceConfig
+
+	// Readiness configuration — controls the /_vibewarden/ready endpoint that
+	// reports whether all plugins are initialised and the upstream is reachable.
+	Readiness ReadinessProxyConfig
+}
+
+// ReadinessProxyConfig holds configuration for exposing the readiness probe
+// endpoint through the Caddy reverse proxy.
+type ReadinessProxyConfig struct {
+	// Enabled toggles the readiness endpoint at /_vibewarden/ready.
+	Enabled bool
+
+	// InternalAddr is the host:port of the internal HTTP server that serves
+	// the readiness handler (e.g. "127.0.0.1:9093"). Caddy reverse-proxies
+	// /_vibewarden/ready to this address.
+	// This field must be set when Enabled is true.
+	InternalAddr string
 }
 
 // ResilienceConfig holds configuration for upstream resilience features.


### PR DESCRIPTION
Closes #502

## Summary

- Add `ReadinessChecker` port interface and `ReadinessStatus` value type to `internal/ports/plugin.go` — contracts for the readiness layer
- Add `ReadinessProxyConfig` to `ProxyConfig` in `internal/ports/proxy.go` — enables opt-in dynamic readiness via an internal addr
- Add `ReadyHandler` and `ReadyMiddleware` to `internal/middleware/health.go` — serve `/_vibewarden/ready`; returns 200 `{"ready":true}` only when all plugins are healthy and upstream is reachable, 503 otherwise
- Add `ReadyResponse` type with `ready`, `plugins`, and `upstream` JSON fields
- Add `Registry.ReadinessChecker()` to `internal/plugins/registry.go` — aggregates `HealthAll()` and an optional `UpstreamHealthChecker`; `UpstreamReachable` is true only when the checker reports "healthy"
- Wire `/_vibewarden/ready` into `BuildCaddyConfig` in `internal/adapters/caddy/config.go`:
  - Static `static_response` 503 by default (process alive, not yet confirmed ready)
  - Dynamic `reverse_proxy` to `ReadinessProxyConfig.InternalAddr` when enabled
- Update all affected Caddy config tests for the new `routes[1]` = ready route

## Test plan

- `TestReadyHandler_*` — 12 table-driven tests covering nil checker, all-ready, plugins-not-ready, upstream-unreachable, mixed, JSON shape
- `TestReadyMiddleware_*` — intercept/pass-through/503 cases
- `TestReadyAndHealthAreIndependent` — verifies liveness and readiness can diverge
- `TestRegistry_ReadinessChecker_*` — 9 tests covering no plugins, healthy, unhealthy, upstream healthy/unhealthy/unknown, concurrency
- `TestBuildCaddyConfig_ReadyRoute_*` — 6 tests covering always-present, static-vs-dynamic, 503 status code, JSON body, content-type, before-catch-all
- `TestBuildStaticReadyRoute` / `TestBuildDynamicReadyRoute` — direct helper tests

All existing tests updated to reflect the new route index layout (health=0, ready=1, others=2+, catch-all=last). `make check` passes with 0 lint issues and `-race` clean.