### PR TITLE
feat(#492): add govulncheck job to security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -95,3 +95,23 @@ jobs:
         with:
           sarif_file: trivy-image.sarif
           category: trivy-image
+
+  govulncheck:
+    name: Go Vulnerability Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...


### PR DESCRIPTION
Closes #492

## Summary

- Adds a `govulncheck` job to `.github/workflows/security.yml`
- Installs `golang.org/x/vuln/cmd/govulncheck@latest` at runtime
- Runs `govulncheck ./...` against the full module tree
- Fails the job on any reachable vulnerability
- `timeout-minutes: 5` as specified
- Uses `actions/setup-go@v5` with `go-version-file: go.mod` and module cache enabled for consistency with other Go jobs in the repo

## Test plan

- [ ] Push to a PR and confirm the `Go Vulnerability Check` job appears in the Actions run
- [ ] Verify the job passes on a clean dependency tree
- [ ] Introduce a known-vulnerable dependency, confirm the job fails with a clear vulnerability report