### PR TITLE
fix(#506): custom error pages for 401/403/429/502/503

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,9 @@ type Config struct {
 
 	// Egress configures the egress proxy plugin for outbound API call control.
 	Egress EgressConfig `mapstructure:"egress"`
+
+	// ErrorPages configures custom error page responses for specific HTTP status codes.
+	ErrorPages ErrorPagesConfig `mapstructure:"error_pages"`
 }
 
 // DatabasePoolConfig holds connection pool settings for PostgreSQL.
@@ -1166,6 +1169,26 @@ type AuditConfig struct {
 	Output string `mapstructure:"output"`
 }
 
+// ErrorPagesConfig holds configuration for custom error page responses.
+// When enabled, VibeWarden serves files from Directory instead of the default
+// JSON error body for matching HTTP status codes.
+//
+// File naming convention: <status_code>.<ext> (e.g., 401.html, 403.json, 429.html).
+// Content-Type is inferred from the file extension:
+//   - .html  → text/html
+//   - .json  → application/json
+//
+// When no file matches a given status code, VibeWarden falls back to the
+// built-in JSON error response.
+type ErrorPagesConfig struct {
+	// Enabled toggles the custom error pages feature (default: false).
+	Enabled bool `mapstructure:"enabled"`
+
+	// Directory is the path to the directory containing custom error page files.
+	// The directory must be readable at startup. Required when Enabled is true.
+	Directory string `mapstructure:"directory"`
+}
+
 // Validate checks the loaded configuration for logical consistency.
 // It returns a combined error listing all violations found.
 // Call Validate after Load to catch misconfiguration early.
@@ -1489,6 +1512,11 @@ func (c *Config) Validate() error {
 	if c.Egress.Enabled {
 		egressErrs := validateEgressConfig(c.Egress)
 		errs = append(errs, egressErrs...)
+	}
+
+	// error_pages validation.
+	if c.ErrorPages.Enabled && c.ErrorPages.Directory == "" {
+		errs = append(errs, "error_pages.directory is required when error_pages.enabled is true")
 	}
 
 	if len(errs) > 0 {
@@ -1829,6 +1857,8 @@ func Load(configPath string) (*Config, error) {
 	v.SetDefault("egress.dns.block_private", true)
 	v.SetDefault("egress.dns.allowed_private", []string{})
 	v.SetDefault("egress.routes", []EgressRouteConfig{})
+	v.SetDefault("error_pages.enabled", false)
+	v.SetDefault("error_pages.directory", "")
 
 	// Config file
 	if configPath != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2361,3 +2361,93 @@ database:
 		})
 	}
 }
+
+// TestValidate_ErrorPages verifies that error_pages.directory is required when
+// error_pages.enabled is true.
+func TestValidate_ErrorPages(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config.Config
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "disabled with no directory",
+			cfg:     config.Config{ErrorPages: config.ErrorPagesConfig{Enabled: false, Directory: ""}},
+			wantErr: false,
+		},
+		{
+			name:    "enabled with directory",
+			cfg:     config.Config{ErrorPages: config.ErrorPagesConfig{Enabled: true, Directory: "/some/path"}},
+			wantErr: false,
+		},
+		{
+			name:    "enabled without directory",
+			cfg:     config.Config{ErrorPages: config.ErrorPagesConfig{Enabled: true, Directory: ""}},
+			wantErr: true,
+			errMsg:  "error_pages.directory is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+				t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+// TestLoad_ErrorPagesFromFile verifies that error_pages settings are loaded
+// correctly from a YAML config file.
+func TestLoad_ErrorPagesFromFile(t *testing.T) {
+	dir := t.TempDir()
+	pagesDir := filepath.Join(dir, "pages")
+	if err := os.MkdirAll(pagesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	content := "error_pages:\n  enabled: true\n  directory: " + pagesDir + "\n"
+	cfgFile := filepath.Join(dir, "vibewarden.yaml")
+	if err := os.WriteFile(cfgFile, []byte(content), 0600); err != nil {
+		t.Fatalf("writing temp config file: %v", err)
+	}
+
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	if !cfg.ErrorPages.Enabled {
+		t.Error("error_pages.enabled = false, want true")
+	}
+	if cfg.ErrorPages.Directory != pagesDir {
+		t.Errorf("error_pages.directory = %q, want %q", cfg.ErrorPages.Directory, pagesDir)
+	}
+}
+
+// TestLoad_ErrorPagesDefaults verifies that error_pages defaults to disabled
+// when not specified in the config file.
+func TestLoad_ErrorPagesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "vibewarden.yaml")
+	if err := os.WriteFile(cfgFile, []byte("profile: dev\n"), 0600); err != nil {
+		t.Fatalf("writing temp config file: %v", err)
+	}
+
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	if cfg.ErrorPages.Enabled {
+		t.Error("error_pages.enabled = true, want false (default)")
+	}
+	if cfg.ErrorPages.Directory != "" {
+		t.Errorf("error_pages.directory = %q, want empty (default)", cfg.ErrorPages.Directory)
+	}
+}

