### PR TITLE
feat(#482): implement response header modification plugin

### DIFF
--- a/cmd/vibewarden/serve_config.go
+++ b/cmd/vibewarden/serve_config.go
@@ -107,6 +107,14 @@ func buildProxyConfig(cfg *config.Config, registry *plugins.Registry) *ports.Pro
 			Enabled:    cfg.Compression.Enabled,
 			Algorithms: cfg.Compression.Algorithms,
 		},
+		ResponseHeaders: ports.ResponseHeadersConfig{
+			Enabled: len(cfg.ResponseHeaders.Set) > 0 ||
+				len(cfg.ResponseHeaders.Add) > 0 ||
+				len(cfg.ResponseHeaders.Remove) > 0,
+			Set:    cfg.ResponseHeaders.Set,
+			Add:    cfg.ResponseHeaders.Add,
+			Remove: cfg.ResponseHeaders.Remove,
+		},
 	}
 }
 

--- a/internal/adapters/caddy/config.go
+++ b/internal/adapters/caddy/config.go
@@ -47,7 +47,7 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 	}
 
 	// Build route handlers (middleware chain + reverse proxy).
-	// Middleware order: StripUserHeaders → SecurityHeaders → AdminAuth → BodySize → RateLimit → CircuitBreaker → Retry → Timeout → Compression → ReverseProxy
+	// Middleware order: StripUserHeaders → SecurityHeaders → ResponseHeaders → AdminAuth → BodySize → RateLimit → CircuitBreaker → Retry → Timeout → Compression → ReverseProxy
 	//
 	// The header strip handler MUST be first so that spoofed X-User-* headers sent
 	// by clients are removed before any other handler (including auth) runs.
@@ -58,6 +58,13 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 	// Add security headers handler if enabled.
 	if cfg.SecurityHeaders.Enabled {
 		handlers = append(handlers, buildSecurityHeadersHandler(cfg.SecurityHeaders, cfg.TLS.Enabled))
+	}
+
+	// Add response header modification handler if any rules are configured.
+	// This runs after security headers so that operator rules can override or
+	// extend headers set by the security-headers plugin.
+	if cfg.ResponseHeaders.Enabled {
+		handlers = append(handlers, buildResponseHeadersHandlerJSON(cfg.ResponseHeaders))
 	}
 
 	// Add admin auth handler. It is always included so that admin paths return

--- a/internal/adapters/caddy/config_handlers.go
+++ b/internal/adapters/caddy/config_handlers.go
@@ -100,6 +100,42 @@ func buildSecurityHeadersHandler(cfg ports.SecurityHeadersConfig, tlsEnabled boo
 	}
 }
 
+// buildResponseHeadersHandlerJSON creates the Caddy headers handler that
+// applies operator-configured arbitrary response header modifications.
+//
+// Operations are applied in the order Caddy processes them: delete, then set,
+// then add. This matches the documented order of operations for the plugin.
+// Only non-empty sub-keys are included in the generated JSON to keep the
+// configuration minimal.
+func buildResponseHeadersHandlerJSON(cfg ports.ResponseHeadersConfig) map[string]any {
+	response := map[string]any{}
+
+	if len(cfg.Remove) > 0 {
+		response["delete"] = cfg.Remove
+	}
+
+	if len(cfg.Set) > 0 {
+		set := make(map[string][]string, len(cfg.Set))
+		for k, v := range cfg.Set {
+			set[k] = []string{v}
+		}
+		response["set"] = set
+	}
+
+	if len(cfg.Add) > 0 {
+		add := make(map[string][]string, len(cfg.Add))
+		for k, v := range cfg.Add {
+			add[k] = []string{v}
+		}
+		response["add"] = add
+	}
+
+	return map[string]any{
+		"handler":  "headers",
+		"response": response,
+	}
+}
+
 // buildCompressionHandlerJSON creates a Caddy encode handler that compresses
 // response bodies using the algorithms listed in cfg.Algorithms.
 //

