### PR TITLE
feat(#480): add configurable HTTP server timeouts (read, write, idle)

### DIFF
--- a/cmd/vibewarden/serve_config.go
+++ b/cmd/vibewarden/serve_config.go
@@ -42,9 +42,10 @@ func buildProxyConfig(cfg *config.Config, registry *plugins.Registry) *ports.Pro
 	}
 
 	return &ports.ProxyConfig{
-		ListenAddr:   fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port),
-		UpstreamAddr: fmt.Sprintf("%s:%d", cfg.Upstream.Host, cfg.Upstream.Port),
-		Version:      version,
+		ListenAddr:     fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port),
+		UpstreamAddr:   fmt.Sprintf("%s:%d", cfg.Upstream.Host, cfg.Upstream.Port),
+		Version:        version,
+		ServerTimeouts: buildServerTimeoutsConfig(cfg),
 		TLS: ports.TLSConfig{
 			Enabled:     cfg.TLS.Enabled,
 			Provider:    ports.TLSProvider(cfg.TLS.Provider),
@@ -150,6 +151,51 @@ func buildBodySizePortsConfig(cfg *config.Config) ports.BodySizeConfig {
 	}
 
 	return bodySizeCfg
+}
+
+// buildServerTimeoutsConfig parses the server-level timeout duration strings and
+// returns a ports.ServerTimeoutsConfig. Unparseable values fall back to the
+// documented defaults (read: 30s, write: 60s, idle: 120s). A value of "0" or ""
+// disables that particular timeout (no limit).
+func buildServerTimeoutsConfig(cfg *config.Config) ports.ServerTimeoutsConfig {
+	result := ports.ServerTimeoutsConfig{}
+
+	parseTimeout := func(raw, name, defaultVal string) time.Duration {
+		if raw == "0" || raw == "" {
+			// Caller explicitly disabled the timeout.
+			return 0
+		}
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			slog.Default().Warn(fmt.Sprintf("server.%s parse error — using default %s", name, defaultVal),
+				slog.String("error", err.Error()),
+				slog.String("value", raw),
+			)
+			d, _ = time.ParseDuration(defaultVal)
+		}
+		return d
+	}
+
+	// Apply defaults when the field is empty (not explicitly set to "0").
+	readRaw := cfg.Server.ReadTimeout
+	if readRaw == "" {
+		readRaw = "30s"
+	}
+	result.ReadTimeout = parseTimeout(readRaw, "read_timeout", "30s")
+
+	writeRaw := cfg.Server.WriteTimeout
+	if writeRaw == "" {
+		writeRaw = "60s"
+	}
+	result.WriteTimeout = parseTimeout(writeRaw, "write_timeout", "60s")
+
+	idleRaw := cfg.Server.IdleTimeout
+	if idleRaw == "" {
+		idleRaw = "120s"
+	}
+	result.IdleTimeout = parseTimeout(idleRaw, "idle_timeout", "120s")
+
+	return result
 }
 
 // buildResiliencePortsConfig parses the resilience duration strings and returns

--- a/cmd/vibewarden/serve_config_test.go
+++ b/cmd/vibewarden/serve_config_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/vibewarden/vibewarden/internal/config"
 )