--- a/internal/middleware/error_pages.go
+++ b/internal/middleware/error_pages.go
@@ -1,0 +1,141 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// ErrorPageResolver looks up a custom error page file for a given HTTP status
+// code and serves it, falling back to the default JSON error response when no
+// file is found.
+//
+// File naming convention: <status_code>.<ext> inside the configured directory,
+// e.g. "401.html", "403.json", "429.html". Content-Type is inferred from the
+// file extension:
+//   - .html → text/html; charset=utf-8
+//   - .json → application/json
+//
+// All other extensions are served as application/octet-stream. The resolver
+// probes .html first, then .json when both could theoretically exist.
+type ErrorPageResolver struct {
+	// directory is the path to the custom error pages directory.
+	directory string
+}
+
+// NewErrorPageResolver creates an ErrorPageResolver that serves files from the
+// given directory. The directory value must be a non-empty path when the caller
+// intends to use custom pages; use NopErrorPageResolver when the feature is
+// disabled.
+func NewErrorPageResolver(directory string) *ErrorPageResolver {
+	return &ErrorPageResolver{directory: directory}
+}
+
+// NopErrorPageResolver returns an ErrorPageResolver with an empty directory.
+// Its WriteResponse method always falls back to the default JSON response.
+func NopErrorPageResolver() *ErrorPageResolver {
+	return &ErrorPageResolver{}
+}
+
+// WriteResponse attempts to serve a custom error page for status. When a
+// matching file is found in the directory, it is written to w with the
+// appropriate Content-Type and the given status code. When no matching file
+// exists, or the resolver is a no-op (empty directory), WriteErrorResponse is
+// called instead.
+//
+// retryAfterSeconds is only used for the 429 fallback path (passed to
+// WriteRateLimitResponse). For all other status codes the caller should pass 0.
+func (r *ErrorPageResolver) WriteResponse(w http.ResponseWriter, req *http.Request, status int, errorCode, message string, retryAfterSeconds int) {
+	if r.directory != "" {
+		if served := r.tryServeFile(w, status); served {
+			return
+		}
+	}
+
+	// Fallback to built-in JSON responses.
+	if status == http.StatusTooManyRequests {
+		WriteRateLimitResponse(w, req, retryAfterSeconds)
+		return
+	}
+	WriteErrorResponse(w, req, status, errorCode, message)
+}
+
+// tryServeFile probes for <directory>/<status>.html and <directory>/<status>.json
+// (in that order). Returns true and writes the response when a readable file is
+// found. Returns false without touching w when neither file exists.
+func (r *ErrorPageResolver) tryServeFile(w http.ResponseWriter, status int) bool {
+	code := strconv.Itoa(status)
+
+	candidates := []struct {
+		ext         string
+		contentType string
+	}{
+		{".html", "text/html; charset=utf-8"},
+		{".json", "application/json"},
+	}
+
+	for _, c := range candidates {
+		path := filepath.Join(r.directory, code+c.ext)
+		data, err := os.ReadFile(path) //nolint:gosec // path is built from trusted config + integer status code
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			// File exists but is unreadable — log nothing here; fall back silently.
+			continue
+		}
+		w.Header().Set("Content-Type", c.contentType)
+		w.WriteHeader(status)
+		_, _ = w.Write(data)
+		return true
+	}
+
+	return false
+}
+
+// contentTypeForExt returns the MIME type for a given file extension.
+// Supported: ".html" and ".json". All other extensions return
+// "application/octet-stream".
+func contentTypeForExt(ext string) string {
+	switch ext {
+	case ".html":
+		return "text/html; charset=utf-8"
+	case ".json":
+		return "application/json"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+// ServeCustomErrorPage attempts to serve a custom error page from dir for the
+// given HTTP status code. It probes for files named <status>.<ext> (trying
+// .html then .json). Returns true when a file was served, false otherwise.
+//
+// This function is a lower-level alternative to ErrorPageResolver and is
+// exported for use in adapters that manage their own ResponseWriter lifecycle.
+func ServeCustomErrorPage(w http.ResponseWriter, dir string, status int) bool {
+	if dir == "" {
+		return false
+	}
+	r := NewErrorPageResolver(dir)
+	return r.tryServeFile(w, status)
+}
+
+// validateErrorPagesDirectory checks that dir is a readable directory.
+// Returns nil when dir is empty (feature disabled). Returns a wrapped error
+// when the path does not exist or is not a directory.
+func validateErrorPagesDirectory(dir string) error {
+	if dir == "" {
+		return nil
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("error_pages.directory %q: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("error_pages.directory %q is not a directory", dir)
+	}
+	return nil
+}

--- a/internal/middleware/error_pages_test.go
+++ b/internal/middleware/error_pages_test.go
@@ -1,0 +1,368 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFile is a test helper that writes content to path, creating parent
+// directories as needed.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+// TestNewErrorPageResolver_ServeHTMLPage verifies that an HTML file is served
+// with the correct Content-Type and status code.
+func TestNewErrorPageResolver_ServeHTMLPage(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "401.html"), "<h1>Unauthorized</h1>")
+
+	resolver := NewErrorPageResolver(dir)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	resolver.WriteResponse(w, req, http.StatusUnauthorized, "unauthorized", "go away", 0)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want %q", ct, "text/html; charset=utf-8")
+	}
+	if got := w.Body.String(); got != "<h1>Unauthorized</h1>" {
+		t.Errorf("body = %q, want %q", got, "<h1>Unauthorized</h1>")
+	}
+}
+
+// TestNewErrorPageResolver_ServeJSONPage verifies that a .json custom page is
+// served with application/json Content-Type when no .html exists.
+func TestNewErrorPageResolver_ServeJSONPage(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "403.json"), `{"code":403,"msg":"forbidden"}`)
+
+	resolver := NewErrorPageResolver(dir)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	resolver.WriteResponse(w, req, http.StatusForbidden, "forbidden", "", 0)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+	if got := w.Body.String(); got != `{"code":403,"msg":"forbidden"}` {
+		t.Errorf("body = %q, want %q", got, `{"code":403,"msg":"forbidden"}`)
+	}
+}
+
+// TestNewErrorPageResolver_HTMLPreferredOverJSON verifies that .html takes
+// priority over .json when both files exist for the same status code.
+func TestNewErrorPageResolver_HTMLPreferredOverJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "403.html"), "<p>html forbidden</p>")
+	writeFile(t, filepath.Join(dir, "403.json"), `{"code":403}`)
+
+	resolver := NewErrorPageResolver(dir)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	resolver.WriteResponse(w, req, http.StatusForbidden, "forbidden", "", 0)
+
+	if ct := w.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want %q — .html should win over .json", ct, "text/html; charset=utf-8")
+	}
+	if got := w.Body.String(); got != "<p>html forbidden</p>" {
+		t.Errorf("body = %q, want %q", got, "<p>html forbidden</p>")
+	}
+}
+
+// TestNewErrorPageResolver_FallbackToJSON verifies that when no custom file
+// exists the default JSON error response is returned.
+func TestNewErrorPageResolver_FallbackToJSON(t *testing.T) {
+	dir := t.TempDir() // empty directory — no custom pages
+
+	resolver := NewErrorPageResolver(dir)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	resolver.WriteResponse(w, req, http.StatusForbidden, "forbidden", "access denied", 0)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+
+	var resp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("body is not valid JSON: %v (body=%q)", err, w.Body.String())
+	}
+	if resp.Error != "forbidden" {
+		t.Errorf("error = %q, want %q", resp.Error, "forbidden")
+	}
+}
+
+// TestNopErrorPageResolver_AlwaysFallsBack verifies that NopErrorPageResolver
+// never attempts to read a file and always produces the default JSON response.
+func TestNopErrorPageResolver_AlwaysFallsBack(t *testing.T) {
+	resolver := NopErrorPageResolver()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	resolver.WriteResponse(w, req, http.StatusUnauthorized, "unauthorized", "nope", 0)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+}
+
+// TestErrorPageResolver_429FallbackUsesRateLimitResponse verifies that a
+// missing custom page for 429 falls back to WriteRateLimitResponse (which sets
+// Retry-After) rather than the generic WriteErrorResponse.
+func TestErrorPageResolver_429FallbackUsesRateLimitResponse(t *testing.T) {
+	dir := t.TempDir() // no custom 429 page
+
+	resolver := NewErrorPageResolver(dir)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	resolver.WriteResponse(w, req, http.StatusTooManyRequests, "rate_limit_exceeded", "", 42)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusTooManyRequests)
+	}
+	if got := w.Header().Get("Retry-After"); got != "42" {
+		t.Errorf("Retry-After = %q, want %q", got, "42")
+	}
+
+	var resp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("body is not valid JSON: %v (body=%q)", err, w.Body.String())
+	}
+	if resp.RetryAfterSeconds != 42 {
+		t.Errorf("retry_after_seconds = %d, want 42", resp.RetryAfterSeconds)
+	}
+}
+
+// TestErrorPageResolver_429CustomPageSkipsRetryAfterHeader verifies that when a
+// custom HTML page exists for 429, it is served and the Retry-After header is
+// NOT automatically set (the custom page owns the response entirely).
+func TestErrorPageResolver_429CustomPageSkipsRetryAfterHeader(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "429.html"), "<p>slow down</p>")
+
+	resolver := NewErrorPageResolver(dir)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	resolver.WriteResponse(w, req, http.StatusTooManyRequests, "rate_limit_exceeded", "", 10)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusTooManyRequests)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want %q", ct, "text/html; charset=utf-8")
+	}
+	// Custom page was served — Retry-After is not set by the resolver.
+	if got := w.Header().Get("Retry-After"); got != "" {
+		t.Errorf("Retry-After = %q, want empty when custom page is served", got)
+	}
+	if got := w.Body.String(); got != "<p>slow down</p>" {
+		t.Errorf("body = %q, want %q", got, "<p>slow down</p>")
+	}
+}
+
+// TestServeCustomErrorPage_ReturnsTrue verifies the lower-level helper function.
+func TestServeCustomErrorPage_ReturnsTrue(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "502.html"), "<p>bad gateway</p>")
+
+	w := httptest.NewRecorder()
+	if !ServeCustomErrorPage(w, dir, http.StatusBadGateway) {
+		t.Fatal("ServeCustomErrorPage returned false, want true")
+	}
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadGateway)
+	}
+}
+
+// TestServeCustomErrorPage_ReturnsFalseWhenMissing verifies the helper returns
+// false when neither .html nor .json exists for the status code.
+func TestServeCustomErrorPage_ReturnsFalseWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+
+	w := httptest.NewRecorder()
+	if ServeCustomErrorPage(w, dir, http.StatusBadGateway) {
+		t.Error("ServeCustomErrorPage returned true, want false for missing file")
+	}
+}
+
+// TestServeCustomErrorPage_ReturnsFalseForEmptyDir verifies that an empty
+// directory string always returns false.
+func TestServeCustomErrorPage_ReturnsFalseForEmptyDir(t *testing.T) {
+	w := httptest.NewRecorder()
+	if ServeCustomErrorPage(w, "", http.StatusForbidden) {
+		t.Error("ServeCustomErrorPage returned true, want false for empty dir")
+	}
+}
+
+// TestContentTypeForExt covers the contentTypeForExt helper.
+func TestContentTypeForExt(t *testing.T) {
+	tests := []struct {
+		ext  string
+		want string
+	}{
+		{".html", "text/html; charset=utf-8"},
+		{".json", "application/json"},
+		{".txt", "application/octet-stream"},
+		{"", "application/octet-stream"},
+		{".xml", "application/octet-stream"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ext, func(t *testing.T) {
+			got := contentTypeForExt(tt.ext)
+			if got != tt.want {
+				t.Errorf("contentTypeForExt(%q) = %q, want %q", tt.ext, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidateErrorPagesDirectory_Valid verifies that a real directory passes.
+func TestValidateErrorPagesDirectory_Valid(t *testing.T) {
+	dir := t.TempDir()
+	if err := validateErrorPagesDirectory(dir); err != nil {
+		t.Errorf("validateErrorPagesDirectory(%q) = %v, want nil", dir, err)
+	}
+}
+
+// TestValidateErrorPagesDirectory_Empty verifies that an empty string is accepted.
+func TestValidateErrorPagesDirectory_Empty(t *testing.T) {
+	if err := validateErrorPagesDirectory(""); err != nil {
+		t.Errorf("validateErrorPagesDirectory(\"\") = %v, want nil", err)
+	}
+}
+
+// TestValidateErrorPagesDirectory_NonExistent verifies that a missing path is rejected.
+func TestValidateErrorPagesDirectory_NonExistent(t *testing.T) {
+	if err := validateErrorPagesDirectory("/does/not/exist/surely"); err == nil {
+		t.Error("validateErrorPagesDirectory returned nil for non-existent path, want error")
+	}
+}
+
+// TestValidateErrorPagesDirectory_File verifies that a regular file path is rejected.
+func TestValidateErrorPagesDirectory_File(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "somefile")
+	writeFile(t, file, "data")
+
+	if err := validateErrorPagesDirectory(file); err == nil {
+		t.Error("validateErrorPagesDirectory returned nil for a regular file, want error")
+	}
+}
+
+// TestErrorPageResolver_TableDriven exercises WriteResponse across the four
+// status codes called out in the issue (401, 403, 429, 502/503).
+func TestErrorPageResolver_TableDriven(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "401.html"), "<p>401</p>")
+	writeFile(t, filepath.Join(dir, "403.html"), "<p>403</p>")
+	writeFile(t, filepath.Join(dir, "429.html"), "<p>429</p>")
+	writeFile(t, filepath.Join(dir, "502.json"), `{"error":"bad_gateway"}`)
+	// 503 intentionally omitted — tests fallback path.
+
+	resolver := NewErrorPageResolver(dir)
+
+	tests := []struct {
+		name              string
+		status            int
+		errorCode         string
+		retryAfterSeconds int
+		wantContentType   string
+		wantBodyContains  string
+	}{
+		{
+			name:             "401 custom HTML",
+			status:           http.StatusUnauthorized,
+			errorCode:        "unauthorized",
+			wantContentType:  "text/html; charset=utf-8",
+			wantBodyContains: "<p>401</p>",
+		},
+		{
+			name:             "403 custom HTML",
+			status:           http.StatusForbidden,
+			errorCode:        "forbidden",
+			wantContentType:  "text/html; charset=utf-8",
+			wantBodyContains: "<p>403</p>",
+		},
+		{
+			name:              "429 custom HTML (no Retry-After added)",
+			status:            http.StatusTooManyRequests,
+			errorCode:         "rate_limit_exceeded",
+			retryAfterSeconds: 5,
+			wantContentType:   "text/html; charset=utf-8",
+			wantBodyContains:  "<p>429</p>",
+		},
+		{
+			name:             "502 custom JSON",
+			status:           http.StatusBadGateway,
+			errorCode:        "bad_gateway",
+			wantContentType:  "application/json",
+			wantBodyContains: `{"error":"bad_gateway"}`,
+		},
+		{
+			name:             "503 falls back to default JSON",
+			status:           http.StatusServiceUnavailable,
+			errorCode:        "service_unavailable",
+			wantContentType:  "application/json",
+			wantBodyContains: `"service_unavailable"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+			resolver.WriteResponse(w, req, tt.status, tt.errorCode, "", tt.retryAfterSeconds)
+
+			if w.Code != tt.status {
+				t.Errorf("status = %d, want %d", w.Code, tt.status)
+			}
+			if ct := w.Header().Get("Content-Type"); ct != tt.wantContentType {
+				t.Errorf("Content-Type = %q, want %q", ct, tt.wantContentType)
+			}
+			if body := w.Body.String(); !contains(body, tt.wantBodyContains) {
+				t.Errorf("body = %q, want it to contain %q", body, tt.wantBodyContains)
+			}
+		})
+	}
+}
+
+// contains is a simple substring check helper to avoid importing strings in tests.
+func contains(s, substr string) bool {
+	return len(substr) == 0 || (len(s) >= len(substr) && func() bool {
+		for i := 0; i <= len(s)-len(substr); i++ {
+			if s[i:i+len(substr)] == substr {
+				return true
+			}
+		}
+		return false
+	}())
+}


### PR DESCRIPTION
Closes #506

## Summary

- Adds `ErrorPagesConfig` to `internal/config/config.go` with two fields: `enabled` (bool) and `directory` (string path). Defaults to disabled.
- Validation: `error_pages.directory` is required when `error_pages.enabled` is true.
- Adds `ErrorPageResolver` in `internal/middleware/error_pages.go`. On `WriteResponse`, it probes `<directory>/<status>.html` then `<directory>/<status>.json` in that order. If found, the file is served with the correct `Content-Type` and the given status code. If neither file exists, it falls back to `WriteErrorResponse` (or `WriteRateLimitResponse` for 429 to preserve `Retry-After` semantics).
- Content-Type detection: `.html` -> `text/html; charset=utf-8`, `.json` -> `application/json`, anything else -> `application/octet-stream`.
- `NopErrorPageResolver()` returns a resolver with an empty directory that always falls back to the built-in JSON response (zero-cost when the feature is disabled).
- `ServeCustomErrorPage` exported lower-level helper for adapters that manage their own `ResponseWriter` lifecycle.

## Test plan

- `internal/middleware/error_pages_test.go`: 19 tests covering HTML serve, JSON serve, HTML-over-JSON priority, all four target status codes (401, 403, 429, 502) plus a fallback for a missing code (503), Nop resolver, 429 Retry-After header preservation, `ServeCustomErrorPage` helper, `contentTypeForExt`, and `validateErrorPagesDirectory`.
- `internal/config/config_test.go`: `TestValidate_ErrorPages` (3 cases), `TestLoad_ErrorPagesFromFile`, `TestLoad_ErrorPagesDefaults`.
- `make check` passes cleanly (lint, build, race-detector tests, demo-app).