### PR TITLE
fix(#501): improve config validation with actionable error messages

### DIFF
--- a/internal/cli/cmd/validate_test.go
+++ b/internal/cli/cmd/validate_test.go
@@ -327,14 +327,17 @@ security_headers:
 }
 
 func TestValidateCmd_MultipleErrors(t *testing.T) {
+	// tls.provider is intentionally omitted here: an invalid provider value is
+	// caught by config.Validate() (inside config.Load()) and that error is
+	// reported alone before validateConfig ever runs. The purpose of this test
+	// is to verify that multiple semantic errors from validateConfig are all
+	// reported together, so we use only fields whose validation lives in that
+	// function.
 	path := writeConfig(t, `
 server:
   port: 0
 upstream:
   port: 99999
-tls:
-  enabled: false
-  provider: bad-provider
 log:
   level: verbose
   format: xml
@@ -352,7 +355,7 @@ log:
 	}
 
 	errOut := errBuf.String()
-	for _, want := range []string{"server.port", "upstream.port", "tls.provider", "log.level", "log.format"} {
+	for _, want := range []string{"server.port", "upstream.port", "log.level", "log.format"} {
 		if !strings.Contains(errOut, want) {
 			t.Errorf("expected %q in stderr, got: %q", want, errOut)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1201,13 +1201,27 @@ func (c *Config) Validate() error {
 		errs = append(errs, fmt.Sprintf("profile must be 'dev', 'tls', or 'prod', got %q", c.Profile))
 	}
 
+	// tls.provider validation: must be one of the accepted values.
+	switch c.TLS.Provider {
+	case "", "self-signed", "letsencrypt", "external":
+		// valid — empty string is accepted (defaults to "self-signed" via Load)
+	default:
+		errs = append(errs, fmt.Sprintf(
+			"tls.provider %q is invalid; accepted values: \"self-signed\", \"letsencrypt\", \"external\" — "+
+				"set tls.provider to one of those values",
+			c.TLS.Provider,
+		))
+	}
+
 	// TLS external provider requires cert_path and key_path.
 	if c.TLS.Enabled && c.TLS.Provider == "external" {
 		if c.TLS.CertPath == "" {
-			errs = append(errs, "tls.cert_path is required when tls.provider is \"external\"")
+			errs = append(errs, "tls.cert_path is required when tls.provider is \"external\" — "+
+				"set tls.cert_path to the path of your PEM-encoded certificate file")
 		}
 		if c.TLS.KeyPath == "" {
-			errs = append(errs, "tls.key_path is required when tls.provider is \"external\"")
+			errs = append(errs, "tls.key_path is required when tls.provider is \"external\" — "+
+				"set tls.key_path to the path of your PEM-encoded private key file")
 		}
 	}
 
@@ -1249,9 +1263,18 @@ func (c *Config) Validate() error {
 		// valid
 	default:
 		errs = append(errs, fmt.Sprintf(
-			"auth.mode %q is invalid; accepted values: \"kratos\", \"jwt\", \"api-key\", \"none\"",
+			"auth.mode %q is invalid; accepted values: \"none\", \"kratos\", \"jwt\", \"api-key\" — "+
+				"set auth.mode to one of those values (use \"none\" to disable authentication)",
 			c.Auth.Mode,
 		))
+	}
+
+	// auth.enabled with mode "none" is almost certainly a misconfiguration: the
+	// user enabled auth but left the mode at its default ("none"), which means no
+	// authentication will actually be enforced.
+	if c.Auth.Enabled && (c.Auth.Mode == AuthModeNone || c.Auth.Mode == "") {
+		errs = append(errs, "auth.enabled is true but auth.mode is \"none\", which means no authentication will be enforced — "+
+			"set auth.mode to \"kratos\", \"jwt\", or \"api-key\" to enable authentication, or set auth.enabled to false")
 	}
 
 	// auth.jwt validation (only when mode is "jwt").
@@ -1370,7 +1393,8 @@ func (c *Config) Validate() error {
 		// valid — "memory" is the default
 	case "redis":
 		if c.RateLimit.Redis.URL == "" && c.RateLimit.Redis.Address == "" {
-			errs = append(errs, "rate_limit.redis.address is required when rate_limit.store is \"redis\" and rate_limit.redis.url is not set")
+			errs = append(errs, "rate_limit.redis.address is required when rate_limit.store is \"redis\" and rate_limit.redis.url is not set — "+
+				"set rate_limit.redis.address to your Redis host:port (e.g. \"127.0.0.1:6379\") or set rate_limit.redis.url to a redis:// URL")
 		}
 		if c.RateLimit.Redis.URL != "" {
 			if err := validateRedisURL(c.RateLimit.Redis.URL); err != nil {
@@ -1379,7 +1403,8 @@ func (c *Config) Validate() error {
 		}
 	default:
 		errs = append(errs, fmt.Sprintf(
-			"rate_limit.store %q is invalid; accepted values: \"memory\", \"redis\"",
+			"rate_limit.store %q is invalid; accepted values: \"memory\", \"redis\" — "+
+				"set rate_limit.store to \"memory\" for a single-process limiter or \"redis\" for a distributed limiter",
 			c.RateLimit.Store,
 		))
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -445,6 +445,7 @@ func TestLoad_NewFieldsFromFile(t *testing.T) {
 	content := `
 auth:
   enabled: true
+  mode: kratos
   identity_schema: email_only
   session_cookie_name: my_session
   login_url: /login
@@ -2449,5 +2450,252 @@ func TestLoad_ErrorPagesDefaults(t *testing.T) {
 	}
 	if cfg.ErrorPages.Directory != "" {
 		t.Errorf("error_pages.directory = %q, want empty (default)", cfg.ErrorPages.Directory)
+	}
+}
+
+// TestValidate_TLSProvider verifies that tls.provider must be one of the accepted values.
+func TestValidate_TLSProvider(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         config.Config
+		wantErr     bool
+		wantContain string
+	}{
+		{
+			name:    "self-signed is valid",
+			cfg:     config.Config{TLS: config.TLSConfig{Provider: "self-signed"}},
+			wantErr: false,
+		},
+		{
+			name:    "letsencrypt is valid",
+			cfg:     config.Config{TLS: config.TLSConfig{Provider: "letsencrypt"}},
+			wantErr: false,
+		},
+		{
+			name: "external with paths is valid",
+			cfg: config.Config{TLS: config.TLSConfig{
+				Enabled:  true,
+				Provider: "external",
+				CertPath: "/etc/tls/cert.pem",
+				KeyPath:  "/etc/tls/key.pem",
+			}},
+			wantErr: false,
+		},
+		{
+			name:    "empty provider is valid (defaults to self-signed via Load)",
+			cfg:     config.Config{TLS: config.TLSConfig{Provider: ""}},
+			wantErr: false,
+		},
+		{
+			name:        "unknown provider acme is rejected",
+			cfg:         config.Config{TLS: config.TLSConfig{Provider: "acme"}},
+			wantErr:     true,
+			wantContain: "tls.provider \"acme\" is invalid",
+		},
+		{
+			name:        "unknown provider cloudflare is rejected with actionable message",
+			cfg:         config.Config{TLS: config.TLSConfig{Provider: "cloudflare"}},
+			wantErr:     true,
+			wantContain: "accepted values: \"self-signed\", \"letsencrypt\", \"external\"",
+		},
+		{
+			name:        "error message suggests fix",
+			cfg:         config.Config{TLS: config.TLSConfig{Provider: "cloudflare"}},
+			wantErr:     true,
+			wantContain: "set tls.provider to one of those values",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.wantContain != "" && err != nil {
+				if !strings.Contains(err.Error(), tt.wantContain) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantContain)
+				}
+			}
+		})
+	}
+}
+
+// TestValidate_AuthEnabledModeNone verifies that enabling auth with mode "none" produces
+// an actionable error.
+func TestValidate_AuthEnabledModeNone(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         config.Config
+		wantErr     bool
+		wantContain string
+	}{
+		{
+			name: "auth.enabled false with mode none is valid",
+			cfg: config.Config{
+				Auth: config.AuthConfig{Enabled: false, Mode: "none"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "auth.enabled true with mode kratos is valid",
+			cfg: config.Config{
+				Auth: config.AuthConfig{Enabled: true, Mode: "kratos"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "auth.enabled true with mode jwt is valid",
+			cfg: config.Config{
+				Auth: config.AuthConfig{Enabled: true, Mode: "jwt"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "auth.enabled true with mode api-key is valid",
+			cfg: config.Config{
+				Auth: config.AuthConfig{Enabled: true, Mode: "api-key"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "auth.enabled true with mode none is a misconfiguration",
+			cfg: config.Config{
+				Auth: config.AuthConfig{Enabled: true, Mode: "none"},
+			},
+			wantErr:     true,
+			wantContain: "auth.enabled is true but auth.mode is \"none\"",
+		},
+		{
+			name: "auth.enabled true with empty mode is a misconfiguration",
+			cfg: config.Config{
+				Auth: config.AuthConfig{Enabled: true, Mode: ""},
+			},
+			wantErr:     true,
+			wantContain: "auth.enabled is true but auth.mode is \"none\"",
+		},
+		{
+			name: "error message suggests fix by listing accepted modes",
+			cfg: config.Config{
+				Auth: config.AuthConfig{Enabled: true, Mode: "none"},
+			},
+			wantErr:     true,
+			wantContain: "set auth.mode to \"kratos\", \"jwt\", or \"api-key\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.wantContain != "" && err != nil {
+				if !strings.Contains(err.Error(), tt.wantContain) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantContain)
+				}
+			}
+		})
+	}
+}
+
+// TestValidate_AuthModeActionable verifies that an invalid auth.mode produces a message
+// that names the accepted values and suggests the fix.
+func TestValidate_AuthModeActionable(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        string
+		wantErr     bool
+		wantContain string
+	}{
+		{name: "none is valid", mode: "none", wantErr: false},
+		{name: "kratos is valid", mode: "kratos", wantErr: false},
+		{name: "jwt is valid", mode: "jwt", wantErr: false},
+		{name: "api-key is valid", mode: "api-key", wantErr: false},
+		{name: "empty is valid", mode: "", wantErr: false},
+		{
+			name:        "oauth is rejected with accepted values",
+			mode:        "oauth",
+			wantErr:     true,
+			wantContain: "accepted values: \"none\", \"kratos\", \"jwt\", \"api-key\"",
+		},
+		{
+			name:        "error message suggests fix",
+			mode:        "oauth",
+			wantErr:     true,
+			wantContain: "set auth.mode to one of those values",
+		},
+		{
+			name:        "basic is rejected",
+			mode:        "basic",
+			wantErr:     true,
+			wantContain: "auth.mode \"basic\" is invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{Auth: config.AuthConfig{Mode: config.AuthMode(tt.mode)}}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.wantContain != "" && err != nil {
+				if !strings.Contains(err.Error(), tt.wantContain) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantContain)
+				}
+			}
+		})
+	}
+}
+
+// TestValidate_RateLimitStoreActionable verifies that an invalid rate_limit.store
+// produces a message that names the accepted values and suggests the fix.
+func TestValidate_RateLimitStoreActionable(t *testing.T) {
+	tests := []struct {
+		name        string
+		store       string
+		wantErr     bool
+		wantContain string
+	}{
+		{name: "memory is valid", store: "memory", wantErr: false},
+		{name: "redis is valid (address set)", store: "redis", wantErr: false},
+		{name: "empty is valid", store: "", wantErr: false},
+		{
+			name:        "memcached is rejected with accepted values",
+			store:       "memcached",
+			wantErr:     true,
+			wantContain: "accepted values: \"memory\", \"redis\"",
+		},
+		{
+			name:        "error message suggests fix",
+			store:       "memcached",
+			wantErr:     true,
+			wantContain: "set rate_limit.store to",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				RateLimit: config.RateLimitConfig{
+					Store: tt.store,
+					Redis: config.RateLimitRedisConfig{Address: "127.0.0.1:6379"},
+				},
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.wantContain != "" && err != nil {
+				if !strings.Contains(err.Error(), tt.wantContain) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantContain)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #501

## Summary

- Added `tls.provider` enum validation (`"self-signed"`, `"letsencrypt"`, `"external"`) in `config.Validate()`. Empty string is still accepted (Load defaults it to `"self-signed"`). Invalid values produce a message that lists accepted values and says _"set tls.provider to one of those values"_.
- Improved `tls.cert_path` / `tls.key_path` missing-field messages to suggest the exact fix (path to PEM file).
- Added a check for `auth.enabled: true` combined with `auth.mode: "none"` (or unset). This is almost always a misconfiguration — auth is enabled but no strategy is enforced. The error message names the accepted modes and suggests setting one.
- Improved `auth.mode` invalid-value message: the accepted values list now starts with `"none"` (logical default first) and appends _"set auth.mode to one of those values"_.
- Improved `rate_limit.store` invalid-value message to append a suggestion; improved the redis-address-missing message to suggest both `rate_limit.redis.address` and `rate_limit.redis.url` as fixes.
- Updated `TestLoad_NewFieldsFromFile` to add `mode: kratos` alongside `auth.enabled: true` (now required by the new rule).
- Updated `TestValidateCmd_MultipleErrors` to stop mixing `config.Validate()` errors with `validateConfig()` errors — `tls.provider` is now caught inside `config.Load()` before the CLI semantic layer runs. The comment in the test explains the split.
- Added four new table-driven test functions covering the new rules: `TestValidate_TLSProvider`, `TestValidate_AuthEnabledModeNone`, `TestValidate_AuthModeActionable`, `TestValidate_RateLimitStoreActionable`.

## Test plan

- `go build ./...` — clean
- `golangci-lint run ./...` — 0 issues
- `go test -race ./...` — all green
- `make check` — all checks passed