### PR TITLE
fix(#510): add validation, value objects, and behavior to User entity

### DIFF
--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -2,7 +2,96 @@
 // This package has zero external dependencies — only the Go standard library.
 package user
 
-import "time"
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// ------------------------------------------------------------------
+// Value objects
+// ------------------------------------------------------------------
+
+// ID is an immutable value object wrapping a Kratos identity UUID.
+// The zero value is invalid; always construct via NewID.
+type ID struct{ id string }
+
+// NewID constructs an ID, returning an error when id is empty.
+func NewID(id string) (ID, error) {
+	if strings.TrimSpace(id) == "" {
+		return ID{}, errors.New("user id cannot be empty")
+	}
+	return ID{id: id}, nil
+}
+
+// String returns the raw string representation of the ID.
+func (u ID) String() string { return u.id }
+
+// emailRegexp is a simple RFC-5321-compatible email pattern.
+// It intentionally avoids the full complexity of RFC 5321 to keep the
+// domain layer dependency-free. Exotic formats (quoted strings, IP
+// literals) are rejected — this is acceptable for VibeWarden's user base.
+var emailRegexp = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
+
+// EmailAddress is an immutable value object wrapping a validated, lower-cased
+// email address. The zero value is invalid; always construct via NewEmailAddress.
+type EmailAddress struct{ address string }
+
+// NewEmailAddress constructs an EmailAddress, normalising the address to
+// lower-case and returning an error when the format is invalid.
+func NewEmailAddress(raw string) (EmailAddress, error) {
+	normalised := strings.ToLower(strings.TrimSpace(raw))
+	if normalised == "" {
+		return EmailAddress{}, errors.New("email address cannot be empty")
+	}
+	if !emailRegexp.MatchString(normalised) {
+		return EmailAddress{}, fmt.Errorf("email address %q is not valid", normalised)
+	}
+	return EmailAddress{address: normalised}, nil
+}
+
+// String returns the normalised email address.
+func (e EmailAddress) String() string { return e.address }
+
+// Role represents the access level granted to a user within VibeWarden.
+type Role struct{ name string }
+
+var (
+	// RoleAdmin grants full administrative access to VibeWarden management APIs.
+	RoleAdmin = Role{name: "admin"}
+
+	// RoleMember grants standard authenticated access with no admin privileges.
+	RoleMember = Role{name: "member"}
+
+	// RoleReadOnly grants read-only access to resources.
+	RoleReadOnly = Role{name: "readonly"}
+)
+
+// validRoles is the set of roles that NewRole accepts.
+var validRoles = map[string]Role{
+	RoleAdmin.name:    RoleAdmin,
+	RoleMember.name:   RoleMember,
+	RoleReadOnly.name: RoleReadOnly,
+}
+
+// NewRole constructs a Role from its string name, returning an error when the
+// name does not match a known role.
+func NewRole(name string) (Role, error) {
+	r, ok := validRoles[strings.ToLower(strings.TrimSpace(name))]
+	if !ok {
+		return Role{}, fmt.Errorf("unknown role %q: must be one of admin, member, readonly", name)
+	}
+	return r, nil
+}
+
+// String returns the role name.
+func (r Role) String() string { return r.name }
+
+// ------------------------------------------------------------------
+// Status
+// ------------------------------------------------------------------
 
 // Status represents the lifecycle state of a user identity.
 // Kratos identities can be active or inactive (deactivated).
@@ -17,19 +106,63 @@ const (
 	StatusInactive Status = "inactive"
 )
 
+// ------------------------------------------------------------------
+// User entity
+// ------------------------------------------------------------------
+
 // User represents a user identity managed via the Kratos admin API.
-// It is a read-only projection — mutations are performed through the
-// UserAdmin port, not by modifying this struct directly.
+//
+// The ID, Email, and Status fields retain their string/Status types for
+// compatibility with existing adapters and serialisation code. Use NewUser
+// to create a validated instance. Mutations must go through the Disable,
+// Enable, and ChangeRole methods — never mutate fields directly.
 type User struct {
 	// ID is the Kratos identity UUID.
 	ID string
 
-	// Email is the user's primary email address.
+	// Email is the user's primary email address (lower-cased).
 	Email string
 
 	// Status is the current lifecycle state of the user.
 	Status Status
 
+	// Role is the access level granted to the user.
+	Role Role
+
 	// CreatedAt is when the identity was created in Kratos.
 	CreatedAt time.Time
+}
+
+// NewUser constructs a User entity after validating all inputs.
+// id must be non-empty. email must be a valid email address.
+// role must be one of the known roles (admin, member, readonly).
+// createdAt is the identity creation timestamp from the identity provider;
+// pass time.Time{} when unknown and it will be set to the zero value.
+func NewUser(id ID, email EmailAddress, role Role, createdAt time.Time) User {
+	return User{
+		ID:        id.String(),
+		Email:     email.String(),
+		Status:    StatusActive,
+		Role:      role,
+		CreatedAt: createdAt,
+	}
+}
+
+// Disable transitions the user to StatusInactive, preventing further
+// authentication. It is idempotent — calling Disable on an already-inactive
+// user is a no-op.
+func (u *User) Disable() {
+	u.Status = StatusInactive
+}
+
+// Enable transitions the user to StatusActive, restoring their ability to
+// authenticate. It is idempotent — calling Enable on an already-active user
+// is a no-op.
+func (u *User) Enable() {
+	u.Status = StatusActive
+}
+
+// ChangeRole updates the user's role to the given value.
+func (u *User) ChangeRole(r Role) {
+	u.Role = r
 }

--- a/internal/domain/user/user_test.go
+++ b/internal/domain/user/user_test.go
@@ -7,6 +7,134 @@ import (
 	"github.com/vibewarden/vibewarden/internal/domain/user"
 )
 
+// ------------------------------------------------------------------
+// ID (value object)
+// ------------------------------------------------------------------
+
+func TestNewID(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid uuid-like id", "550e8400-e29b-41d4-a716-446655440000", false},
+		{"valid short id", "abc-123", false},
+		{"empty string", "", true},
+		{"whitespace only", "   ", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := user.NewID(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewID(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && got.String() != tt.input {
+				t.Errorf("NewID(%q).String() = %q, want %q", tt.input, got.String(), tt.input)
+			}
+		})
+	}
+}
+
+func TestID_String(t *testing.T) {
+	id, err := user.NewID("usr-42")
+	if err != nil {
+		t.Fatalf("NewID: unexpected error: %v", err)
+	}
+	if id.String() != "usr-42" {
+		t.Errorf("String() = %q, want %q", id.String(), "usr-42")
+	}
+}
+
+// ------------------------------------------------------------------
+// EmailAddress
+// ------------------------------------------------------------------
+
+func TestNewEmailAddress(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantAddr string
+		wantErr  bool
+	}{
+		{"valid lowercase", "alice@example.com", "alice@example.com", false},
+		{"valid uppercase normalised", "Alice@Example.COM", "alice@example.com", false},
+		{"valid with plus", "alice+tag@example.com", "alice+tag@example.com", false},
+		{"valid with subdomain", "user@mail.example.co.uk", "user@mail.example.co.uk", false},
+		{"empty string", "", "", true},
+		{"whitespace only", "   ", "", true},
+		{"missing at sign", "notanemail", "", true},
+		{"missing domain", "user@", "", true},
+		{"missing local part", "@example.com", "", true},
+		{"missing tld", "user@example", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := user.NewEmailAddress(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewEmailAddress(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && got.String() != tt.wantAddr {
+				t.Errorf("NewEmailAddress(%q).String() = %q, want %q", tt.input, got.String(), tt.wantAddr)
+			}
+		})
+	}
+}
+
+// ------------------------------------------------------------------
+// Role
+// ------------------------------------------------------------------
+
+func TestNewRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantRole user.Role
+		wantErr  bool
+	}{
+		{"admin lowercase", "admin", user.RoleAdmin, false},
+		{"member lowercase", "member", user.RoleMember, false},
+		{"readonly lowercase", "readonly", user.RoleReadOnly, false},
+		{"admin uppercase", "ADMIN", user.RoleAdmin, false},
+		{"mixed case member", "Member", user.RoleMember, false},
+		{"unknown role", "superuser", user.Role{}, true},
+		{"empty string", "", user.Role{}, true},
+		{"whitespace only", "  ", user.Role{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := user.NewRole(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewRole(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && got.String() != tt.wantRole.String() {
+				t.Errorf("NewRole(%q).String() = %q, want %q", tt.input, got.String(), tt.wantRole.String())
+			}
+		})
+	}
+}
+
+func TestRole_String(t *testing.T) {
+	tests := []struct {
+		role user.Role
+		want string
+	}{
+		{user.RoleAdmin, "admin"},
+		{user.RoleMember, "member"},
+		{user.RoleReadOnly, "readonly"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if tt.role.String() != tt.want {
+				t.Errorf("Role.String() = %q, want %q", tt.role.String(), tt.want)
+			}
+		})
+	}
+}
+
+// ------------------------------------------------------------------
+// Status constants
+// ------------------------------------------------------------------
+
 func TestStatusConstants(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -25,7 +153,155 @@ func TestStatusConstants(t *testing.T) {
 	}
 }
 
