### PR TITLE
fix(#525): migrate docs site diagrams from ASCII to Mermaid

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,16 +12,11 @@ the codebase, and how Caddy is embedded.
 VibeWarden always runs **on the same machine as your app**. It is never hosted
 on a remote server.
 
-```
-[Internet]
-     │
-     │ :8080 (HTTP) or :443 (HTTPS)
-     ▼
-[VibeWarden]   ←── vibewarden.yaml
-     │
-     │ localhost (e.g., :3000)
-     ▼
-[Your App]
+```mermaid
+flowchart TD
+    Internet["Internet"] -->|":8080 HTTP / :443 HTTPS"| VW["VibeWarden"]
+    Config["vibewarden.yaml"] -.->|config| VW
+    VW -->|"localhost :3000"| App["Your App"]
 ```
 
 The sidecar intercepts all inbound traffic, applies the configured middleware
@@ -35,47 +30,21 @@ redaction.
 
 Every inbound request passes through the following ordered chain:
 
-```
-Request
-   │
-   ▼  1. IP filter
-   │     Allowlist or blocklist by IP/CIDR.
-   │
-   ▼  2. Body size limit
-   │     Global and per-path maximum request body sizes.
-   │
-   ▼  3. Rate limiter — per-IP
-   │     Token-bucket, in-memory or Redis-backed.
-   │
-   ▼  4. WAF
-   │     Pattern matching for SQLi, XSS, path traversal.
-   │     Modes: detect (log only) or block (return 403).
-   │
-   ▼  5. Content-Type validation
-   │     Rejects unexpected media types (optional).
-   │
-   ▼  6. Authentication
-   │     JWT/OIDC bearer token, Kratos session cookie,
-   │     or API key. Injects user identity headers.
-   │
-   ▼  7. Rate limiter — per-user
-   │     Applied only to authenticated requests.
-   │
-   ▼  8. Secret injection
-   │     Fetches secrets from OpenBao and injects them
-   │     as request headers before forwarding.
-   │
-   ▼  9. Reverse proxy (Caddy)
-   │     Forwards the request to the upstream app.
-   │
-   ▼ 10. Security headers
-   │     Added to the upstream response:
-   │     HSTS, CSP, X-Frame-Options, Referrer-Policy, etc.
-   │
-   ▼ 11. Audit log
-         Structured event emitted for every security-relevant action.
-
-Response
+```mermaid
+flowchart TD
+    Req(["Request"]) --> s1
+    s1["1. IP filter\nAllowlist or blocklist by IP/CIDR"] --> s2
+    s2["2. Body size limit\nGlobal and per-path maximum sizes"] --> s3
+    s3["3. Rate limiter — per-IP\nToken-bucket, in-memory or Redis-backed"] --> s4
+    s4["4. WAF\nSQLi, XSS, path traversal\ndetect (log) or block (403)"] --> s5
+    s5["5. Content-Type validation\nRejects unexpected media types (optional)"] --> s6
+    s6["6. Authentication\nJWT/OIDC, Kratos session, or API key\nInjects user identity headers"] --> s7
+    s7["7. Rate limiter — per-user\nApplied only to authenticated requests"] --> s8
+    s8["8. Secret injection\nFetches from OpenBao, injects as request headers"] --> s9
+    s9["9. Reverse proxy (Caddy)\nForwards request to upstream app"] --> s10
+    s10["10. Security headers\nHSTS, CSP, X-Frame-Options, Referrer-Policy, …"] --> s11
+    s11["11. Audit log\nStructured event emitted for every security-relevant action"] --> Resp
+    Resp(["Response"])
 ```
 
 Plugins that are disabled in `vibewarden.yaml` are skipped entirely — no
@@ -128,27 +97,16 @@ plugin API.
 VibeWarden's codebase is organized around the hexagonal architecture (ports and
 adapters) pattern combined with domain-driven design (DDD).
 
