### PR TITLE
feat(#513): add --watch flag to vibew dev for config file hot-reload

### DIFF
--- a/internal/adapters/ops/compose.go
+++ b/internal/adapters/ops/compose.go
@@ -48,6 +48,22 @@ func (c *ComposeAdapter) Up(ctx context.Context, composeFile string, profiles []
 	return nil
 }
 
+// Restart runs "docker compose [-f <composeFile>] restart".
+// When composeFile is non-empty it is passed as the -f flag.
+func (c *ComposeAdapter) Restart(ctx context.Context, composeFile string) error {
+	args := []string{"compose"}
+	if composeFile != "" {
+		args = append(args, "-f", composeFile)
+	}
+	args = append(args, "restart")
+
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker compose restart: %w", err)
+	}
+	return nil
+}
+
 // Version runs "docker compose version" and returns the raw output.
 func (c *ComposeAdapter) Version(ctx context.Context) (string, error) {
 	out, err := exec.CommandContext(ctx, "docker", "compose", "version").Output()

--- a/internal/adapters/ops/watcher.go
+++ b/internal/adapters/ops/watcher.go
@@ -1,0 +1,91 @@
+package ops
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+const defaultDebounceDuration = 500 * time.Millisecond
+
+// FsnotifyWatcher implements ports.ConfigWatcher using the fsnotify library.
+// It debounces rapid successive file-write events before forwarding them to
+// the caller.
+type FsnotifyWatcher struct {
+	debounce time.Duration
+}
+
+// NewFsnotifyWatcher creates a new FsnotifyWatcher with the default 500 ms
+// debounce window.
+func NewFsnotifyWatcher() *FsnotifyWatcher {
+	return &FsnotifyWatcher{debounce: defaultDebounceDuration}
+}
+
+// NewFsnotifyWatcherWithDebounce creates a FsnotifyWatcher with a custom
+// debounce duration.  Intended for tests where a shorter window speeds up
+// execution.
+func NewFsnotifyWatcherWithDebounce(d time.Duration) *FsnotifyWatcher {
+	return &FsnotifyWatcher{debounce: d}
+}
+
+// Watch watches the file at path and sends on the returned channel each time a
+// write or create event is debounced.  The channel is closed when ctx is
+// cancelled.
+func (w *FsnotifyWatcher) Watch(ctx context.Context, path string) (<-chan struct{}, error) {
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("creating fsnotify watcher: %w", err)
+	}
+	if err := fw.Add(path); err != nil {
+		fw.Close() //nolint:errcheck
+		return nil, fmt.Errorf("watching %s: %w", path, err)
+	}
+
+	ch := make(chan struct{}, 1)
+
+	go func() {
+		defer fw.Close() //nolint:errcheck
+		defer close(ch)
+
+		var timer *time.Timer
+
+		for {
+			select {
+			case <-ctx.Done():
+				if timer != nil {
+					timer.Stop()
+				}
+				return
+
+			case event, ok := <-fw.Events:
+				if !ok {
+					return
+				}
+				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
+					// Reset the debounce timer on each new event.
+					if timer != nil {
+						timer.Stop()
+					}
+					timer = time.AfterFunc(w.debounce, func() {
+						select {
+						case ch <- struct{}{}:
+						default:
+							// A notification is already queued; drop the duplicate.
+						}
+					})
+				}
+
+			case _, ok := <-fw.Errors:
+				if !ok {
+					return
+				}
+				// Non-fatal watcher errors are silently ignored; the goroutine
+				// continues watching.
+			}
+		}
+	}()
+
+	return ch, nil
+}

