### PR TITLE
feat(#521): implement vibew eject command

### DIFF
--- a/internal/adapters/caddy/eject_builder.go
+++ b/internal/adapters/caddy/eject_builder.go
@@ -1,0 +1,21 @@
+package caddy
+
+import (
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// EjectBuilder implements the eject.ConfigBuilder interface using the Caddy
+// JSON configuration builder. It wraps BuildCaddyConfig so that the eject
+// application service can depend on the interface rather than the concrete
+// caddy package.
+type EjectBuilder struct{}
+
+// NewEjectBuilder returns a new EjectBuilder.
+func NewEjectBuilder() *EjectBuilder {
+	return &EjectBuilder{}
+}
+
+// Build delegates to BuildCaddyConfig and satisfies eject.ConfigBuilder.
+func (b *EjectBuilder) Build(cfg *ports.ProxyConfig) (map[string]any, error) {
+	return BuildCaddyConfig(cfg)
+}

--- a/internal/app/eject/eject.go
+++ b/internal/app/eject/eject.go
@@ -1,0 +1,260 @@
+// Package eject implements the "vibew eject" use case: reading vibewarden.yaml
+// and producing the equivalent raw proxy configuration so that operators can
+// graduate past VibeWarden and run Caddy (or another proxy) directly.
+package eject
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// Format identifies the target proxy format for the generated configuration.
+type Format string
+
+const (
+	// FormatCaddy produces Caddy's native JSON configuration.
+	FormatCaddy Format = "caddy"
+)
+
+// ErrUnsupportedFormat is returned when the requested format is not supported.
+type ErrUnsupportedFormat struct {
+	Format Format
+}
+
+func (e ErrUnsupportedFormat) Error() string {
+	return fmt.Sprintf("unsupported eject format %q; supported: caddy", e.Format)
+}
+
+// ConfigBuilder builds a proxy configuration map from a ProxyConfig.
+// The caddy adapter implements this interface.
+type ConfigBuilder interface {
+	// Build returns a proxy-format-specific configuration map.
+	Build(cfg *ports.ProxyConfig) (map[string]any, error)
+}
+
+// Service orchestrates the eject use case.
+// It translates a vibewarden.yaml Config into a proxy-native configuration
+// that can be used to run the proxy directly without VibeWarden.
+type Service struct {
+	builder ConfigBuilder
+}
+
+// NewService creates a new eject Service using the given ConfigBuilder.
+func NewService(builder ConfigBuilder) *Service {
+	return &Service{builder: builder}
+}
+
+// Eject translates the loaded VibeWarden config into a proxy-native
+// configuration map. The returned map can be serialised to JSON and fed
+// directly to the target proxy (e.g. Caddy's /load API or a config file).
+//
+// Note: internal-only addresses (metrics, admin, readiness) are omitted from
+// the generated config because those internal HTTP servers are managed by
+// VibeWarden itself and are not meaningful outside of it.
+func (s *Service) Eject(cfg *config.Config) (map[string]any, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+
+	proxyCfg := buildProxyConfig(cfg)
+	result, err := s.builder.Build(proxyCfg)
+	if err != nil {
+		return nil, fmt.Errorf("building proxy config: %w", err)
+	}
+	return result, nil
+}
+
+// buildProxyConfig converts a VibeWarden config.Config into a ports.ProxyConfig
+// suitable for the eject use case. Internal-service addresses (metrics, admin,
+// readiness) are intentionally left empty because those services are managed by
+// VibeWarden and not meaningful in a standalone proxy deployment.
+func buildProxyConfig(cfg *config.Config) *ports.ProxyConfig {
+	return &ports.ProxyConfig{
+		ListenAddr:   fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port),
+		UpstreamAddr: fmt.Sprintf("%s:%d", cfg.Upstream.Host, cfg.Upstream.Port),
+		Version:      "ejected",
+		TLS: ports.TLSConfig{
+			Enabled:     cfg.TLS.Enabled,
+			Provider:    ports.TLSProvider(cfg.TLS.Provider),
+			Domain:      cfg.TLS.Domain,
+			CertPath:    cfg.TLS.CertPath,
+			KeyPath:     cfg.TLS.KeyPath,
+			StoragePath: cfg.TLS.StoragePath,
+		},
+		SecurityHeaders: ports.SecurityHeadersConfig{
+			Enabled:                      cfg.SecurityHeaders.Enabled,
+			HSTSMaxAge:                   cfg.SecurityHeaders.HSTSMaxAge,
+			HSTSIncludeSubDomains:        cfg.SecurityHeaders.HSTSIncludeSubDomains,
+			HSTSPreload:                  cfg.SecurityHeaders.HSTSPreload,
+			ContentTypeNosniff:           cfg.SecurityHeaders.ContentTypeNosniff,
+			FrameOption:                  cfg.SecurityHeaders.FrameOption,
+			ContentSecurityPolicy:        cfg.SecurityHeaders.ContentSecurityPolicy,
+			ReferrerPolicy:               cfg.SecurityHeaders.ReferrerPolicy,
+			PermissionsPolicy:            cfg.SecurityHeaders.PermissionsPolicy,
+			CrossOriginOpenerPolicy:      cfg.SecurityHeaders.CrossOriginOpenerPolicy,
+			CrossOriginResourcePolicy:    cfg.SecurityHeaders.CrossOriginResourcePolicy,
+			PermittedCrossDomainPolicies: cfg.SecurityHeaders.PermittedCrossDomainPolicies,
+			SuppressViaHeader:            cfg.SecurityHeaders.SuppressViaHeader,
+		},
+		Auth: ports.AuthConfig{
+			Enabled:             cfg.Auth.Enabled,
+			KratosPublicURL:     cfg.Kratos.PublicURL,
+			KratosAdminURL:      cfg.Kratos.AdminURL,
+			PublicPaths:         cfg.Auth.PublicPaths,
+			SessionCookieName:   cfg.Auth.SessionCookieName,
+			LoginURL:            cfg.Auth.LoginURL,
+			OnKratosUnavailable: ports.KratosUnavailableBehavior(cfg.Auth.OnKratosUnavailable),
+		},
+		RateLimit: ports.RateLimitConfig{
+			Enabled:           cfg.RateLimit.Enabled,
+			TrustProxyHeaders: cfg.RateLimit.TrustProxyHeaders,
+			ExemptPaths:       cfg.RateLimit.ExemptPaths,
+			PerIP: ports.RateLimitRule{
+				RequestsPerSecond: cfg.RateLimit.PerIP.RequestsPerSecond,
+				Burst:             cfg.RateLimit.PerIP.Burst,
+			},
+			PerUser: ports.RateLimitRule{
+				RequestsPerSecond: cfg.RateLimit.PerUser.RequestsPerSecond,
+				Burst:             cfg.RateLimit.PerUser.Burst,
+			},
+		},
+		AdminAuth: ports.AdminAuthConfig{
+			Enabled: cfg.Admin.Enabled,
+			Token:   cfg.Admin.Token,
+		},
+		BodySize: buildBodySizeConfig(cfg),
+		IPFilter: ports.IPFilterConfig{
+			Enabled:           cfg.IPFilter.Enabled,
+			Mode:              cfg.IPFilter.Mode,
+			Addresses:         cfg.IPFilter.Addresses,
+			TrustProxyHeaders: cfg.IPFilter.TrustProxyHeaders,
+		},
+		Resilience: buildResilienceConfig(cfg),
+		Compression: ports.CompressionConfig{
+			Enabled:    cfg.Compression.Enabled,
+			Algorithms: cfg.Compression.Algorithms,
+		},
+		ResponseHeaders: ports.ResponseHeadersConfig{
+			Enabled: len(cfg.ResponseHeaders.Set) > 0 ||
+				len(cfg.ResponseHeaders.Add) > 0 ||
+				len(cfg.ResponseHeaders.Remove) > 0,
+			Set:    cfg.ResponseHeaders.Set,
+			Add:    cfg.ResponseHeaders.Add,
+			Remove: cfg.ResponseHeaders.Remove,
+		},
+		// Metrics, Admin (internal), and Readiness are intentionally omitted:
+		// these internal HTTP servers are managed by VibeWarden and have no
+		// equivalent in a standalone Caddy deployment.
+	}
+}
+
+// buildBodySizeConfig converts the app config body size settings into a
+// ports.BodySizeConfig, parsing human-readable size strings into bytes.
+// Unparseable values are silently skipped (the config has already been validated).
+func buildBodySizeConfig(cfg *config.Config) ports.BodySizeConfig {
+	if cfg.BodySize.Max == "" {
+		return ports.BodySizeConfig{}
+	}
+
+	maxBytes, err := config.ParseBodySize(cfg.BodySize.Max)
+	if err != nil {
+		return ports.BodySizeConfig{}
+	}
+
+	result := ports.BodySizeConfig{
+		Enabled:  maxBytes > 0 || len(cfg.BodySize.Overrides) > 0,
+		MaxBytes: maxBytes,
+	}
+
+	for _, ov := range cfg.BodySize.Overrides {
+		ovBytes, ovErr := config.ParseBodySize(ov.Max)
+		if ovErr != nil {
+			continue
+		}
+		result.Overrides = append(result.Overrides, ports.BodySizeOverride{
+			Path:     ov.Path,
+			MaxBytes: ovBytes,
+		})
+	}
+
+	return result
+}
+
+// buildResilienceConfig parses the resilience duration strings from the app
+// config and returns a ports.ResilienceConfig. Unparseable values fall back
+// to the same defaults used by the serve command.
+func buildResilienceConfig(cfg *config.Config) ports.ResilienceConfig {
+	result := ports.ResilienceConfig{}
+
+	raw := cfg.Resilience.Timeout
+	if raw != "" && raw != "0" {
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			result.Timeout = 30 * time.Second
+		} else {
+			result.Timeout = d
+		}
+	}
+
+	cbCfg := cfg.Resilience.CircuitBreaker
+	if cbCfg.Enabled {
+		threshold := cbCfg.Threshold
+		if threshold <= 0 {
+			threshold = 5
+		}
+
+		cbTimeout := 60 * time.Second
+		if cbCfg.Timeout != "" && cbCfg.Timeout != "0" {
+			d, err := time.ParseDuration(cbCfg.Timeout)
+			if err == nil {
+				cbTimeout = d
+			}
+		}
+
+		result.CircuitBreaker = ports.CircuitBreakerConfig{
+			Enabled:   true,
+			Threshold: threshold,
+			Timeout:   cbTimeout,
+		}
+	}
+
+	retryCfg := cfg.Resilience.Retry
+	if retryCfg.Enabled {
+		maxAttempts := retryCfg.MaxAttempts
+		if maxAttempts < 2 {
+			maxAttempts = 3
+		}
+
+		initialBackoff := 100 * time.Millisecond
+		if retryCfg.InitialBackoff != "" && retryCfg.InitialBackoff != "0" {
+			if d, err := time.ParseDuration(retryCfg.InitialBackoff); err == nil {
+				initialBackoff = d
+			}
+		}
+
+		maxBackoff := 10 * time.Second
+		if retryCfg.MaxBackoff != "" && retryCfg.MaxBackoff != "0" {
+			if d, err := time.ParseDuration(retryCfg.MaxBackoff); err == nil {
+				maxBackoff = d
+			}
+		}
+
+		retryOn := retryCfg.RetryOn
+		if len(retryOn) == 0 {
+			retryOn = []int{502, 503, 504}
+		}
+
+		result.Retry = ports.RetryConfig{
+			Enabled:        true,
+			MaxAttempts:    maxAttempts,
+			InitialBackoff: initialBackoff,
+			MaxBackoff:     maxBackoff,
+			RetryOn:        retryOn,
+		}
+	}
+
+	return result
+}

