### PR TITLE
fix(#499): run vibewarden generate via Docker in demo targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # VibeWarden Makefile
 
-.PHONY: build test lint run docker-up docker-down observability-up observability-down grafana-open prometheus-open loki-open clean check setup-hooks demo demo-tls demo-down demo-clean deploy-demo
+.PHONY: build test lint run docker-up docker-down observability-up observability-down grafana-open prometheus-open loki-open clean check setup-hooks demo demo-build demo-tls demo-down demo-clean deploy-demo
 
 # Build variables
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -71,10 +71,20 @@ check: ## Run all quality checks (lint, build, tests)
 	cd examples/demo-app && go vet ./... && go build ./... && go test -race ./...
 	@echo "==> All checks passed!"
 
-# Start the full local demo stack
-demo: build ## Start the full local demo stack (http://localhost:8080, Grafana http://localhost:3001)
+# Build the VibeWarden Docker image locally and tag it so demo targets work
+# without pulling from ghcr.io. No Go toolchain required — Docker handles the build.
+demo-build: ## Build the VibeWarden Docker image locally (required before running demo targets)
+	docker build --tag ghcr.io/vibewarden/vibewarden:latest .
+
+# Start the full local demo stack — no Go toolchain required.
+# `vibewarden generate` runs inside the locally-built Docker image.
+demo: demo-build ## Start the full local demo stack (http://localhost:8080, Grafana http://localhost:3001)
+	docker run --rm \
+	  -v "$(CURDIR)/examples/demo-app:/work" \
+	  -w /work \
+	  ghcr.io/vibewarden/vibewarden:latest \
+	  generate
 	cd examples/demo-app && \
-	  ../../bin/vibewarden generate && \
 	  COMPOSE_PROFILES=observability \
 	  docker compose -f .vibewarden/generated/docker-compose.yml up -d
 	@echo ""
@@ -87,13 +97,17 @@ demo: build ## Start the full local demo stack (http://localhost:8080, Grafana h
 	@echo "Demo credentials: demo@vibewarden.dev / demo1234"
 	@echo "Run 'vibew secret get postgres' to retrieve generated credentials."
 
-# Start demo with TLS
-demo-tls: build ## Start the full local demo stack with self-signed TLS (https://localhost:8443)
+# Start demo with TLS — no Go toolchain required.
+demo-tls: demo-build ## Start the full local demo stack with self-signed TLS (https://localhost:8443)
+	docker run --rm \
+	  -v "$(CURDIR)/examples/demo-app:/work" \
+	  -w /work \
+	  -e VIBEWARDEN_TLS_ENABLED=true \
+	  -e VIBEWARDEN_TLS_PROVIDER=self-signed \
+	  -e VIBEWARDEN_SERVER_PORT=8443 \
+	  ghcr.io/vibewarden/vibewarden:latest \
+	  generate
 	cd examples/demo-app && \
-	  VIBEWARDEN_TLS_ENABLED=true \
-	  VIBEWARDEN_TLS_PROVIDER=self-signed \
-	  VIBEWARDEN_SERVER_PORT=8443 \
-	  ../../bin/vibewarden generate && \
 	  COMPOSE_PROFILES=observability \
 	  docker compose -f .vibewarden/generated/docker-compose.yml up -d
 	@echo ""

--- a/examples/demo-app/README.md
+++ b/examples/demo-app/README.md
@@ -14,29 +14,43 @@ This demo showcases the intended VibeWarden user workflow:
 
 Generated files are written to `.vibewarden/generated/` which is gitignored.
 
+**No Go toolchain required.** All steps use Docker.
+
 ### Quick start
 
 ```bash
-cd examples/demo-app
 make demo
-# Visit https://localhost:8443
+# Visit http://localhost:8080
 ```
+
+`make demo` builds the VibeWarden Docker image locally, runs `vibewarden generate`
+inside that image, then starts the full stack with Docker Compose.
 
 Wait ~30 seconds for the full stack to be healthy.
 
 | Service | URL | Credentials |
 |---|---|---|
-| Demo app (via VibeWarden) | https://localhost:8443 | see Demo credentials below |
+| Demo app (via VibeWarden) | http://localhost:8080 | see Demo credentials below |
 | Grafana | http://localhost:3001 | admin / admin |
 | Prometheus | http://localhost:9090 | — |
 | Kratos public API | http://localhost:4433 | — |
 | OpenBao (secrets) | http://localhost:8200 | token: see `.vibewarden/generated/.credentials` |
 
-Or step by step:
+Or step by step (from the repo root):
 
 ```bash
+# Build the VibeWarden image once
+make demo-build
+
+# Generate runtime config files
+docker run --rm \
+  -v "$(pwd)/examples/demo-app:/work" \
+  -w /work \
+  ghcr.io/vibewarden/vibewarden:latest \
+  generate
+
+# Start the stack
 cd examples/demo-app
-../../bin/vibewarden generate
 COMPOSE_PROFILES=observability \
   docker compose -f .vibewarden/generated/docker-compose.yml up -d
 ```
@@ -49,14 +63,21 @@ make demo-tls
 # Grafana: http://localhost:3001
 ```
 
-Or manually:
+Or step by step (from the repo root):
 
 ```bash
+make demo-build
+
+docker run --rm \
+  -v "$(pwd)/examples/demo-app:/work" \
+  -w /work \
+  -e VIBEWARDEN_TLS_ENABLED=true \
+  -e VIBEWARDEN_TLS_PROVIDER=self-signed \
+  -e VIBEWARDEN_SERVER_PORT=8443 \
+  ghcr.io/vibewarden/vibewarden:latest \
+  generate
+
 cd examples/demo-app
-VIBEWARDEN_TLS_ENABLED=true \
-VIBEWARDEN_TLS_PROVIDER=self-signed \
-VIBEWARDEN_SERVER_PORT=8443 \
-  ../../bin/vibewarden generate
 COMPOSE_PROFILES=observability \
   docker compose -f .vibewarden/generated/docker-compose.yml up -d
 ```


### PR DESCRIPTION
Closes #499

## Summary

- Add `make demo-build` target that builds the VibeWarden Docker image locally tagged as `ghcr.io/vibewarden/vibewarden:latest`
- Change `make demo` and `make demo-tls` to depend on `demo-build` instead of `build`, removing the Go toolchain requirement
- Both targets now invoke `vibewarden generate` via `docker run` with the local `vibewarden.yaml` mounted at `/work`
- Remove the `build` dependency from `demo` and `demo-tls` entirely — Docker handles everything
- Update `examples/demo-app/README.md` quick start and step-by-step instructions to reflect the Docker-only workflow

## Test plan

- [ ] `make check` passes (all Go tests and lint clean)
- [ ] `make demo-build` produces a local `ghcr.io/vibewarden/vibewarden:latest` image
- [ ] `make demo` completes without a Go toolchain installed (only Docker required)
- [ ] Generated `.vibewarden/generated/docker-compose.yml` references `ghcr.io/vibewarden/vibewarden:latest` which resolves to the locally-built image
- [ ] `make demo-tls` starts the stack on port 8443 with self-signed TLS
- [ ] `make demo-down` and `make demo-clean` still work unchanged