-func TestUserStruct(t *testing.T) {
+// ------------------------------------------------------------------
+// NewUser constructor
+// ------------------------------------------------------------------
+
+func TestNewUser(t *testing.T) {
+	id, _ := user.NewID("550e8400-e29b-41d4-a716-446655440000")
+	email, _ := user.NewEmailAddress("alice@example.com")
+	now := time.Now().UTC().Truncate(time.Second)
+
+	u := user.NewUser(id, email, user.RoleAdmin, now)
+
+	if u.ID != id.String() {
+		t.Errorf("ID = %q, want %q", u.ID, id.String())
+	}
+	if u.Email != email.String() {
+		t.Errorf("Email = %q, want %q", u.Email, email.String())
+	}
+	if u.Status != user.StatusActive {
+		t.Errorf("Status = %q, want %q", u.Status, user.StatusActive)
+	}
+	if u.Role.String() != user.RoleAdmin.String() {
+		t.Errorf("Role = %q, want %q", u.Role.String(), user.RoleAdmin.String())
+	}
+	if !u.CreatedAt.Equal(now) {
+		t.Errorf("CreatedAt = %v, want %v", u.CreatedAt, now)
+	}
+}
+
+func TestNewUser_DefaultsToActive(t *testing.T) {
+	id, _ := user.NewID("id-1")
+	email, _ := user.NewEmailAddress("bob@example.com")
+
+	u := user.NewUser(id, email, user.RoleMember, time.Time{})
+
+	if u.Status != user.StatusActive {
+		t.Errorf("new user status = %q, want active", u.Status)
+	}
+}
+
+// ------------------------------------------------------------------
+// User.Disable / Enable
+// ------------------------------------------------------------------
+
+func TestUser_Disable(t *testing.T) {
+	id, _ := user.NewID("id-1")
+	email, _ := user.NewEmailAddress("charlie@example.com")
+	u := user.NewUser(id, email, user.RoleMember, time.Now())
+
+	if u.Status != user.StatusActive {
+		t.Fatalf("pre-condition: expected active, got %q", u.Status)
+	}
+
+	u.Disable()
+
+	if u.Status != user.StatusInactive {
+		t.Errorf("after Disable(): Status = %q, want inactive", u.Status)
+	}
+}
+
+func TestUser_Disable_Idempotent(t *testing.T) {
+	id, _ := user.NewID("id-1")
+	email, _ := user.NewEmailAddress("charlie@example.com")
+	u := user.NewUser(id, email, user.RoleMember, time.Now())
+
+	u.Disable()
+	u.Disable() // second call must not panic or change state
+
+	if u.Status != user.StatusInactive {
+		t.Errorf("after double Disable(): Status = %q, want inactive", u.Status)
+	}
+}
+
+func TestUser_Enable(t *testing.T) {
+	id, _ := user.NewID("id-1")
+	email, _ := user.NewEmailAddress("dave@example.com")
+	u := user.NewUser(id, email, user.RoleMember, time.Now())
+	u.Disable()
+
+	u.Enable()
+
+	if u.Status != user.StatusActive {
+		t.Errorf("after Enable(): Status = %q, want active", u.Status)
+	}
+}
+
+func TestUser_Enable_Idempotent(t *testing.T) {
+	id, _ := user.NewID("id-1")
+	email, _ := user.NewEmailAddress("dave@example.com")
+	u := user.NewUser(id, email, user.RoleMember, time.Now())
+
+	u.Enable()
+	u.Enable() // second call must not panic
+
+	if u.Status != user.StatusActive {
+		t.Errorf("after double Enable(): Status = %q, want active", u.Status)
+	}
+}
+
+func TestUser_DisableEnable_Roundtrip(t *testing.T) {
+	id, _ := user.NewID("id-1")
+	email, _ := user.NewEmailAddress("eve@example.com")
+	u := user.NewUser(id, email, user.RoleMember, time.Now())
+
+	u.Disable()
+	u.Enable()
+
+	if u.Status != user.StatusActive {
+		t.Errorf("after Disable→Enable: Status = %q, want active", u.Status)
+	}
+}
+
+// ------------------------------------------------------------------
+// User.ChangeRole
+// ------------------------------------------------------------------
+
+func TestUser_ChangeRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  user.Role
+		newRole  user.Role
+		expected string
+	}{
+		{"member to admin", user.RoleMember, user.RoleAdmin, "admin"},
+		{"admin to readonly", user.RoleAdmin, user.RoleReadOnly, "readonly"},
+		{"readonly to member", user.RoleReadOnly, user.RoleMember, "member"},
+		{"same role is idempotent", user.RoleMember, user.RoleMember, "member"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, _ := user.NewID("id-1")
+			email, _ := user.NewEmailAddress("frank@example.com")
+			u := user.NewUser(id, email, tt.initial, time.Now())
+
+			u.ChangeRole(tt.newRole)
+
+			if u.Role.String() != tt.expected {
+				t.Errorf("after ChangeRole: Role = %q, want %q", u.Role.String(), tt.expected)
+			}
+		})
+	}
+}
+
+// ------------------------------------------------------------------
+// Backward-compat: direct struct literal still compiles
+// ------------------------------------------------------------------
+
+func TestUserStruct_DirectLiteral(t *testing.T) {
+	// Existing adapters and tests construct user.User directly.
+	// This test verifies those call sites continue to compile and work.
 	now := time.Now().UTC().Truncate(time.Second)
 	u := user.User{
 		ID:        "abc-123",


### PR DESCRIPTION
Closes #510

## Summary

- Adds three value objects to `internal/domain/user/`:
  - `user.ID` — immutable wrapper for a Kratos identity UUID; rejects empty/whitespace values
  - `user.EmailAddress` — normalises to lower-case and validates against a regex; rejects malformed addresses
  - `user.Role` — typed constant set (`admin`, `member`, `readonly`) with `NewRole` for case-insensitive construction
- Adds `NewUser(id ID, email EmailAddress, role Role, createdAt time.Time) User` — the canonical validated constructor; new users always start as `StatusActive`
- Adds `Role Role` field to the `User` entity
- Adds `Disable()`, `Enable()`, and `ChangeRole()` methods; all three are idempotent
- Preserves the existing `ID string`, `Email string`, and `Status` fields so all adapter and test call sites remain unmodified

## Test plan

- 28 table-driven unit tests covering: `NewID`, `NewEmailAddress`, `NewRole`, `NewUser`, `Disable`/`Enable` idempotency, `ChangeRole`, and backward-compat struct literal construction
- `make check` passes (gofmt, golangci-lint, go build, go test -race, demo-app)