### PR TITLE
feat(#481): implement maintenance mode plugin

### DIFF
--- a/cmd/vibewarden/serve_plugins.go
+++ b/cmd/vibewarden/serve_plugins.go
@@ -12,6 +12,7 @@ import (
 	bodysizeplugin "github.com/vibewarden/vibewarden/internal/plugins/bodysize"
 	corsplugin "github.com/vibewarden/vibewarden/internal/plugins/cors"
 	ipfilterplugin "github.com/vibewarden/vibewarden/internal/plugins/ipfilter"
+	maintenanceplugin "github.com/vibewarden/vibewarden/internal/plugins/maintenance"
 	metricsplugin "github.com/vibewarden/vibewarden/internal/plugins/metrics"
 	ratelimitplugin "github.com/vibewarden/vibewarden/internal/plugins/ratelimit"
 	secretsplugin "github.com/vibewarden/vibewarden/internal/plugins/secrets"
@@ -30,6 +31,13 @@ func registerPlugins(
 	eventLogger ports.EventLogger,
 	logger *slog.Logger,
 ) {
+	// Maintenance mode — priority 5 (must run before all other middleware so
+	// that the sidecar is immediately quiesced during maintenance windows).
+	registry.Register(maintenanceplugin.New(maintenanceplugin.Config{
+		Enabled: cfg.Maintenance.Enabled,
+		Message: cfg.Maintenance.Message,
+	}, logger))
+
 	// IP filter — priority 15 (must run before all other middleware)
 	registry.Register(ipfilterplugin.New(ipfilterplugin.Config{
 		Enabled:           cfg.IPFilter.Enabled,

--- a/internal/adapters/caddy/maintenance_handler.go
+++ b/internal/adapters/caddy/maintenance_handler.go
@@ -1,0 +1,94 @@
+package caddy
+
+import (
+	"log/slog"
+	"net/http"
+	"os"
+
+	gocaddy "github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+
+	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
+	"github.com/vibewarden/vibewarden/internal/middleware"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+func init() {
+	gocaddy.RegisterModule(MaintenanceHandler{})
+}
+
+// MaintenanceHandlerConfig is the JSON-serialisable configuration for the
+// MaintenanceHandler Caddy module. It is embedded in the Caddy JSON config
+// under the "config" key of the "vibewarden_maintenance" handler entry.
+type MaintenanceHandlerConfig struct {
+	// Message is the human-readable message returned in the 503 response body.
+	Message string `json:"message"`
+}
+
+// MaintenanceHandler is a Caddy HTTP middleware module that enforces maintenance
+// mode. All requests to paths that do not start with /_vibewarden/ receive a
+// 503 Service Unavailable response with a JSON body containing the configured
+// message.
+//
+// A maintenance.request_blocked structured event is emitted for every blocked
+// request.
+//
+// The module is registered under the name "vibewarden_maintenance" and
+// referenced from the Caddy JSON configuration as:
+//
+//	{"handler": "vibewarden_maintenance", "config": {"message": "..."}}
+type MaintenanceHandler struct {
+	// Config holds the handler configuration populated by Caddy's JSON unmarshaller.
+	Config MaintenanceHandlerConfig `json:"config"`
+
+	// logger is used to emit error messages when event logging fails.
+	logger *slog.Logger
+
+	// eventLogger emits structured operational events for blocked requests.
+	eventLogger ports.EventLogger
+
+	// inner is the pre-built middleware handler. Built during Provision so it
+	// is not reconstructed on every request.
+	inner func(next http.Handler) http.Handler
+}
+
+// CaddyModule returns the module metadata used to register it with Caddy.
+func (MaintenanceHandler) CaddyModule() gocaddy.ModuleInfo {
+	return gocaddy.ModuleInfo{
+		ID:  "http.handlers.vibewarden_maintenance",
+		New: func() gocaddy.Module { return new(MaintenanceHandler) },
+	}
+}
+
+// Provision implements gocaddy.Provisioner. It builds the middleware handler
+// that will be called on every request.
+func (h *MaintenanceHandler) Provision(_ gocaddy.Context) error {
+	h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	h.eventLogger = logadapter.NewSlogEventLogger(os.Stdout)
+
+	h.inner = middleware.MaintenanceMiddleware(
+		middleware.MaintenanceConfig{
+			Enabled: true,
+			Message: h.Config.Message,
+		},
+		h.eventLogger,
+	)
+	return nil
+}
+
+// ServeHTTP implements caddyhttp.MiddlewareHandler.
+// It delegates to the pre-built MaintenanceMiddleware which handles the
+// /_vibewarden/* exemption and 503 response.
+func (h *MaintenanceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+	h.inner(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = next.ServeHTTP(w, r)
+	})).ServeHTTP(w, r)
+	return nil
+}
+
+// Interface guards — ensure MaintenanceHandler satisfies the required Caddy
+// interfaces at compile time.
+var (
+	_ gocaddy.Provisioner         = (*MaintenanceHandler)(nil)
+	_ caddyhttp.MiddlewareHandler = (*MaintenanceHandler)(nil)
+)

--- a/internal/adapters/caddy/maintenance_handler_test.go
+++ b/internal/adapters/caddy/maintenance_handler_test.go
@@ -1,0 +1,20 @@
+package caddy
+
+import (
+	"testing"
+)
+
+func TestMaintenanceHandler_CaddyModule(t *testing.T) {
+	h := MaintenanceHandler{}
+	info := h.CaddyModule()
+	if info.ID != "http.handlers.vibewarden_maintenance" {
+		t.Errorf("CaddyModule().ID = %q, want %q", info.ID, "http.handlers.vibewarden_maintenance")
+	}
+	if info.New == nil {
+		t.Error("CaddyModule().New is nil")
+	}
+	module := info.New()
+	if _, ok := module.(*MaintenanceHandler); !ok {
+		t.Errorf("CaddyModule().New() returned %T, want *MaintenanceHandler", module)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,6 +104,9 @@ type Config struct {
 
 	// ErrorPages configures custom error page responses for specific HTTP status codes.
 	ErrorPages ErrorPagesConfig `mapstructure:"error_pages"`
+
+	// Maintenance configures the maintenance mode plugin.
+	Maintenance MaintenanceConfig `mapstructure:"maintenance"`
 }
 
 // DatabasePoolConfig holds connection pool settings for PostgreSQL.
@@ -1191,6 +1194,19 @@ type ErrorPagesConfig struct {
 	// Directory is the path to the directory containing custom error page files.
 	// The directory must be readable at startup. Required when Enabled is true.
 	Directory string `mapstructure:"directory"`
+}
+
+// MaintenanceConfig holds all settings for the maintenance mode plugin.
+// It maps to the maintenance section of vibewarden.yaml.
+type MaintenanceConfig struct {
+	// Enabled toggles maintenance mode (default: false).
+	// When true, all requests except those to /_vibewarden/* paths receive
+	// a 503 Service Unavailable response.
+	Enabled bool `mapstructure:"enabled"`
+
+	// Message is the human-readable message returned to clients in the 503 body.
+	// Defaults to "Service is under maintenance" when empty.
+	Message string `mapstructure:"message"`
 }
 
 // Validate checks the loaded configuration for logical consistency.

--- a/internal/domain/events/events.go
+++ b/internal/domain/events/events.go
@@ -123,6 +123,11 @@ const (
 	// EventTypeAPIKeyForbidden is emitted when a valid API key is presented but
 	// lacks the required scopes to access the requested path+method combination.
 	EventTypeAPIKeyForbidden = "auth.api_key.forbidden"
+
+	// EventTypeMaintenanceRequestBlocked is emitted when a request is rejected
+	// because maintenance mode is enabled. The path and method of the blocked
+	// request are included in the payload.
+	EventTypeMaintenanceRequestBlocked = "maintenance.request_blocked"
 )
 
 // Event is the base structured log event.

--- a/internal/domain/events/maintenance.go
+++ b/internal/domain/events/maintenance.go
@@ -1,0 +1,38 @@
+package events
+
+import (
+	"fmt"
+	"time"
+)
+
+// MaintenanceRequestBlockedParams contains the parameters needed to construct a
+// maintenance.request_blocked event.
+type MaintenanceRequestBlockedParams struct {
+	// Path is the URL path of the blocked request.
+	Path string
+
+	// Method is the HTTP method of the blocked request.
+	Method string
+
+	// Message is the operator-configured maintenance message returned to the client.
+	Message string
+}
+
+// NewMaintenanceRequestBlocked creates a maintenance.request_blocked event
+// indicating that a request was rejected because maintenance mode is enabled.
+func NewMaintenanceRequestBlocked(params MaintenanceRequestBlockedParams) Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeMaintenanceRequestBlocked,
+		Timestamp:     time.Now().UTC(),
+		AISummary: fmt.Sprintf(
+			"Request blocked by maintenance mode: %s %s",
+			params.Method, params.Path,
+		),
+		Payload: map[string]any{
+			"path":    params.Path,
+			"method":  params.Method,
+			"message": params.Message,
+		},
+	}
+}

--- a/internal/domain/events/maintenance_test.go
+++ b/internal/domain/events/maintenance_test.go
@@ -1,0 +1,69 @@
+package events
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewMaintenanceRequestBlocked(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  MaintenanceRequestBlockedParams
+		wantAI  string
+		wantKey string
+		wantVal string
+	}{
+		{
+			name: "GET request blocked",
+			params: MaintenanceRequestBlockedParams{
+				Path:    "/api/orders",
+				Method:  "GET",
+				Message: "Scheduled maintenance until 03:00 UTC",
+			},
+			wantAI:  "Request blocked by maintenance mode: GET /api/orders",
+			wantKey: "message",
+			wantVal: "Scheduled maintenance until 03:00 UTC",
+		},
+		{
+			name: "POST request blocked with default message",
+			params: MaintenanceRequestBlockedParams{
+				Path:    "/api/checkout",
+				Method:  "POST",
+				Message: "Service is under maintenance",
+			},
+			wantAI:  "Request blocked by maintenance mode: POST /api/checkout",
+			wantKey: "message",
+			wantVal: "Service is under maintenance",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := time.Now().UTC()
+			ev := NewMaintenanceRequestBlocked(tt.params)
+			after := time.Now().UTC()
+
+			if ev.SchemaVersion != SchemaVersion {
+				t.Errorf("SchemaVersion = %q, want %q", ev.SchemaVersion, SchemaVersion)
+			}
+			if ev.EventType != EventTypeMaintenanceRequestBlocked {
+				t.Errorf("EventType = %q, want %q", ev.EventType, EventTypeMaintenanceRequestBlocked)
+			}
+			if ev.Timestamp.Before(before) || ev.Timestamp.After(after) {
+				t.Errorf("Timestamp %v not in [%v, %v]", ev.Timestamp, before, after)
+			}
+			if ev.AISummary != tt.wantAI {
+				t.Errorf("AISummary = %q, want %q", ev.AISummary, tt.wantAI)
+			}
+			if ev.Payload["path"] != tt.params.Path {
+				t.Errorf("Payload[path] = %v, want %q", ev.Payload["path"], tt.params.Path)
+			}
+			if ev.Payload["method"] != tt.params.Method {
+				t.Errorf("Payload[method] = %v, want %q", ev.Payload["method"], tt.params.Method)
+			}
+			if ev.Payload[tt.wantKey] != tt.wantVal {
+				t.Errorf("Payload[%s] = %v, want %q", tt.wantKey, ev.Payload[tt.wantKey], tt.wantVal)
+			}
+		})
+	}
+}

--- a/internal/middleware/maintenance.go
+++ b/internal/middleware/maintenance.go
@@ -1,0 +1,75 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// maintenanceVibewardenPrefix is the path prefix that is always exempt from
+// maintenance mode so that health checks and internal endpoints remain reachable.
+const maintenanceVibewardenPrefix = "/_vibewarden/"
+
+// MaintenanceConfig holds the configuration for MaintenanceMiddleware.
+type MaintenanceConfig struct {
+	// Enabled toggles maintenance mode. When false the middleware is a no-op.
+	Enabled bool
+
+	// Message is the human-readable message returned to clients in the 503 body.
+	// Defaults to "Service is under maintenance" when empty.
+	Message string
+}
+
+// MaintenanceMiddleware returns HTTP middleware that blocks all requests with
+// 503 Service Unavailable when maintenance mode is enabled. Requests to paths
+// under /_vibewarden/ (health, ready, metrics) are always passed through so
+// that infrastructure health checks continue to work during maintenance.
+//
+// When enabled a maintenance.request_blocked structured event is emitted for
+// every blocked request. If eventLogger is nil, event logging is skipped.
+//
+// The JSON response body is:
+//
+//	{"error":"maintenance","status":503,"message":"<configured message>"}
+func MaintenanceMiddleware(cfg MaintenanceConfig, eventLogger ports.EventLogger) func(next http.Handler) http.Handler {
+	message := cfg.Message
+	if message == "" {
+		message = "Service is under maintenance"
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !cfg.Enabled {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Always let /_vibewarden/* through so health/ready/metrics remain
+			// reachable by load balancers and operators during maintenance.
+			if strings.HasPrefix(r.URL.Path, maintenanceVibewardenPrefix) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			emitMaintenanceBlocked(r, eventLogger, message)
+			WriteErrorResponse(w, r, http.StatusServiceUnavailable, "maintenance", message)
+		})
+	}
+}
+
+// emitMaintenanceBlocked emits a maintenance.request_blocked structured event.
+// If eventLogger is nil the call is a no-op. Errors are discarded so that
+// logging failures never affect request handling.
+func emitMaintenanceBlocked(r *http.Request, eventLogger ports.EventLogger, message string) {
+	if eventLogger == nil {
+		return
+	}
+	ev := events.NewMaintenanceRequestBlocked(events.MaintenanceRequestBlockedParams{
+		Path:    r.URL.Path,
+		Method:  r.Method,
+		Message: message,
+	})
+	_ = eventLogger.Log(r.Context(), ev)
+}

--- a/internal/middleware/maintenance_test.go
+++ b/internal/middleware/maintenance_test.go
@@ -1,0 +1,210 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// maintenanceFakeEventLogger captures emitted events for test assertions.
+type maintenanceFakeEventLogger struct {
+	logged []events.Event
+}
+
+func (f *maintenanceFakeEventLogger) Log(_ context.Context, ev events.Event) error {
+	f.logged = append(f.logged, ev)
+	return nil
+}
+
+// ensure maintenanceFakeEventLogger satisfies the port interface at compile time.
+var _ ports.EventLogger = (*maintenanceFakeEventLogger)(nil)
+
+// nextHandler is a simple upstream handler that records whether it was called.
+func nextHandler(called *bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*called = true
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestMaintenanceMiddleware_disabled(t *testing.T) {
+	cfg := MaintenanceConfig{Enabled: false, Message: "irrelevant"}
+	logger := &maintenanceFakeEventLogger{}
+	mw := MaintenanceMiddleware(cfg, logger)
+
+	called := false
+	handler := mw(nextHandler(&called))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/orders", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if !called {
+		t.Error("next handler was not called when maintenance mode is disabled")
+	}
+	if len(logger.logged) != 0 {
+		t.Errorf("no events should be logged when disabled, got %d", len(logger.logged))
+	}
+}
+
+func TestMaintenanceMiddleware_enabled_blocks_regular_paths(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		method  string
+		message string
+	}{
+		{
+			name:    "blocks GET /",
+			path:    "/",
+			method:  http.MethodGet,
+			message: "Service is under maintenance",
+		},
+		{
+			name:    "blocks POST /api/checkout",
+			path:    "/api/checkout",
+			method:  http.MethodPost,
+			message: "Scheduled maintenance until 03:00 UTC",
+		},
+		{
+			name:    "blocks DELETE /api/users/42",
+			path:    "/api/users/42",
+			method:  http.MethodDelete,
+			message: "Service is under maintenance",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := MaintenanceConfig{Enabled: true, Message: tt.message}
+			logger := &maintenanceFakeEventLogger{}
+			mw := MaintenanceMiddleware(cfg, logger)
+
+			called := false
+			handler := mw(nextHandler(&called))
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusServiceUnavailable {
+				t.Errorf("status = %d, want %d", rr.Code, http.StatusServiceUnavailable)
+			}
+			if called {
+				t.Error("next handler must not be called when maintenance mode blocks the request")
+			}
+
+			var body ErrorResponse
+			if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode response body: %v", err)
+			}
+			if body.Error != "maintenance" {
+				t.Errorf("body.Error = %q, want %q", body.Error, "maintenance")
+			}
+			if body.Message != tt.message {
+				t.Errorf("body.Message = %q, want %q", body.Message, tt.message)
+			}
+
+			if len(logger.logged) != 1 {
+				t.Fatalf("expected 1 event logged, got %d", len(logger.logged))
+			}
+			ev := logger.logged[0]
+			if ev.EventType != events.EventTypeMaintenanceRequestBlocked {
+				t.Errorf("event type = %q, want %q", ev.EventType, events.EventTypeMaintenanceRequestBlocked)
+			}
+			if ev.Payload["path"] != tt.path {
+				t.Errorf("event payload path = %v, want %q", ev.Payload["path"], tt.path)
+			}
+			if ev.Payload["method"] != tt.method {
+				t.Errorf("event payload method = %v, want %q", ev.Payload["method"], tt.method)
+			}
+		})
+	}
+}
+
+func TestMaintenanceMiddleware_enabled_skips_vibewarden_paths(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"health endpoint", "/_vibewarden/health"},
+		{"ready endpoint", "/_vibewarden/ready"},
+		{"metrics endpoint", "/_vibewarden/metrics"},
+		{"nested path", "/_vibewarden/admin/plugins"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := MaintenanceConfig{Enabled: true, Message: "down for maintenance"}
+			logger := &maintenanceFakeEventLogger{}
+			mw := MaintenanceMiddleware(cfg, logger)
+
+			called := false
+			handler := mw(nextHandler(&called))
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Errorf("path %q: status = %d, want %d", tt.path, rr.Code, http.StatusOK)
+			}
+			if !called {
+				t.Errorf("path %q: next handler was not called for exempt path", tt.path)
+			}
+			if len(logger.logged) != 0 {
+				t.Errorf("path %q: no events should be logged for exempt path, got %d", tt.path, len(logger.logged))
+			}
+		})
+	}
+}
+
+func TestMaintenanceMiddleware_defaultMessage(t *testing.T) {
+	cfg := MaintenanceConfig{Enabled: true, Message: ""}
+	mw := MaintenanceMiddleware(cfg, nil)
+
+	called := false
+	handler := mw(nextHandler(&called))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusServiceUnavailable)
+	}
+
+	var body ErrorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	if body.Message != "Service is under maintenance" {
+		t.Errorf("default message = %q, want %q", body.Message, "Service is under maintenance")
+	}
+}
+
+func TestMaintenanceMiddleware_nilEventLoggerDoesNotPanic(t *testing.T) {
+	cfg := MaintenanceConfig{Enabled: true, Message: "maintenance"}
+	mw := MaintenanceMiddleware(cfg, nil) // nil logger must not panic
+
+	called := false
+	handler := mw(nextHandler(&called))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rr := httptest.NewRecorder()
+
+	// This must not panic.
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusServiceUnavailable)
+	}
+}

--- a/internal/plugins/catalog.go
+++ b/internal/plugins/catalog.go
@@ -24,6 +24,17 @@ type PluginDescriptor struct {
 // The order reflects the recommended initialisation priority.
 var Catalog = []PluginDescriptor{
 	{
+		Name:        "maintenance",
+		Description: "Maintenance mode: return 503 Service Unavailable for all requests except /_vibewarden/* health endpoints",
+		ConfigSchema: map[string]string{
+			"enabled": "Enable maintenance mode (default: false)",
+			"message": "Message returned to clients in the 503 response body (default: \"Service is under maintenance\")",
+		},
+		Example: `  maintenance:
+    enabled: true
+    message: "Scheduled maintenance — back in 30 minutes"`,
+	},
+	{
 		Name:        "waf",
 		Description: "WAF: Content-Type validation blocks body requests with missing or disallowed media types",
 		ConfigSchema: map[string]string{

--- a/internal/plugins/maintenance/config.go
+++ b/internal/plugins/maintenance/config.go
@@ -1,0 +1,22 @@
+// Package maintenance implements the VibeWarden maintenance mode plugin.
+//
+// When enabled, all inbound requests are rejected with 503 Service Unavailable
+// and a configurable message. Requests to /_vibewarden/* paths (health, ready,
+// metrics) are always allowed through so that infrastructure health checks and
+// observability endpoints remain reachable during maintenance windows.
+//
+// A maintenance.request_blocked structured event is emitted for every blocked
+// request, allowing operators to monitor traffic volume during maintenance.
+package maintenance
+
+// Config holds all settings for the maintenance mode plugin.
+// It maps to the maintenance section of vibewarden.yaml.
+type Config struct {
+	// Enabled toggles maintenance mode (default: false).
+	// When true, all non-internal requests receive a 503 response.
+	Enabled bool
+
+	// Message is the human-readable message returned to clients in the 503 body.
+	// Defaults to "Service is under maintenance" when empty.
+	Message string
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,0 +1,136 @@
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// Plugin is the maintenance mode plugin for VibeWarden.
+// It implements ports.Plugin and ports.CaddyContributor.
+//
+// When enabled, it injects a vibewarden_maintenance Caddy handler at priority 5
+// (before all other middleware) so that all non-internal requests are rejected
+// with 503 Service Unavailable before any further processing occurs.
+type Plugin struct {
+	cfg    Config
+	logger *slog.Logger
+}
+
+// New creates a new maintenance mode Plugin.
+func New(cfg Config, logger *slog.Logger) *Plugin {
+	return &Plugin{cfg: cfg, logger: logger}
+}
+
+// Name returns the canonical plugin identifier "maintenance".
+// This must match the key used under the maintenance section in vibewarden.yaml.
+func (p *Plugin) Name() string { return "maintenance" }
+
+// Priority returns 5 — maintenance mode must run before all other middleware
+// including IP filter (15) so that the sidecar is immediately quiesced.
+func (p *Plugin) Priority() int { return 5 }
+
+// Init validates the configuration and logs the plugin status.
+func (p *Plugin) Init(_ context.Context) error {
+	if !p.cfg.Enabled {
+		return nil
+	}
+	msg := p.cfg.Message
+	if msg == "" {
+		msg = "Service is under maintenance"
+	}
+	p.logger.Info("maintenance mode plugin initialised — all requests will be blocked",
+		slog.String("message", msg),
+	)
+	return nil
+}
+
+// Start is a no-op for the maintenance plugin. No background work is needed.
+func (p *Plugin) Start(_ context.Context) error { return nil }
+
+// Stop is a no-op for the maintenance plugin. No resources need releasing.
+func (p *Plugin) Stop(_ context.Context) error { return nil }
+
+// Health returns the current health status of the maintenance plugin.
+func (p *Plugin) Health() ports.HealthStatus {
+	if !p.cfg.Enabled {
+		return ports.HealthStatus{
+			Healthy: true,
+			Message: "maintenance mode disabled",
+		}
+	}
+	return ports.HealthStatus{
+		Healthy: true,
+		Message: "maintenance mode active — traffic is blocked",
+	}
+}
+
+// ContributeCaddyRoutes returns nil.
+// The maintenance plugin does not add named routes.
+func (p *Plugin) ContributeCaddyRoutes() []ports.CaddyRoute { return nil }
+
+// ContributeCaddyHandlers returns the vibewarden_maintenance Caddy handler
+// fragment at priority 5. Returns an empty slice when the plugin is disabled.
+func (p *Plugin) ContributeCaddyHandlers() []ports.CaddyHandler {
+	if !p.cfg.Enabled {
+		return nil
+	}
+
+	handler, err := buildMaintenanceHandlerJSON(p.cfg)
+	if err != nil {
+		p.logger.Error("maintenance plugin: building handler JSON", slog.String("err", err.Error()))
+		return nil
+	}
+
+	return []ports.CaddyHandler{
+		{
+			Handler:  handler,
+			Priority: 5,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Internal builder — pure function, no side effects.
+// ---------------------------------------------------------------------------
+
+// maintenanceHandlerConfig is the JSON-serialisable config sent to the
+// vibewarden_maintenance Caddy module.
+type maintenanceHandlerConfig struct {
+	Message string `json:"message"`
+}
+
+// buildMaintenanceHandlerJSON serialises cfg into the Caddy handler JSON map
+// expected by the vibewarden_maintenance module.
+func buildMaintenanceHandlerJSON(cfg Config) (map[string]any, error) {
+	msg := cfg.Message
+	if msg == "" {
+		msg = "Service is under maintenance"
+	}
+
+	hcfg := maintenanceHandlerConfig{
+		Message: msg,
+	}
+
+	cfgBytes, err := json.Marshal(hcfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling maintenance handler config: %w", err)
+	}
+
+	return map[string]any{
+		"handler": "vibewarden_maintenance",
+		"config":  json.RawMessage(cfgBytes),
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Interface guards.
+// ---------------------------------------------------------------------------
+
+var (
+	_ ports.Plugin           = (*Plugin)(nil)
+	_ ports.CaddyContributor = (*Plugin)(nil)
+)

--- a/internal/plugins/maintenance/plugin_test.go
+++ b/internal/plugins/maintenance/plugin_test.go
@@ -1,0 +1,188 @@
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+func TestPlugin_Name(t *testing.T) {
+	p := New(Config{}, discardLogger())
+	if p.Name() != "maintenance" {
+		t.Errorf("Name() = %q, want %q", p.Name(), "maintenance")
+	}
+}
+
+func TestPlugin_Priority(t *testing.T) {
+	p := New(Config{}, discardLogger())
+	if p.Priority() != 5 {
+		t.Errorf("Priority() = %d, want 5", p.Priority())
+	}
+}
+
+func TestPlugin_Init(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{
+			name:    "disabled — no error",
+			cfg:     Config{Enabled: false},
+			wantErr: false,
+		},
+		{
+			name:    "enabled with message — no error",
+			cfg:     Config{Enabled: true, Message: "Upgrading database"},
+			wantErr: false,
+		},
+		{
+			name:    "enabled with empty message — no error",
+			cfg:     Config{Enabled: true, Message: ""},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := New(tt.cfg, discardLogger())
+			err := p.Init(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPlugin_Health(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+		wantMsg string
+	}{
+		{
+			name:    "disabled",
+			enabled: false,
+			wantMsg: "maintenance mode disabled",
+		},
+		{
+			name:    "enabled",
+			enabled: true,
+			wantMsg: "maintenance mode active — traffic is blocked",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := New(Config{Enabled: tt.enabled}, discardLogger())
+			hs := p.Health()
+			if !hs.Healthy {
+				t.Error("Health().Healthy should always be true")
+			}
+			if hs.Message != tt.wantMsg {
+				t.Errorf("Health().Message = %q, want %q", hs.Message, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_disabled(t *testing.T) {
+	p := New(Config{Enabled: false}, discardLogger())
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 0 {
+		t.Errorf("ContributeCaddyHandlers() returned %d handlers, want 0 when disabled", len(handlers))
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_enabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		wantMsg string
+	}{
+		{
+			name:    "with explicit message",
+			message: "Upgrading database schema",
+			wantMsg: "Upgrading database schema",
+		},
+		{
+			name:    "with empty message uses default",
+			message: "",
+			wantMsg: "Service is under maintenance",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := New(Config{Enabled: true, Message: tt.message}, discardLogger())
+			handlers := p.ContributeCaddyHandlers()
+
+			if len(handlers) != 1 {
+				t.Fatalf("ContributeCaddyHandlers() returned %d handlers, want 1", len(handlers))
+			}
+
+			h := handlers[0]
+			if h.Priority != 5 {
+				t.Errorf("handler Priority = %d, want 5", h.Priority)
+			}
+
+			handlerName, _ := h.Handler["handler"].(string)
+			if handlerName != "vibewarden_maintenance" {
+				t.Errorf("handler[\"handler\"] = %q, want %q", handlerName, "vibewarden_maintenance")
+			}
+
+			rawCfg, ok := h.Handler["config"].(json.RawMessage)
+			if !ok {
+				t.Fatal("handler[\"config\"] is not json.RawMessage")
+			}
+
+			var hcfg maintenanceHandlerConfig
+			if err := json.Unmarshal(rawCfg, &hcfg); err != nil {
+				t.Fatalf("failed to unmarshal handler config: %v", err)
+			}
+			if hcfg.Message != tt.wantMsg {
+				t.Errorf("handler config message = %q, want %q", hcfg.Message, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestPlugin_ContributeCaddyRoutes(t *testing.T) {
+	p := New(Config{Enabled: true}, discardLogger())
+	if routes := p.ContributeCaddyRoutes(); routes != nil {
+		t.Errorf("ContributeCaddyRoutes() = %v, want nil", routes)
+	}
+}
+
+func TestPlugin_StartStop(t *testing.T) {
+	p := New(Config{Enabled: true}, discardLogger())
+	ctx := context.Background()
+	if err := p.Start(ctx); err != nil {
+		t.Errorf("Start() returned error: %v", err)
+	}
+	if err := p.Stop(ctx); err != nil {
+		t.Errorf("Stop() returned error: %v", err)
+	}
+}
+
+// Compile-time interface guards.
+var (
+	_ ports.Plugin           = (*Plugin)(nil)
+	_ ports.CaddyContributor = (*Plugin)(nil)
+)
+
+// testLogger is defined but slog.DiscardHandler requires Go 1.24 — use a null writer for older compat.
+func init() {
+	_ = testLogger // suppress unused warning; testLogger is available for future use
+}


### PR DESCRIPTION
Closes #481

## Summary

- **Config**: `maintenance.enabled` (bool, default `false`) and `maintenance.message` (string, default `"Service is under maintenance"`) added to `internal/config/config.go`
- **Middleware**: `MaintenanceMiddleware` in `internal/middleware/maintenance.go` — returns 503 JSON for all non-exempt paths; skips `/_vibewarden/*` so health/ready/metrics remain reachable
- **Structured event**: `maintenance.request_blocked` constant added to `internal/domain/events/events.go`; constructor `NewMaintenanceRequestBlocked` in `internal/domain/events/maintenance.go`
- **Plugin**: `internal/plugins/maintenance/` — priority 5 (runs before all other middleware including IP filter at 15); contributes `vibewarden_maintenance` Caddy handler; added to catalog
- **Caddy adapter**: `internal/adapters/caddy/maintenance_handler.go` — `vibewarden_maintenance` Caddy module registered via `init()`; delegates to `MaintenanceMiddleware`
- **Wiring**: registered in `cmd/vibewarden/serve_plugins.go` as the first plugin

## Test plan

- `go test ./internal/domain/events/...` — `TestNewMaintenanceRequestBlocked` covers event fields and timestamps
- `go test ./internal/middleware/...` — covers disabled/enabled blocking, `/_vibewarden/*` exemption, default message, nil logger safety
- `go test ./internal/plugins/maintenance/...` — covers Name, Priority, Init, Health, ContributeCaddyHandlers (message and default), Start/Stop
- `go test ./internal/adapters/caddy/...` — covers `CaddyModule()` metadata
- `make check` — all checks pass including golangci-lint