--- a/internal/adapters/ops/watcher_test.go
+++ b/internal/adapters/ops/watcher_test.go
@@ -1,0 +1,147 @@
+package ops_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	opsadapter "github.com/vibewarden/vibewarden/internal/adapters/ops"
+)
+
+func TestFsnotifyWatcher_SendsEventOnWrite(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "vibewarden.yaml")
+
+	// Create the file first so the watcher can add it.
+	if err := os.WriteFile(cfgPath, []byte("initial: true\n"), 0o600); err != nil {
+		t.Fatalf("writing initial config: %v", err)
+	}
+
+	// Use a very short debounce so the test is fast.
+	w := opsadapter.NewFsnotifyWatcherWithDebounce(10 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ch, err := w.Watch(ctx, cfgPath)
+	if err != nil {
+		t.Fatalf("Watch() error: %v", err)
+	}
+
+	// Write to the file to trigger a change event.
+	if err := os.WriteFile(cfgPath, []byte("updated: true\n"), 0o600); err != nil {
+		t.Fatalf("writing updated config: %v", err)
+	}
+
+	select {
+	case _, ok := <-ch:
+		if !ok {
+			t.Fatal("channel closed before receiving event")
+		}
+		// Success — event received.
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for file-change event")
+	}
+}
+
+func TestFsnotifyWatcher_NoEventAfterCancel(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "vibewarden.yaml")
+
+	if err := os.WriteFile(cfgPath, []byte("initial: true\n"), 0o600); err != nil {
+		t.Fatalf("writing initial config: %v", err)
+	}
+
+	w := opsadapter.NewFsnotifyWatcherWithDebounce(10 * time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := w.Watch(ctx, cfgPath)
+	if err != nil {
+		t.Fatalf("Watch() error: %v", err)
+	}
+
+	// Cancel the context before any writes.
+	cancel()
+
+	// The channel should be closed shortly after cancel.
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected channel to be closed after context cancel, but received a value")
+		}
+		// Channel closed — correct.
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for channel to close after cancel")
+	}
+}
+
+func TestFsnotifyWatcher_ErrorOnMissingFile(t *testing.T) {
+	w := opsadapter.NewFsnotifyWatcher()
+	ctx := context.Background()
+
+	_, err := w.Watch(ctx, "/nonexistent/path/vibewarden.yaml")
+	if err == nil {
+		t.Fatal("Watch() expected error for missing file, got nil")
+	}
+}
+
+func TestFsnotifyWatcher_DebouncesRapidWrites(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "vibewarden.yaml")
+
+	if err := os.WriteFile(cfgPath, []byte("v: 1\n"), 0o600); err != nil {
+		t.Fatalf("writing initial config: %v", err)
+	}
+
+	// Use a 100 ms debounce window.
+	w := opsadapter.NewFsnotifyWatcherWithDebounce(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ch, err := w.Watch(ctx, cfgPath)
+	if err != nil {
+		t.Fatalf("Watch() error: %v", err)
+	}
+
+	// Write three times in rapid succession — should produce at most one event.
+	for i := 0; i < 3; i++ {
+		if err := os.WriteFile(cfgPath, []byte("v: 2\n"), 0o600); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+
+	// Wait for the debounce to fire.
+	select {
+	case _, ok := <-ch:
+		if !ok {
+			t.Fatal("channel closed unexpectedly")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for debounced event")
+	}
+
+	// There should be at most one more event queued; the channel capacity is 1
+	// so any extra events are dropped.
+	extraEvents := 0
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return
+			}
+			extraEvents++
+		case <-time.After(200 * time.Millisecond):
+			// No more events — done draining.
+			goto done
+		}
+	}
+done:
+	// We may see 0 or 1 extra event depending on timing; the important thing is
+	// we do not see more than 1 (the channel cap prevents flooding).
+	if extraEvents > 1 {
+		t.Errorf("expected at most 1 extra event after rapid writes, got %d", extraEvents)
+	}
+}

--- a/internal/app/ops/dev.go
+++ b/internal/app/ops/dev.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -17,14 +18,17 @@ const generatedOutputDir = ".vibewarden/generated"
 
 // DevService orchestrates the "vibewarden dev" use case.
 // It optionally generates runtime configuration files from vibewarden.yaml
-// before starting the Docker Compose stack.
+// before starting the Docker Compose stack and can watch the config file for
+// changes when --watch is enabled.
 type DevService struct {
 	compose   ports.ComposeRunner
 	generator ports.ConfigGenerator // optional; nil disables generation
+	watcher   ports.ConfigWatcher   // optional; nil disables file watching
 }
 
-// NewDevService creates a new DevService without config generation.
+// NewDevService creates a new DevService without config generation or file watching.
 // Use NewDevServiceWithGenerator to enable automatic config generation.
+// Use NewDevServiceWithWatcher to also enable config-file watching.
 func NewDevService(compose ports.ComposeRunner) *DevService {
 	return &DevService{compose: compose}
 }
@@ -35,16 +39,35 @@ func NewDevServiceWithGenerator(compose ports.ComposeRunner, generator ports.Con
 	return &DevService{compose: compose, generator: generator}
 }
 
