### PR TITLE
feat(#475): implement CSP builder — generate Content-Security-Policy from config

### DIFF
--- a/cmd/vibewarden/serve_config.go
+++ b/cmd/vibewarden/serve_config.go
@@ -8,6 +8,7 @@ import (
 
 	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
 	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/domain/csp"
 	"github.com/vibewarden/vibewarden/internal/plugins"
 	egressplugin "github.com/vibewarden/vibewarden/internal/plugins/egress"
 	metricsplugin "github.com/vibewarden/vibewarden/internal/plugins/metrics"
@@ -53,13 +54,14 @@ func buildProxyConfig(cfg *config.Config, registry *plugins.Registry) *ports.Pro
 			StoragePath: cfg.TLS.StoragePath,
 		},
 		SecurityHeaders: ports.SecurityHeadersConfig{
-			Enabled:                      cfg.SecurityHeaders.Enabled,
-			HSTSMaxAge:                   cfg.SecurityHeaders.HSTSMaxAge,
-			HSTSIncludeSubDomains:        cfg.SecurityHeaders.HSTSIncludeSubDomains,
-			HSTSPreload:                  cfg.SecurityHeaders.HSTSPreload,
-			ContentTypeNosniff:           cfg.SecurityHeaders.ContentTypeNosniff,
-			FrameOption:                  cfg.SecurityHeaders.FrameOption,
-			ContentSecurityPolicy:        cfg.SecurityHeaders.ContentSecurityPolicy,
+			Enabled:               cfg.SecurityHeaders.Enabled,
+			HSTSMaxAge:            cfg.SecurityHeaders.HSTSMaxAge,
+			HSTSIncludeSubDomains: cfg.SecurityHeaders.HSTSIncludeSubDomains,
+			HSTSPreload:           cfg.SecurityHeaders.HSTSPreload,
+			ContentTypeNosniff:    cfg.SecurityHeaders.ContentTypeNosniff,
+			FrameOption:           cfg.SecurityHeaders.FrameOption,
+			// Resolve CSP: raw string takes precedence; fall back to structured builder.
+			ContentSecurityPolicy:        resolveCSP(cfg),
 			ReferrerPolicy:               cfg.SecurityHeaders.ReferrerPolicy,
 			PermissionsPolicy:            cfg.SecurityHeaders.PermissionsPolicy,
 			CrossOriginOpenerPolicy:      cfg.SecurityHeaders.CrossOriginOpenerPolicy,
@@ -344,6 +346,33 @@ func buildEgressPlugin(cfg *config.Config, eventLogger ports.EventLogger, logger
 	}
 
 	return egressplugin.New(pluginCfg, eventLogger, logger)
+}
+
+// resolveCSP returns the Content-Security-Policy header value to use.
+// The raw content_security_policy string takes precedence for backward
+// compatibility. When it is empty, the structured csp block is passed to
+// csp.Build and the generated string is returned instead.
+func resolveCSP(cfg *config.Config) string {
+	if cfg.SecurityHeaders.ContentSecurityPolicy != "" {
+		return cfg.SecurityHeaders.ContentSecurityPolicy
+	}
+	return csp.Build(csp.Config{
+		DefaultSrc:     cfg.SecurityHeaders.CSP.DefaultSrc,
+		ScriptSrc:      cfg.SecurityHeaders.CSP.ScriptSrc,
+		StyleSrc:       cfg.SecurityHeaders.CSP.StyleSrc,
+		ImgSrc:         cfg.SecurityHeaders.CSP.ImgSrc,
+		ConnectSrc:     cfg.SecurityHeaders.CSP.ConnectSrc,
+		FontSrc:        cfg.SecurityHeaders.CSP.FontSrc,
+		FrameSrc:       cfg.SecurityHeaders.CSP.FrameSrc,
+		MediaSrc:       cfg.SecurityHeaders.CSP.MediaSrc,
+		ObjectSrc:      cfg.SecurityHeaders.CSP.ObjectSrc,
+		ManifestSrc:    cfg.SecurityHeaders.CSP.ManifestSrc,
+		WorkerSrc:      cfg.SecurityHeaders.CSP.WorkerSrc,
+		ChildSrc:       cfg.SecurityHeaders.CSP.ChildSrc,
+		FormAction:     cfg.SecurityHeaders.CSP.FormAction,
+		FrameAncestors: cfg.SecurityHeaders.CSP.FrameAncestors,
+		BaseURI:        cfg.SecurityHeaders.CSP.BaseURI,
+	})
 }
 
 // buildEventLogger constructs the event logger used by the caddy adapter and

--- a/cmd/vibewarden/serve_config_test.go
+++ b/cmd/vibewarden/serve_config_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+func TestResolveCSP(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		want string
+	}{
+		{
+			name: "raw string takes precedence over structured config",
+			cfg: &config.Config{
+				SecurityHeaders: config.SecurityHeadersConfig{
+					ContentSecurityPolicy: "default-src 'self'; script-src 'none'",
+					CSP: config.CSPConfig{
+						DefaultSrc: []string{"'self'", "https://cdn.example.com"},
+					},
+				},
+			},
+			want: "default-src 'self'; script-src 'none'",
+		},
+		{
+			name: "structured config used when raw string is empty",
+			cfg: &config.Config{
+				SecurityHeaders: config.SecurityHeadersConfig{
+					ContentSecurityPolicy: "",
+					CSP: config.CSPConfig{
+						DefaultSrc: []string{"'self'"},
+						ScriptSrc:  []string{"'self'", "https://cdn.example.com"},
+						StyleSrc:   []string{"'self'", "'unsafe-inline'"},
+						ImgSrc:     []string{"'self'", "data:"},
+						ConnectSrc: []string{"'self'"},
+						FontSrc:    []string{"'self'"},
+						FrameSrc:   []string{"'none'"},
+					},
+				},
+			},
+			want: "default-src 'self'; script-src 'self' https://cdn.example.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self'; frame-src 'none'",
+		},
+		{
+			name: "both empty produces empty string",
+			cfg: &config.Config{
+				SecurityHeaders: config.SecurityHeadersConfig{
+					ContentSecurityPolicy: "",
+					CSP:                   config.CSPConfig{},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "raw string only — no structured config",
+			cfg: &config.Config{
+				SecurityHeaders: config.SecurityHeadersConfig{
+					ContentSecurityPolicy: "default-src 'none'",
+				},
+			},
+			want: "default-src 'none'",
+		},
+		{
+			name: "structured config only — default-src self",
+			cfg: &config.Config{
+				SecurityHeaders: config.SecurityHeadersConfig{
+					CSP: config.CSPConfig{
+						DefaultSrc: []string{"'self'"},
+					},
+				},
+			},
+			want: "default-src 'self'",
+		},
+		{
+			name: "all structured directives",
+			cfg: &config.Config{
+				SecurityHeaders: config.SecurityHeadersConfig{
+					CSP: config.CSPConfig{
+						DefaultSrc:     []string{"'self'"},
+						ScriptSrc:      []string{"'self'"},
+						StyleSrc:       []string{"'self'"},
+						ImgSrc:         []string{"'self'"},
+						ConnectSrc:     []string{"'self'"},
+						FontSrc:        []string{"'self'"},
+						FrameSrc:       []string{"'none'"},
+						MediaSrc:       []string{"'self'"},
+						ObjectSrc:      []string{"'none'"},
+						ManifestSrc:    []string{"'self'"},
+						WorkerSrc:      []string{"'self'"},
+						ChildSrc:       []string{"'self'"},
+						FormAction:     []string{"'self'"},
+						FrameAncestors: []string{"'none'"},
+						BaseURI:        []string{"'self'"},
+					},
+				},
+			},
+			want: "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src 'self'; font-src 'self'; frame-src 'none'; media-src 'self'; object-src 'none'; manifest-src 'self'; worker-src 'self'; child-src 'self'; form-action 'self'; frame-ancestors 'none'; base-uri 'self'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveCSP(tt.cfg)
+			if got != tt.want {
+				t.Errorf("resolveCSP() =\n  %q\nwant:\n  %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/vibewarden/serve_plugins.go
+++ b/cmd/vibewarden/serve_plugins.go
@@ -76,6 +76,9 @@ func registerPlugins(
 	}, logger))
 
 	// Security headers — priority 20
+	//
+	// resolveCSP picks the raw content_security_policy string when set
+	// (backward compat) and falls back to the structured csp builder otherwise.
 	registry.Register(sechdrs.New(sechdrs.Config{
 		Enabled:                      cfg.SecurityHeaders.Enabled,
 		HSTSMaxAge:                   cfg.SecurityHeaders.HSTSMaxAge,
@@ -83,7 +86,7 @@ func registerPlugins(
 		HSTSPreload:                  cfg.SecurityHeaders.HSTSPreload,
 		ContentTypeNosniff:           cfg.SecurityHeaders.ContentTypeNosniff,
 		FrameOption:                  cfg.SecurityHeaders.FrameOption,
-		ContentSecurityPolicy:        cfg.SecurityHeaders.ContentSecurityPolicy,
+		ContentSecurityPolicy:        resolveCSP(cfg),
 		ReferrerPolicy:               cfg.SecurityHeaders.ReferrerPolicy,
 		PermissionsPolicy:            cfg.SecurityHeaders.PermissionsPolicy,
 		CrossOriginOpenerPolicy:      cfg.SecurityHeaders.CrossOriginOpenerPolicy,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -724,7 +724,15 @@ type SecurityHeadersConfig struct {
 	// ContentSecurityPolicy sets Content-Security-Policy value.
 	// An empty string (the default) disables the header entirely; users opt in
 	// by setting an explicit policy in vibewarden.yaml.
+	// When both ContentSecurityPolicy and CSP are set, ContentSecurityPolicy
+	// takes precedence for backward compatibility.
 	ContentSecurityPolicy string `mapstructure:"content_security_policy"`
+
+	// CSP holds a structured, declarative Content-Security-Policy configuration.
+	// It is used to generate a Content-Security-Policy header value when
+	// ContentSecurityPolicy is not set. If ContentSecurityPolicy is non-empty it
+	// always takes precedence.
+	CSP CSPConfig `mapstructure:"csp"`
 
 	// ReferrerPolicy sets Referrer-Policy value (default: "strict-origin-when-cross-origin")
 	ReferrerPolicy string `mapstructure:"referrer_policy"`
@@ -743,6 +751,58 @@ type SecurityHeadersConfig struct {
 
 	// SuppressViaHeader removes the Via header from proxied responses (default: true)
 	SuppressViaHeader bool `mapstructure:"suppress_via_header"`
+}
+
+// CSPConfig holds a declarative Content-Security-Policy configuration.
+// Each field maps to a CSP fetch directive and contains the list of allowed
+// sources. Sources are written verbatim, so keyword tokens must include their
+// surrounding single-quotes (e.g. "'self'", "'none'", "'unsafe-inline'").
+// An empty slice means the directive is omitted from the generated header.
+type CSPConfig struct {
+	// DefaultSrc sets the default-src directive.
+	DefaultSrc []string `mapstructure:"default_src"`
+
+	// ScriptSrc sets the script-src directive.
+	ScriptSrc []string `mapstructure:"script_src"`
+
+	// StyleSrc sets the style-src directive.
+	StyleSrc []string `mapstructure:"style_src"`
+
+	// ImgSrc sets the img-src directive.
+	ImgSrc []string `mapstructure:"img_src"`
+
+	// ConnectSrc sets the connect-src directive.
+	ConnectSrc []string `mapstructure:"connect_src"`
+
+	// FontSrc sets the font-src directive.
+	FontSrc []string `mapstructure:"font_src"`
+
+	// FrameSrc sets the frame-src directive.
+	FrameSrc []string `mapstructure:"frame_src"`
+
+	// MediaSrc sets the media-src directive.
+	MediaSrc []string `mapstructure:"media_src"`
+
+	// ObjectSrc sets the object-src directive.
+	ObjectSrc []string `mapstructure:"object_src"`
+
+	// ManifestSrc sets the manifest-src directive.
+	ManifestSrc []string `mapstructure:"manifest_src"`
+
+	// WorkerSrc sets the worker-src directive.
+	WorkerSrc []string `mapstructure:"worker_src"`
+
+	// ChildSrc sets the child-src directive.
+	ChildSrc []string `mapstructure:"child_src"`
+
+	// FormAction sets the form-action directive.
+	FormAction []string `mapstructure:"form_action"`
+
+	// FrameAncestors sets the frame-ancestors directive.
+	FrameAncestors []string `mapstructure:"frame_ancestors"`
+
+	// BaseURI sets the base-uri directive.
+	BaseURI []string `mapstructure:"base_uri"`
 }
 
 // WAFConfig holds Web Application Firewall settings.

--- a/internal/domain/csp/builder.go
+++ b/internal/domain/csp/builder.go
@@ -1,0 +1,117 @@
+// Package csp provides a domain-level builder for Content-Security-Policy
+// header values.
+//
+// Instead of writing a raw CSP string, callers populate a Config struct with
+// per-directive source lists and call Build to obtain the serialised header
+// value. The package has zero external dependencies — only the Go standard
+// library is imported.
+package csp
+
+import (
+	"strings"
+)
+
+// Config holds a declarative Content-Security-Policy configuration.
+// Each field corresponds to a CSP fetch directive and contains the list of
+// allowed sources for that directive.
+//
+// Sources are written verbatim into the header value, so keyword sources must
+// include their surrounding single-quotes (e.g. "'self'", "'none'",
+// "'unsafe-inline'").
+//
+// An empty slice for a directive means that directive is omitted from the
+// generated header. To explicitly forbid a resource type, set the slice to
+// []string{"'none'"}.
+type Config struct {
+	// DefaultSrc sets the default-src directive — the fallback for all fetch
+	// directives that are not explicitly specified.
+	DefaultSrc []string
+
+	// ScriptSrc sets the script-src directive for JavaScript sources.
+	ScriptSrc []string
+
+	// StyleSrc sets the style-src directive for CSS sources.
+	StyleSrc []string
+
+	// ImgSrc sets the img-src directive for image sources.
+	ImgSrc []string
+
+	// ConnectSrc sets the connect-src directive for fetch/XHR/WebSocket targets.
+	ConnectSrc []string
+
+	// FontSrc sets the font-src directive for web font sources.
+	FontSrc []string
+
+	// FrameSrc sets the frame-src directive for nested browsing contexts
+	// (iframes).
+	FrameSrc []string
+
+	// MediaSrc sets the media-src directive for audio and video sources.
+	MediaSrc []string
+
+	// ObjectSrc sets the object-src directive for plugin content (e.g. Flash).
+	ObjectSrc []string
+
+	// ManifestSrc sets the manifest-src directive for web app manifests.
+	ManifestSrc []string
+
+	// WorkerSrc sets the worker-src directive for Worker and SharedWorker
+	// scripts.
+	WorkerSrc []string
+
+	// ChildSrc sets the child-src directive for web workers and nested
+	// browsing contexts.
+	ChildSrc []string
+
+	// FormAction sets the form-action directive, restricting URLs that can be
+	// used as HTML form targets.
+	FormAction []string
+
+	// FrameAncestors sets the frame-ancestors directive, controlling which
+	// origins may embed this page in a frame.
+	FrameAncestors []string
+
+	// BaseURI sets the base-uri directive, restricting the URLs that can be
+	// used in a <base> element.
+	BaseURI []string
+}
+
+// directive is a (name, sources) pair used for ordered serialisation.
+type directive struct {
+	name    string
+	sources []string
+}
+
+// Build serialises cfg into a Content-Security-Policy header value string.
+// Directives with no configured sources are omitted. Directives are emitted
+// in a deterministic order that matches the order of fields in Config.
+// Build returns an empty string when no directives are configured.
+func Build(cfg Config) string {
+	directives := []directive{
+		{"default-src", cfg.DefaultSrc},
+		{"script-src", cfg.ScriptSrc},
+		{"style-src", cfg.StyleSrc},
+		{"img-src", cfg.ImgSrc},
+		{"connect-src", cfg.ConnectSrc},
+		{"font-src", cfg.FontSrc},
+		{"frame-src", cfg.FrameSrc},
+		{"media-src", cfg.MediaSrc},
+		{"object-src", cfg.ObjectSrc},
+		{"manifest-src", cfg.ManifestSrc},
+		{"worker-src", cfg.WorkerSrc},
+		{"child-src", cfg.ChildSrc},
+		{"form-action", cfg.FormAction},
+		{"frame-ancestors", cfg.FrameAncestors},
+		{"base-uri", cfg.BaseURI},
+	}
+
+	parts := make([]string, 0, len(directives))
+	for _, d := range directives {
+		if len(d.sources) == 0 {
+			continue
+		}
+		parts = append(parts, d.name+" "+strings.Join(d.sources, " "))
+	}
+
+	return strings.Join(parts, "; ")
+}

--- a/internal/domain/csp/builder_test.go
+++ b/internal/domain/csp/builder_test.go
@@ -1,0 +1,166 @@
+package csp_test
+
+import (
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/domain/csp"
+)
+
+func TestBuild(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  csp.Config
+		want string
+	}{
+		{
+			name: "empty config produces empty string",
+			cfg:  csp.Config{},
+			want: "",
+		},
+		{
+			name: "default-src only",
+			cfg: csp.Config{
+				DefaultSrc: []string{"'self'"},
+			},
+			want: "default-src 'self'",
+		},
+		{
+			name: "default-src with multiple sources",
+			cfg: csp.Config{
+				DefaultSrc: []string{"'self'", "https://cdn.example.com"},
+			},
+			want: "default-src 'self' https://cdn.example.com",
+		},
+		{
+			name: "script-src with unsafe-inline",
+			cfg: csp.Config{
+				ScriptSrc: []string{"'self'", "'unsafe-inline'"},
+			},
+			want: "script-src 'self' 'unsafe-inline'",
+		},
+		{
+			name: "none as single source",
+			cfg: csp.Config{
+				FrameSrc: []string{"'none'"},
+			},
+			want: "frame-src 'none'",
+		},
+		{
+			name: "full config from issue example",
+			cfg: csp.Config{
+				DefaultSrc: []string{"'self'"},
+				ScriptSrc:  []string{"'self'", "https://cdn.example.com"},
+				StyleSrc:   []string{"'self'", "'unsafe-inline'"},
+				ImgSrc:     []string{"'self'", "data:"},
+				ConnectSrc: []string{"'self'"},
+				FontSrc:    []string{"'self'"},
+				FrameSrc:   []string{"'none'"},
+			},
+			want: "default-src 'self'; script-src 'self' https://cdn.example.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self'; frame-src 'none'",
+		},
+		{
+			name: "directive order is deterministic — default-src first",
+			cfg: csp.Config{
+				FontSrc:    []string{"'self'"},
+				DefaultSrc: []string{"'self'"},
+				ScriptSrc:  []string{"'none'"},
+			},
+			want: "default-src 'self'; script-src 'none'; font-src 'self'",
+		},
+		{
+			name: "media-src directive",
+			cfg: csp.Config{
+				MediaSrc: []string{"'self'", "https://media.example.com"},
+			},
+			want: "media-src 'self' https://media.example.com",
+		},
+		{
+			name: "object-src none",
+			cfg: csp.Config{
+				ObjectSrc: []string{"'none'"},
+			},
+			want: "object-src 'none'",
+		},
+		{
+			name: "manifest-src directive",
+			cfg: csp.Config{
+				ManifestSrc: []string{"'self'"},
+			},
+			want: "manifest-src 'self'",
+		},
+		{
+			name: "worker-src directive",
+			cfg: csp.Config{
+				WorkerSrc: []string{"'self'", "blob:"},
+			},
+			want: "worker-src 'self' blob:",
+		},
+		{
+			name: "child-src directive",
+			cfg: csp.Config{
+				ChildSrc: []string{"'self'"},
+			},
+			want: "child-src 'self'",
+		},
+		{
+			name: "form-action directive",
+			cfg: csp.Config{
+				FormAction: []string{"'self'"},
+			},
+			want: "form-action 'self'",
+		},
+		{
+			name: "frame-ancestors directive",
+			cfg: csp.Config{
+				FrameAncestors: []string{"'none'"},
+			},
+			want: "frame-ancestors 'none'",
+		},
+		{
+			name: "base-uri directive",
+			cfg: csp.Config{
+				BaseURI: []string{"'self'"},
+			},
+			want: "base-uri 'self'",
+		},
+		{
+			name: "all directives populated",
+			cfg: csp.Config{
+				DefaultSrc:     []string{"'self'"},
+				ScriptSrc:      []string{"'self'"},
+				StyleSrc:       []string{"'self'"},
+				ImgSrc:         []string{"'self'"},
+				ConnectSrc:     []string{"'self'"},
+				FontSrc:        []string{"'self'"},
+				FrameSrc:       []string{"'none'"},
+				MediaSrc:       []string{"'self'"},
+				ObjectSrc:      []string{"'none'"},
+				ManifestSrc:    []string{"'self'"},
+				WorkerSrc:      []string{"'self'"},
+				ChildSrc:       []string{"'self'"},
+				FormAction:     []string{"'self'"},
+				FrameAncestors: []string{"'none'"},
+				BaseURI:        []string{"'self'"},
+			},
+			want: "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src 'self'; font-src 'self'; frame-src 'none'; media-src 'self'; object-src 'none'; manifest-src 'self'; worker-src 'self'; child-src 'self'; form-action 'self'; frame-ancestors 'none'; base-uri 'self'",
+		},
+		{
+			name: "omitted directives are not emitted",
+			cfg: csp.Config{
+				DefaultSrc: []string{"'self'"},
+				// ScriptSrc intentionally omitted — should not appear in output
+				StyleSrc: []string{"'unsafe-inline'"},
+			},
+			want: "default-src 'self'; style-src 'unsafe-inline'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := csp.Build(tt.cfg)
+			if got != tt.want {
+				t.Errorf("Build() =\n  %q\nwant:\n  %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #475

## Summary

- Added `internal/domain/csp` package with a pure `Build(Config) string` function that serialises a declarative per-directive source list into a valid `Content-Security-Policy` header value. Zero external dependencies; stdlib only.
- Extended `internal/config.SecurityHeadersConfig` with a `CSP CSPConfig` sub-struct (15 directive fields mapped to `security_headers.csp.*` in `vibewarden.yaml`).
- Added `CSPConfig` type to `internal/config/config.go` with all 15 supported CSP fetch directives.
- Added `resolveCSP(*config.Config) string` helper in `cmd/vibewarden/serve_config.go`: the existing `content_security_policy` raw string takes precedence (backward compat), falling back to `csp.Build` when it is empty.
- Wired `resolveCSP` into both `buildProxyConfig` (Caddy adapter path) and `registerPlugins` (plugin path) replacing the previous direct field assignment.

## Test plan

- `internal/domain/csp/builder_test.go` — 17 table-driven cases covering: empty config, single directive, multiple sources, all directives, directive ordering, omitted directives.
- `cmd/vibewarden/serve_config_test.go` — 6 table-driven cases covering: raw string precedence, structured config fallback, both empty, raw only, structured only, all directives.
- `make check` passes (gofmt, golangci-lint 0 issues, build, race-detector tests).

To verify manually add to `vibewarden.yaml`:

```yaml
security_headers:
  enabled: true
  csp:
    default_src: ["'self'"]
    script_src: ["'self'", "https://cdn.example.com"]
    style_src: ["'self'", "'unsafe-inline'"]
    img_src: ["'self'", "data:"]
    connect_src: ["'self'"]
    font_src: ["'self'"]
    frame_src: ["'none'"]
```

The `Content-Security-Policy` response header should read:
`default-src 'self'; script-src 'self' https://cdn.example.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self'; frame-src 'none'`

Setting `content_security_policy` to any non-empty string overrides the structured config entirely (backward compatibility).
