### PR TITLE
feat(#494): add GitHub Dependency Review Action to PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,16 @@ jobs:
           name: coverage-report
           path: coverage.out
           retention-days: 7
+
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high


### PR DESCRIPTION
Closes #494

## Summary

- Adds a `dependency-review` job to `.github/workflows/ci.yml`
- The job runs only on `pull_request` events (guarded by `if: github.event_name == 'pull_request'`)
- Uses `actions/dependency-review-action@v4` with `fail-on-severity: high`, which blocks any PR that introduces a HIGH or CRITICAL CVE
- No new Go dependencies — this is a pure CI workflow change

## Test plan

- [ ] Open a PR and verify the `Dependency Review` check appears in the status checks list
- [ ] Confirm the job is skipped on direct pushes to `main`
- [ ] Confirm `make check` passes locally (verified before this PR)