+// NewDevServiceWithWatcher creates a DevService that generates config before
+// starting the stack and watches the config file for changes, re-generating and
+// restarting on each debounced change event.
+func NewDevServiceWithWatcher(compose ports.ComposeRunner, generator ports.ConfigGenerator, watcher ports.ConfigWatcher) *DevService {
+	return &DevService{compose: compose, generator: generator, watcher: watcher}
+}
+
 // DevOptions holds options for the dev command.
 type DevOptions struct {
 	// Observability enables the "observability" compose profile, which starts
 	// Prometheus and Grafana alongside the core stack.
 	Observability bool
+
+	// Watch enables file-system watching of vibewarden.yaml.  When true,
+	// any write to the config file triggers a regenerate + compose restart
+	// cycle after a 500 ms debounce window.  Requires a ConfigWatcher to be
+	// wired into the DevService.
+	Watch bool
+
+	// ConfigPath is the path to vibewarden.yaml that should be watched.
+	// When empty the default "./vibewarden.yaml" is used.
+	ConfigPath string
 }
 
 // Run generates runtime config files (when a generator is configured), then
 // starts the Docker Compose stack and prints the service URLs.
 // The cfg is used to derive service addresses for the post-start summary.
+// When opts.Watch is true and a ConfigWatcher is wired, Run also starts the
+// watch loop and blocks until ctx is cancelled.
 func (s *DevService) Run(ctx context.Context, cfg *config.Config, opts DevOptions, out io.Writer) error {
 	var profiles []string
 	if opts.Observability {
@@ -67,7 +90,55 @@ func (s *DevService) Run(ctx context.Context, cfg *config.Config, opts DevOption
 	}
 
 	printServiceURLs(cfg, opts, out)
+
+	if opts.Watch && s.watcher != nil {
+		return s.watchLoop(ctx, cfg, opts, composeFile, out)
+	}
 	return nil
+}
+
+// watchLoop watches vibewarden.yaml for changes and, on each debounced event,
+// re-generates configuration files and restarts the compose stack.
+// It blocks until ctx is cancelled.
+func (s *DevService) watchLoop(ctx context.Context, cfg *config.Config, opts DevOptions, composeFile string, out io.Writer) error {
+	configPath := opts.ConfigPath
+	if configPath == "" {
+		configPath = "vibewarden.yaml"
+	}
+
+	ch, err := s.watcher.Watch(ctx, configPath)
+	if err != nil {
+		return fmt.Errorf("starting config watcher: %w", err)
+	}
+
+	fmt.Fprintf(out, "Watching %s for changes (press Ctrl+C to stop)...\n", configPath)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case _, ok := <-ch:
+			if !ok {
+				// Channel closed — watcher stopped.
+				return nil
+			}
+			slog.Info("config changed, regenerating...")
+			fmt.Fprintln(out, "config changed, regenerating...")
+
+			if s.generator != nil {
+				if err := s.generator.Generate(ctx, cfg, generatedOutputDir); err != nil {
+					slog.Error("regeneration failed", "error", err)
+					fmt.Fprintf(out, "regeneration failed: %v\n", err)
+					continue
+				}
+			}
+
+			if err := s.compose.Restart(ctx, composeFile); err != nil {
+				slog.Error("compose restart failed", "error", err)
+				fmt.Fprintf(out, "compose restart failed: %v\n", err)
+			}
+		}
+	}
 }
 
 // resolveComposeFile determines the docker-compose.yml path to pass to

