### PR TITLE
feat(#479): implement response compression via Caddy encode handler

### DIFF
--- a/cmd/vibewarden/serve_config.go
+++ b/cmd/vibewarden/serve_config.go
@@ -103,6 +103,10 @@ func buildProxyConfig(cfg *config.Config, registry *plugins.Registry) *ports.Pro
 			TrustProxyHeaders: cfg.IPFilter.TrustProxyHeaders,
 		},
 		Resilience: buildResiliencePortsConfig(cfg),
+		Compression: ports.CompressionConfig{
+			Enabled:    cfg.Compression.Enabled,
+			Algorithms: cfg.Compression.Algorithms,
+		},
 	}
 }
 

--- a/internal/adapters/caddy/compression_handler_test.go
+++ b/internal/adapters/caddy/compression_handler_test.go
@@ -1,0 +1,216 @@
+package caddy
+
+import (
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+func TestBuildCompressionHandlerJSON(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            ports.CompressionConfig
+		wantHandler    string
+		wantAlgorithms []string
+	}{
+		{
+			name: "default algorithms when empty",
+			cfg: ports.CompressionConfig{
+				Enabled:    true,
+				Algorithms: nil,
+			},
+			wantHandler:    "encode",
+			wantAlgorithms: []string{"zstd", "gzip"},
+		},
+		{
+			name: "gzip only",
+			cfg: ports.CompressionConfig{
+				Enabled:    true,
+				Algorithms: []string{"gzip"},
+			},
+			wantHandler:    "encode",
+			wantAlgorithms: []string{"gzip"},
+		},
+		{
+			name: "zstd only",
+			cfg: ports.CompressionConfig{
+				Enabled:    true,
+				Algorithms: []string{"zstd"},
+			},
+			wantHandler:    "encode",
+			wantAlgorithms: []string{"zstd"},
+		},
+		{
+			name: "gzip and zstd explicit order",
+			cfg: ports.CompressionConfig{
+				Enabled:    true,
+				Algorithms: []string{"gzip", "zstd"},
+			},
+			wantHandler:    "encode",
+			wantAlgorithms: []string{"gzip", "zstd"},
+		},
+		{
+			name: "unknown algorithm is ignored",
+			cfg: ports.CompressionConfig{
+				Enabled:    true,
+				Algorithms: []string{"br", "gzip"},
+			},
+			wantHandler:    "encode",
+			wantAlgorithms: []string{"gzip"},
+		},
+		{
+			name: "all unknown algorithms produce empty encodings",
+			cfg: ports.CompressionConfig{
+				Enabled:    true,
+				Algorithms: []string{"br", "deflate"},
+			},
+			wantHandler:    "encode",
+			wantAlgorithms: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildCompressionHandlerJSON(tt.cfg)
+
+			handler, _ := result["handler"].(string)
+			if handler != tt.wantHandler {
+				t.Errorf("handler = %q, want %q", handler, tt.wantHandler)
+			}
+
+			encodings, ok := result["encodings"].(map[string]any)
+			if !ok {
+				t.Fatal("encodings not found or wrong type in result")
+			}
+
+			// Verify each expected algorithm key is present.
+			for _, algo := range tt.wantAlgorithms {
+				if _, found := encodings[algo]; !found {
+					t.Errorf("expected algorithm %q not found in encodings", algo)
+				}
+			}
+
+			// Verify no extra algorithm keys are present.
+			if len(encodings) != len(tt.wantAlgorithms) {
+				t.Errorf("encodings has %d entries, want %d", len(encodings), len(tt.wantAlgorithms))
+			}
+		})
+	}
+}
+
+func TestBuildCaddyConfig_Compression(t *testing.T) {
+	tests := []struct {
+		name              string
+		cfg               *ports.ProxyConfig
+		wantEncodeHandler bool
+		wantAlgorithms    []string
+	}{
+		{
+			name: "compression enabled with defaults produces encode handler",
+			cfg: &ports.ProxyConfig{
+				ListenAddr:   "127.0.0.1:8080",
+				UpstreamAddr: "127.0.0.1:3000",
+				Compression: ports.CompressionConfig{
+					Enabled:    true,
+					Algorithms: []string{"zstd", "gzip"},
+				},
+			},
+			wantEncodeHandler: true,
+			wantAlgorithms:    []string{"zstd", "gzip"},
+		},
+		{
+			name: "compression disabled omits encode handler",
+			cfg: &ports.ProxyConfig{
+				ListenAddr:   "127.0.0.1:8080",
+				UpstreamAddr: "127.0.0.1:3000",
+				Compression: ports.CompressionConfig{
+					Enabled: false,
+				},
+			},
+			wantEncodeHandler: false,
+		},
+		{
+			name: "compression enabled gzip only",
+			cfg: &ports.ProxyConfig{
+				ListenAddr:   "127.0.0.1:8080",
+				UpstreamAddr: "127.0.0.1:3000",
+				Compression: ports.CompressionConfig{
+					Enabled:    true,
+					Algorithms: []string{"gzip"},
+				},
+			},
+			wantEncodeHandler: true,
+			wantAlgorithms:    []string{"gzip"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := BuildCaddyConfig(tt.cfg)
+			if err != nil {
+				t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+			}
+
+			handlers := extractCatchAllHandlers(t, result)
+
+			encodeHandler := findHandlerByType(handlers, "encode")
+			if tt.wantEncodeHandler && encodeHandler == nil {
+				t.Fatal("expected encode handler in catch-all route, but not found")
+			}
+			if !tt.wantEncodeHandler && encodeHandler != nil {
+				t.Fatal("unexpected encode handler found in catch-all route")
+			}
+
+			if encodeHandler == nil {
+				return
+			}
+
+			encodings, ok := encodeHandler["encodings"].(map[string]any)
+			if !ok {
+				t.Fatal("encodings not found or wrong type in encode handler")
+			}
+
+			for _, algo := range tt.wantAlgorithms {
+				if _, found := encodings[algo]; !found {
+					t.Errorf("expected algorithm %q not found in encodings", algo)
+				}
+			}
+		})
+	}
+}
+
+// extractCatchAllHandlers returns the handlers slice from the catch-all route
+// (the last route in the vibewarden server routes list).
+func extractCatchAllHandlers(t *testing.T, result map[string]any) []map[string]any {
+	t.Helper()
+
+	server := extractServer(t, result)
+
+	routes, ok := server["routes"].([]map[string]any)
+	if !ok {
+		t.Fatal("routes not found or wrong type in server config")
+	}
+	if len(routes) == 0 {
+		t.Fatal("no routes in server config")
+	}
+
+	// The catch-all route is always last.
+	catchAll := routes[len(routes)-1]
+	rawHandlers, ok := catchAll["handle"].([]map[string]any)
+	if !ok {
+		t.Fatal("handle not found or wrong type in catch-all route")
+	}
+
+	return rawHandlers
+}
+
+// findHandlerByType returns the first handler map with the given "handler" value,
+// or nil if not found.
+func findHandlerByType(handlers []map[string]any, handlerType string) map[string]any {
+	for _, h := range handlers {
+		if h["handler"] == handlerType {
+			return h
+		}
+	}
+	return nil
+}

