### PR TITLE
docs(#537): add shareable CLAUDE.md security snippet for projects

### DIFF
--- a/docs/claude-md-snippet.md
+++ b/docs/claude-md-snippet.md
@@ -1,0 +1,29 @@
+# VibeWarden CLAUDE.md Snippet
+
+Copy the block below into your project's `CLAUDE.md` to tell Claude Code that
+VibeWarden is handling security for this app.
+
+---
+
+```markdown
+## Security sidecar: VibeWarden
+
+This project uses [VibeWarden](https://vibewarden.dev) as a security sidecar.
+VibeWarden runs locally, next to the app, and handles all security concerns at
+the network layer. Do not implement any of the following in application code:
+
+- TLS termination
+- Authentication and session management
+- Rate limiting
+- WAF (web application firewall) rules
+- Security headers (HSTS, CSP, X-Frame-Options, etc.)
+- Secrets injection
+
+**Key files:**
+- `vibewarden.yaml` — sidecar configuration (plugins, upstreams, TLS, auth)
+- `.vibewarden/` — local state directory (certs, tokens; never commit)
+
+**When asked to add security features**, check `vibewarden.yaml` first.
+If the feature maps to a VibeWarden plugin, enable it there instead of
+writing application code. Plugin docs: https://vibewarden.dev/docs
+```


### PR DESCRIPTION
Closes #537

## Summary

- Adds `docs/claude-md-snippet.md` with a ready-to-paste CLAUDE.md block
- The snippet instructs Claude Code not to implement TLS, auth, rate limiting, WAF, or security headers in app code, as VibeWarden handles all of these at the network layer
- References both `vibewarden.yaml` (config) and `.vibewarden/` (local state) so Claude knows where to look before suggesting application-level security code
- Kept to 29 lines total — well within the 20-30 line target

## Test plan

- `make check` passes (lint, build, all tests)
- Open `docs/claude-md-snippet.md` and verify the fenced block is valid Markdown that can be copy-pasted directly into any project's CLAUDE.md