--- a/internal/app/ops/dev_test.go
+++ b/internal/app/ops/dev_test.go
@@ -15,6 +15,7 @@ import (
 // fakeCompose is a test double for ports.ComposeRunner.
 type fakeCompose struct {
 	upErr      error
+	restartErr error
 	versionStr string
 	versionErr error
 	infoErr    error
@@ -23,12 +24,18 @@ type fakeCompose struct {
 
 	capturedComposeFile string
 	capturedProfiles    []string
+	restartCalled       int
 }
 
 func (f *fakeCompose) Up(_ context.Context, composeFile string, profiles []string) error {
 	f.capturedComposeFile = composeFile
 	f.capturedProfiles = profiles
 	return f.upErr
+}
+
+func (f *fakeCompose) Restart(_ context.Context, _ string) error {
+	f.restartCalled++
+	return f.restartErr
 }
 
 func (f *fakeCompose) Version(_ context.Context) (string, error) {
@@ -48,10 +55,12 @@ type fakeGenerator struct {
 	generateErr       error
 	capturedOutputDir string
 	generateCalled    bool
+	generateCallCount int
 }
 
 func (f *fakeGenerator) Generate(_ context.Context, _ *config.Config, outputDir string) error {
 	f.generateCalled = true
+	f.generateCallCount++
 	f.capturedOutputDir = outputDir
 	return f.generateErr
 }
@@ -225,5 +234,113 @@ func TestDevService_WithGenerator_PrintsGeneratedOutputMessage(t *testing.T) {
 	out := buf.String()
 	if !strings.Contains(out, ".vibewarden/generated") {
 		t.Errorf("expected output to mention generated dir, got:\n%s", out)
+	}
+}
+
+// fakeWatcher is a test double for ports.ConfigWatcher.
+type fakeWatcher struct {
+	// ch is the channel returned by Watch. Tests send on this channel to
+	// simulate a file-change event.
+	ch       chan struct{}
+	watchErr error
+}
+
+func newFakeWatcher() *fakeWatcher {
+	return &fakeWatcher{ch: make(chan struct{}, 1)}
+}
+
+func (f *fakeWatcher) Watch(_ context.Context, _ string) (<-chan struct{}, error) {
+	if f.watchErr != nil {
+		return nil, f.watchErr
+	}
+	return f.ch, nil
+}
+
+// Ensure fakeWatcher satisfies the interface at compile time.
+var _ ports.ConfigWatcher = (*fakeWatcher)(nil)
+
+func TestDevService_Watch_PrintsWatchingMessage(t *testing.T) {
+	fc := &fakeCompose{}
+	fg := &fakeGenerator{}
+	fw := newFakeWatcher()
+	svc := ops.NewDevServiceWithWatcher(fc, fg, fw)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately so watchLoop exits right away.
+	cancel()
+
+	if err := svc.Run(ctx, cfg, ops.DevOptions{Watch: true, ConfigPath: "vibewarden.yaml"}, &buf); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Watching") {
+		t.Errorf("expected output to contain 'Watching', got:\n%s", out)
+	}
+}
+
+func TestDevService_Watch_RegeneratesAndRestartsOnChange(t *testing.T) {
+	fc := &fakeCompose{}
+	fg := &fakeGenerator{}
+	fw := newFakeWatcher()
+	svc := ops.NewDevServiceWithWatcher(fc, fg, fw)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.Run(ctx, cfg, ops.DevOptions{Watch: true, ConfigPath: "vibewarden.yaml"}, &buf)
+	}()
+
+	// Simulate one config-change event and then close the watcher channel so
+	// watchLoop exits naturally (simulates the watcher being shut down).
+	fw.ch <- struct{}{}
+	close(fw.ch)
+
+	if err := <-done; err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	if fc.restartCalled == 0 {
+		t.Error("expected Restart() to be called after a file-change event")
+	}
+	// Generate should have been called at least twice: once on startup, once on change.
+	if fg.generateCallCount < 2 {
+		t.Errorf("expected Generate() called at least 2 times, got %d", fg.generateCallCount)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "config changed, regenerating") {
+		t.Errorf("expected output to contain regenerating message, got:\n%s", out)
+	}
+}
+
+func TestDevService_Watch_WatcherSetupError_ReturnsError(t *testing.T) {
+	fc := &fakeCompose{}
+	fg := &fakeGenerator{}
+	fw := &fakeWatcher{watchErr: errors.New("inotify limit reached")}
+	svc := ops.NewDevServiceWithWatcher(fc, fg, fw)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{Watch: true, ConfigPath: "vibewarden.yaml"}, &buf)
+	if err == nil {
+		t.Fatal("Run() expected error when watcher setup fails, got nil")
+	}
+}
+
+func TestDevService_Watch_WatcherNil_DoesNotBlock(t *testing.T) {
+	// When watch=true but no watcher is wired, Run should return without blocking.
+	fc := &fakeCompose{}
+	svc := ops.NewDevService(fc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	if err := svc.Run(context.Background(), cfg, ops.DevOptions{Watch: true}, &buf); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
 	}
 }

