### PR TITLE
fix(#509): implement partial-start mode for non-critical plugins

### DIFF
--- a/internal/middleware/health.go
+++ b/internal/middleware/health.go
@@ -207,6 +207,12 @@ type ReadyResponse struct {
 	// Possible values: "reachable", "unreachable". Omitted when no upstream
 	// health checker is configured.
 	Upstream string `json:"upstream,omitempty"`
+
+	// Degraded maps the name of each non-critical plugin that failed Init or
+	// Start to the failure reason. A non-empty Degraded map means the sidecar
+	// is running in partial-start mode: critical plugins are healthy, but one
+	// or more observability/feature plugins could not start.
+	Degraded map[string]string `json:"degraded,omitempty"`
 }
 
 // ReadyHandler returns an http.HandlerFunc for the readiness probe endpoint
@@ -254,6 +260,11 @@ func ReadyHandler(readinessChecker ports.ReadinessChecker) http.HandlerFunc {
 				resp.Upstream = "reachable"
 			} else {
 				resp.Upstream = "unreachable"
+			}
+
+			// Populate degraded plugin map when partial-start mode is active.
+			if len(rs.DegradedPlugins) > 0 {
+				resp.Degraded = rs.DegradedPlugins
 			}
 		}
 

--- a/internal/plugins/auth/meta.go
+++ b/internal/plugins/auth/meta.go
@@ -19,6 +19,11 @@ func (p *Plugin) ConfigSchema() map[string]string {
 	}
 }
 
