### PR TITLE
fix(#526): extract IP filter domain logic into domain/ipfilter

### DIFF
--- a/internal/adapters/caddy/ipfilter_handler.go
+++ b/internal/adapters/caddy/ipfilter_handler.go
@@ -3,7 +3,6 @@ package caddy
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -16,6 +15,7 @@ import (
 	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
 	"github.com/vibewarden/vibewarden/internal/domain/audit"
 	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/domain/ipfilter"
 	"github.com/vibewarden/vibewarden/internal/middleware"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
@@ -56,9 +56,8 @@ type IPFilterHandler struct {
 	// Config holds the handler configuration populated by Caddy's JSON unmarshaller.
 	Config IPFilterHandlerConfig `json:"config"`
 
-	// nets and ips hold the parsed address entries. Built during Provision.
-	nets []*net.IPNet
-	ips  []net.IP
+	// list holds the parsed address entries. Built during Provision.
+	list ipfilter.List
 
 	// logger is used to emit error messages when event logging fails.
 	logger *slog.Logger
@@ -79,40 +78,29 @@ func (IPFilterHandler) CaddyModule() gocaddy.ModuleInfo {
 }
 
 // Provision implements gocaddy.Provisioner. It parses all configured address
-// strings into net.IP and *net.IPNet values for efficient per-request matching.
+// strings into an ipfilter.List for efficient per-request matching.
 func (h *IPFilterHandler) Provision(_ gocaddy.Context) error {
 	h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	h.eventLogger = logadapter.NewSlogEventLogger(os.Stdout)
 	h.auditLogger = auditadapter.NewJSONWriter(os.Stdout)
 
-	h.nets = h.nets[:0]
-	h.ips = h.ips[:0]
-
-	for _, addr := range h.Config.Addresses {
-		if _, ipNet, err := net.ParseCIDR(addr); err == nil {
-			h.nets = append(h.nets, ipNet)
-			continue
-		}
-		if ip := net.ParseIP(addr); ip != nil {
-			h.ips = append(h.ips, ip)
-			continue
-		}
-		return fmt.Errorf("ip_filter: %q is not a valid IP address or CIDR", addr)
+	list, err := ipfilter.ParseList(h.Config.Addresses)
+	if err != nil {
+		return err
 	}
+	h.list = list
 
 	return nil
 }
 
 // ServeHTTP implements caddyhttp.MiddlewareHandler.
-// It extracts the client IP, evaluates the filter rule, and either blocks the
-// request with 403 or delegates to the next handler.
+// It extracts the client IP, delegates blocking logic to the domain package,
+// and either blocks the request with 403 or delegates to the next handler.
 func (h *IPFilterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	clientIP := middleware.ExtractClientIP(r, h.Config.TrustProxyHeaders)
 
 	ip := net.ParseIP(clientIP)
-	matched := h.matchesAny(ip)
-
-	blocked := h.isBlocked(matched)
+	blocked := ipfilter.IsBlocked(ip, h.list, ipfilter.Mode(h.Config.Mode))
 	if blocked {
 		h.emitBlockedEvent(r.Context(), clientIP, r.Method, r.URL.Path)
 		h.emitAuditBlockedEvent(r.Context(), clientIP, r.Method, r.URL.Path)
@@ -121,37 +109,6 @@ func (h *IPFilterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next
 	}
 
 	return next.ServeHTTP(w, r)
-}
-
-// matchesAny returns true when ip matches any configured address or CIDR.
-// A nil ip never matches.
-func (h *IPFilterHandler) matchesAny(ip net.IP) bool {
-	if ip == nil {
-		return false
-	}
-	for _, known := range h.ips {
-		if known.Equal(ip) {
-			return true
-		}
-	}
-	for _, cidr := range h.nets {
-		if cidr.Contains(ip) {
-			return true
-		}
-	}
-	return false
-}
-
-// isBlocked evaluates whether a request should be blocked given the match result.
-// In allowlist mode a non-matching IP is blocked.
-// In blocklist mode a matching IP is blocked.
-func (h *IPFilterHandler) isBlocked(matched bool) bool {
-	switch h.Config.Mode {
-	case "allowlist":
-		return !matched
-	default: // "blocklist" and any unrecognised value
-		return matched
-	}
 }
 
 // emitBlockedEvent emits a structured ip_filter.blocked event. Errors are

--- a/internal/domain/ipfilter/matcher.go
+++ b/internal/domain/ipfilter/matcher.go
@@ -1,0 +1,81 @@
+// Package ipfilter contains pure domain logic for IP-based access control.
+// It has no external dependencies — only the Go standard library.
+package ipfilter
+
+import (
+	"fmt"
+	"net"
+)
+
+// Mode represents the IP filter operating mode.
+type Mode string
+
+const (
+	// ModeAllowlist permits only requests from addresses in the configured list.
+	// Any IP not in the list is blocked.
+	ModeAllowlist Mode = "allowlist"
+
+	// ModeBlocklist blocks requests from addresses in the configured list.
+	// Any IP not in the list is permitted. This is the default/fallback mode.
+	ModeBlocklist Mode = "blocklist"
+)
+
+// List is a parsed, immutable set of IP addresses and CIDR ranges used for
+// matching. Construct one with ParseList; the zero value matches nothing.
+type List struct {
+	nets []*net.IPNet
+	ips  []net.IP
+}
+
+// ParseList parses a slice of address strings (plain IPs or CIDR notation) into
+// a List. It returns an error if any entry cannot be parsed as either form.
+func ParseList(addresses []string) (List, error) {
+	var l List
+	for _, addr := range addresses {
+		if _, ipNet, err := net.ParseCIDR(addr); err == nil {
+			l.nets = append(l.nets, ipNet)
+			continue
+		}
+		if ip := net.ParseIP(addr); ip != nil {
+			l.ips = append(l.ips, ip)
+			continue
+		}
+		return List{}, fmt.Errorf("ipfilter: %q is not a valid IP address or CIDR", addr)
+	}
+	return l, nil
+}
+
+// MatchesAny reports whether ip matches any entry in the list.
+// A nil ip always returns false.
+func (l List) MatchesAny(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	for _, known := range l.ips {
+		if known.Equal(ip) {
+			return true
+		}
+	}
+	for _, cidr := range l.nets {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsBlocked reports whether a request from ip should be blocked, given the
+// filter mode.
+//
+//   - ModeAllowlist: the IP is blocked when it does NOT appear in the list.
+//   - ModeBlocklist (and any unrecognised value): the IP is blocked when it
+//     DOES appear in the list.
+func IsBlocked(ip net.IP, list List, mode Mode) bool {
+	matched := list.MatchesAny(ip)
+	switch mode {
+	case ModeAllowlist:
+		return !matched
+	default: // ModeBlocklist and any unrecognised value
+		return matched
+	}
+}

--- a/internal/domain/ipfilter/matcher_test.go
+++ b/internal/domain/ipfilter/matcher_test.go
@@ -1,0 +1,205 @@
+package ipfilter_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/domain/ipfilter"
+)
+
+// TestParseList_Valid verifies that valid IP and CIDR strings are accepted.
+func TestParseList_Valid(t *testing.T) {
+	tests := []struct {
+		name      string
+		addresses []string
+	}{
+		{"empty list", []string{}},
+		{"single IPv4", []string{"192.168.1.1"}},
+		{"IPv4 CIDR", []string{"10.0.0.0/8"}},
+		{"single IPv6", []string{"2001:db8::1"}},
+		{"IPv6 CIDR", []string{"2001:db8::/32"}},
+		{"mixed", []string{"10.0.0.0/8", "192.168.1.100", "2001:db8::/32"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ipfilter.ParseList(tt.addresses)
+			if err != nil {
+				t.Errorf("ParseList(%v) unexpected error: %v", tt.addresses, err)
+			}
+		})
+	}
+}
+
+// TestParseList_Invalid verifies that an unparseable entry returns an error.
+func TestParseList_Invalid(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+	}{
+		{"hostname", "example.com"},
+		{"garbage", "not-an-ip"},
+		{"partial CIDR", "10.0.0/8"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ipfilter.ParseList([]string{tt.address})
+			if err == nil {
+				t.Errorf("ParseList([%q]) expected error, got nil", tt.address)
+			}
+		})
+	}
+}
+
+// TestList_MatchesAny verifies IP matching logic for both plain IPs and CIDRs.
+func TestList_MatchesAny(t *testing.T) {
+	tests := []struct {
+		name      string
+		addresses []string
+		clientIP  string
+		want      bool
+	}{
+		{"exact IPv4 match", []string{"192.168.1.100"}, "192.168.1.100", true},
+		{"exact IPv4 no match", []string{"192.168.1.100"}, "192.168.1.101", false},
+		{"IPv4 CIDR match", []string{"10.0.0.0/8"}, "10.255.255.254", true},
+		{"IPv4 CIDR no match", []string{"10.0.0.0/8"}, "11.0.0.1", false},
+		{"empty list", []string{}, "10.0.0.1", false},
+		{"IPv6 exact match", []string{"2001:db8::1"}, "2001:db8::1", true},
+		{"IPv6 exact no match", []string{"2001:db8::1"}, "2001:db8::2", false},
+		{"IPv6 CIDR match", []string{"2001:db8::/32"}, "2001:db8::cafe", true},
+		{"IPv6 CIDR no match", []string{"2001:db8::/32"}, "2001:db9::1", false},
+		{"nil ip", []string{"192.168.1.1"}, "", false}, // handled specially below
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list, err := ipfilter.ParseList(tt.addresses)
+			if err != nil {
+				t.Fatalf("ParseList() error: %v", err)
+			}
+
+			var ip net.IP
+			if tt.clientIP != "" {
+				ip = net.ParseIP(tt.clientIP)
+				if ip == nil {
+					t.Fatalf("test setup: net.ParseIP(%q) returned nil", tt.clientIP)
+				}
+			}
+
+			got := list.MatchesAny(ip)
+			if got != tt.want {
+				t.Errorf("MatchesAny(%q) = %v, want %v", tt.clientIP, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestList_MatchesAny_NilIP verifies that a nil net.IP never matches.
+func TestList_MatchesAny_NilIP(t *testing.T) {
+	list, err := ipfilter.ParseList([]string{"192.168.1.1", "10.0.0.0/8"})
+	if err != nil {
+		t.Fatalf("ParseList() error: %v", err)
+	}
+	if list.MatchesAny(nil) {
+		t.Error("MatchesAny(nil) = true, want false")
+	}
+}
+
+// TestIsBlocked_Blocklist verifies IsBlocked in blocklist mode.
+func TestIsBlocked_Blocklist(t *testing.T) {
+	tests := []struct {
+		name      string
+		addresses []string
+		clientIP  string
+		want      bool
+	}{
+		{"IP in list — blocked", []string{"10.0.0.1"}, "10.0.0.1", true},
+		{"IP in CIDR — blocked", []string{"10.0.0.0/8"}, "10.1.2.3", true},
+		{"IP not in list — allowed", []string{"10.0.0.1"}, "203.0.113.5", false},
+		{"empty list — all allowed", []string{}, "10.0.0.1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list, err := ipfilter.ParseList(tt.addresses)
+			if err != nil {
+				t.Fatalf("ParseList() error: %v", err)
+			}
+			ip := net.ParseIP(tt.clientIP)
+			if ip == nil {
+				t.Fatalf("test setup: net.ParseIP(%q) returned nil", tt.clientIP)
+			}
+
+			got := ipfilter.IsBlocked(ip, list, ipfilter.ModeBlocklist)
+			if got != tt.want {
+				t.Errorf("IsBlocked(%q, blocklist) = %v, want %v", tt.clientIP, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsBlocked_Allowlist verifies IsBlocked in allowlist mode.
+func TestIsBlocked_Allowlist(t *testing.T) {
+	tests := []struct {
+		name      string
+		addresses []string
+		clientIP  string
+		want      bool
+	}{
+		{"IP in list — allowed", []string{"203.0.113.5"}, "203.0.113.5", false},
+		{"IP in CIDR — allowed", []string{"203.0.113.0/24"}, "203.0.113.42", false},
+		{"IP not in list — blocked", []string{"203.0.113.5"}, "192.168.1.100", true},
+		{"empty list — all blocked", []string{}, "203.0.113.5", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list, err := ipfilter.ParseList(tt.addresses)
+			if err != nil {
+				t.Fatalf("ParseList() error: %v", err)
+			}
+			ip := net.ParseIP(tt.clientIP)
+			if ip == nil {
+				t.Fatalf("test setup: net.ParseIP(%q) returned nil", tt.clientIP)
+			}
+
+			got := ipfilter.IsBlocked(ip, list, ipfilter.ModeAllowlist)
+			if got != tt.want {
+				t.Errorf("IsBlocked(%q, allowlist) = %v, want %v", tt.clientIP, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsBlocked_UnknownMode verifies that an unrecognised mode falls back to
+// blocklist semantics (matching IP is blocked).
+func TestIsBlocked_UnknownMode(t *testing.T) {
+	list, err := ipfilter.ParseList([]string{"10.0.0.1"})
+	if err != nil {
+		t.Fatalf("ParseList() error: %v", err)
+	}
+	ip := net.ParseIP("10.0.0.1")
+
+	// Unknown mode should behave like blocklist: IP in list => blocked.
+	if !ipfilter.IsBlocked(ip, list, ipfilter.Mode("unknown")) {
+		t.Error("IsBlocked with unknown mode and IP in list = false, want true (blocklist fallback)")
+	}
+}
+
+// TestIsBlocked_NilIP verifies that a nil IP is never blocked in blocklist mode
+// (nil never matches) and is always blocked in allowlist mode (nil never
+// matches the allowlist).
+func TestIsBlocked_NilIP(t *testing.T) {
+	list, err := ipfilter.ParseList([]string{"10.0.0.1"})
+	if err != nil {
+		t.Fatalf("ParseList() error: %v", err)
+	}
+
+	if ipfilter.IsBlocked(nil, list, ipfilter.ModeBlocklist) {
+		t.Error("IsBlocked(nil, blocklist) = true, want false (nil never matches)")
+	}
+	if !ipfilter.IsBlocked(nil, list, ipfilter.ModeAllowlist) {
+		t.Error("IsBlocked(nil, allowlist) = false, want true (nil never in allowlist)")
+	}
+}


### PR DESCRIPTION
Closes #526

## Summary

- Created `internal/domain/ipfilter/matcher.go` with two exported types and two pure functions:
  - `ParseList(addresses []string) (List, error)` — parses IP strings and CIDR ranges into an immutable `List`
  - `List.MatchesAny(ip net.IP) bool` — reports whether an IP matches any entry in the list
  - `IsBlocked(ip net.IP, list List, mode Mode) bool` — applies allowlist/blocklist semantics
- Removed inline CIDR-parsing loop and `matchesAny`/`isBlocked` methods from `IPFilterHandler`
- `Provision` now calls `ipfilter.ParseList`; `ServeHTTP` now calls `ipfilter.IsBlocked`
- Added table-driven tests in `internal/domain/ipfilter/matcher_test.go` covering valid/invalid parse, nil IP, both modes, unknown mode fallback

Pure refactor — no behaviour change.

## Test plan

- `go test ./internal/domain/ipfilter/...` — all domain unit tests pass
- `go test ./internal/adapters/caddy/...` — all existing handler tests pass unchanged
- `make check` — lint, build, race tests, demo-app all green