--- a/internal/adapters/caddy/response_headers_handler_test.go
+++ b/internal/adapters/caddy/response_headers_handler_test.go
@@ -1,0 +1,328 @@
+package caddy
+
+import (
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+func TestBuildResponseHeadersHandlerJSON_Remove(t *testing.T) {
+	cfg := ports.ResponseHeadersConfig{
+		Enabled: true,
+		Remove:  []string{"Server", "X-Powered-By"},
+	}
+	result := buildResponseHeadersHandlerJSON(cfg)
+
+	if result["handler"] != "headers" {
+		t.Errorf("handler = %q, want \"headers\"", result["handler"])
+	}
+
+	resp, ok := result["response"].(map[string]any)
+	if !ok {
+		t.Fatalf("response = %T, want map[string]any", result["response"])
+	}
+
+	del, ok := resp["delete"].([]string)
+	if !ok {
+		t.Fatalf("response.delete = %T, want []string", resp["delete"])
+	}
+	if len(del) != 2 {
+		t.Fatalf("response.delete len = %d, want 2", len(del))
+	}
+	for _, want := range []string{"Server", "X-Powered-By"} {
+		found := false
+		for _, got := range del {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("response.delete does not contain %q; got %v", want, del)
+		}
+	}
+
+	// Must not have set or add keys.
+	if _, has := resp["set"]; has {
+		t.Error("response.set should not be present when Set map is empty")
+	}
+	if _, has := resp["add"]; has {
+		t.Error("response.add should not be present when Add map is empty")
+	}
+}
+
+func TestBuildResponseHeadersHandlerJSON_Set(t *testing.T) {
+	cfg := ports.ResponseHeadersConfig{
+		Enabled: true,
+		Set:     map[string]string{"X-Service-Version": "1.0.0"},
+	}
+	result := buildResponseHeadersHandlerJSON(cfg)
+
+	resp, ok := result["response"].(map[string]any)
+	if !ok {
+		t.Fatalf("response = %T, want map[string]any", result["response"])
+	}
+
+	set, ok := resp["set"].(map[string][]string)
+	if !ok {
+		t.Fatalf("response.set = %T, want map[string][]string", resp["set"])
+	}
+	vals, exists := set["X-Service-Version"]
+	if !exists {
+		t.Fatal("response.set missing X-Service-Version")
+	}
+	if len(vals) != 1 || vals[0] != "1.0.0" {
+		t.Errorf("X-Service-Version = %v, want [\"1.0.0\"]", vals)
+	}
+
+	// Must not have delete or add keys.
+	if _, has := resp["delete"]; has {
+		t.Error("response.delete should not be present when Remove is empty")
+	}
+	if _, has := resp["add"]; has {
+		t.Error("response.add should not be present when Add map is empty")
+	}
+}
+
+func TestBuildResponseHeadersHandlerJSON_Add(t *testing.T) {
+	cfg := ports.ResponseHeadersConfig{
+		Enabled: true,
+		Add:     map[string]string{"Cache-Control": "no-store"},
+	}
+	result := buildResponseHeadersHandlerJSON(cfg)
+
+	resp, ok := result["response"].(map[string]any)
+	if !ok {
+		t.Fatalf("response = %T, want map[string]any", result["response"])
+	}
+
+	add, ok := resp["add"].(map[string][]string)
+	if !ok {
+		t.Fatalf("response.add = %T, want map[string][]string", resp["add"])
+	}
+	vals, exists := add["Cache-Control"]
+	if !exists {
+		t.Fatal("response.add missing Cache-Control")
+	}
+	if len(vals) != 1 || vals[0] != "no-store" {
+		t.Errorf("Cache-Control = %v, want [\"no-store\"]", vals)
+	}
+
+	// Must not have delete or set keys.
+	if _, has := resp["delete"]; has {
+		t.Error("response.delete should not be present when Remove is empty")
+	}
+	if _, has := resp["set"]; has {
+		t.Error("response.set should not be present when Set map is empty")
+	}
+}
+
+func TestBuildResponseHeadersHandlerJSON_AllOperations(t *testing.T) {
+	cfg := ports.ResponseHeadersConfig{
+		Enabled: true,
+		Set:     map[string]string{"X-Version": "2"},
+		Add:     map[string]string{"X-Extra": "yes"},
+		Remove:  []string{"Server"},
+	}
+	result := buildResponseHeadersHandlerJSON(cfg)
+
+	resp, ok := result["response"].(map[string]any)
+	if !ok {
+		t.Fatalf("response = %T, want map[string]any", result["response"])
+	}
+
+	if _, ok := resp["delete"]; !ok {
+		t.Error("expected response.delete to be present")
+	}
+	if _, ok := resp["set"]; !ok {
+		t.Error("expected response.set to be present")
+	}
+	if _, ok := resp["add"]; !ok {
+		t.Error("expected response.add to be present")
+	}
+}
+
+func TestBuildResponseHeadersHandlerJSON_EnvVarPassThrough(t *testing.T) {
+	cfg := ports.ResponseHeadersConfig{
+		Enabled: true,
+		Set:     map[string]string{"X-Version": "${APP_VERSION}"},
+	}
+	result := buildResponseHeadersHandlerJSON(cfg)
+
+	resp := result["response"].(map[string]any)
+	set := resp["set"].(map[string][]string)
+	vals := set["X-Version"]
+	if len(vals) != 1 || vals[0] != "${APP_VERSION}" {
+		t.Errorf("X-Version = %v, want [\"${APP_VERSION}\"]", vals)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration with BuildCaddyConfig
+// ---------------------------------------------------------------------------
+
+func TestBuildCaddyConfig_ResponseHeaders_Disabled(t *testing.T) {
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "127.0.0.1:8080",
+		UpstreamAddr: "127.0.0.1:3000",
+		ResponseHeaders: ports.ResponseHeadersConfig{
+			Enabled: false,
+		},
+	}
+	result, err := BuildCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+	}
+
+	handlers := extractCatchAllHandlers(t, result)
+
+	// When disabled, no extra headers handler should appear beyond the
+	// user-header-strip handler and the reverse proxy.
+	for _, h := range handlers {
+		handler, _ := h["handler"].(string)
+		if handler != "headers" {
+			continue
+		}
+		// The user-header-strip handler operates on "request", not "response".
+		// If any headers handler has a "response" key it came from our plugin.
+		if _, hasResp := h["response"]; hasResp {
+			t.Error("unexpected response headers handler when ResponseHeaders.Enabled is false")
+		}
+	}
+}
+
+func TestBuildCaddyConfig_ResponseHeaders_RemoveServer(t *testing.T) {
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "127.0.0.1:8080",
+		UpstreamAddr: "127.0.0.1:3000",
+		ResponseHeaders: ports.ResponseHeadersConfig{
+			Enabled: true,
+			Remove:  []string{"Server"},
+		},
+	}
+	result, err := BuildCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+	}
+
+	handlers := extractCatchAllHandlers(t, result)
+
+	found := false
+	for _, h := range handlers {
+		resp, ok := h["response"].(map[string]any)
+		if !ok {
+			continue
+		}
+		del, ok := resp["delete"].([]string)
+		if !ok {
+			continue
+		}
+		for _, name := range del {
+			if name == "Server" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("expected response headers handler with Server in delete list")
+	}
+}
+
+func TestBuildCaddyConfig_ResponseHeaders_SetHeader(t *testing.T) {
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "127.0.0.1:8080",
+		UpstreamAddr: "127.0.0.1:3000",
+		ResponseHeaders: ports.ResponseHeadersConfig{
+			Enabled: true,
+			Set:     map[string]string{"X-Service-Version": "1.2.3"},
+		},
+	}
+	result, err := BuildCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+	}
+
+	handlers := extractCatchAllHandlers(t, result)
+
+	found := false
+	for _, h := range handlers {
+		resp, ok := h["response"].(map[string]any)
+		if !ok {
+			continue
+		}
+		set, ok := resp["set"].(map[string][]string)
+		if !ok {
+			continue
+		}
+		if vals, exists := set["X-Service-Version"]; exists {
+			if len(vals) == 1 && vals[0] == "1.2.3" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("expected response headers handler with X-Service-Version set to 1.2.3")
+	}
+}
+
+func TestBuildCaddyConfig_ResponseHeaders_AfterSecurityHeaders(t *testing.T) {
+	// Verify that the response-headers handler appears after the security-headers
+	// handler in the catch-all chain. This ensures operator rules can override
+	// security headers.
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "127.0.0.1:8080",
+		UpstreamAddr: "127.0.0.1:3000",
+		SecurityHeaders: ports.SecurityHeadersConfig{
+			Enabled:     true,
+			FrameOption: "DENY",
+		},
+		ResponseHeaders: ports.ResponseHeadersConfig{
+			Enabled: true,
+			Set:     map[string]string{"X-Frame-Options": "SAMEORIGIN"},
+		},
+	}
+	result, err := BuildCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+	}
+
+	handlers := extractCatchAllHandlers(t, result)
+
+	secHeadersIdx := -1
+	respHeadersIdx := -1
+
+	for i, h := range handlers {
+		if h["handler"] != "headers" {
+			continue
+		}
+		resp, ok := h["response"].(map[string]any)
+		if !ok {
+			continue
+		}
+		setMap, ok := resp["set"].(map[string][]string)
+		if !ok {
+			continue
+		}
+		if _, hasFrame := setMap["X-Frame-Options"]; hasFrame {
+			// The security-headers handler sets X-Frame-Options to DENY.
+			// The response-headers handler sets it to SAMEORIGIN.
+			// We identify the first by index.
+			if secHeadersIdx == -1 {
+				secHeadersIdx = i
+			} else {
+				respHeadersIdx = i
+			}
+		}
+	}
+
+	if secHeadersIdx == -1 {
+		t.Fatal("could not find security-headers handler in catch-all chain")
+	}
+	if respHeadersIdx == -1 {
+		t.Fatal("could not find response-headers handler in catch-all chain")
+	}
+	if respHeadersIdx <= secHeadersIdx {
+		t.Errorf("response-headers handler (index %d) must come after security-headers handler (index %d)",
+			respHeadersIdx, secHeadersIdx)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,6 +110,10 @@ type Config struct {
 
 	// Compression configures response body compression.
 	Compression CompressionConfig `mapstructure:"compression"`
+
+	// ResponseHeaders configures arbitrary response header modifications applied
+	// after all other middleware including security headers.
+	ResponseHeaders ResponseHeadersConfig `mapstructure:"response_headers"`
 }
 
 // DatabasePoolConfig holds connection pool settings for PostgreSQL.
@@ -1223,6 +1227,24 @@ type CompressionConfig struct {
 	// Valid values: "gzip", "zstd".
 	// Default: ["zstd", "gzip"].
 	Algorithms []string `mapstructure:"algorithms"`
+}
+
+// ResponseHeadersConfig holds settings for arbitrary response header modification.
+// Maps to the response_headers section of vibewarden.yaml.
+// Operations are applied in the order: remove, then set, then add.
+type ResponseHeadersConfig struct {
+	// Set maps header names to values that overwrite any existing value (or create
+	// the header when absent). Values may reference environment variables using
+	// ${VAR} syntax; Caddy resolves these at request time.
+	Set map[string]string `mapstructure:"set"`
+
+	// Add maps header names to values that are appended to any existing value (or
+	// create the header when absent). Values may reference environment variables
+	// using ${VAR} syntax.
+	Add map[string]string `mapstructure:"add"`
+
+	// Remove is the list of header names to delete from every response.
+	Remove []string `mapstructure:"remove"`
 }
 
 // Validate checks the loaded configuration for logical consistency.

--- a/internal/plugins/catalog.go
+++ b/internal/plugins/catalog.go
@@ -261,6 +261,23 @@ var Catalog = []PluginDescriptor{
           reset_after: "30s"`,
 	},
 	{
+		Name:        "response-headers",
+		Description: "Response header modification: set, add, or remove arbitrary response headers",
+		ConfigSchema: map[string]string{
+			"set":    "Map of header names to values that overwrite any existing value (or create the header). Values support ${ENV_VAR} substitution.",
+			"add":    "Map of header names to values that are appended to any existing value (or create the header). Values support ${ENV_VAR} substitution.",
+			"remove": "List of header names to delete from every response.",
+		},
+		Example: `  response_headers:
+    remove:
+      - Server
+    set:
+      X-Service-Version: "${APP_VERSION}"
+      X-Frame-Options: SAMEORIGIN
+    add:
+      Cache-Control: no-store`,
+	},
+	{
 		Name:        "secrets",
 		Description: "Secret management: fetch static and dynamic secrets from OpenBao and inject them into proxied requests",
 		ConfigSchema: map[string]string{

--- a/internal/plugins/responseheaders/config.go
+++ b/internal/plugins/responseheaders/config.go
@@ -1,0 +1,28 @@
+// Package responseheaders implements the VibeWarden response-headers plugin.
+//
+// It allows operators to add, set (overwrite), and remove arbitrary HTTP
+// response headers via config-driven rules in vibewarden.yaml.  The
+// modifications are applied after all other middleware — including the
+// security-headers plugin — so they can extend or override any header.
+//
+// Operations are applied in the order: remove → set → add.
+package responseheaders
+
+// Config holds all settings for the response-headers plugin.
+// It maps to the response_headers section of vibewarden.yaml.
+type Config struct {
+	// Set maps header names to values that overwrite any existing value, or
+	// create the header when it is not already present in the response.
+	// Values may reference environment variables using the ${VAR} syntax;
+	// Caddy resolves these at request time via its placeholder mechanism.
+	Set map[string]string
+
+	// Add maps header names to values that are appended to any existing value,
+	// or create the header when it is not already present.
+	// Values may reference environment variables using the ${VAR} syntax.
+	Add map[string]string
+
+	// Remove is the list of header names to delete from every response.
+	// Header names are matched case-insensitively by Caddy.
+	Remove []string
+}

--- a/internal/plugins/responseheaders/meta.go
+++ b/internal/plugins/responseheaders/meta.go
@@ -1,0 +1,28 @@
+package responseheaders
+
+// Description returns a short description of the response-headers plugin.
+func (p *Plugin) Description() string {
+	return "Response header modification: set, add, or remove arbitrary response headers"
+}
+
+// ConfigSchema returns the configuration field descriptions for the
+// response-headers plugin, used by "vibewarden plugins show response-headers".
+func (p *Plugin) ConfigSchema() map[string]string {
+	return map[string]string{
+		"set":    "Map of header names to values that overwrite any existing value (or create the header). Values support ${ENV_VAR} substitution.",
+		"add":    "Map of header names to values that are appended to any existing value (or create the header). Values support ${ENV_VAR} substitution.",
+		"remove": "List of header names to delete from every response.",
+	}
+}
+
+// Example returns an example YAML configuration for the response-headers plugin.
+func (p *Plugin) Example() string {
+	return `  response_headers:
+    remove:
+      - Server
+    set:
+      X-Service-Version: "${APP_VERSION}"
+      X-Frame-Options: SAMEORIGIN
+    add:
+      Cache-Control: no-store`
+}

--- a/internal/plugins/responseheaders/plugin.go
+++ b/internal/plugins/responseheaders/plugin.go
@@ -1,0 +1,140 @@
+package responseheaders
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// Plugin is the response-headers plugin for VibeWarden.
+// It implements ports.Plugin and ports.CaddyContributor.
+//
+// The plugin is active whenever at least one of Set, Add, or Remove is
+// non-empty.  There is no explicit Enabled toggle: an empty configuration is
+// a no-op.
+//
+// Caddy's built-in headers handler applies the modifications in the following
+// order: delete (Remove), then set (Set), then add (Add).  This matches the
+// documented order of operations.
+//
+// Start and Stop are no-ops; the plugin is fully stateless.
+type Plugin struct {
+	cfg    Config
+	logger *slog.Logger
+}
+
+// New creates a new response-headers Plugin with the given configuration.
+func New(cfg Config, logger *slog.Logger) *Plugin {
+	return &Plugin{cfg: cfg, logger: logger}
+}
+
+// Name returns the canonical plugin identifier "response-headers".
+// This must match the key used under plugins: in vibewarden.yaml.
+func (p *Plugin) Name() string { return "response-headers" }
+
+// Priority returns the plugin's initialisation priority.
+// Response-headers is assigned priority 25 so that it runs after the
+// security-headers plugin (priority 20), ensuring that user-supplied rules
+// can override security headers when explicitly configured to do so.
+func (p *Plugin) Priority() int { return 25 }
+
+// Init is a no-op for the response-headers plugin.
+// The configuration requires no validation beyond what the YAML parser enforces.
+func (p *Plugin) Init(_ context.Context) error {
+	if !p.active() {
+		return nil
+	}
+	p.logger.Info("response-headers plugin initialised",
+		slog.Int("set", len(p.cfg.Set)),
+		slog.Int("add", len(p.cfg.Add)),
+		slog.Int("remove", len(p.cfg.Remove)),
+	)
+	return nil
+}
+
+// Start is a no-op for the response-headers plugin.
+func (p *Plugin) Start(_ context.Context) error { return nil }
+
+// Stop is a no-op for the response-headers plugin.
+func (p *Plugin) Stop(_ context.Context) error { return nil }
+
+// Health returns the current health status of the response-headers plugin.
+// The plugin is always healthy; it reports whether it is active or inactive.
+func (p *Plugin) Health() ports.HealthStatus {
+	if !p.active() {
+		return ports.HealthStatus{
+			Healthy: true,
+			Message: "response-headers inactive (no rules configured)",
+		}
+	}
+	return ports.HealthStatus{
+		Healthy: true,
+		Message: "response-headers configured",
+	}
+}
+
+// ContributeCaddyRoutes returns nil.
+// The response-headers plugin does not add named routes; it contributes a
+// catch-all handler via ContributeCaddyHandlers.
+func (p *Plugin) ContributeCaddyRoutes() []ports.CaddyRoute { return nil }
+
+// ContributeCaddyHandlers returns the Caddy headers handler that applies all
+// configured response header modifications to every response.
+// Returns an empty slice when no rules are configured.
+func (p *Plugin) ContributeCaddyHandlers() []ports.CaddyHandler {
+	if !p.active() {
+		return nil
+	}
+	return []ports.CaddyHandler{
+		{
+			Handler:  buildResponseHeadersHandler(p.cfg),
+			Priority: 25,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers — pure functions, no side effects.
+// ---------------------------------------------------------------------------
+
+// active reports whether the plugin has at least one rule to apply.
+func (p *Plugin) active() bool {
+	return len(p.cfg.Set) > 0 || len(p.cfg.Add) > 0 || len(p.cfg.Remove) > 0
+}
+
+// buildResponseHeadersHandler creates the Caddy headers handler map that
+// applies the remove → set → add operations described in cfg.
+//
+// The "response" key in the Caddy headers handler supports three sub-keys:
+//   - "delete": []string of header names to remove.
+//   - "set":    map[string][]string of headers to overwrite.
+//   - "add":    map[string][]string of headers to append.
+func buildResponseHeadersHandler(cfg Config) map[string]any {
+	response := map[string]any{}
+
+	if len(cfg.Remove) > 0 {
+		response["delete"] = cfg.Remove
+	}
+
+	if len(cfg.Set) > 0 {
+		set := make(map[string][]string, len(cfg.Set))
+		for k, v := range cfg.Set {
+			set[k] = []string{v}
+		}
+		response["set"] = set
+	}
+
+	if len(cfg.Add) > 0 {
+		add := make(map[string][]string, len(cfg.Add))
+		for k, v := range cfg.Add {
+			add[k] = []string{v}
+		}
+		response["add"] = add
+	}
+
+	return map[string]any{
+		"handler":  "headers",
+		"response": response,
+	}
+}

--- a/internal/plugins/responseheaders/plugin_test.go
+++ b/internal/plugins/responseheaders/plugin_test.go
@@ -1,0 +1,403 @@
+package responseheaders_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/plugins/responseheaders"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type noopWriter struct{}
+
+func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(noopWriter{}, nil))
+}
+
+func newPlugin(cfg responseheaders.Config) *responseheaders.Plugin {
+	return responseheaders.New(cfg, discardLogger())
+}
+
+// responseSection extracts the "response" sub-map from a Caddy headers handler.
+func responseSection(t *testing.T, handler map[string]any) map[string]any {
+	t.Helper()
+	resp, ok := handler["response"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected response key to be map[string]any, got %T", handler["response"])
+	}
+	return resp
+}
+
+// ---------------------------------------------------------------------------
+// Name / Priority
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Name(t *testing.T) {
+	p := newPlugin(responseheaders.Config{})
+	if got := p.Name(); got != "response-headers" {
+		t.Errorf("Name() = %q, want %q", got, "response-headers")
+	}
+}
+
+func TestPlugin_Priority(t *testing.T) {
+	p := newPlugin(responseheaders.Config{})
+	if got := p.Priority(); got != 25 {
+		t.Errorf("Priority() = %d, want 25", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Init — no-op, always succeeds
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Init_AlwaysSucceeds(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  responseheaders.Config
+	}{
+		{"empty config", responseheaders.Config{}},
+		{
+			"full config",
+			responseheaders.Config{
+				Set:    map[string]string{"X-Foo": "bar"},
+				Add:    map[string]string{"Cache-Control": "no-store"},
+				Remove: []string{"Server"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			if err := p.Init(context.Background()); err != nil {
+				t.Errorf("Init() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Start / Stop — no-ops
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Start_IsNoop(t *testing.T) {
+	p := newPlugin(responseheaders.Config{Set: map[string]string{"X-A": "1"}})
+	if err := p.Start(context.Background()); err != nil {
+		t.Errorf("Start() unexpected error: %v", err)
+	}
+}
+
+func TestPlugin_Stop_IsNoop(t *testing.T) {
+	p := newPlugin(responseheaders.Config{Remove: []string{"Server"}})
+	if err := p.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Health(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            responseheaders.Config
+		wantHealthy    bool
+		wantMsgContain string
+	}{
+		{
+			name:           "inactive — empty config",
+			cfg:            responseheaders.Config{},
+			wantHealthy:    true,
+			wantMsgContain: "inactive",
+		},
+		{
+			name:           "active — has set rules",
+			cfg:            responseheaders.Config{Set: map[string]string{"X-A": "1"}},
+			wantHealthy:    true,
+			wantMsgContain: "configured",
+		},
+		{
+			name:           "active — has add rules",
+			cfg:            responseheaders.Config{Add: map[string]string{"X-B": "2"}},
+			wantHealthy:    true,
+			wantMsgContain: "configured",
+		},
+		{
+			name:           "active — has remove rules",
+			cfg:            responseheaders.Config{Remove: []string{"Server"}},
+			wantHealthy:    true,
+			wantMsgContain: "configured",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			h := p.Health()
+			if h.Healthy != tt.wantHealthy {
+				t.Errorf("Health().Healthy = %v, want %v", h.Healthy, tt.wantHealthy)
+			}
+			if tt.wantMsgContain != "" {
+				found := false
+				for i := 0; i < len(h.Message)-len(tt.wantMsgContain)+1; i++ {
+					if h.Message[i:i+len(tt.wantMsgContain)] == tt.wantMsgContain {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Health().Message = %q, want it to contain %q", h.Message, tt.wantMsgContain)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyRoutes
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyRoutes_AlwaysEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  responseheaders.Config
+	}{
+		{"empty config", responseheaders.Config{}},
+		{"active config", responseheaders.Config{Remove: []string{"Server"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			if routes := p.ContributeCaddyRoutes(); len(routes) != 0 {
+				t.Errorf("ContributeCaddyRoutes() = %v, want empty", routes)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyHandlers
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyHandlers_InactiveReturnsNil(t *testing.T) {
+	p := newPlugin(responseheaders.Config{})
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 0 {
+		t.Errorf("ContributeCaddyHandlers() = %v, want empty when no rules configured", handlers)
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_ActiveReturnsOne(t *testing.T) {
+	p := newPlugin(responseheaders.Config{Remove: []string{"Server"}})
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 1 {
+		t.Fatalf("ContributeCaddyHandlers() len = %d, want 1", len(handlers))
+	}
+	if handlers[0].Priority != 25 {
+		t.Errorf("handler Priority = %d, want 25", handlers[0].Priority)
+	}
+	if handlers[0].Handler["handler"] != "headers" {
+		t.Errorf("handler[\"handler\"] = %v, want \"headers\"", handlers[0].Handler["handler"])
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_Remove(t *testing.T) {
+	cfg := responseheaders.Config{
+		Remove: []string{"Server", "X-Powered-By"},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) == 0 {
+		t.Fatal("expected at least one handler")
+	}
+
+	resp := responseSection(t, handlers[0].Handler)
+	del, ok := resp["delete"].([]string)
+	if !ok {
+		t.Fatalf("response.delete = %T, want []string", resp["delete"])
+	}
+	if len(del) != 2 {
+		t.Errorf("response.delete len = %d, want 2", len(del))
+	}
+	for _, want := range []string{"Server", "X-Powered-By"} {
+		found := false
+		for _, got := range del {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("response.delete does not contain %q; got %v", want, del)
+		}
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_Set(t *testing.T) {
+	cfg := responseheaders.Config{
+		Set: map[string]string{
+			"X-Service-Version": "1.2.3",
+			"X-Frame-Options":   "SAMEORIGIN",
+		},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) == 0 {
+		t.Fatal("expected at least one handler")
+	}
+
+	resp := responseSection(t, handlers[0].Handler)
+	set, ok := resp["set"].(map[string][]string)
+	if !ok {
+		t.Fatalf("response.set = %T, want map[string][]string", resp["set"])
+	}
+
+	tests := []struct {
+		header string
+		want   string
+	}{
+		{"X-Service-Version", "1.2.3"},
+		{"X-Frame-Options", "SAMEORIGIN"},
+	}
+	for _, tt := range tests {
+		vals, exists := set[tt.header]
+		if !exists {
+			t.Errorf("response.set missing header %q", tt.header)
+			continue
+		}
+		if len(vals) != 1 || vals[0] != tt.want {
+			t.Errorf("response.set[%q] = %v, want [%q]", tt.header, vals, tt.want)
+		}
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_Add(t *testing.T) {
+	cfg := responseheaders.Config{
+		Add: map[string]string{
+			"Cache-Control": "no-store",
+		},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) == 0 {
+		t.Fatal("expected at least one handler")
+	}
+
+	resp := responseSection(t, handlers[0].Handler)
+	add, ok := resp["add"].(map[string][]string)
+	if !ok {
+		t.Fatalf("response.add = %T, want map[string][]string", resp["add"])
+	}
+
+	vals, exists := add["Cache-Control"]
+	if !exists {
+		t.Fatal("response.add missing Cache-Control header")
+	}
+	if len(vals) != 1 || vals[0] != "no-store" {
+		t.Errorf("response.add[Cache-Control] = %v, want [\"no-store\"]", vals)
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_NoDeleteKeyWhenRemoveEmpty(t *testing.T) {
+	cfg := responseheaders.Config{
+		Set: map[string]string{"X-Foo": "bar"},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	resp := responseSection(t, handlers[0].Handler)
+	if _, hasDelete := resp["delete"]; hasDelete {
+		t.Error("response.delete should not be set when Remove is empty")
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_NoSetKeyWhenSetEmpty(t *testing.T) {
+	cfg := responseheaders.Config{
+		Remove: []string{"Server"},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	resp := responseSection(t, handlers[0].Handler)
+	if _, hasSet := resp["set"]; hasSet {
+		t.Error("response.set should not be set when Set map is empty")
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_NoAddKeyWhenAddEmpty(t *testing.T) {
+	cfg := responseheaders.Config{
+		Remove: []string{"Server"},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	resp := responseSection(t, handlers[0].Handler)
+	if _, hasAdd := resp["add"]; hasAdd {
+		t.Error("response.add should not be set when Add map is empty")
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_AllOperationsTogether(t *testing.T) {
+	cfg := responseheaders.Config{
+		Set:    map[string]string{"X-Version": "2"},
+		Add:    map[string]string{"X-Extra": "yes"},
+		Remove: []string{"Server"},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 1 {
+		t.Fatalf("expected 1 handler, got %d", len(handlers))
+	}
+
+	resp := responseSection(t, handlers[0].Handler)
+
+	if _, ok := resp["delete"]; !ok {
+		t.Error("expected response.delete to be set")
+	}
+	if _, ok := resp["set"]; !ok {
+		t.Error("expected response.set to be set")
+	}
+	if _, ok := resp["add"]; !ok {
+		t.Error("expected response.add to be set")
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_EnvVarValuePassedThrough(t *testing.T) {
+	// Caddy resolves ${VAR} placeholders at request time; the plugin must pass
+	// the raw string through unchanged so Caddy can perform substitution.
+	cfg := responseheaders.Config{
+		Set: map[string]string{
+			"X-Service-Version": "${APP_VERSION}",
+		},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	resp := responseSection(t, handlers[0].Handler)
+	set, ok := resp["set"].(map[string][]string)
+	if !ok {
+		t.Fatalf("response.set = %T, want map[string][]string", resp["set"])
+	}
+	vals := set["X-Service-Version"]
+	if len(vals) != 1 || vals[0] != "${APP_VERSION}" {
+		t.Errorf("X-Service-Version = %v, want [\"${APP_VERSION}\"]", vals)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Interface compliance
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ImplementsPortsPlugin(t *testing.T) {
+	var _ ports.Plugin = (*responseheaders.Plugin)(nil)
+}
+
+func TestPlugin_ImplementsCaddyContributor(t *testing.T) {
+	var _ ports.CaddyContributor = (*responseheaders.Plugin)(nil)
+}
+
+func TestPlugin_ImplementsPluginMeta(t *testing.T) {
+	var _ ports.PluginMeta = (*responseheaders.Plugin)(nil)
+}

--- a/internal/ports/proxy.go
+++ b/internal/ports/proxy.go
@@ -73,6 +73,33 @@ type ProxyConfig struct {
 
 	// Compression configuration — controls response body compression.
 	Compression CompressionConfig
+
+	// ResponseHeaders configuration — controls arbitrary response header
+	// modifications applied after all other middleware (including security headers).
+	ResponseHeaders ResponseHeadersConfig
+}
+
+// ResponseHeadersConfig holds configuration for arbitrary response header modifications.
+// Operations are applied in the order: remove, then set, then add.
+// This handler is applied after security headers so that it can override or
+// extend any header set by the security-headers plugin.
+type ResponseHeadersConfig struct {
+	// Enabled toggles response header modification.
+	Enabled bool
+
+	// Set maps header names to values that overwrite the existing header value,
+	// or create the header if it is not already present.
+	// Values may reference environment variables using the ${VAR} syntax, which
+	// Caddy evaluates at request time via its placeholder mechanism.
+	Set map[string]string
+
+	// Add maps header names to values that are appended to the existing header
+	// value, or created when the header is not already present.
+	// Values may reference environment variables using the ${VAR} syntax.
+	Add map[string]string
+
+	// Remove is the list of header names to delete from every response.
+	Remove []string
 }
 
 // CompressionConfig holds configuration for response body compression.


### PR DESCRIPTION
Closes #482

## Summary

- Adds `internal/plugins/responseheaders/` — a new plugin (`Config`, `Plugin`, `meta.go`) that contributes a Caddy `headers` handler with remove, set, and add operations on response headers.
- Adds `ports.ResponseHeadersConfig` (with `Enabled`, `Set`, `Add`, `Remove` fields) to `internal/ports/proxy.go`.
- Adds `ResponseHeadersConfig` struct and `ResponseHeaders` field to `internal/config/config.go` under the `response_headers` YAML key.
- Adds `buildResponseHeadersHandlerJSON` to `internal/adapters/caddy/config_handlers.go` — a pure function that builds the Caddy handler JSON for remove/set/add operations.
- Wires the handler into `internal/adapters/caddy/config.go` after the security-headers handler (priority 25 vs 20) so operator rules can override security headers when explicitly configured.
- Wires the config in `cmd/vibewarden/serve_config.go` — `Enabled` is derived from whether any rules are present (no explicit toggle needed).
- Adds `response-headers` descriptor to `internal/plugins/catalog.go`.

## Test plan

- `internal/plugins/responseheaders/plugin_test.go` — full table-driven coverage of Name/Priority, Init/Start/Stop (no-ops), Health, ContributeCaddyRoutes (always nil), ContributeCaddyHandlers for each operation and their combinations, env-var pass-through, and interface compliance.
- `internal/adapters/caddy/response_headers_handler_test.go` — unit tests for `buildResponseHeadersHandlerJSON` (each operation in isolation, all together, env-var pass-through) and integration tests via `BuildCaddyConfig` (disabled state, remove Server, set header, ordering after security-headers).
- `go test -race ./...` passes all 70+ packages.
- `golangci-lint run ./...` reports 0 issues.
- Pre-push hook (`make check`) passes.