-```
-┌─────────────────────────────────────────────┐
-│                  Domain layer               │
-│  Pure Go — zero external dependencies       │
-│  Entities, value objects, domain events     │
-└────────────────────┬────────────────────────┘
-                     │
-      ┌──────────────▼──────────────┐
-      │         Ports layer         │
-      │  Interfaces (inbound +      │
-      │  outbound) — no impl here   │
-      └──────┬───────────────┬──────┘
-             │               │
-   ┌─────────▼──────┐  ┌─────▼─────────────┐
-   │ Application    │  │   Adapters         │
-   │ services       │  │   (implementations)│
-   │ (use cases)    │  │                    │
-   └────────────────┘  │ caddy/  postgres/  │
-                       │ kratos/ openbao/   │
-                       │ redis/  webhook/   │
-                       └───────────────────┘
+```mermaid
+flowchart TD
+    Domain["Domain layer\nPure Go — zero external dependencies\nEntities, value objects, domain events"]
+    Ports["Ports layer\nInterfaces (inbound + outbound)\nNo implementations here"]
+    App["Application services\nUse cases — orchestrate domain + ports"]
+    Adapters["Adapters (implementations)\ncaddy / postgres / kratos\nopenbao / redis / webhook"]
+
+    Domain --> Ports
+    Ports --> App
+    Ports --> Adapters
 ```
 
 ### Directory layout

--- a/docs/egress.md
+++ b/docs/egress.md
@@ -22,25 +22,25 @@ and full structured-event observability — all without any code changes to your
 
 ## Architecture
 
-```
-Your App :3000
-     |
-     |  HTTP_PROXY=http://127.0.0.1:8081
-     |
-     v
-Egress Proxy :8081  (VibeWarden)
-     |
-     |--- DNS resolve + SSRF check
-     |--- Route match + policy enforce
-     |--- Secret injection (OpenBao)
-     |--- Rate limit check
-     |--- Circuit breaker check
-     |--- PII redaction
-     |--- mTLS handshake (optional)
-     |
-     +---> api.stripe.com (HTTPS)
-     +---> api.github.com (HTTPS)
-     +---> payments.internal (private net, if allowed)
+```mermaid
+sequenceDiagram
+    participant App as Your App :3000
+    participant Proxy as Egress Proxy :8081 (VibeWarden)
+    participant Ext1 as api.stripe.com
+    participant Ext2 as api.github.com
+    participant Ext3 as payments.internal
+
+    App->>Proxy: HTTP_PROXY=http://127.0.0.1:8081
+    Note over Proxy: DNS resolve + SSRF check
+    Note over Proxy: Route match + policy enforce
+    Note over Proxy: Secret injection (OpenBao)
+    Note over Proxy: Rate limit check
+    Note over Proxy: Circuit breaker check
+    Note over Proxy: PII redaction
+    Note over Proxy: mTLS handshake (optional)
+    Proxy->>Ext1: HTTPS (if route matches)
+    Proxy->>Ext2: HTTPS (if route matches)
+    Proxy->>Ext3: private net (if allowed)
 ```
 
 In transparent mode the app sets the `HTTP_PROXY` environment variable and all
@@ -216,12 +216,12 @@ routes:
 
 State transitions:
 
-```
-Closed ──(threshold failures)──> Open ──(reset_after)──> Half-Open
-  ^                                                           |
-  └──────────────── probe succeeds ──────────────────────────┘
-                           |
-            probe fails → back to Open
+```mermaid
+flowchart LR
+    Closed -->|"threshold failures"| Open
+    Open -->|"reset_after elapsed"| HalfOpen["Half-Open"]
+    HalfOpen -->|"probe succeeds"| Closed
+    HalfOpen -->|"probe fails"| Open
 ```
 
 Structured events emitted:

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,21 +37,22 @@ Your app on port 3000 is now behind VibeWarden at `https://localhost:8443`. Done
 
 ## How It Works
 
-```
-             ┌────────────────────────────────┐
-Internet ────►│  VibeWarden  :8443 (HTTPS)     │
-             │                                │
-             │  TLS termination               │
-             │  Authentication (JWT / Kratos) │
-             │  Rate limiting (IP + user)     │
-             │  WAF (SQLi, XSS, traversal)    │
-             │  Security headers              │
-             │  Secret injection              │
-             │  AI-readable audit logs        │
-             └───────────────┬────────────────┘
-                             │ localhost
-                             ▼
-                    Your App  :3000
+```mermaid
+flowchart LR
+    Internet["Internet"] --> VW
+
+    subgraph VW["VibeWarden :8443 (HTTPS)"]
+        direction TB
+        tls["TLS termination"]
+        auth["Authentication (JWT / Kratos)"]
+        rl["Rate limiting (IP + user)"]
+        waf["WAF (SQLi, XSS, traversal)"]
+        sh["Security headers"]
+        si["Secret injection"]
+        al["AI-readable audit logs"]
+    end
+
+    VW -->|localhost| App["Your App :3000"]
 ```
 
 VibeWarden is a **local sidecar** — it always runs on the same machine as your app.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,11 +40,16 @@ extra_css:
 
 plugins:
   - search
+  - mermaid2
 
 markdown_extensions:
   - admonition
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span


### PR DESCRIPTION
Closes #525

## Summary

- Enable the `mermaid2` MkDocs plugin in `mkdocs.yml` and configure `pymdownx.superfences` with a `custom_fences` entry for `mermaid`, so fenced code blocks tagged `mermaid` are rendered by the Mermaid JS library in the Material theme.
- Replace the ASCII architecture overview in `docs/index.md` with a `flowchart LR` diagram.
- Replace three ASCII diagrams in `docs/architecture.md` (sidecar model, middleware stack, hexagonal architecture) with `flowchart TD` diagrams.
- Replace two ASCII diagrams in `docs/egress.md` (ingress/egress request flow, circuit-breaker state machine) with a `sequenceDiagram` and a `flowchart LR` respectively.
- `README.md` ASCII diagrams are intentionally left as-is — not all Markdown viewers render Mermaid.

## Test plan

- [ ] `go build ./...`, `go vet ./...`, `go test -race ./...` all pass (pre-push hook verified this).
- [ ] `pip install mkdocs-material mkdocs-mermaid2-plugin && mkdocs serve` renders all diagrams correctly in the browser.
- [ ] README.md still displays ASCII diagrams correctly on GitHub.