--- a/internal/adapters/caddy/config.go
+++ b/internal/adapters/caddy/config.go
@@ -47,7 +47,7 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 	}
 
 	// Build route handlers (middleware chain + reverse proxy).
-	// Middleware order: StripUserHeaders → SecurityHeaders → AdminAuth → BodySize → RateLimit → CircuitBreaker → Retry → Timeout → ReverseProxy
+	// Middleware order: StripUserHeaders → SecurityHeaders → AdminAuth → BodySize → RateLimit → CircuitBreaker → Retry → Timeout → Compression → ReverseProxy
 	//
 	// The header strip handler MUST be first so that spoofed X-User-* headers sent
 	// by clients are removed before any other handler (including auth) runs.
@@ -125,6 +125,14 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 		if timeoutHandler != nil {
 			handlers = append(handlers, timeoutHandler)
 		}
+	}
+
+	// Add compression handler before the reverse proxy so that Caddy can
+	// compress the upstream response before writing it to the client.
+	// The encode handler wraps the downstream response writer; it must appear
+	// in the chain before any handler that writes response bytes.
+	if cfg.Compression.Enabled {
+		handlers = append(handlers, buildCompressionHandlerJSON(cfg.Compression))
 	}
 
 	// Add reverse proxy as final handler.

--- a/internal/adapters/caddy/config_handlers.go
+++ b/internal/adapters/caddy/config_handlers.go
@@ -6,6 +6,10 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
+// defaultCompressionAlgorithms is the fallback list used when
+// CompressionConfig.Algorithms is empty.
+var defaultCompressionAlgorithms = []string{"zstd", "gzip"}
+
 // buildUserHeaderStripHandler creates a Caddy headers handler that deletes the
 // X-User-Id, X-User-Email, and X-User-Verified request headers.
 //
