### PR TITLE
feat(#477): add access log middleware with log.access_log config flag

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -678,6 +678,10 @@ type LogConfig struct {
 	Level string `mapstructure:"level"`
 	// Format: "json" or "text" (default: "json")
 	Format string `mapstructure:"format"`
+	// AccessLog enables access logging of every completed HTTP request (default: true).
+	// When true, each request is logged at INFO level with method, path, status,
+	// duration, client IP, request ID, user agent, and bytes written.
+	AccessLog bool `mapstructure:"access_log"`
 }
 
 // AdminConfig holds admin API settings.
@@ -1785,6 +1789,7 @@ func Load(configPath string) (*Config, error) {
 	v.SetDefault("rate_limit.exempt_paths", []string{})
 	v.SetDefault("log.level", "info")
 	v.SetDefault("log.format", "json")
+	v.SetDefault("log.access_log", true)
 	v.SetDefault("admin.enabled", false)
 	v.SetDefault("admin.token", "")
 	v.SetDefault("security_headers.enabled", true)

--- a/internal/middleware/access_log.go
+++ b/internal/middleware/access_log.go
@@ -1,0 +1,83 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// accessLogResponseWriter wraps http.ResponseWriter to capture the HTTP status
+// code and the number of bytes written by the downstream handler.
+type accessLogResponseWriter struct {
+	http.ResponseWriter
+	statusCode   int
+	bytesWritten int
+	written      bool
+}
+
+func (rw *accessLogResponseWriter) WriteHeader(code int) {
+	if !rw.written {
+		rw.statusCode = code
+		rw.written = true
+	}
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (rw *accessLogResponseWriter) Write(b []byte) (int, error) {
+	if !rw.written {
+		rw.statusCode = http.StatusOK
+		rw.written = true
+	}
+	n, err := rw.ResponseWriter.Write(b)
+	rw.bytesWritten += n
+	return n, err
+}
+
+// AccessLogMiddleware returns HTTP middleware that logs a structured INFO record
+// for every completed request after the response has been written.
+//
+// Each log record contains:
+//   - method       — HTTP method (GET, POST, …)
+//   - path         — raw request URI path
+//   - status       — HTTP response status code
+//   - duration_ms  — request duration in milliseconds (float64)
+//   - client_ip    — client IP address (X-Forwarded-For when trustProxy is true)
+//   - request_id   — correlation ID from the request context
+//   - user_agent   — value of the User-Agent header
+//   - bytes        — number of bytes written to the response body
+//
+// When enabled is false the middleware is a transparent pass-through and the
+// logger argument may be nil.
+//
+// The logger argument must not be nil when enabled is true.
+func AccessLogMiddleware(logger *slog.Logger, enabled bool, trustProxy bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !enabled {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			start := time.Now()
+			rw := &accessLogResponseWriter{
+				ResponseWriter: w,
+				statusCode:     http.StatusOK,
+			}
+
+			next.ServeHTTP(rw, r)
+
+			duration := time.Since(start)
+
+			logger.InfoContext(r.Context(), "access",
+				slog.String("method", r.Method),
+				slog.String("path", r.URL.Path),
+				slog.Int("status", rw.statusCode),
+				slog.Float64("duration_ms", float64(duration.Nanoseconds())/1e6),
+				slog.String("client_ip", ExtractClientIP(r, trustProxy)),
+				slog.String("request_id", CorrelationID(r.Context())),
+				slog.String("user_agent", r.UserAgent()),
+				slog.Int("bytes", rw.bytesWritten),
+			)
+		})
+	}
+}

--- a/internal/middleware/access_log_test.go
+++ b/internal/middleware/access_log_test.go
@@ -1,0 +1,320 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newAccessLogTestLogger returns a slog.Logger that writes JSON to buf.
+func newAccessLogTestLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func TestAccessLogMiddleware_Disabled(t *testing.T) {
+	// When disabled the middleware must be a transparent pass-through; the
+	// logger is never called so we can pass nil safely.
+	called := false
+	handler := AccessLogMiddleware(nil, false, false)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if !called {
+		t.Error("downstream handler was not called when access log is disabled")
+	}
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("response status = %d, want %d", rr.Code, http.StatusNoContent)
+	}
+}
+
+func TestAccessLogMiddleware_LogsAfterResponse(t *testing.T) {
+	tests := []struct {
+		name         string
+		method       string
+		path         string
+		handlerFn    func(http.ResponseWriter, *http.Request)
+		wantStatus   int
+		wantBytesMin int
+	}{
+		{
+			name:   "GET 200 with body",
+			method: http.MethodGet,
+			path:   "/hello",
+			handlerFn: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("hello world"))
+			},
+			wantStatus:   http.StatusOK,
+			wantBytesMin: 11,
+		},
+		{
+			name:   "POST 201 no body",
+			method: http.MethodPost,
+			path:   "/users",
+			handlerFn: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+			},
+			wantStatus:   http.StatusCreated,
+			wantBytesMin: 0,
+		},
+		{
+			name:   "DELETE 404",
+			method: http.MethodDelete,
+			path:   "/items/42",
+			handlerFn: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			wantStatus:   http.StatusNotFound,
+			wantBytesMin: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := newAccessLogTestLogger(&buf)
+
+			handler := AccessLogMiddleware(logger, true, false)(
+				http.HandlerFunc(tt.handlerFn),
+			)
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req.Header.Set("User-Agent", "test-agent/1.0")
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			// Parse the JSON log record.
+			var record map[string]any
+			if err := json.NewDecoder(&buf).Decode(&record); err != nil {
+				t.Fatalf("failed to decode log record: %v", err)
+			}
+
+			if got := record["msg"]; got != "access" {
+				t.Errorf("msg = %q, want %q", got, "access")
+			}
+			if got := record["method"]; got != tt.method {
+				t.Errorf("method = %q, want %q", got, tt.method)
+			}
+			if got := record["path"]; got != tt.path {
+				t.Errorf("path = %q, want %q", got, tt.path)
+			}
+			gotStatus, _ := record["status"].(float64)
+			if int(gotStatus) != tt.wantStatus {
+				t.Errorf("status = %v, want %d", gotStatus, tt.wantStatus)
+			}
+			if _, ok := record["duration_ms"]; !ok {
+				t.Error("duration_ms field missing from log record")
+			}
+			if _, ok := record["client_ip"]; !ok {
+				t.Error("client_ip field missing from log record")
+			}
+			if _, ok := record["request_id"]; !ok {
+				t.Error("request_id field missing from log record")
+			}
+			if got := record["user_agent"]; got != "test-agent/1.0" {
+				t.Errorf("user_agent = %q, want %q", got, "test-agent/1.0")
+			}
+			gotBytes, _ := record["bytes"].(float64)
+			if int(gotBytes) < tt.wantBytesMin {
+				t.Errorf("bytes = %v, want >= %d", gotBytes, tt.wantBytesMin)
+			}
+		})
+	}
+}
+
+func TestAccessLogMiddleware_CapturesBytesWritten(t *testing.T) {
+	const body = "response body text"
+	var buf bytes.Buffer
+	logger := newAccessLogTestLogger(&buf)
+
+	handler := AccessLogMiddleware(logger, true, false)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(body))
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/data", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	var record map[string]any
+	if err := json.NewDecoder(&buf).Decode(&record); err != nil {
+		t.Fatalf("failed to decode log record: %v", err)
+	}
+
+	gotBytes, _ := record["bytes"].(float64)
+	if int(gotBytes) != len(body) {
+		t.Errorf("bytes = %v, want %d", gotBytes, len(body))
+	}
+}
+
+func TestAccessLogMiddleware_CapturesBytesFromMultipleWrites(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newAccessLogTestLogger(&buf)
+
+	handler := AccessLogMiddleware(logger, true, false)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("abc"))
+			_, _ = w.Write([]byte("de"))
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/multi", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	var record map[string]any
+	if err := json.NewDecoder(&buf).Decode(&record); err != nil {
+		t.Fatalf("failed to decode log record: %v", err)
+	}
+
+	gotBytes, _ := record["bytes"].(float64)
+	if int(gotBytes) != 5 {
+		t.Errorf("bytes = %v, want 5", gotBytes)
+	}
+}
+
+func TestAccessLogMiddleware_DefaultStatusOK_WhenNoWriteHeader(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newAccessLogTestLogger(&buf)
+
+	handler := AccessLogMiddleware(logger, true, false)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Handler writes body but never calls WriteHeader — Go defaults to 200.
+			_, _ = w.Write([]byte("ok"))
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/ok", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	var record map[string]any
+	if err := json.NewDecoder(&buf).Decode(&record); err != nil {
+		t.Fatalf("failed to decode log record: %v", err)
+	}
+
+	gotStatus, _ := record["status"].(float64)
+	if int(gotStatus) != http.StatusOK {
+		t.Errorf("status = %v, want %d", gotStatus, http.StatusOK)
+	}
+}
+
+func TestAccessLogMiddleware_ClientIP_TrustProxy(t *testing.T) {
+	tests := []struct {
+		name       string
+		trustProxy bool
+		xff        string
+		remoteAddr string
+		wantIP     string
+	}{
+		{
+			name:       "trust proxy uses XFF",
+			trustProxy: true,
+			xff:        "203.0.113.5, 10.0.0.1",
+			remoteAddr: "10.0.0.1:12345",
+			wantIP:     "203.0.113.5",
+		},
+		{
+			name:       "no trust proxy uses RemoteAddr",
+			trustProxy: false,
+			xff:        "203.0.113.5",
+			remoteAddr: "10.0.0.1:12345",
+			wantIP:     "10.0.0.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := newAccessLogTestLogger(&buf)
+
+			handler := AccessLogMiddleware(logger, true, tt.trustProxy)(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}),
+			)
+
+			req := httptest.NewRequest(http.MethodGet, "/ip", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.xff != "" {
+				req.Header.Set("X-Forwarded-For", tt.xff)
+			}
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			var record map[string]any
+			if err := json.NewDecoder(&buf).Decode(&record); err != nil {
+				t.Fatalf("failed to decode log record: %v", err)
+			}
+
+			if got := record["client_ip"]; got != tt.wantIP {
+				t.Errorf("client_ip = %q, want %q", got, tt.wantIP)
+			}
+		})
+	}
+}
+
+func TestAccessLogMiddleware_RequestID_FromContext(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newAccessLogTestLogger(&buf)
+
+	const wantID = "req_TESTID000001"
+
+	handler := AccessLogMiddleware(logger, true, false)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/rid", nil)
+	// Inject a known request ID into the context.
+	ctx := ContextWithRequestID(req.Context(), wantID)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	var record map[string]any
+	if err := json.NewDecoder(&buf).Decode(&record); err != nil {
+		t.Fatalf("failed to decode log record: %v", err)
+	}
+
+	if got := record["request_id"]; got != wantID {
+		t.Errorf("request_id = %q, want %q", got, wantID)
+	}
+}
+
+func TestAccessLogMiddleware_DurationIsPositive(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newAccessLogTestLogger(&buf)
+
+	handler := AccessLogMiddleware(logger, true, false)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/dur", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	var record map[string]any
+	if err := json.NewDecoder(&buf).Decode(&record); err != nil {
+		t.Fatalf("failed to decode log record: %v", err)
+	}
+
+	durMS, _ := record["duration_ms"].(float64)
+	if durMS < 0 {
+		t.Errorf("duration_ms = %v, want >= 0", durMS)
+	}
+}


### PR DESCRIPTION
Closes #477

## Summary

- New `internal/middleware/access_log.go` — `AccessLogMiddleware` wraps every request's `ResponseWriter` to capture status code and bytes written, then logs a structured INFO record after the response is flushed. Logged fields: `method`, `path`, `status`, `duration_ms`, `client_ip`, `request_id`, `user_agent`, `bytes`.
- Uses the stdlib `log/slog` logger passed in — no new event schema type, plain structured INFO log.
- `trustProxy bool` parameter controls whether `client_ip` is read from `X-Forwarded-For` (delegated to the existing `ExtractClientIP` helper).
- `request_id` is read from the request context via the existing `CorrelationID` helper.
- New `log.access_log bool` field added to `LogConfig` in `internal/config/config.go` with default `true` wired through viper.
- 9 table-driven unit tests cover: disabled pass-through, status capture, byte counting across multiple writes, default-200 when no `WriteHeader` call, proxy IP extraction, request ID injection, and duration non-negativity.

## Test plan

- `go test ./internal/middleware/ -run TestAccessLog -v` — all 9 tests pass
- `make check` — lint, build, and full test suite pass (including race detector)