--- a/internal/cli/cmd/dev.go
+++ b/internal/cli/cmd/dev.go
@@ -19,11 +19,13 @@ import (
 //
 // The command generates runtime config files under .vibewarden/generated/,
 // then starts the Docker Compose dev environment in detached mode and
-// prints the running service URLs. Pass --observability to also start the
-// Prometheus + Grafana observability stack.
+// prints the running service URLs.  Pass --observability to also start the
+// Prometheus + Grafana observability stack.  Pass --watch to watch
+// vibewarden.yaml for changes and auto-regenerate + restart the stack.
 func NewDevCmd() *cobra.Command {
 	var (
 		observability bool
+		watch         bool
 		configPath    string
 	)
 
@@ -42,10 +44,13 @@ The baseline stack includes:
   - Mailslurper (email sink)
 
 Pass --observability to also start Prometheus and Grafana.
+Pass --watch to watch vibewarden.yaml for changes and automatically
+regenerate config files and restart the stack (blocks until Ctrl+C).
 
 Examples:
   vibewarden dev
   vibewarden dev --observability
+  vibewarden dev --watch
   vibewarden dev --config ./my-vibewarden.yaml`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg, err := config.Load(configPath)
@@ -60,10 +65,19 @@ Examples:
 				credentialsadapter.NewGenerator(),
 				credentialsadapter.NewStore(),
 			)
-			svc := opsapp.NewDevServiceWithGenerator(compose, generator)
+
+			var svc *opsapp.DevService
+			if watch {
+				watcher := opsadapter.NewFsnotifyWatcher()
+				svc = opsapp.NewDevServiceWithWatcher(compose, generator, watcher)
+			} else {
+				svc = opsapp.NewDevServiceWithGenerator(compose, generator)
+			}
 
 			opts := opsapp.DevOptions{
 				Observability: observability,
+				Watch:         watch,
+				ConfigPath:    configPath,
 			}
 
 			return svc.Run(cmd.Context(), cfg, opts, cmd.OutOrStdout())
@@ -71,6 +85,7 @@ Examples:
 	}
 
 	cmd.Flags().BoolVar(&observability, "observability", false, "start Prometheus and Grafana alongside the core stack")
+	cmd.Flags().BoolVar(&watch, "watch", false, "watch vibewarden.yaml for changes and auto-regenerate + restart")
 	cmd.Flags().StringVar(&configPath, "config", "", "path to vibewarden.yaml (default: ./vibewarden.yaml)")
 
 	if err := cmd.RegisterFlagCompletionFunc("config", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/internal/ports/ops.go
+++ b/internal/ports/ops.go
@@ -25,6 +25,11 @@ type ComposeRunner interface {
 	// The output of the command is streamed to the caller via the returned channel.
 	Up(ctx context.Context, composeFile string, profiles []string) error
 
+	// Restart restarts all running services in the compose project.
+	// composeFile is the path to the docker-compose.yml; when empty the default
+	// discovery logic applies.
+	Restart(ctx context.Context, composeFile string) error
+
 	// Version returns the docker compose version string.
 	// Returns an error when docker compose is not available.
 	Version(ctx context.Context) (string, error)

--- a/internal/ports/watcher.go
+++ b/internal/ports/watcher.go
@@ -1,0 +1,13 @@
+package ports
+
+import "context"
+
+// ConfigWatcher watches a file for changes and notifies over a channel.
+// Implementations must debounce rapid successive events before signalling.
+type ConfigWatcher interface {
+	// Watch watches the file at path and sends on the returned channel each
+	// time a write or create event is detected.  The channel is closed when
+	// ctx is cancelled or an unrecoverable error occurs.  Watch blocks until
+	// the watcher is initialised and returns an error only on setup failure.
+	Watch(ctx context.Context, path string) (<-chan struct{}, error)
+}


### PR DESCRIPTION
Closes #513

## Summary

- Adds `--watch` flag to `vibew dev` (default: `false`, opt-in)
- New `ConfigWatcher` port (`internal/ports/watcher.go`) decouples the watch contract from the fsnotify implementation
- `FsnotifyWatcher` adapter (`internal/adapters/ops/watcher.go`) uses `github.com/fsnotify/fsnotify` (MIT, already an indirect dep via Viper; now promoted to direct)
- 500 ms debounce window prevents rapid-save noise; implemented with `time.AfterFunc` reset on each event
- On each debounced event: logs `"config changed, regenerating..."`, calls `generator.Generate`, then `compose.Restart`
- `Restart(ctx, composeFile)` added to `ComposeRunner` port and implemented in `ComposeAdapter`
- `DevService` gains `NewDevServiceWithWatcher` constructor and an internal `watchLoop` that blocks until `ctx` is cancelled or the watcher channel closes
- CLI wires `FsnotifyWatcher` only when `--watch` is set; existing code path unchanged otherwise

## Test plan

- `go test -race ./internal/app/ops/...` — unit tests for `DevService.watchLoop`: prints watching message, calls `Generate` + `Restart` on event, propagates watcher setup error, does not block when watcher is nil
- `go test -race ./internal/adapters/ops/...` — integration tests for `FsnotifyWatcher`: fires on real file write, closes channel on context cancel, returns error for missing file, debounces rapid writes
- `make check` — all 68 packages pass with `-race`

Manual smoke test:
```
vibew dev --watch
# edit vibewarden.yaml and save — observe "config changed, regenerating..." in stdout
# Ctrl+C exits cleanly
```