--- a/internal/app/eject/eject_test.go
+++ b/internal/app/eject/eject_test.go
@@ -1,0 +1,271 @@
+package eject_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/app/eject"
+	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// fakeBuilder is a test double for eject.ConfigBuilder.
+type fakeBuilder struct {
+	called bool
+	got    *ports.ProxyConfig
+	result map[string]any
+	err    error
+}
+
+func (f *fakeBuilder) Build(cfg *ports.ProxyConfig) (map[string]any, error) {
+	f.called = true
+	f.got = cfg
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.result != nil {
+		return f.result, nil
+	}
+	return map[string]any{"apps": map[string]any{}}, nil
+}
+
+func minimalConfig() *config.Config {
+	return &config.Config{
+		Server: config.ServerConfig{
+			Host: "127.0.0.1",
+			Port: 8080,
+		},
+		Upstream: config.UpstreamConfig{
+			Host: "127.0.0.1",
+			Port: 3000,
+		},
+		TLS: config.TLSConfig{
+			Provider: "self-signed",
+		},
+	}
+}
+
+func TestService_Eject_NilConfig(t *testing.T) {
+	b := &fakeBuilder{}
+	svc := eject.NewService(b)
+
+	_, err := svc.Eject(nil)
+	if err == nil {
+		t.Fatal("expected error for nil config, got nil")
+	}
+}
+
+func TestService_Eject_BuilderError(t *testing.T) {
+	b := &fakeBuilder{err: errors.New("build failed")}
+	svc := eject.NewService(b)
+
+	_, err := svc.Eject(minimalConfig())
+	if err == nil {
+		t.Fatal("expected error when builder fails, got nil")
+	}
+}
+
+func TestService_Eject_ReturnsBuilderResult(t *testing.T) {
+	want := map[string]any{"apps": map[string]any{"http": "ok"}}
+	b := &fakeBuilder{result: want}
+	svc := eject.NewService(b)
+
+	got, err := svc.Eject(minimalConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestService_Eject_CallsBuilder(t *testing.T) {
+	b := &fakeBuilder{}
+	svc := eject.NewService(b)
+
+	cfg := minimalConfig()
+	_, err := svc.Eject(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !b.called {
+		t.Error("expected builder.Build to be called, was not")
+	}
+}
+
+func TestService_Eject_ProxyConfigListenAddr(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		port     int
+		wantAddr string
+	}{
+		{"localhost default", "127.0.0.1", 8080, "127.0.0.1:8080"},
+		{"all interfaces", "0.0.0.0", 443, "0.0.0.0:443"},
+		{"custom host", "10.0.0.1", 9000, "10.0.0.1:9000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &fakeBuilder{}
+			svc := eject.NewService(b)
+
+			cfg := minimalConfig()
+			cfg.Server.Host = tt.host
+			cfg.Server.Port = tt.port
+
+			_, err := svc.Eject(cfg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if b.got == nil {
+				t.Fatal("expected builder.Build to be called with a ProxyConfig")
+			}
+
+			if b.got.ListenAddr != tt.wantAddr {
+				t.Errorf("ListenAddr = %q, want %q", b.got.ListenAddr, tt.wantAddr)
+			}
+		})
+	}
+}
+
+func TestService_Eject_ProxyConfigUpstreamAddr(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		port     int
+		wantAddr string
+	}{
+		{"default upstream", "127.0.0.1", 3000, "127.0.0.1:3000"},
+		{"external upstream", "app.internal", 8000, "app.internal:8000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &fakeBuilder{}
+			svc := eject.NewService(b)
+
+			cfg := minimalConfig()
+			cfg.Upstream.Host = tt.host
+			cfg.Upstream.Port = tt.port
+
+			_, err := svc.Eject(cfg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if b.got.UpstreamAddr != tt.wantAddr {
+				t.Errorf("UpstreamAddr = %q, want %q", b.got.UpstreamAddr, tt.wantAddr)
+			}
+		})
+	}
+}
+
+func TestService_Eject_TLSConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		tlsCfg       config.TLSConfig
+		wantEnabled  bool
+		wantProvider ports.TLSProvider
+		wantDomain   string
+	}{
+		{
+			name:        "tls disabled",
+			tlsCfg:      config.TLSConfig{Enabled: false, Provider: "self-signed"},
+			wantEnabled: false,
+		},
+		{
+			name:         "self-signed",
+			tlsCfg:       config.TLSConfig{Enabled: true, Provider: "self-signed", Domain: "localhost"},
+			wantEnabled:  true,
+			wantProvider: ports.TLSProviderSelfSigned,
+			wantDomain:   "localhost",
+		},
+		{
+			name:         "letsencrypt",
+			tlsCfg:       config.TLSConfig{Enabled: true, Provider: "letsencrypt", Domain: "example.com"},
+			wantEnabled:  true,
+			wantProvider: ports.TLSProviderLetsEncrypt,
+			wantDomain:   "example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &fakeBuilder{}
+			svc := eject.NewService(b)
+
+			cfg := minimalConfig()
+			cfg.TLS = tt.tlsCfg
+
+			_, err := svc.Eject(cfg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got := b.got.TLS
+			if got.Enabled != tt.wantEnabled {
+				t.Errorf("TLS.Enabled = %v, want %v", got.Enabled, tt.wantEnabled)
+			}
+			if tt.wantEnabled {
+				if got.Provider != tt.wantProvider {
+					t.Errorf("TLS.Provider = %q, want %q", got.Provider, tt.wantProvider)
+				}
+				if got.Domain != tt.wantDomain {
+					t.Errorf("TLS.Domain = %q, want %q", got.Domain, tt.wantDomain)
+				}
+			}
+		})
+	}
+}
+
+func TestService_Eject_VersionIsEjected(t *testing.T) {
+	b := &fakeBuilder{}
+	svc := eject.NewService(b)
+
+	_, err := svc.Eject(minimalConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if b.got.Version != "ejected" {
+		t.Errorf("Version = %q, want %q", b.got.Version, "ejected")
+	}
+}
+
+func TestService_Eject_InternalAddrsOmitted(t *testing.T) {
+	b := &fakeBuilder{}
+	svc := eject.NewService(b)
+
+	_, err := svc.Eject(minimalConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if b.got.Metrics.InternalAddr != "" {
+		t.Errorf("Metrics.InternalAddr should be empty, got %q", b.got.Metrics.InternalAddr)
+	}
+	if b.got.Admin.InternalAddr != "" {
+		t.Errorf("Admin.InternalAddr should be empty, got %q", b.got.Admin.InternalAddr)
+	}
+	if b.got.Readiness.InternalAddr != "" {
+		t.Errorf("Readiness.InternalAddr should be empty, got %q", b.got.Readiness.InternalAddr)
+	}
+}
+
+func TestErrUnsupportedFormat_Error(t *testing.T) {
+	err := eject.ErrUnsupportedFormat{Format: eject.Format("nginx")}
+	msg := err.Error()
+
+	if msg == "" {
+		t.Error("expected non-empty error message")
+	}
+
+	want := "nginx"
+	if len(msg) < len(want) {
+		t.Errorf("error message %q does not mention format", msg)
+	}
+}

--- a/internal/cli/cmd/eject.go
+++ b/internal/cli/cmd/eject.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	caddyadapter "github.com/vibewarden/vibewarden/internal/adapters/caddy"
+	ejectapp "github.com/vibewarden/vibewarden/internal/app/eject"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+// NewEjectCmd creates the "vibewarden eject" subcommand.
+//
+// The command reads vibewarden.yaml (or the path supplied via --config) and
+// prints the equivalent raw proxy configuration to stdout. This allows
+// operators to graduate past VibeWarden and run the underlying proxy (e.g.
+// Caddy) directly with an equivalent configuration.
+//
+// Only --format caddy is supported in v1. Additional formats (nginx, traefik)
+// are reserved for future releases.
+func NewEjectCmd() *cobra.Command {
+	var (
+		configPath string
+		format     string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "eject",
+		Short: "Export the equivalent raw proxy config from vibewarden.yaml",
+		Long: `Export the raw proxy configuration equivalent to the current vibewarden.yaml.
+
+The generated configuration can be used to run the underlying proxy directly,
+without VibeWarden. This is useful when you have outgrown VibeWarden and want
+to manage the proxy configuration yourself.
+
+Supported formats:
+  caddy  — Caddy JSON config (default). Feed it to Caddy's /load API or use
+            it as a config file: caddy run --config caddy.json --adapter json
+
+Note: VibeWarden-internal endpoints (/_vibewarden/health, /_vibewarden/ready,
+/_vibewarden/metrics, /_vibewarden/admin) are included as static stubs in the
+generated config. Metrics and admin API routes are omitted because their
+internal servers are managed by VibeWarden and have no equivalent outside it.
+
+Examples:
+  vibewarden eject
+  vibewarden eject --config ./path/to/vibewarden.yaml
+  vibewarden eject --format caddy > caddy.json`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			f := ejectapp.Format(format)
+			if f != ejectapp.FormatCaddy {
+				return ejectapp.ErrUnsupportedFormat{Format: f}
+			}
+
+			// Check file existence explicitly when a path is supplied so we can
+			// surface a clear error message.
+			if configPath != "" {
+				if _, err := os.Stat(configPath); err != nil {
+					if os.IsNotExist(err) {
+						return fmt.Errorf("config file not found: %s", configPath)
+					}
+					return fmt.Errorf("accessing config file: %w", err)
+				}
+			}
+
+			cfg, err := config.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			builder := caddyadapter.NewEjectBuilder()
+			svc := ejectapp.NewService(builder)
+
+			result, err := svc.Eject(cfg)
+			if err != nil {
+				return fmt.Errorf("ejecting config: %w", err)
+			}
+
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(result); err != nil {
+				return fmt.Errorf("encoding config: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&configPath, "config", "c", "", "path to vibewarden.yaml (default: ./vibewarden.yaml)")
+	cmd.Flags().StringVar(&format, "format", "caddy", "output format (supported: caddy)")
+
+	if err := cmd.RegisterFlagCompletionFunc("config", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"yaml", "yml"}, cobra.ShellCompDirectiveFilterFileExt
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, "warning: flag completion registration failed:", err)
+	}
+
+	if err := cmd.RegisterFlagCompletionFunc("format", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"caddy"}, cobra.ShellCompDirectiveNoFileComp
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, "warning: flag completion registration failed:", err)
+	}
+
+	return cmd
+}

--- a/internal/cli/cmd/eject_test.go
+++ b/internal/cli/cmd/eject_test.go
@@ -1,0 +1,227 @@
+package cmd_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/cli/cmd"
+)
+
+func TestEjectCmd_DefaultConfig(t *testing.T) {
+	path := writeConfig(t, `
+server:
+  port: 8080
+upstream:
+  port: 3000
+tls:
+  enabled: false
+  provider: self-signed
+`)
+
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"eject", "--config", path})
+
+	err := root.Execute()
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v\nstderr: %s", err, errBuf.String())
+	}
+
+	out := outBuf.String()
+	if out == "" {
+		t.Fatal("expected non-empty output, got empty string")
+	}
+
+	// Output must be valid JSON.
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+	}
+
+	// Caddy config must contain an "apps" key.
+	if _, ok := result["apps"]; !ok {
+		t.Errorf("expected 'apps' key in output, got keys: %v", mapKeys(result))
+	}
+}
+
+func TestEjectCmd_TLSEnabled(t *testing.T) {
+	path := writeConfig(t, `
+server:
+  port: 8443
+upstream:
+  port: 3000
+tls:
+  enabled: true
+  provider: self-signed
+  domain: localhost
+`)
+
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"eject", "--config", path})
+
+	err := root.Execute()
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v\nstderr: %s", err, errBuf.String())
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(outBuf.Bytes(), &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	apps, _ := result["apps"].(map[string]any)
+	if apps == nil {
+		t.Fatal("expected 'apps' to be a map")
+	}
+
+	// With TLS enabled Caddy config includes a "tls" section.
+	if _, ok := apps["tls"]; !ok {
+		t.Errorf("expected 'tls' key in apps, got: %v", mapKeys(apps))
+	}
+}
+
+func TestEjectCmd_FormatFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		wantErr bool
+	}{
+		{"caddy explicit", "caddy", false},
+		{"nginx unsupported", "nginx", true},
+		{"traefik unsupported", "traefik", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeConfig(t, `
+server:
+  port: 8080
+upstream:
+  port: 3000
+`)
+
+			root := cmd.NewRootCmd("test")
+			var outBuf, errBuf bytes.Buffer
+			root.SetOut(&outBuf)
+			root.SetErr(&errBuf)
+			root.SetArgs([]string{"eject", "--config", path, "--format", tt.format})
+
+			err := root.Execute()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Execute() error = %v, wantErr %v\nstderr: %s", err, tt.wantErr, errBuf.String())
+			}
+		})
+	}
+}
+
+func TestEjectCmd_FileNotFound(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"eject", "--config", "/nonexistent/vibewarden.yaml"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Error("Execute() expected error for nonexistent config file, got nil")
+	}
+}
+
+func TestEjectCmd_OutputIsIndentedJSON(t *testing.T) {
+	path := writeConfig(t, `
+server:
+  port: 8080
+upstream:
+  port: 3000
+`)
+
+	root := cmd.NewRootCmd("test")
+	var outBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetArgs([]string{"eject", "--config", path})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	out := outBuf.String()
+	// Indented JSON contains newlines and spaces inside the object.
+	if !strings.Contains(out, "\n") {
+		t.Error("expected indented JSON (with newlines), got a single line")
+	}
+	if !strings.Contains(out, "  ") {
+		t.Error("expected indented JSON (with spaces), got unindented output")
+	}
+}
+
+func TestEjectCmd_ShorthandConfigFlag(t *testing.T) {
+	path := writeConfig(t, `
+server:
+  port: 8080
+upstream:
+  port: 3000
+`)
+
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"eject", "-c", path})
+
+	err := root.Execute()
+	if err != nil {
+		t.Fatalf("Execute() unexpected error using -c shorthand: %v\nstderr: %s", err, errBuf.String())
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(outBuf.Bytes(), &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+}
+
+func TestEjectCmd_ContainsHTTPSection(t *testing.T) {
+	path := writeConfig(t, `
+server:
+  port: 8080
+upstream:
+  port: 3000
+`)
+
+	root := cmd.NewRootCmd("test")
+	var outBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetArgs([]string{"eject", "--config", path})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(outBuf.Bytes(), &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	apps, _ := result["apps"].(map[string]any)
+	if apps == nil {
+		t.Fatal("expected 'apps' key to be a map")
+	}
+	if _, ok := apps["http"]; !ok {
+		t.Errorf("expected 'http' key under apps, got: %v", mapKeys(apps))
+	}
+}
+
+// mapKeys returns the string keys of a map, for use in error messages.
+func mapKeys(m map[string]any) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -41,6 +41,7 @@ Zero-to-secure in minutes.`,
 	root.AddCommand(NewPluginsCmd())
 	root.AddCommand(NewCertCmd())
 	root.AddCommand(NewTokenCmd())
+	root.AddCommand(NewEjectCmd())
 
 	return root
 }


### PR DESCRIPTION
Closes #521

## Summary

- Adds `vibewarden eject --format caddy` (default) that reads `vibewarden.yaml` and prints the equivalent Caddy JSON config to stdout
- Users can pipe the output directly into a file and run `caddy run --config caddy.json --adapter json` to operate Caddy without VibeWarden
- `--format nginx` and `--format traefik` are reserved for future releases; unsupported formats return a clear error
- VibeWarden-internal addresses (metrics, admin, readiness internal servers) are intentionally omitted from the output — those servers are managed by VibeWarden and have no equivalent in a standalone Caddy deployment

## Architecture

Follows hexagonal architecture exactly:

- `internal/app/eject/` — application service (`Service`) with a `ConfigBuilder` port interface; zero external deps beyond stdlib and internal packages
- `internal/adapters/caddy/eject_builder.go` — thin `EjectBuilder` adapter that wraps the existing `BuildCaddyConfig` function
- `internal/cli/cmd/eject.go` — cobra command wired to the application service
- `internal/cli/cmd/root.go` — registers the new `eject` subcommand

## Test plan

- [ ] `go test ./internal/app/eject/...` — 12 unit tests covering nil config, builder errors, address formatting, TLS mapping, internal addr omission, and error type
- [ ] `go test ./internal/cli/cmd/... -run TestEject` — 7 integration-style tests covering JSON output validity, TLS section presence, format flag validation, file-not-found error, indented output, and shorthand flag
- [ ] `make check` passes (formatting, lint, build, all tests including demo-app)
- [ ] Manual smoke test: `vibewarden eject --config vibewarden.example.yaml | jq .apps.http.servers.vibewarden.listen`