+// Critical returns true because the auth plugin enforces authentication on
+// every proxied request. A failure to initialise auth means the sidecar
+// would forward unauthenticated traffic, which is a security violation.
+func (p *Plugin) Critical() bool { return true }
+
 // Example returns an example YAML configuration for the auth plugin.
 func (p *Plugin) Example() string {
 	return `  auth:

--- a/internal/plugins/ratelimit/meta.go
+++ b/internal/plugins/ratelimit/meta.go
@@ -19,6 +19,11 @@ func (p *Plugin) ConfigSchema() map[string]string {
 	}
 }
 
+// Critical returns true because rate limiting protects against abuse. A
+// broken rate-limiter means the sidecar would forward unlimited traffic to
+// the upstream, enabling denial-of-service attacks.
+func (p *Plugin) Critical() bool { return true }
+
 // Example returns an example YAML configuration for the rate-limiting plugin.
 func (p *Plugin) Example() string {
 	return `  rate-limiting:

--- a/internal/plugins/registry.go
+++ b/internal/plugins/registry.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
@@ -15,14 +16,23 @@ import (
 // Plugins are registered at startup and then driven through Init → Start → Stop.
 // Stop is always called in the reverse of registration order so that
 // dependent plugins shut down before their dependencies.
+//
+// Critical plugins (those implementing ports.CriticalPlugin with Critical()
+// returning true) abort startup on Init or Start failure. Non-critical plugins
+// that fail are marked degraded and skipped; startup continues.
 type Registry struct {
-	plugins []ports.Plugin
-	logger  *slog.Logger
+	plugins  []ports.Plugin
+	logger   *slog.Logger
+	mu       sync.RWMutex
+	degraded map[string]string // plugin name → failure reason
 }
 
 // NewRegistry creates a Registry that uses logger for lifecycle events.
 func NewRegistry(logger *slog.Logger) *Registry {
-	return &Registry{logger: logger}
+	return &Registry{
+		logger:   logger,
+		degraded: make(map[string]string),
+	}
 }
 
 // Register adds p to the registry. It must be called before InitAll.
@@ -39,10 +49,17 @@ func (r *Registry) Plugins() []ports.Plugin {
 }
 
 // CaddyContributors returns every registered plugin that implements
-// ports.CaddyContributor.
+// ports.CaddyContributor and has not been marked degraded.
 func (r *Registry) CaddyContributors() []ports.CaddyContributor {
+	r.mu.RLock()
+	deg := r.degraded
+	r.mu.RUnlock()
+
 	var contributors []ports.CaddyContributor
 	for _, p := range r.plugins {
+		if _, isDegraded := deg[p.Name()]; isDegraded {
+			continue
+		}
 		if c, ok := p.(ports.CaddyContributor); ok {
 			contributors = append(contributors, c)
 		}
@@ -50,27 +67,90 @@ func (r *Registry) CaddyContributors() []ports.CaddyContributor {
 	return contributors
 }
 
+// isCritical returns true when p implements ports.CriticalPlugin and reports
+// Critical() == true. Plugins that do not implement the interface are treated
+// as non-critical.
+func isCritical(p ports.Plugin) bool {
+	if cp, ok := p.(ports.CriticalPlugin); ok {
+		return cp.Critical()
+	}
+	return false
+}
+
+// markDegraded records name as degraded with the given reason, thread-safely.
+func (r *Registry) markDegraded(name, reason string) {
+	r.mu.Lock()
+	r.degraded[name] = reason
+	r.mu.Unlock()
+}
+
+// DegradedPlugins returns a snapshot of the currently degraded plugins as a
+// map from plugin name to the failure reason string. The returned map is a
+// copy and is safe to use after the call returns.
+func (r *Registry) DegradedPlugins() map[string]string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	cp := make(map[string]string, len(r.degraded))
+	for k, v := range r.degraded {
+		cp[k] = v
+	}
+	return cp
+}
+
 // InitAll calls Init on every registered plugin in registration order.
-// If any plugin's Init returns an error the function returns immediately
+//
+// If a critical plugin's Init returns an error the function returns immediately
 // with that error; subsequent plugins are not initialised.
+//
+// If a non-critical plugin's Init returns an error the error is logged, the
+// plugin is marked degraded, and initialisation continues with the next plugin.
 func (r *Registry) InitAll(ctx context.Context) error {
 	for _, p := range r.plugins {
 		r.logger.InfoContext(ctx, "initialising plugin", slog.String("plugin", p.Name()))
 		if err := p.Init(ctx); err != nil {
-			return fmt.Errorf("init plugin %q: %w", p.Name(), err)
+			if isCritical(p) {
+				return fmt.Errorf("init plugin %q: %w", p.Name(), err)
+			}
+			r.logger.ErrorContext(ctx, "non-critical plugin init failed — plugin degraded",
+				slog.String("plugin", p.Name()),
+				slog.String("error", err.Error()),
+			)
+			r.markDegraded(p.Name(), fmt.Sprintf("init failed: %s", err.Error()))
 		}
 	}
 	return nil
 }
 
-// StartAll calls Start on every registered plugin in registration order.
-// If any plugin's Start returns an error the function returns immediately
+// StartAll calls Start on every registered plugin in registration order,
+// skipping any plugin that was already marked degraded during InitAll.
+//
+// If a critical plugin's Start returns an error the function returns immediately
 // with that error; subsequent plugins are not started.
+//
+// If a non-critical plugin's Start returns an error the error is logged, the
+// plugin is marked degraded, and startup continues with the next plugin.
 func (r *Registry) StartAll(ctx context.Context) error {
 	for _, p := range r.plugins {
+		r.mu.RLock()
+		_, isDegraded := r.degraded[p.Name()]
+		r.mu.RUnlock()
+		if isDegraded {
+			r.logger.WarnContext(ctx, "skipping degraded plugin on start",
+				slog.String("plugin", p.Name()),
+			)
+			continue
+		}
+
 		r.logger.InfoContext(ctx, "starting plugin", slog.String("plugin", p.Name()))
 		if err := p.Start(ctx); err != nil {
-			return fmt.Errorf("start plugin %q: %w", p.Name(), err)
+			if isCritical(p) {
+				return fmt.Errorf("start plugin %q: %w", p.Name(), err)
+			}
+			r.logger.ErrorContext(ctx, "non-critical plugin start failed — plugin degraded",
+				slog.String("plugin", p.Name()),
+				slog.String("error", err.Error()),
+			)
+			r.markDegraded(p.Name(), fmt.Sprintf("start failed: %s", err.Error()))
 		}
 	}
 	return nil
@@ -98,9 +178,25 @@ func (r *Registry) StopAll(ctx context.Context) error {
 }
 
 // HealthAll returns a map from plugin name to its current HealthStatus.
+// Degraded plugins receive a synthesised unhealthy status that includes the
+// failure reason recorded at Init/Start time.
 func (r *Registry) HealthAll() map[string]ports.HealthStatus {
+	r.mu.RLock()
+	deg := make(map[string]string, len(r.degraded))
+	for k, v := range r.degraded {
+		deg[k] = v
+	}
+	r.mu.RUnlock()
+
 	result := make(map[string]ports.HealthStatus, len(r.plugins))
 	for _, p := range r.plugins {
+		if reason, isDegraded := deg[p.Name()]; isDegraded {
+			result[p.Name()] = ports.HealthStatus{
+				Healthy: false,
+				Message: "degraded: " + reason,
+			}
+			continue
+		}
 		result[p.Name()] = p.Health()
 	}
 	return result
@@ -155,6 +251,7 @@ func (rc *registryReadinessChecker) ReadinessStatus() ports.ReadinessStatus {
 		PluginsReady:      pluginsReady,
 		UpstreamReachable: upstreamReachable,
 		Plugins:           pluginStatuses,
+		DegradedPlugins:   rc.registry.DegradedPlugins(),
 	}
 }
 

--- a/internal/plugins/registry_test.go
+++ b/internal/plugins/registry_test.go
@@ -23,7 +23,11 @@ type fakePlugin struct {
 	stopErr   error
 	health    ports.HealthStatus
 	callOrder *[]string // shared slice so callers can observe cross-plugin order
+	critical  bool      // when true, plugin implements ports.CriticalPlugin
 }
+
+// Critical implements ports.CriticalPlugin. Only called when f.critical == true.
+func (f *fakePlugin) Critical() bool { return f.critical }
 
 func (f *fakePlugin) Name() string { return f.name }
 
@@ -157,8 +161,9 @@ func TestRegistry_InitAll_StopsOnFirstError(t *testing.T) {
 	boom := errors.New("init boom")
 	r := plugins.NewRegistry(discardLogger())
 
+	// beta is a critical plugin — its failure must abort startup.
 	r.Register(&fakePlugin{name: "alpha", callOrder: order})
-	r.Register(&fakePlugin{name: "beta", initErr: boom, callOrder: order})
+	r.Register(&fakePlugin{name: "beta", initErr: boom, callOrder: order, critical: true})
 	r.Register(&fakePlugin{name: "gamma", callOrder: order})
 
 	err := r.InitAll(context.Background())
@@ -181,8 +186,9 @@ func TestRegistry_StartAll_StopsOnFirstError(t *testing.T) {
 	boom := errors.New("start boom")
 	r := plugins.NewRegistry(discardLogger())
 
+	// beta is a critical plugin — its failure must abort startup.
 	r.Register(&fakePlugin{name: "alpha", callOrder: order})
-	r.Register(&fakePlugin{name: "beta", startErr: boom, callOrder: order})
+	r.Register(&fakePlugin{name: "beta", startErr: boom, callOrder: order, critical: true})
 	r.Register(&fakePlugin{name: "gamma", callOrder: order})
 
 	err := r.StartAll(context.Background())
@@ -314,6 +320,191 @@ func TestRegistry_EmptyRegistry(t *testing.T) {
 	}
 	if h := r.HealthAll(); len(h) != 0 {
 		t.Errorf("HealthAll on empty registry should return empty map, got %v", h)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Partial-start (non-critical plugin degradation) tests
+// ----------------------------------------------------------------------------
+
+func TestRegistry_InitAll_NonCriticalFailure_ContinuesStartup(t *testing.T) {
+	order := newOrder()
+	boom := errors.New("init boom")
+	r := plugins.NewRegistry(discardLogger())
+
+	// beta is non-critical — its failure must not abort startup.
+	r.Register(&fakePlugin{name: "alpha", callOrder: order})
+	r.Register(&fakePlugin{name: "beta", initErr: boom, callOrder: order, critical: false})
+	r.Register(&fakePlugin{name: "gamma", callOrder: order})
+
+	err := r.InitAll(context.Background())
+	if err != nil {
+		t.Fatalf("InitAll: unexpected error for non-critical failure: %v", err)
+	}
+
+	// gamma must still have been initialised.
+	found := false
+	for _, call := range *order {
+		if call == "gamma:init" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("gamma should have been initialised even though beta failed")
+	}
+}
+
+func TestRegistry_InitAll_NonCriticalFailure_MarksDegraded(t *testing.T) {
+	order := newOrder()
+	boom := errors.New("init boom")
+	r := plugins.NewRegistry(discardLogger())
+
+	r.Register(&fakePlugin{name: "alpha", callOrder: order})
+	r.Register(&fakePlugin{name: "beta", initErr: boom, callOrder: order, critical: false})
+
+	if err := r.InitAll(context.Background()); err != nil {
+		t.Fatalf("InitAll: unexpected error: %v", err)
+	}
+
+	degraded := r.DegradedPlugins()
+	if _, ok := degraded["beta"]; !ok {
+		t.Error("beta should be in DegradedPlugins after init failure")
+	}
+	if _, ok := degraded["alpha"]; ok {
+		t.Error("alpha should not be in DegradedPlugins")
+	}
+}
+
+func TestRegistry_StartAll_SkipsDegradedPlugins(t *testing.T) {
+	order := newOrder()
+	boom := errors.New("init boom")
+	r := plugins.NewRegistry(discardLogger())
+
+	r.Register(&fakePlugin{name: "alpha", callOrder: order})
+	r.Register(&fakePlugin{name: "beta", initErr: boom, callOrder: order, critical: false})
+	r.Register(&fakePlugin{name: "gamma", callOrder: order})
+
+	// Init — beta degrades.
+	if err := r.InitAll(context.Background()); err != nil {
+		t.Fatalf("InitAll: %v", err)
+	}
+
+	// Reset call log so we only observe Start calls.
+	*order = []string{}
+
+	if err := r.StartAll(context.Background()); err != nil {
+		t.Fatalf("StartAll: unexpected error: %v", err)
+	}
+
+	for _, call := range *order {
+		if call == "beta:start" {
+			t.Error("beta:start should not have been called — plugin was degraded at init")
+		}
+	}
+}
+
+func TestRegistry_StartAll_NonCriticalFailure_ContinuesStartup(t *testing.T) {
+	order := newOrder()
+	boom := errors.New("start boom")
+	r := plugins.NewRegistry(discardLogger())
+
+	r.Register(&fakePlugin{name: "alpha", callOrder: order})
+	r.Register(&fakePlugin{name: "beta", startErr: boom, callOrder: order, critical: false})
+	r.Register(&fakePlugin{name: "gamma", callOrder: order})
+
+	if err := r.InitAll(context.Background()); err != nil {
+		t.Fatalf("InitAll: %v", err)
+	}
+	err := r.StartAll(context.Background())
+	if err != nil {
+		t.Fatalf("StartAll: unexpected error for non-critical start failure: %v", err)
+	}
+
+	// gamma must still have been started.
+	found := false
+	for _, call := range *order {
+		if call == "gamma:start" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("gamma should have been started even though beta failed")
+	}
+
+	degraded := r.DegradedPlugins()
+	if _, ok := degraded["beta"]; !ok {
+		t.Error("beta should be in DegradedPlugins after start failure")
+	}
+}
+
+func TestRegistry_HealthAll_DegradedPlugin_ReportsUnhealthy(t *testing.T) {
+	order := newOrder()
+	boom := errors.New("init boom")
+	r := plugins.NewRegistry(discardLogger())
+
+	r.Register(&fakePlugin{name: "alpha", callOrder: order, health: ports.HealthStatus{Healthy: true}})
+	r.Register(&fakePlugin{name: "beta", initErr: boom, callOrder: order, critical: false})
+
+	if err := r.InitAll(context.Background()); err != nil {
+		t.Fatalf("InitAll: %v", err)
+	}
+
+	health := r.HealthAll()
+	if health["alpha"].Healthy != true {
+		t.Error("alpha should be healthy")
+	}
+	if health["beta"].Healthy != false {
+		t.Error("beta should be unhealthy (degraded)")
+	}
+	if health["beta"].Message == "" {
+		t.Error("beta health message should describe the degraded reason")
+	}
+}
+
+func TestRegistry_DegradedPlugins_ReflectsInReadinessStatus(t *testing.T) {
+	order := newOrder()
+	boom := errors.New("init boom")
+	r := plugins.NewRegistry(discardLogger())
+
+	r.Register(&fakePlugin{name: "alpha", callOrder: order, health: ports.HealthStatus{Healthy: true}})
+	r.Register(&fakePlugin{name: "beta", initErr: boom, callOrder: order, critical: false})
+
+	if err := r.InitAll(context.Background()); err != nil {
+		t.Fatalf("InitAll: %v", err)
+	}
+
+	rc := r.ReadinessChecker(nil)
+	rs := rc.ReadinessStatus()
+
+	if _, ok := rs.DegradedPlugins["beta"]; !ok {
+		t.Error("DegradedPlugins in ReadinessStatus should contain beta")
+	}
+}
+
+func TestRegistry_CaddyContributors_ExcludesDegradedPlugins(t *testing.T) {
+	order := newOrder()
+	boom := errors.New("init boom")
+	r := plugins.NewRegistry(discardLogger())
+
+	r.Register(&fakeCaddyPlugin{
+		fakePlugin: fakePlugin{name: "alpha", callOrder: order},
+		routes:     []ports.CaddyRoute{{MatchPath: "/a", Priority: 10}},
+	})
+	r.Register(&fakeCaddyPlugin{
+		fakePlugin: fakePlugin{name: "beta", initErr: boom, callOrder: order, critical: false},
+		routes:     []ports.CaddyRoute{{MatchPath: "/b", Priority: 20}},
+	})
+
+	if err := r.InitAll(context.Background()); err != nil {
+		t.Fatalf("InitAll: %v", err)
+	}
+
+	contributors := r.CaddyContributors()
+	if len(contributors) != 1 {
+		t.Fatalf("expected 1 contributor (non-degraded), got %d", len(contributors))
+	}
+	if contributors[0].(*fakeCaddyPlugin).name != "alpha" {
+		t.Error("expected alpha as the only contributor")
 	}
 }
 

--- a/internal/plugins/tls/meta.go
+++ b/internal/plugins/tls/meta.go
@@ -18,6 +18,11 @@ func (p *Plugin) ConfigSchema() map[string]string {
 	}
 }
 
+// Critical returns true because TLS termination is a fundamental security
+// boundary. If TLS fails to initialise when enabled the sidecar must not
+// serve plain-text traffic in its place.
+func (p *Plugin) Critical() bool { return true }
+
 // Example returns an example YAML configuration for the TLS plugin.
 func (p *Plugin) Example() string {
 	return `  tls:

--- a/internal/ports/plugin.go
+++ b/internal/ports/plugin.go
@@ -174,6 +174,27 @@ type ReadinessStatus struct {
 
 	// Plugins maps each plugin name to its current HealthStatus.
 	Plugins map[string]HealthStatus
+
+	// DegradedPlugins maps the name of each plugin that failed Init or Start
+	// to the reason string recorded at failure time. Non-critical plugins that
+	// degrade during startup are listed here so callers can surface a
+	// "degraded" overall status instead of "unhealthy".
+	DegradedPlugins map[string]string
+}
+
+// CriticalPlugin is an optional interface implemented by plugins whose
+// failure must abort sidecar startup. When a plugin does not implement this
+// interface it is treated as non-critical: Init/Start failures are logged as
+// errors and the plugin is marked degraded, but startup continues.
+//
+// Critical plugins: auth, tls, rate-limiting.
+// Non-critical plugins: metrics, WAF, secrets, egress, webhooks, body-size,
+// CORS, security-headers, ip-filter, user-management.
+type CriticalPlugin interface {
+	// Critical returns true when the plugin must start successfully for the
+	// sidecar to serve requests safely. Returning false (or not implementing
+	// this interface at all) means the plugin may degrade gracefully.
+	Critical() bool
 }
 
 // PluginMeta is an optional interface implemented by plugins that expose


### PR DESCRIPTION
Closes #509

## Summary

- Add `ports.CriticalPlugin` optional interface to `internal/ports/plugin.go`. Plugins that implement it and return `Critical() == true` abort startup on failure. Plugins that do not implement it, or return `false`, degrade gracefully.
- Mark **auth**, **tls**, and **rate-limiting** as critical (`Critical() bool { return true }`) in their respective `meta.go` files.
- All other plugins (metrics, WAF, secrets, egress, webhooks, body-size, CORS, security-headers, ip-filter, user-management) remain non-critical by default — no change required in those packages.
- `Registry.InitAll`: on non-critical Init failure, log at ERROR level, record the plugin in a thread-safe `degraded` map, continue to the next plugin.
- `Registry.StartAll`: skip already-degraded plugins with a WARN log; on non-critical Start failure, same degradation path.
- `Registry.CaddyContributors`: excludes degraded plugins so they cannot inject broken Caddy routes.
- `Registry.HealthAll`: returns a synthesised `HealthStatus{Healthy: false, Message: "degraded: ..."}` for each degraded plugin.
- `Registry.DegradedPlugins()`: new public method returning a snapshot map of plugin name to failure reason.
- `ports.ReadinessStatus`: new `DegradedPlugins map[string]string` field populated by `ReadinessChecker.ReadinessStatus()`.
- `middleware.ReadyResponse`: new `Degraded map[string]string` JSON field — surfaces degraded plugins to the `/_vibewarden/ready` endpoint.

## Test plan

- `TestRegistry_InitAll_NonCriticalFailure_ContinuesStartup` — startup does not abort when a non-critical plugin fails Init.
- `TestRegistry_InitAll_NonCriticalFailure_MarksDegraded` — failed plugin appears in `DegradedPlugins()`.
- `TestRegistry_StartAll_SkipsDegradedPlugins` — plugins degraded at Init are not started.
- `TestRegistry_StartAll_NonCriticalFailure_ContinuesStartup` — startup does not abort when a non-critical plugin fails Start.
- `TestRegistry_HealthAll_DegradedPlugin_ReportsUnhealthy` — `HealthAll` returns unhealthy status with reason for degraded plugin.
- `TestRegistry_DegradedPlugins_ReflectsInReadinessStatus` — `ReadinessStatus.DegradedPlugins` contains the failed plugin.
- `TestRegistry_CaddyContributors_ExcludesDegradedPlugins` — degraded plugins do not contribute Caddy routes.
- Existing `TestRegistry_InitAll_StopsOnFirstError` and `TestRegistry_StartAll_StopsOnFirstError` updated to use `critical: true` plugins — critical failures still abort startup.
- `make check` passes (formatting, lint, build, race tests, demo-app).