### PR TITLE
fix(#528): declare middleware as the inbound application layer

### DIFF
--- a/internal/middleware/doc.go
+++ b/internal/middleware/doc.go
@@ -1,0 +1,48 @@
+// Package middleware is the inbound application layer in VibeWarden's hexagonal
+// architecture. It contains all HTTP middleware that sits between the reverse
+// proxy (Caddy) and the application services (internal/app).
+//
+// # Architectural role
+//
+// In hexagonal architecture the inbound side (also called the "driving side")
+// consists of adapters that translate external signals — in this case incoming
+// HTTP requests — into calls that exercise the domain through application
+// services. This package is that inbound adapter layer for HTTP traffic.
+//
+//	┌─────────────────────────────────────────────────┐
+//	│                  Caddy (reverse proxy)           │
+//	└────────────────────────┬────────────────────────┘
+//	                         │ HTTP request
+//	┌────────────────────────▼────────────────────────┐
+//	│          internal/middleware  (this package)     │
+//	│   inbound application layer — drives the domain  │
+//	│                                                  │
+//	│  auth · rate-limit · WAF · security-headers …    │
+//	└────────────────────────┬────────────────────────┘
+//	                         │ calls ports (interfaces)
+//	┌────────────────────────▼────────────────────────┐
+//	│               internal/app  (use cases)          │
+//	└────────────────────────┬────────────────────────┘
+//	                         │
+//	┌────────────────────────▼────────────────────────┐
+//	│              internal/domain  (business logic)   │
+//	└─────────────────────────────────────────────────┘
+//
+// # Dependency rules
+//
+// Middleware constructors accept their dependencies through the port interfaces
+// defined in internal/ports — never concrete adapter types. This keeps the
+// middleware layer decoupled from infrastructure (Postgres, Redis, Kratos …).
+//
+// The middleware package must not import internal/adapters/* directly. Any
+// outbound I/O required by a middleware (e.g. persisting an audit event,
+// checking rate-limit counters) must go through a port interface.
+//
+// # Middleware registration
+//
+// Each middleware is a standard [net/http] handler wrapper of type
+// [github.com/vibewarden/vibewarden/internal/ports.Middleware]. Middlewares are
+// assembled into a [github.com/vibewarden/vibewarden/internal/ports.MiddlewareChain]
+// and applied to the Caddy handler during plugin initialisation in
+// internal/plugins.
+package middleware

--- a/internal/middleware/health.go
+++ b/internal/middleware/health.go
@@ -1,4 +1,3 @@
-// Package middleware provides HTTP middleware for VibeWarden.
 package middleware
 
 import (

--- a/internal/middleware/ip.go
+++ b/internal/middleware/ip.go
@@ -1,4 +1,3 @@
-// Package middleware provides HTTP middleware for VibeWarden.
 package middleware
 
 import (


### PR DESCRIPTION
Closes #528

## Summary

- Adds `internal/middleware/doc.go` — a package-level godoc that explicitly declares `internal/middleware` as the **inbound application layer** (driving side) of the hexagonal architecture.
- The doc includes an ASCII dependency diagram showing the flow: Caddy → middleware → app (use cases) → domain.
- Documents the two dependency rules that must hold for this layer: accept dependencies through `internal/ports` interfaces only; never import `internal/adapters/*` directly.
- Removes the duplicate bare `// Package middleware provides HTTP middleware for VibeWarden.` comment from `health.go` and `ip.go` so the canonical declaration lives in exactly one place (`doc.go`).

No code changes — this is a documentation/architecture clarity fix only. The package location (`internal/middleware/`) is already correct per the directory layout in `CLAUDE.md`.

## Test plan

- `make check` passes (lint, build, all tests, demo-app) — verified locally.
- `go doc github.com/vibewarden/vibewarden/internal/middleware` now shows the full architectural description.