@@ -104,6 +105,106 @@ func TestResolveCSP(t *testing.T) {
 			got := resolveCSP(tt.cfg)
 			if got != tt.want {
 				t.Errorf("resolveCSP() =\n  %q\nwant:\n  %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildServerTimeoutsConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		serverCfg config.ServerConfig
+		wantRead  time.Duration
+		wantWrite time.Duration
+		wantIdle  time.Duration
+	}{
+		{
+			name:      "empty strings use defaults",
+			serverCfg: config.ServerConfig{},
+			wantRead:  30 * time.Second,
+			wantWrite: 60 * time.Second,
+			wantIdle:  120 * time.Second,
+		},
+		{
+			name: "explicit zero disables timeout",
+			serverCfg: config.ServerConfig{
+				ReadTimeout:  "0",
+				WriteTimeout: "0",
+				IdleTimeout:  "0",
+			},
+			wantRead:  0,
+			wantWrite: 0,
+			wantIdle:  0,
+		},
+		{
+			name: "custom valid durations are parsed",
+			serverCfg: config.ServerConfig{
+				ReadTimeout:  "10s",
+				WriteTimeout: "20s",
+				IdleTimeout:  "90s",
+			},
+			wantRead:  10 * time.Second,
+			wantWrite: 20 * time.Second,
+			wantIdle:  90 * time.Second,
+		},
+		{
+			name: "invalid read timeout falls back to default",
+			serverCfg: config.ServerConfig{
+				ReadTimeout:  "notaduration",
+				WriteTimeout: "60s",
+				IdleTimeout:  "120s",
+			},
+			wantRead:  30 * time.Second,
+			wantWrite: 60 * time.Second,
+			wantIdle:  120 * time.Second,
+		},
+		{
+			name: "invalid write timeout falls back to default",
+			serverCfg: config.ServerConfig{
+				ReadTimeout:  "30s",
+				WriteTimeout: "bad",
+				IdleTimeout:  "120s",
+			},
+			wantRead:  30 * time.Second,
+			wantWrite: 60 * time.Second,
+			wantIdle:  120 * time.Second,
+		},
+		{
+			name: "invalid idle timeout falls back to default",
+			serverCfg: config.ServerConfig{
+				ReadTimeout:  "30s",
+				WriteTimeout: "60s",
+				IdleTimeout:  "bad",
+			},
+			wantRead:  30 * time.Second,
+			wantWrite: 60 * time.Second,
+			wantIdle:  120 * time.Second,
+		},
+		{
+			name: "minute durations are accepted",
+			serverCfg: config.ServerConfig{
+				ReadTimeout:  "1m",
+				WriteTimeout: "2m",
+				IdleTimeout:  "5m",
+			},
+			wantRead:  time.Minute,
+			wantWrite: 2 * time.Minute,
+			wantIdle:  5 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{Server: tt.serverCfg}
+			got := buildServerTimeoutsConfig(cfg)
+			if got.ReadTimeout != tt.wantRead {
+				t.Errorf("ReadTimeout = %v, want %v", got.ReadTimeout, tt.wantRead)
+			}
+			if got.WriteTimeout != tt.wantWrite {
+				t.Errorf("WriteTimeout = %v, want %v", got.WriteTimeout, tt.wantWrite)
+			}
+			if got.IdleTimeout != tt.wantIdle {
+				t.Errorf("IdleTimeout = %v, want %v", got.IdleTimeout, tt.wantIdle)
 			}
 		})
 	}

--- a/internal/adapters/caddy/config.go
+++ b/internal/adapters/caddy/config.go
@@ -225,6 +225,18 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 		"routes": routes,
 	}
 