@@ -93,5 +97,38 @@ func buildSecurityHeadersHandler(cfg ports.SecurityHeadersConfig, tlsEnabled boo
 	return map[string]any{
 		"handler":  "headers",
 		"response": response,
+	}
+}
+
+// buildCompressionHandlerJSON creates a Caddy encode handler that compresses
+// response bodies using the algorithms listed in cfg.Algorithms.
+//
+// Caddy's encode handler (module: http.handlers.encode) negotiates the best
+// encoding with the client via the Accept-Encoding request header. Algorithms
+// are applied in the order they appear in the encodings map; zstd is preferred
+// over gzip when both are offered by the client.
+//
+// The handler is placed in the middleware chain after all request-phase
+// middleware (auth, rate limit, etc.) and before the reverse proxy so that
+// Caddy can compress the upstream response before sending it to the client.
+func buildCompressionHandlerJSON(cfg ports.CompressionConfig) map[string]any {
+	algos := cfg.Algorithms
+	if len(algos) == 0 {
+		algos = defaultCompressionAlgorithms
+	}
+
+	encodings := map[string]any{}
+	for _, algo := range algos {
+		switch algo {
+		case "gzip":
+			encodings["gzip"] = map[string]any{}
+		case "zstd":
+			encodings["zstd"] = map[string]any{}
+		}
+	}
+
+	return map[string]any{
+		"handler":   "encode",
+		"encodings": encodings,
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,6 +107,9 @@ type Config struct {
 
 	// Maintenance configures the maintenance mode plugin.
 	Maintenance MaintenanceConfig `mapstructure:"maintenance"`
+
+	// Compression configures response body compression.
+	Compression CompressionConfig `mapstructure:"compression"`
 }
 
 // DatabasePoolConfig holds connection pool settings for PostgreSQL.
@@ -1209,6 +1212,19 @@ type MaintenanceConfig struct {
 	Message string `mapstructure:"message"`
 }
 
+// CompressionConfig holds settings for response body compression.
+// Maps to the compression section of vibewarden.yaml.
+type CompressionConfig struct {
+	// Enabled toggles response compression. Default: true.
+	Enabled bool `mapstructure:"enabled"`
+
+	// Algorithms is the ordered list of compression algorithms to offer.
+	// Caddy negotiates the best match with the client via Accept-Encoding.
+	// Valid values: "gzip", "zstd".
+	// Default: ["zstd", "gzip"].
+	Algorithms []string `mapstructure:"algorithms"`
+}
+
 // Validate checks the loaded configuration for logical consistency.
 // It returns a combined error listing all violations found.
 // Call Validate after Load to catch misconfiguration early.
@@ -1905,6 +1921,8 @@ func Load(configPath string) (*Config, error) {
 	v.SetDefault("egress.routes", []EgressRouteConfig{})
 	v.SetDefault("error_pages.enabled", false)
 	v.SetDefault("error_pages.directory", "")
+	v.SetDefault("compression.enabled", true)
+	v.SetDefault("compression.algorithms", []string{"zstd", "gzip"})
 
 	// Config file
 	if configPath != "" {

--- a/internal/ports/proxy.go
+++ b/internal/ports/proxy.go
@@ -70,6 +70,23 @@ type ProxyConfig struct {
 	// Readiness configuration — controls the /_vibewarden/ready endpoint that
 	// reports whether all plugins are initialised and the upstream is reachable.
 	Readiness ReadinessProxyConfig
+
+	// Compression configuration — controls response body compression.
+	Compression CompressionConfig
+}
+
+// CompressionConfig holds configuration for response body compression.
+// Caddy's native encode handler is used to perform the compression, so no
+// additional dependencies are required.
+type CompressionConfig struct {
+	// Enabled toggles response compression. Defaults to true.
+	Enabled bool
+
+	// Algorithms is the ordered list of compression algorithms to offer.
+	// Caddy negotiates the best algorithm with the client via Accept-Encoding.
+	// Valid values: "gzip", "zstd".
+	// Defaults to ["zstd", "gzip"] when empty.
+	Algorithms []string
 }
 
 // ReadinessProxyConfig holds configuration for exposing the readiness probe


### PR DESCRIPTION
Closes #479

## Summary

- Add `CompressionConfig` to `internal/ports/proxy.go` with `Enabled bool` and `Algorithms []string` fields
- Add `CompressionConfig` to `internal/config/config.go` with defaults: `enabled=true`, `algorithms=["zstd","gzip"]`
- Add `buildCompressionHandlerJSON` in `internal/adapters/caddy/config_handlers.go` — builds a Caddy `encode` handler with the configured algorithms; unknown algorithms are silently ignored; empty algorithms list falls back to `["zstd","gzip"]`
- Wire the encode handler in `BuildCaddyConfig` (placed immediately before the reverse proxy handler so it wraps the upstream response)
- Wire `cfg.Compression` through `buildProxyConfig` in `cmd/vibewarden/serve_config.go`
- No new dependencies — Caddy's encode module ships with Caddy v2

## Test plan

- `TestBuildCompressionHandlerJSON` — table-driven unit tests covering: nil algorithms (defaults), gzip-only, zstd-only, explicit order, unknown algorithms ignored, all-unknown produces empty encodings map
- `TestBuildCaddyConfig_Compression` — integration tests covering: handler present when enabled, handler absent when disabled, gzip-only config
- `make check` passes: formatting, lint, build, race tests, demo-app