+	// Apply server-level timeouts when non-zero. Caddy's Duration JSON type
+	// accepts nanosecond integers, matching the representation of time.Duration.
+	if cfg.ServerTimeouts.ReadTimeout > 0 {
+		server["read_timeout"] = int64(cfg.ServerTimeouts.ReadTimeout)
+	}
+	if cfg.ServerTimeouts.WriteTimeout > 0 {
+		server["write_timeout"] = int64(cfg.ServerTimeouts.WriteTimeout)
+	}
+	if cfg.ServerTimeouts.IdleTimeout > 0 {
+		server["idle_timeout"] = int64(cfg.ServerTimeouts.IdleTimeout)
+	}
+
 	if cfg.TLS.Enabled {
 		// When TLS is enabled, only disable Caddy's automatic HTTP→HTTPS
 		// redirects (we add our own redirect server). Certificate management

--- a/internal/adapters/caddy/config_test.go
+++ b/internal/adapters/caddy/config_test.go
@@ -2,6 +2,7 @@ package caddy
 
 import (
 	"testing"
+	"time"
 
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
@@ -1893,6 +1894,97 @@ func TestBuildCaddyConfig_DocsRoute(t *testing.T) {
 			if upstreams[0]["dial"] != tt.wantDocsDialAddr {
 				t.Errorf("docs upstream dial = %v, want %q", upstreams[0]["dial"], tt.wantDocsDialAddr)
 			}
+		})
+	}
+}
+
+func TestBuildCaddyConfig_ServerTimeouts(t *testing.T) {
+	tests := []struct {
+		name             string
+		serverTimeouts   ports.ServerTimeoutsConfig
+		wantReadTimeout  int64 // 0 means key must be absent
+		wantWriteTimeout int64
+		wantIdleTimeout  int64
+	}{
+		{
+			name:             "all timeouts absent when zero",
+			serverTimeouts:   ports.ServerTimeoutsConfig{},
+			wantReadTimeout:  0,
+			wantWriteTimeout: 0,
+			wantIdleTimeout:  0,
+		},
+		{
+			name: "default timeouts wired correctly",
+			serverTimeouts: ports.ServerTimeoutsConfig{
+				ReadTimeout:  30 * time.Second,
+				WriteTimeout: 60 * time.Second,
+				IdleTimeout:  120 * time.Second,
+			},
+			wantReadTimeout:  int64(30 * time.Second),
+			wantWriteTimeout: int64(60 * time.Second),
+			wantIdleTimeout:  int64(120 * time.Second),
+		},
+		{
+			name: "custom timeouts wired correctly",
+			serverTimeouts: ports.ServerTimeoutsConfig{
+				ReadTimeout:  5 * time.Second,
+				WriteTimeout: 10 * time.Second,
+				IdleTimeout:  15 * time.Second,
+			},
+			wantReadTimeout:  int64(5 * time.Second),
+			wantWriteTimeout: int64(10 * time.Second),
+			wantIdleTimeout:  int64(15 * time.Second),
+		},
+		{
+			name: "only read timeout set",
+			serverTimeouts: ports.ServerTimeoutsConfig{
+				ReadTimeout: 45 * time.Second,
+			},
+			wantReadTimeout:  int64(45 * time.Second),
+			wantWriteTimeout: 0,
+			wantIdleTimeout:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &ports.ProxyConfig{
+				ListenAddr:     "127.0.0.1:8080",
+				UpstreamAddr:   "127.0.0.1:3000",
+				ServerTimeouts: tt.serverTimeouts,
+			}
+			result, err := BuildCaddyConfig(cfg)
+			if err != nil {
+				t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+			}
+			server := extractServer(t, result)
+
+			checkTimeout := func(key string, want int64) {
+				t.Helper()
+				val, present := server[key]
+				if want == 0 {
+					if present {
+						t.Errorf("server[%q] = %v, expected key to be absent when timeout is zero", key, val)
+					}
+					return
+				}
+				if !present {
+					t.Errorf("server[%q] not found, want %d", key, want)
+					return
+				}
+				got, ok := val.(int64)
+				if !ok {
+					t.Errorf("server[%q] has type %T, want int64", key, val)
+					return
+				}
+				if got != want {
+					t.Errorf("server[%q] = %d, want %d", key, got, want)
+				}
+			}
+
+			checkTimeout("read_timeout", tt.wantReadTimeout)
+			checkTimeout("write_timeout", tt.wantWriteTimeout)
+			checkTimeout("idle_timeout", tt.wantIdleTimeout)
 		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,6 +212,24 @@ type ServerConfig struct {
 	Host string `mapstructure:"host"`
 	// Port to listen on (default: 8443)
 	Port int `mapstructure:"port"`
+
+	// ReadTimeout is the maximum duration for reading the entire incoming
+	// request including body, expressed as a Go duration string (e.g. "30s").
+	// A value of "0" or "" disables the timeout (no limit).
+	// Default: "30s".
+	ReadTimeout string `mapstructure:"read_timeout"`
+
+	// WriteTimeout is the maximum duration before timing out writes of the
+	// response, expressed as a Go duration string (e.g. "60s").
+	// A value of "0" or "" disables the timeout (no limit).
+	// Default: "60s".
+	WriteTimeout string `mapstructure:"write_timeout"`
+
+	// IdleTimeout is the maximum amount of time to wait for the next request
+	// when keep-alives are enabled, expressed as a Go duration string (e.g. "120s").
+	// A value of "0" or "" disables the timeout (no limit).
+	// Default: "120s".
+	IdleTimeout string `mapstructure:"idle_timeout"`
 }
 
 // UpstreamConfig holds settings for the upstream application being protected.

--- a/internal/ports/proxy.go
+++ b/internal/ports/proxy.go
@@ -22,6 +22,27 @@ type ProxyServer interface {
 	Reload(ctx context.Context) error
 }
 
+// ServerTimeoutsConfig holds HTTP server-level timeout settings.
+// These are applied to the Caddy HTTP server and bound the total time for each
+// phase of an HTTP connection, independent of the upstream resilience timeout
+// (which only covers the time waiting for the upstream to respond).
+type ServerTimeoutsConfig struct {
+	// ReadTimeout is the maximum duration for reading the entire incoming request,
+	// including the body. A zero value means no timeout.
+	// Default: 30s.
+	ReadTimeout time.Duration
+
+	// WriteTimeout is the maximum duration before timing out writes of the
+	// response. A zero value means no timeout.
+	// Default: 60s.
+	WriteTimeout time.Duration
+
+	// IdleTimeout is the maximum amount of time to wait for the next request
+	// when keep-alives are enabled. A zero value means no timeout.
+	// Default: 120s.
+	IdleTimeout time.Duration
+}
+
 // ProxyConfig holds configuration for the proxy server.
 // This is a domain-agnostic configuration that ports can depend on.
 type ProxyConfig struct {
@@ -33,6 +54,9 @@ type ProxyConfig struct {
 
 	// Version is the binary version string, used in health check responses.
 	Version string
+
+	// ServerTimeouts holds HTTP server-level connection timeouts.
+	ServerTimeouts ServerTimeoutsConfig
 
 	// TLS configuration
 	TLS TLSConfig


### PR DESCRIPTION
Closes #480

## Summary

- Adds `server.read_timeout` (default `30s`), `server.write_timeout` (default `60s`), and `server.idle_timeout` (default `120s`) to `vibewarden.yaml` under the existing `server:` block
- Introduces `ports.ServerTimeoutsConfig` as a value object in the domain port layer, keeping the domain isolated from config parsing
- `buildServerTimeoutsConfig` in `cmd/vibewarden/serve_config.go` parses the duration strings, applies defaults when the field is empty, disables the timeout when the value is `"0"`, and falls back to the documented default on parse error (with a `slog.Warn`)
- `BuildCaddyConfig` wires non-zero timeouts into the Caddy HTTP server JSON map as `read_timeout`, `write_timeout`, `idle_timeout` (nanosecond integers matching Caddy's `caddy.Duration` JSON type); zero values are omitted so Caddy uses its own defaults
- These timeouts are server-level connection bounds, separate from `resilience.timeout` which only covers upstream response time

## Test plan

- `TestBuildServerTimeoutsConfig` in `cmd/vibewarden/serve_config_test.go` — 7 table cases covering defaults, explicit zero, custom values, and fallback on bad input
- `TestBuildCaddyConfig_ServerTimeouts` in `internal/adapters/caddy/config_test.go` — 4 table cases covering zero (keys absent), defaults, custom, and partial configuration
- `go test -race ./...` passes across all packages
- `golangci-lint run ./...` reports 0 issues