### PR TITLE
feat(#488): implement TLS certificate expiry monitoring

### DIFF
--- a/cmd/vibewarden/serve.go
+++ b/cmd/vibewarden/serve.go
@@ -91,6 +91,12 @@ func runServe(configPath string) error {
 	// (if log export is enabled) and build the final event logger.
 	eventLogger := buildEventLogger(registry, logger)
 
+	// Wire the metrics collector into the TLS cert expiry monitor so that
+	// the vibewarden_tls_cert_expiry_seconds gauge is populated. This must
+	// happen after InitAll (metrics provider is ready) and before StartAll
+	// (monitor background goroutine launches on Start).
+	wireTLSMetricsCollector(registry)
+
 	// Start all plugins (background servers, etc.).
 	if err := registry.StartAll(ctx); err != nil {
 		return fmt.Errorf("starting plugins: %w", err)

--- a/cmd/vibewarden/serve_config.go
+++ b/cmd/vibewarden/serve_config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vibewarden/vibewarden/internal/plugins"
 	egressplugin "github.com/vibewarden/vibewarden/internal/plugins/egress"
 	metricsplugin "github.com/vibewarden/vibewarden/internal/plugins/metrics"
+	tlsplugin "github.com/vibewarden/vibewarden/internal/plugins/tls"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
@@ -436,4 +437,26 @@ func buildEventLogger(registry *plugins.Registry, logger *slog.Logger) ports.Eve
 		}
 	}
 	return logadapter.NewSlogEventLogger(os.Stdout)
+}
+
+// wireTLSMetricsCollector injects the MetricsCollector from the metrics plugin
+// into the TLS plugin's certificate expiry monitor. It must be called after
+// InitAll (so the metrics provider is ready) and before StartAll (so the
+// monitor goroutine receives the collector before it first runs).
+func wireTLSMetricsCollector(registry *plugins.Registry) {
+	var collector ports.MetricsCollector
+	var tlsPlugin *tlsplugin.Plugin
+
+	for _, p := range registry.Plugins() {
+		switch v := p.(type) {
+		case *metricsplugin.Plugin:
+			collector = v.Collector()
+		case *tlsplugin.Plugin:
+			tlsPlugin = v
+		}
+	}
+
+	if tlsPlugin != nil && collector != nil {
+		tlsPlugin.SetMetricsCollector(collector)
+	}
 }

--- a/cmd/vibewarden/serve_plugins.go
+++ b/cmd/vibewarden/serve_plugins.go
@@ -47,14 +47,7 @@ func registerPlugins(
 	}, logger))
 
 	// TLS — priority 10
-	registry.Register(tlsplugin.New(ports.TLSConfig{
-		Enabled:     cfg.TLS.Enabled,
-		Provider:    ports.TLSProvider(cfg.TLS.Provider),
-		Domain:      cfg.TLS.Domain,
-		CertPath:    cfg.TLS.CertPath,
-		KeyPath:     cfg.TLS.KeyPath,
-		StoragePath: cfg.TLS.StoragePath,
-	}, logger))
+	registry.Register(buildTLSPlugin(cfg, eventLogger, logger))
 
 	// CORS — priority 10 (before all middleware; OPTIONS preflight must be handled first)
 	registry.Register(corsplugin.New(corsplugin.Config{
@@ -300,4 +293,48 @@ func buildSecretsPlugin(cfg *config.Config, eventLogger ports.EventLogger, logge
 	}
 
 	return secretsplugin.New(secretsCfg, eventLogger, logger)
+}
+
+// buildTLSPlugin constructs the TLS plugin from cfg, parsing the optional
+// cert_monitoring duration strings into time.Duration values. Falls back to
+// plugin defaults on parse errors.
+func buildTLSPlugin(cfg *config.Config, eventLogger ports.EventLogger, logger *slog.Logger) *tlsplugin.Plugin {
+	monCfg := ports.TLSCertMonitoringConfig{
+		Enabled: cfg.TLS.CertMonitoring.Enabled,
+	}
+
+	if cfg.TLS.CertMonitoring.CheckInterval != "" {
+		if d, err := time.ParseDuration(cfg.TLS.CertMonitoring.CheckInterval); err != nil {
+			logger.Warn("tls.cert_monitoring.check_interval parse error — using default",
+				slog.String("error", err.Error()))
+		} else {
+			monCfg.CheckInterval = d
+		}
+	}
+	if cfg.TLS.CertMonitoring.WarningThreshold != "" {
+		if d, err := time.ParseDuration(cfg.TLS.CertMonitoring.WarningThreshold); err != nil {
+			logger.Warn("tls.cert_monitoring.warning_threshold parse error — using default",
+				slog.String("error", err.Error()))
+		} else {
+			monCfg.WarningThreshold = d
+		}
+	}
+	if cfg.TLS.CertMonitoring.CriticalThreshold != "" {
+		if d, err := time.ParseDuration(cfg.TLS.CertMonitoring.CriticalThreshold); err != nil {
+			logger.Warn("tls.cert_monitoring.critical_threshold parse error — using default",
+				slog.String("error", err.Error()))
+		} else {
+			monCfg.CriticalThreshold = d
+		}
+	}
+
+	return tlsplugin.New(ports.TLSConfig{
+		Enabled:        cfg.TLS.Enabled,
+		Provider:       ports.TLSProvider(cfg.TLS.Provider),
+		Domain:         cfg.TLS.Domain,
+		CertPath:       cfg.TLS.CertPath,
+		KeyPath:        cfg.TLS.KeyPath,
+		StoragePath:    cfg.TLS.StoragePath,
+		CertMonitoring: monCfg,
+	}, eventLogger, logger)
 }

--- a/internal/adapters/caddy/retry_handler_test.go
+++ b/internal/adapters/caddy/retry_handler_test.go
@@ -34,6 +34,7 @@ func (f *fakeMetrics) IncWAFDetection(_, _ string)                              
 func (f *fakeMetrics) IncEgressRequestTotal(_, _, _ string)                         {}
 func (f *fakeMetrics) ObserveEgressDuration(_, _ string, _ time.Duration)           {}
 func (f *fakeMetrics) IncEgressErrorTotal(_ string)                                 {}
+func (f *fakeMetrics) SetTLSCertExpirySeconds(_ string, _ float64)                  {}
 
 // sequentialHandler calls each inner handler in sequence, one per ServeHTTP call.
 type sequentialHandler struct {

--- a/internal/adapters/egress/observability_test.go
+++ b/internal/adapters/egress/observability_test.go
@@ -108,6 +108,9 @@ func (f *fakeMetricsCollector) IncEgressErrorTotal(route string) {
 	f.errorTotals = append(f.errorTotals, route)
 }
 
+// SetTLSCertExpirySeconds implements ports.MetricsCollector and does nothing.
+func (f *fakeMetricsCollector) SetTLSCertExpirySeconds(_ string, _ float64) {}
+
 // Snapshot methods for assertions.
 func (f *fakeMetricsCollector) RequestTotals() []egressRequestTotalCall {
 	f.mu.Lock()

--- a/internal/adapters/health/checker_test.go
+++ b/internal/adapters/health/checker_test.go
@@ -62,6 +62,7 @@ func (f *fakeMetrics) IncWAFDetection(_, _ string)                              
 func (f *fakeMetrics) IncEgressRequestTotal(_, _, _ string)                         {}
 func (f *fakeMetrics) ObserveEgressDuration(_, _ string, _ time.Duration)           {}
 func (f *fakeMetrics) IncEgressErrorTotal(_ string)                                 {}
+func (f *fakeMetrics) SetTLSCertExpirySeconds(_ string, _ float64)                  {}
 
 // Compile-time assertion.
 var _ ports.MetricsCollectorWithUpstreamHealth = (*fakeMetrics)(nil)

--- a/internal/adapters/metrics/noop.go
+++ b/internal/adapters/metrics/noop.go
@@ -53,3 +53,6 @@ func (NoOpMetricsCollector) ObserveEgressDuration(_, _ string, _ time.Duration) 
 
 // IncEgressErrorTotal implements ports.MetricsCollector and does nothing.
 func (NoOpMetricsCollector) IncEgressErrorTotal(_ string) {}
+
+// SetTLSCertExpirySeconds implements ports.MetricsCollector and does nothing.
+func (NoOpMetricsCollector) SetTLSCertExpirySeconds(_ string, _ float64) {}

--- a/internal/adapters/metrics/noop_test.go
+++ b/internal/adapters/metrics/noop_test.go
@@ -41,4 +41,6 @@ func TestNoOpMetricsCollector_AllMethodsAreNoOps(t *testing.T) {
 	mc.ObserveEgressDuration("stripe", "POST", 150*time.Millisecond)
 	mc.IncEgressErrorTotal("stripe")
 	mc.IncEgressErrorTotal("unmatched")
+	mc.SetTLSCertExpirySeconds("example.com", 2592000)
+	mc.SetTLSCertExpirySeconds("example.com", -1)
 }

--- a/internal/adapters/metrics/otel.go
+++ b/internal/adapters/metrics/otel.go
@@ -2,7 +2,9 @@ package metrics
 
 import (
 	"context"
+	"math"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -14,25 +16,27 @@ import (
 // It creates counters and histograms via ports.Meter and records observations.
 // All methods are safe for concurrent use.
 type OTelAdapter struct {
-	requestsTotal          ports.Int64Counter
-	requestDuration        ports.Float64Histogram
-	rateLimitHits          ports.Int64Counter
-	authDecisions          ports.Int64Counter
-	upstreamErrors         ports.Int64Counter
-	upstreamTimeouts       ports.Int64Counter
-	upstreamRetries        ports.Int64Counter
-	activeConnections      ports.Int64UpDownCounter
-	circuitBreakerState    ports.Int64UpDownCounter
-	upstreamHealthy        ports.Int64UpDownCounter
-	wafDetections          ports.Int64Counter
-	egressRequestsTotal    ports.Int64Counter
-	egressDuration         ports.Float64Histogram
-	egressErrorsTotal      ports.Int64Counter
-	currentConns           atomic.Int64
-	currentCBState         atomic.Int64
-	currentUpstreamHealthy atomic.Int64
-	pathMatcher            *PathMatcher
-	handler                http.Handler
+	requestsTotal             ports.Int64Counter
+	requestDuration           ports.Float64Histogram
+	rateLimitHits             ports.Int64Counter
+	authDecisions             ports.Int64Counter
+	upstreamErrors            ports.Int64Counter
+	upstreamTimeouts          ports.Int64Counter
+	upstreamRetries           ports.Int64Counter
+	activeConnections         ports.Int64UpDownCounter
+	circuitBreakerState       ports.Int64UpDownCounter
+	upstreamHealthy           ports.Int64UpDownCounter
+	wafDetections             ports.Int64Counter
+	egressRequestsTotal       ports.Int64Counter
+	egressDuration            ports.Float64Histogram
+	egressErrorsTotal         ports.Int64Counter
+	tlsCertExpirySeconds      ports.Int64UpDownCounter
+	currentConns              atomic.Int64
+	currentCBState            atomic.Int64
+	currentUpstreamHealthy    atomic.Int64
+	currentCertExpiryByDomain sync.Map // map[string]*atomic.Int64
+	pathMatcher               *PathMatcher
+	handler                   http.Handler
 }
 
 // NewOTelAdapter creates a new OTel-backed MetricsCollector.
@@ -144,23 +148,32 @@ func NewOTelAdapter(provider ports.OTelProvider, pathPatterns []string) (*OTelAd
 		return nil, err
 	}
 
+	tlsCertExpirySeconds, err := meter.Int64UpDownCounter("vibewarden_tls_cert_expiry_seconds",
+		ports.WithDescription("Seconds until the monitored TLS certificate expires. Negative when already expired."),
+		ports.WithUnit("s"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &OTelAdapter{
-		requestsTotal:       requestsTotal,
-		requestDuration:     requestDuration,
-		rateLimitHits:       rateLimitHits,
-		authDecisions:       authDecisions,
-		upstreamErrors:      upstreamErrors,
-		upstreamTimeouts:    upstreamTimeouts,
-		upstreamRetries:     upstreamRetries,
-		activeConnections:   activeConnections,
-		circuitBreakerState: circuitBreakerState,
-		upstreamHealthy:     upstreamHealthy,
-		wafDetections:       wafDetections,
-		egressRequestsTotal: egressRequestsTotal,
-		egressDuration:      egressDuration,
-		egressErrorsTotal:   egressErrorsTotal,
-		pathMatcher:         NewPathMatcher(pathPatterns),
-		handler:             provider.Handler(),
+		requestsTotal:        requestsTotal,
+		requestDuration:      requestDuration,
+		rateLimitHits:        rateLimitHits,
+		authDecisions:        authDecisions,
+		upstreamErrors:       upstreamErrors,
+		upstreamTimeouts:     upstreamTimeouts,
+		upstreamRetries:      upstreamRetries,
+		activeConnections:    activeConnections,
+		circuitBreakerState:  circuitBreakerState,
+		upstreamHealthy:      upstreamHealthy,
+		wafDetections:        wafDetections,
+		egressRequestsTotal:  egressRequestsTotal,
+		egressDuration:       egressDuration,
+		egressErrorsTotal:    egressErrorsTotal,
+		tlsCertExpirySeconds: tlsCertExpirySeconds,
+		pathMatcher:          NewPathMatcher(pathPatterns),
+		handler:              provider.Handler(),
 	}, nil
 }
 
@@ -292,4 +305,21 @@ func (a *OTelAdapter) IncEgressErrorTotal(route string) {
 	a.egressErrorsTotal.Add(context.Background(), 1,
 		ports.Attribute{Key: "route", Value: route},
 	)
+}
+
+// SetTLSCertExpirySeconds implements ports.MetricsCollector.
+// Sets the vibewarden_tls_cert_expiry_seconds gauge for the given domain to the
+// provided number of seconds until expiry. The value is stored per-domain using
+// an atomic counter; the delta between the new and previous value is emitted.
+// The seconds value is rounded to the nearest integer before recording.
+func (a *OTelAdapter) SetTLSCertExpirySeconds(domain string, seconds float64) {
+	next := int64(math.Round(seconds))
+	prevPtr, _ := a.currentCertExpiryByDomain.LoadOrStore(domain, &atomic.Int64{})
+	prev := prevPtr.(*atomic.Int64).Swap(next)
+	delta := next - prev
+	if delta != 0 {
+		a.tlsCertExpirySeconds.Add(context.Background(), delta,
+			ports.Attribute{Key: "domain", Value: domain},
+		)
+	}
 }

--- a/internal/adapters/metrics/otel_test.go
+++ b/internal/adapters/metrics/otel_test.go
@@ -354,3 +354,26 @@ func TestOTelAdapter_EgressMetrics_AllPresentAfterCalls(t *testing.T) {
 		}
 	}
 }
+
+func TestOTelAdapter_SetTLSCertExpirySeconds(t *testing.T) {
+	a := newOTelTestAdapter(t, nil)
+
+	a.SetTLSCertExpirySeconds("example.com", 2592000)
+
+	body := scrapeOTelMetrics(t, a)
+	if !strings.Contains(body, "vibewarden_tls_cert_expiry_seconds") {
+		t.Errorf("expected vibewarden_tls_cert_expiry_seconds in Prometheus output\n\nFull output:\n%s", body)
+	}
+}
+
+func TestOTelAdapter_SetTLSCertExpirySeconds_MultipleDomains(t *testing.T) {
+	a := newOTelTestAdapter(t, nil)
+
+	a.SetTLSCertExpirySeconds("app.example.com", 2592000)
+	a.SetTLSCertExpirySeconds("api.example.com", 604800)
+
+	body := scrapeOTelMetrics(t, a)
+	if !strings.Contains(body, "vibewarden_tls_cert_expiry_seconds") {
+		t.Errorf("expected vibewarden_tls_cert_expiry_seconds in Prometheus output\n\nFull output:\n%s", body)
+	}
+}

--- a/internal/adapters/resilience/circuit_breaker_test.go
+++ b/internal/adapters/resilience/circuit_breaker_test.go
@@ -77,6 +77,7 @@ func (f *fakeMetrics) IncWAFDetection(_, _ string)                         {}
 func (f *fakeMetrics) IncEgressRequestTotal(_, _, _ string)                {}
 func (f *fakeMetrics) ObserveEgressDuration(_, _ string, _ time.Duration)  {}
 func (f *fakeMetrics) IncEgressErrorTotal(_ string)                        {}
+func (f *fakeMetrics) SetTLSCertExpirySeconds(_ string, _ float64)         {}
 
 var _ ports.MetricsCollectorWithCircuitBreaker = (*fakeMetrics)(nil)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -286,6 +286,18 @@ type AppConfig struct {
 	Image string `mapstructure:"image"`
 }
 
+// TLSCertMonitoringConfig holds configuration for the certificate expiry monitor.
+type TLSCertMonitoringConfig struct {
+	// Enabled toggles the certificate expiry monitor (default: true when TLS is enabled).
+	Enabled bool `mapstructure:"enabled"`
+	// CheckInterval is how often the monitor checks certificate expiry (default: 6h).
+	CheckInterval string `mapstructure:"check_interval"`
+	// WarningThreshold is the time-before-expiry that triggers a warning event (default: 720h = 30 days).
+	WarningThreshold string `mapstructure:"warning_threshold"`
+	// CriticalThreshold is the time-before-expiry that triggers a critical event and degraded health (default: 168h = 7 days).
+	CriticalThreshold string `mapstructure:"critical_threshold"`
+}
+
 // TLSConfig holds TLS-related settings.
 type TLSConfig struct {
 	// Enabled toggles TLS (default: false for local dev)
@@ -303,6 +315,8 @@ type TLSConfig struct {
 	// StoragePath is the directory where Caddy stores ACME certificates.
 	// Only applies when Provider is "letsencrypt".
 	StoragePath string `mapstructure:"storage_path"`
+	// CertMonitoring holds configuration for the background certificate expiry monitor.
+	CertMonitoring TLSCertMonitoringConfig `mapstructure:"cert_monitoring"`
 }
 
 // KratosSMTPConfig holds SMTP settings used by Ory Kratos to send emails.
@@ -1878,6 +1892,10 @@ func Load(configPath string) (*Config, error) {
 	v.SetDefault("upstream.port", 3000)
 	v.SetDefault("tls.enabled", true)
 	v.SetDefault("tls.provider", "self-signed")
+	v.SetDefault("tls.cert_monitoring.enabled", true)
+	v.SetDefault("tls.cert_monitoring.check_interval", "6h")
+	v.SetDefault("tls.cert_monitoring.warning_threshold", "720h")
+	v.SetDefault("tls.cert_monitoring.critical_threshold", "168h")
 	v.SetDefault("kratos.public_url", "http://127.0.0.1:4433")
 	v.SetDefault("kratos.admin_url", "http://127.0.0.1:4434")
 	v.SetDefault("kratos.dsn", "")

--- a/internal/domain/events/events.go
+++ b/internal/domain/events/events.go
@@ -128,6 +128,16 @@ const (
 	// because maintenance mode is enabled. The path and method of the blocked
 	// request are included in the payload.
 	EventTypeMaintenanceRequestBlocked = "maintenance.request_blocked"
+
+	// EventTypeTLSCertExpiryWarning is emitted by the certificate expiry monitor
+	// when a TLS certificate expires within 30 days. The payload includes the
+	// certificate subject, issuer, expiry time, and days remaining.
+	EventTypeTLSCertExpiryWarning = "tls.cert_expiry_warning"
+
+	// EventTypeTLSCertExpiryCritical is emitted by the certificate expiry monitor
+	// when a TLS certificate expires within 7 days. The payload includes the
+	// certificate subject, issuer, expiry time, and days remaining.
+	EventTypeTLSCertExpiryCritical = "tls.cert_expiry_critical"
 )
 
 // Event is the base structured log event.

--- a/internal/middleware/metrics_test.go
+++ b/internal/middleware/metrics_test.go
@@ -78,6 +78,9 @@ func (f *fakeMetricsCollector) ObserveEgressDuration(_, _ string, _ time.Duratio
 // IncEgressErrorTotal implements ports.MetricsCollector and does nothing.
 func (f *fakeMetricsCollector) IncEgressErrorTotal(_ string) {}
 
+// SetTLSCertExpirySeconds implements ports.MetricsCollector and does nothing.
+func (f *fakeMetricsCollector) SetTLSCertExpirySeconds(_ string, _ float64) {}
+
 // Compile-time check: fakeMetricsCollector satisfies ports.MetricsCollector.
 var _ ports.MetricsCollector = (*fakeMetricsCollector)(nil)
 

--- a/internal/middleware/waf_test.go
+++ b/internal/middleware/waf_test.go
@@ -48,6 +48,7 @@ func (f *fakeWAFCollector) IncWAFDetection(rule, mode string) {
 func (f *fakeWAFCollector) IncEgressRequestTotal(_, _, _ string)               {}
 func (f *fakeWAFCollector) ObserveEgressDuration(_, _ string, _ time.Duration) {}
 func (f *fakeWAFCollector) IncEgressErrorTotal(_ string)                       {}
+func (f *fakeWAFCollector) SetTLSCertExpirySeconds(_ string, _ float64)        {}
 
 // fakeWAFAuditLogger records audit events.
 type fakeWAFAuditLogger struct {

--- a/internal/plugins/tls/certio.go
+++ b/internal/plugins/tls/certio.go
@@ -1,0 +1,33 @@
+package tls
+
+import (
+	"encoding/pem"
+	"os"
+)
+
+// readFileBytes reads all bytes from a file path.
+func readFileBytes(path string) ([]byte, error) {
+	return os.ReadFile(path) //nolint:wrapcheck,gosec // caller wraps; path is operator-controlled config, not user input
+}
+
+// pemDecode strips PEM armor and returns the raw DER bytes.
+// If the input is not PEM-encoded it is returned as-is (assumed to be DER).
+func pemDecode(data []byte) []byte {
+	var der []byte
+	rest := data
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			der = append(der, block.Bytes...)
+		}
+	}
+	if len(der) == 0 {
+		// Input may already be DER.
+		return data
+	}
+	return der
+}

--- a/internal/plugins/tls/monitor.go
+++ b/internal/plugins/tls/monitor.go
@@ -1,0 +1,371 @@
+package tls
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+const (
+	defaultCheckInterval     = 6 * time.Hour
+	defaultWarningThreshold  = 30 * 24 * time.Hour // 30 days
+	defaultCriticalThreshold = 7 * 24 * time.Hour  // 7 days
+)
+
+// certReader is the interface used to load a TLS certificate from disk.
+// It is abstracted for testability.
+type certReader interface {
+	// ReadCert loads the leaf certificate from the given PEM files.
+	ReadCert(certPath, keyPath string) (*x509.Certificate, error)
+}
+
+// fileCertReader loads certificates from the filesystem using standard crypto/tls.
+type fileCertReader struct{}
+
+// ReadCert loads a TLS certificate pair from PEM files and returns the leaf certificate.
+func (fileCertReader) ReadCert(certPath, keyPath string) (*x509.Certificate, error) {
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading key pair: %w", err)
+	}
+	if len(cert.Certificate) == 0 {
+		return nil, fmt.Errorf("certificate chain is empty")
+	}
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, fmt.Errorf("parsing leaf certificate: %w", err)
+	}
+	return leaf, nil
+}
+
+// caddyCertReader resolves the certificate path for letsencrypt/self-signed
+// providers by looking up the certificate in Caddy's storage directory.
+// For the external provider, it delegates to a fileCertReader.
+type caddyCertReader struct {
+	cfg    ports.TLSConfig
+	reader certReader
+}
+
+// ReadCert returns the leaf certificate appropriate for the provider.
+// For letsencrypt/self-signed it scans the storage directory for PEM files.
+// For external it reads cfg.CertPath and cfg.KeyPath directly.
+func (r *caddyCertReader) ReadCert() (*x509.Certificate, error) {
+	switch r.cfg.Provider {
+	case ports.TLSProviderExternal:
+		return r.reader.ReadCert(r.cfg.CertPath, r.cfg.KeyPath)
+	case ports.TLSProviderLetsEncrypt, ports.TLSProviderSelfSigned, "":
+		return r.readCaddyStoredCert()
+	default:
+		return nil, fmt.Errorf("unsupported provider %q for certificate monitoring", r.cfg.Provider)
+	}
+}
+
+// readCaddyStoredCert searches Caddy's data directory for a certificate file
+// matching the configured domain. It uses the standard Caddy file layout:
+//
+//	<storage_path>/certificates/<acme-dir>/<domain>/<domain>.crt
+//
+// For self-signed certificates the path is:
+//
+//	<storage_path>/pki/authorities/local/<domain>.crt (or similar)
+//
+// When StoragePath is empty the Caddy default is used (~/.local/share/caddy).
+// Because the exact path varies by Caddy version and OS, the monitor first
+// tries the ACME path, then falls back to glob-searching the storage directory.
+func (r *caddyCertReader) readCaddyStoredCert() (*x509.Certificate, error) {
+	storagePath := r.cfg.StoragePath
+	if storagePath == "" {
+		return nil, fmt.Errorf("storage_path is required for certificate monitoring with provider %q; set tls.storage_path in vibewarden.yaml", r.cfg.Provider)
+	}
+
+	domain := r.cfg.Domain
+	if domain == "" {
+		// For self-signed without a domain use a glob to find any cert.
+		return r.findAnyCert(storagePath)
+	}
+
+	// Standard ACME path: <storage>/certificates/<acme-dir>/<domain>/<domain>.crt
+	acmePath := filepath.Join(storagePath, "certificates", "*", domain, domain+".crt")
+	matches, err := filepath.Glob(acmePath)
+	if err == nil && len(matches) > 0 {
+		return readCertFile(matches[0])
+	}
+
+	// Fallback: search anywhere under storagePath.
+	return r.findAnyCert(storagePath)
+}
+
+// findAnyCert searches the storagePath tree for any .crt or .pem certificate file.
+func (r *caddyCertReader) findAnyCert(storagePath string) (*x509.Certificate, error) {
+	patterns := []string{
+		filepath.Join(storagePath, "**", "*.crt"),
+		filepath.Join(storagePath, "**", "*.pem"),
+		filepath.Join(storagePath, "*.crt"),
+		filepath.Join(storagePath, "*.pem"),
+	}
+	for _, pat := range patterns {
+		matches, err := filepath.Glob(pat)
+		if err != nil || len(matches) == 0 {
+			continue
+		}
+		for _, m := range matches {
+			cert, err := readCertFile(m)
+			if err == nil {
+				return cert, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("no certificate found under storage path %q", storagePath)
+}
+
+// readCertFile parses the first PEM-encoded certificate block in a .crt/.pem file.
+func readCertFile(path string) (*x509.Certificate, error) {
+	data, err := readFileBytes(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading certificate file %q: %w", path, err)
+	}
+	certs, err := x509.ParseCertificates(pemDecode(data))
+	if err != nil {
+		return nil, fmt.Errorf("parsing certificate file %q: %w", path, err)
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no certificates in file %q", path)
+	}
+	return certs[0], nil
+}
+
+// CertMonitor runs a background goroutine that periodically checks TLS
+// certificate expiry, emits structured events, updates metrics, and sets
+// the plugin's health status to degraded when the certificate is within the
+// critical threshold.
+type CertMonitor struct {
+	cfg      ports.TLSConfig
+	reader   *caddyCertReader
+	eventLog ports.EventLogger
+	metrics  ports.MetricsCollector
+	logger   *slog.Logger
+
+	// mu protects degraded and degradedMsg.
+	mu          sync.RWMutex
+	degraded    bool
+	degradedMsg string
+
+	stopCh chan struct{}
+	wg     sync.WaitGroup
+}
+
+// NewCertMonitor creates a CertMonitor for the given TLS configuration.
+// eventLog and metrics may be nil; when nil those outputs are skipped.
+func NewCertMonitor(
+	cfg ports.TLSConfig,
+	eventLog ports.EventLogger,
+	metrics ports.MetricsCollector,
+	logger *slog.Logger,
+) *CertMonitor {
+	applyMonitorDefaults(&cfg.CertMonitoring)
+	return &CertMonitor{
+		cfg: cfg,
+		reader: &caddyCertReader{
+			cfg:    cfg,
+			reader: fileCertReader{},
+		},
+		eventLog: eventLog,
+		metrics:  metrics,
+		logger:   logger,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// applyMonitorDefaults fills zero-value fields with sensible defaults.
+func applyMonitorDefaults(m *ports.TLSCertMonitoringConfig) {
+	if m.CheckInterval == 0 {
+		m.CheckInterval = defaultCheckInterval
+	}
+	if m.WarningThreshold == 0 {
+		m.WarningThreshold = defaultWarningThreshold
+	}
+	if m.CriticalThreshold == 0 {
+		m.CriticalThreshold = defaultCriticalThreshold
+	}
+}
+
+// Start launches the background check loop. It must be called at most once.
+func (m *CertMonitor) Start(ctx context.Context) {
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		m.run(ctx)
+	}()
+}
+
+// Stop signals the monitor to stop and waits for the goroutine to finish.
+func (m *CertMonitor) Stop() {
+	close(m.stopCh)
+	m.wg.Wait()
+}
+
+// Degraded returns true when the certificate is within the critical threshold.
+// It is safe for concurrent use.
+func (m *CertMonitor) Degraded() (bool, string) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.degraded, m.degradedMsg
+}
+
+// run executes the check loop until ctx is cancelled or Stop is called.
+func (m *CertMonitor) run(ctx context.Context) {
+	// Run immediately on start.
+	m.check(ctx)
+
+	ticker := time.NewTicker(m.cfg.CertMonitoring.CheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.check(ctx)
+		}
+	}
+}
+
+// check performs a single certificate expiry check.
+func (m *CertMonitor) check(ctx context.Context) {
+	cert, err := m.reader.ReadCert()
+	if err != nil {
+		m.logger.WarnContext(ctx, "tls cert monitor: failed to read certificate",
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	now := time.Now()
+	remaining := cert.NotAfter.Sub(now)
+	domain := m.cfg.Domain
+	if domain == "" {
+		domain = cert.Subject.CommonName
+	}
+
+	// Update metric gauge.
+	if m.metrics != nil {
+		m.metrics.SetTLSCertExpirySeconds(domain, remaining.Seconds())
+	}
+
+	daysRemaining := remaining.Hours() / 24
+
+	m.logger.DebugContext(ctx, "tls cert monitor: checked certificate",
+		slog.String("domain", domain),
+		slog.Time("expires_at", cert.NotAfter),
+		slog.Float64("days_remaining", daysRemaining),
+	)
+
+	switch {
+	case remaining <= m.cfg.CertMonitoring.CriticalThreshold:
+		m.setCritical(ctx, cert, domain, remaining, daysRemaining)
+	case remaining <= m.cfg.CertMonitoring.WarningThreshold:
+		m.setWarning(ctx, cert, domain, remaining, daysRemaining)
+	default:
+		// Certificate is healthy — clear any previous degraded state.
+		m.mu.Lock()
+		m.degraded = false
+		m.degradedMsg = ""
+		m.mu.Unlock()
+	}
+}
+
+// setCritical emits a tls.cert_expiry_critical event and marks the monitor degraded.
+func (m *CertMonitor) setCritical(
+	ctx context.Context,
+	cert *x509.Certificate,
+	domain string,
+	remaining time.Duration,
+	daysRemaining float64,
+) {
+	msg := fmt.Sprintf(
+		"TLS certificate for %q expires in %.1f days (%s) — CRITICAL",
+		domain, daysRemaining, cert.NotAfter.UTC().Format(time.RFC3339),
+	)
+	m.logger.ErrorContext(ctx, "tls cert monitor: certificate expiry critical",
+		slog.String("domain", domain),
+		slog.Time("expires_at", cert.NotAfter),
+		slog.Float64("days_remaining", daysRemaining),
+	)
+	m.emitEvent(ctx, events.EventTypeTLSCertExpiryCritical, msg, cert, domain, remaining)
+
+	m.mu.Lock()
+	m.degraded = true
+	m.degradedMsg = fmt.Sprintf("TLS certificate expires in %.0f days", daysRemaining)
+	m.mu.Unlock()
+}
+
+// setWarning emits a tls.cert_expiry_warning event. The health status is not
+// changed to degraded for warnings — only critical threshold triggers degraded.
+func (m *CertMonitor) setWarning(
+	ctx context.Context,
+	cert *x509.Certificate,
+	domain string,
+	remaining time.Duration,
+	daysRemaining float64,
+) {
+	msg := fmt.Sprintf(
+		"TLS certificate for %q expires in %.1f days (%s) — WARNING",
+		domain, daysRemaining, cert.NotAfter.UTC().Format(time.RFC3339),
+	)
+	m.logger.WarnContext(ctx, "tls cert monitor: certificate expiry warning",
+		slog.String("domain", domain),
+		slog.Time("expires_at", cert.NotAfter),
+		slog.Float64("days_remaining", daysRemaining),
+	)
+	m.emitEvent(ctx, events.EventTypeTLSCertExpiryWarning, msg, cert, domain, remaining)
+
+	// Warning does not change the degraded state.
+	m.mu.Lock()
+	m.degraded = false
+	m.degradedMsg = ""
+	m.mu.Unlock()
+}
+
+// emitEvent emits a structured domain event. Errors are logged but not propagated.
+func (m *CertMonitor) emitEvent(
+	ctx context.Context,
+	eventType string,
+	aiSummary string,
+	cert *x509.Certificate,
+	domain string,
+	remaining time.Duration,
+) {
+	if m.eventLog == nil {
+		return
+	}
+	ev := events.Event{
+		SchemaVersion: events.SchemaVersion,
+		EventType:     eventType,
+		Timestamp:     time.Now().UTC(),
+		AISummary:     aiSummary,
+		Payload: map[string]any{
+			"domain":         domain,
+			"subject":        cert.Subject.String(),
+			"issuer":         cert.Issuer.String(),
+			"expires_at":     cert.NotAfter.UTC().Format(time.RFC3339),
+			"days_remaining": remaining.Hours() / 24,
+			"serial_number":  cert.SerialNumber.String(),
+		},
+	}
+	if err := m.eventLog.Log(ctx, ev); err != nil {
+		m.logger.WarnContext(ctx, "tls cert monitor: failed to emit event",
+			slog.String("event_type", eventType),
+			slog.String("error", err.Error()),
+		)
+	}
+}

--- a/internal/plugins/tls/monitor_test.go
+++ b/internal/plugins/tls/monitor_test.go
@@ -1,0 +1,563 @@
+package tls
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"log/slog"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/domain/resilience"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// noopWriter discards all log output.
+type noopWriter struct{}
+
+func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// discardLogger returns an slog.Logger that discards all output.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(noopWriter{}, nil))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// fakeCertReader is a certReader implementation that returns a fixed certificate.
+type fakeCertReader struct {
+	cert *x509.Certificate
+	err  error
+}
+
+func (f *fakeCertReader) ReadCert(_, _ string) (*x509.Certificate, error) {
+	return f.cert, f.err
+}
+
+// fakeEventLogger records emitted events.
+type fakeEventLogger struct {
+	logged []events.Event
+}
+
+func (f *fakeEventLogger) Log(_ context.Context, ev events.Event) error {
+	f.logged = append(f.logged, ev)
+	return nil
+}
+
+// fakeMetricsCollector records SetTLSCertExpirySeconds calls.
+type fakeMonitorMetrics struct {
+	domain  string
+	seconds float64
+	called  int
+}
+
+func (f *fakeMonitorMetrics) SetTLSCertExpirySeconds(domain string, seconds float64) {
+	f.domain = domain
+	f.seconds = seconds
+	f.called++
+}
+
+// All other MetricsCollector methods are no-ops.
+func (f *fakeMonitorMetrics) IncRequestTotal(_, _, _ string)                               {}
+func (f *fakeMonitorMetrics) ObserveRequestDuration(_, _ string, _ time.Duration)          {}
+func (f *fakeMonitorMetrics) IncRateLimitHit(_ string)                                     {}
+func (f *fakeMonitorMetrics) IncAuthDecision(_ string)                                     {}
+func (f *fakeMonitorMetrics) IncUpstreamError()                                            {}
+func (f *fakeMonitorMetrics) IncUpstreamTimeout()                                          {}
+func (f *fakeMonitorMetrics) IncUpstreamRetry(_ string)                                    {}
+func (f *fakeMonitorMetrics) SetActiveConnections(_ int)                                   {}
+func (f *fakeMonitorMetrics) SetCircuitBreakerState(_ context.Context, _ resilience.State) {}
+func (f *fakeMonitorMetrics) IncWAFDetection(_, _ string)                                  {}
+func (f *fakeMonitorMetrics) IncEgressRequestTotal(_, _, _ string)                         {}
+func (f *fakeMonitorMetrics) ObserveEgressDuration(_, _ string, _ time.Duration)           {}
+func (f *fakeMonitorMetrics) IncEgressErrorTotal(_ string)                                 {}
+
+// Compile-time assertion: fakeMonitorMetrics implements ports.MetricsCollector.
+var _ ports.MetricsCollector = (*fakeMonitorMetrics)(nil)
+
+// makeCert creates a self-signed certificate with the given validity window.
+func makeCert(t *testing.T, notBefore, notAfter time.Time, cn string) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		t.Fatalf("parsing certificate: %v", err)
+	}
+	return cert
+}
+
+// writeCertAndKey writes a PEM cert+key pair to a temp directory and returns
+// the cert path and key path.
+func writeCertAndKey(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	notBefore := time.Now().Add(-time.Hour)
+	notAfter := time.Now().Add(60 * 24 * time.Hour) // 60 days
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test.example.com"},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+
+	certPath = filepath.Join(dir, "cert.pem")
+	cf, err := os.Create(certPath)
+	if err != nil {
+		t.Fatalf("creating cert file: %v", err)
+	}
+	if err := pem.Encode(cf, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		_ = cf.Close()
+		t.Fatalf("encoding cert pem: %v", err)
+	}
+	if err := cf.Close(); err != nil {
+		t.Fatalf("closing cert file: %v", err)
+	}
+
+	keyPath = filepath.Join(dir, "key.pem")
+	kf, err := os.Create(keyPath)
+	if err != nil {
+		t.Fatalf("creating key file: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		_ = kf.Close()
+		t.Fatalf("marshalling private key: %v", err)
+	}
+	if err := pem.Encode(kf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}); err != nil {
+		_ = kf.Close()
+		t.Fatalf("encoding key pem: %v", err)
+	}
+	if err := kf.Close(); err != nil {
+		t.Fatalf("closing key file: %v", err)
+	}
+
+	return certPath, keyPath
+}
+
+// newMonitorWithFakeReader returns a CertMonitor that uses a fake cert reader.
+// eventLog may be nil; when nil the monitor's EventLogger field is left nil.
+func newMonitorWithFakeReader(
+	cfg ports.TLSConfig,
+	reader certReader,
+	eventLog *fakeEventLogger,
+	mc ports.MetricsCollector,
+) *CertMonitor {
+	applyMonitorDefaults(&cfg.CertMonitoring)
+	m := &CertMonitor{
+		cfg: cfg,
+		reader: &caddyCertReader{
+			cfg:    cfg,
+			reader: reader,
+		},
+		metrics: mc,
+		logger:  discardLogger(),
+		stopCh:  make(chan struct{}),
+	}
+	// Assign eventLog only when non-nil to avoid a non-nil interface wrapping a nil pointer.
+	if eventLog != nil {
+		m.eventLog = eventLog
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// applyMonitorDefaults
+// ---------------------------------------------------------------------------
+
+func TestApplyMonitorDefaults_ZeroValues(t *testing.T) {
+	m := ports.TLSCertMonitoringConfig{}
+	applyMonitorDefaults(&m)
+
+	if m.CheckInterval != defaultCheckInterval {
+		t.Errorf("CheckInterval = %v, want %v", m.CheckInterval, defaultCheckInterval)
+	}
+	if m.WarningThreshold != defaultWarningThreshold {
+		t.Errorf("WarningThreshold = %v, want %v", m.WarningThreshold, defaultWarningThreshold)
+	}
+	if m.CriticalThreshold != defaultCriticalThreshold {
+		t.Errorf("CriticalThreshold = %v, want %v", m.CriticalThreshold, defaultCriticalThreshold)
+	}
+}
+
+func TestApplyMonitorDefaults_PreservesCustomValues(t *testing.T) {
+	m := ports.TLSCertMonitoringConfig{
+		CheckInterval:     1 * time.Hour,
+		WarningThreshold:  10 * 24 * time.Hour,
+		CriticalThreshold: 3 * 24 * time.Hour,
+	}
+	applyMonitorDefaults(&m)
+
+	if m.CheckInterval != 1*time.Hour {
+		t.Errorf("CheckInterval = %v, want 1h", m.CheckInterval)
+	}
+	if m.WarningThreshold != 10*24*time.Hour {
+		t.Errorf("WarningThreshold = %v, want 240h", m.WarningThreshold)
+	}
+	if m.CriticalThreshold != 3*24*time.Hour {
+		t.Errorf("CriticalThreshold = %v, want 72h", m.CriticalThreshold)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// check — healthy certificate
+// ---------------------------------------------------------------------------
+
+func TestCertMonitor_Check_HealthyCert(t *testing.T) {
+	cert := makeCert(t, time.Now().Add(-time.Hour), time.Now().Add(60*24*time.Hour), "example.com")
+	el := &fakeEventLogger{}
+	mc := &fakeMonitorMetrics{}
+
+	cfg := ports.TLSConfig{
+		Enabled:  true,
+		Provider: ports.TLSProviderExternal,
+		Domain:   "example.com",
+		CertMonitoring: ports.TLSCertMonitoringConfig{
+			Enabled:           true,
+			CheckInterval:     6 * time.Hour,
+			WarningThreshold:  30 * 24 * time.Hour,
+			CriticalThreshold: 7 * 24 * time.Hour,
+		},
+	}
+	m := newMonitorWithFakeReader(cfg, &fakeCertReader{cert: cert}, el, mc)
+	m.check(context.Background())
+
+	// Healthy cert: no events emitted.
+	if len(el.logged) != 0 {
+		t.Errorf("expected no events for healthy cert, got %d: %v", len(el.logged), el.logged)
+	}
+
+	// Degraded should be false.
+	if degraded, _ := m.Degraded(); degraded {
+		t.Error("Degraded() = true, want false for healthy cert")
+	}
+
+	// Metric should have been updated.
+	if mc.called == 0 {
+		t.Error("SetTLSCertExpirySeconds was not called")
+	}
+	if mc.seconds <= 0 {
+		t.Errorf("SetTLSCertExpirySeconds seconds = %f, want > 0", mc.seconds)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// check — warning threshold
+// ---------------------------------------------------------------------------
+
+func TestCertMonitor_Check_WarningThreshold(t *testing.T) {
+	// Cert expires in 15 days: within warning (30d) but outside critical (7d).
+	cert := makeCert(t, time.Now().Add(-time.Hour), time.Now().Add(15*24*time.Hour), "example.com")
+	el := &fakeEventLogger{}
+
+	cfg := ports.TLSConfig{
+		Enabled:  true,
+		Provider: ports.TLSProviderExternal,
+		Domain:   "example.com",
+		CertMonitoring: ports.TLSCertMonitoringConfig{
+			Enabled:           true,
+			CheckInterval:     6 * time.Hour,
+			WarningThreshold:  30 * 24 * time.Hour,
+			CriticalThreshold: 7 * 24 * time.Hour,
+		},
+	}
+	m := newMonitorWithFakeReader(cfg, &fakeCertReader{cert: cert}, el, nil)
+	m.check(context.Background())
+
+	if len(el.logged) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(el.logged))
+	}
+	if el.logged[0].EventType != events.EventTypeTLSCertExpiryWarning {
+		t.Errorf("event type = %q, want %q", el.logged[0].EventType, events.EventTypeTLSCertExpiryWarning)
+	}
+
+	// Warning does not set degraded.
+	if degraded, _ := m.Degraded(); degraded {
+		t.Error("Degraded() = true, want false for warning threshold")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// check — critical threshold
+// ---------------------------------------------------------------------------
+
+func TestCertMonitor_Check_CriticalThreshold(t *testing.T) {
+	// Cert expires in 3 days: within critical threshold (7d).
+	cert := makeCert(t, time.Now().Add(-time.Hour), time.Now().Add(3*24*time.Hour), "example.com")
+	el := &fakeEventLogger{}
+
+	cfg := ports.TLSConfig{
+		Enabled:  true,
+		Provider: ports.TLSProviderExternal,
+		Domain:   "example.com",
+		CertMonitoring: ports.TLSCertMonitoringConfig{
+			Enabled:           true,
+			CheckInterval:     6 * time.Hour,
+			WarningThreshold:  30 * 24 * time.Hour,
+			CriticalThreshold: 7 * 24 * time.Hour,
+		},
+	}
+	m := newMonitorWithFakeReader(cfg, &fakeCertReader{cert: cert}, el, nil)
+	m.check(context.Background())
+
+	if len(el.logged) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(el.logged))
+	}
+	if el.logged[0].EventType != events.EventTypeTLSCertExpiryCritical {
+		t.Errorf("event type = %q, want %q", el.logged[0].EventType, events.EventTypeTLSCertExpiryCritical)
+	}
+
+	// Critical sets degraded.
+	if degraded, _ := m.Degraded(); !degraded {
+		t.Error("Degraded() = false, want true for critical threshold")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// check — already expired
+// ---------------------------------------------------------------------------
+
+func TestCertMonitor_Check_AlreadyExpired(t *testing.T) {
+	cert := makeCert(t, time.Now().Add(-48*time.Hour), time.Now().Add(-time.Hour), "example.com")
+	el := &fakeEventLogger{}
+	mc := &fakeMonitorMetrics{}
+
+	cfg := ports.TLSConfig{
+		Enabled:  true,
+		Provider: ports.TLSProviderExternal,
+		Domain:   "example.com",
+		CertMonitoring: ports.TLSCertMonitoringConfig{
+			Enabled:           true,
+			CheckInterval:     6 * time.Hour,
+			WarningThreshold:  30 * 24 * time.Hour,
+			CriticalThreshold: 7 * 24 * time.Hour,
+		},
+	}
+	m := newMonitorWithFakeReader(cfg, &fakeCertReader{cert: cert}, el, mc)
+	m.check(context.Background())
+
+	// Should emit critical event.
+	if len(el.logged) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(el.logged))
+	}
+	if el.logged[0].EventType != events.EventTypeTLSCertExpiryCritical {
+		t.Errorf("event type = %q, want %q", el.logged[0].EventType, events.EventTypeTLSCertExpiryCritical)
+	}
+
+	// Metric seconds should be negative.
+	if mc.seconds >= 0 {
+		t.Errorf("SetTLSCertExpirySeconds seconds = %f, want < 0 for expired cert", mc.seconds)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// check — degraded cleared when cert recovers
+// ---------------------------------------------------------------------------
+
+func TestCertMonitor_Check_DegradedClearedOnRecovery(t *testing.T) {
+	criticalCert := makeCert(t, time.Now().Add(-time.Hour), time.Now().Add(3*24*time.Hour), "example.com")
+	cfg := ports.TLSConfig{
+		Enabled:  true,
+		Provider: ports.TLSProviderExternal,
+		Domain:   "example.com",
+		CertMonitoring: ports.TLSCertMonitoringConfig{
+			Enabled:           true,
+			WarningThreshold:  30 * 24 * time.Hour,
+			CriticalThreshold: 7 * 24 * time.Hour,
+		},
+	}
+
+	reader := &fakeCertReader{cert: criticalCert}
+	m := newMonitorWithFakeReader(cfg, reader, nil, nil)
+	m.check(context.Background())
+
+	if degraded, _ := m.Degraded(); !degraded {
+		t.Fatal("expected degraded after critical cert check")
+	}
+
+	// Now replace with a healthy cert.
+	reader.cert = makeCert(t, time.Now().Add(-time.Hour), time.Now().Add(60*24*time.Hour), "example.com")
+	m.check(context.Background())
+
+	if degraded, _ := m.Degraded(); degraded {
+		t.Error("Degraded() = true after recovering to healthy cert, want false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// check — nil eventLog does not panic
+// ---------------------------------------------------------------------------
+
+func TestCertMonitor_Check_NilEventLog(t *testing.T) {
+	cert := makeCert(t, time.Now().Add(-time.Hour), time.Now().Add(3*24*time.Hour), "example.com")
+	cfg := ports.TLSConfig{
+		Enabled:  true,
+		Provider: ports.TLSProviderExternal,
+		Domain:   "example.com",
+		CertMonitoring: ports.TLSCertMonitoringConfig{
+			Enabled:           true,
+			WarningThreshold:  30 * 24 * time.Hour,
+			CriticalThreshold: 7 * 24 * time.Hour,
+		},
+	}
+	m := newMonitorWithFakeReader(cfg, &fakeCertReader{cert: cert}, nil, nil)
+	// Must not panic.
+	m.check(context.Background())
+}
+
+// ---------------------------------------------------------------------------
+// event payload fields
+// ---------------------------------------------------------------------------
+
+func TestCertMonitor_Check_EventPayloadFields(t *testing.T) {
+	cert := makeCert(t, time.Now().Add(-time.Hour), time.Now().Add(15*24*time.Hour), "example.com")
+	el := &fakeEventLogger{}
+
+	cfg := ports.TLSConfig{
+		Enabled:  true,
+		Provider: ports.TLSProviderExternal,
+		Domain:   "example.com",
+		CertMonitoring: ports.TLSCertMonitoringConfig{
+			Enabled:           true,
+			WarningThreshold:  30 * 24 * time.Hour,
+			CriticalThreshold: 7 * 24 * time.Hour,
+		},
+	}
+	m := newMonitorWithFakeReader(cfg, &fakeCertReader{cert: cert}, el, nil)
+	m.check(context.Background())
+
+	if len(el.logged) == 0 {
+		t.Fatal("expected at least one event")
+	}
+	ev := el.logged[0]
+
+	requiredKeys := []string{"domain", "subject", "issuer", "expires_at", "days_remaining", "serial_number"}
+	for _, k := range requiredKeys {
+		if _, ok := ev.Payload[k]; !ok {
+			t.Errorf("event payload missing key %q", k)
+		}
+	}
+	if ev.SchemaVersion != events.SchemaVersion {
+		t.Errorf("SchemaVersion = %q, want %q", ev.SchemaVersion, events.SchemaVersion)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// fileCertReader — round-trip
+// ---------------------------------------------------------------------------
+
+func TestFileCertReader_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeCertAndKey(t, dir)
+
+	reader := fileCertReader{}
+	cert, err := reader.ReadCert(certPath, keyPath)
+	if err != nil {
+		t.Fatalf("ReadCert() error = %v", err)
+	}
+	if cert == nil {
+		t.Fatal("ReadCert() returned nil certificate")
+	}
+	if cert.Subject.CommonName != "test.example.com" {
+		t.Errorf("CommonName = %q, want %q", cert.Subject.CommonName, "test.example.com")
+	}
+	if cert.NotAfter.IsZero() {
+		t.Error("NotAfter is zero")
+	}
+}
+
+func TestFileCertReader_InvalidPath(t *testing.T) {
+	reader := fileCertReader{}
+	_, err := reader.ReadCert("/nonexistent/cert.pem", "/nonexistent/key.pem")
+	if err == nil {
+		t.Error("expected error for non-existent path, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// caddyCertReader — external provider delegates to fileCertReader
+// ---------------------------------------------------------------------------
+
+func TestCaddyCertReader_External_DelegatesToFileReader(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeCertAndKey(t, dir)
+
+	cfg := ports.TLSConfig{
+		Provider: ports.TLSProviderExternal,
+		CertPath: certPath,
+		KeyPath:  keyPath,
+	}
+	r := &caddyCertReader{cfg: cfg, reader: fileCertReader{}}
+	cert, err := r.ReadCert()
+	if err != nil {
+		t.Fatalf("ReadCert() error = %v", err)
+	}
+	if cert == nil {
+		t.Fatal("ReadCert() returned nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Start / Stop
+// ---------------------------------------------------------------------------
+
+func TestCertMonitor_StartStop(t *testing.T) {
+	cert := makeCert(t, time.Now().Add(-time.Hour), time.Now().Add(60*24*time.Hour), "example.com")
+	cfg := ports.TLSConfig{
+		Enabled:  true,
+		Provider: ports.TLSProviderExternal,
+		Domain:   "example.com",
+		CertMonitoring: ports.TLSCertMonitoringConfig{
+			Enabled:           true,
+			CheckInterval:     100 * time.Millisecond,
+			WarningThreshold:  30 * 24 * time.Hour,
+			CriticalThreshold: 7 * 24 * time.Hour,
+		},
+	}
+	m := newMonitorWithFakeReader(cfg, &fakeCertReader{cert: cert}, nil, nil)
+	m.Start(context.Background())
+
+	// Give the goroutine a tick to run.
+	time.Sleep(200 * time.Millisecond)
+
+	// Stop must return without hanging.
+	done := make(chan struct{})
+	go func() {
+		m.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not return within 2 seconds")
+	}
+}

--- a/internal/plugins/tls/plugin.go
+++ b/internal/plugins/tls/plugin.go
@@ -26,13 +26,29 @@ import (
 // It implements ports.Plugin and ports.CaddyContributor.
 // The TLS plugin has priority 10 so it is configured before other plugins.
 type Plugin struct {
-	cfg    ports.TLSConfig
-	logger *slog.Logger
+	cfg     ports.TLSConfig
+	logger  *slog.Logger
+	monitor *CertMonitor
 }
 
 // New creates a new TLS Plugin with the given configuration and logger.
-func New(cfg ports.TLSConfig, logger *slog.Logger) *Plugin {
-	return &Plugin{cfg: cfg, logger: logger}
+// eventLog may be nil; when non-nil, certificate expiry events are emitted through it.
+// The metrics collector may be set later with SetMetricsCollector before Start is called.
+func New(cfg ports.TLSConfig, eventLog ports.EventLogger, logger *slog.Logger) *Plugin {
+	p := &Plugin{cfg: cfg, logger: logger}
+	if cfg.Enabled && cfg.CertMonitoring.Enabled {
+		p.monitor = NewCertMonitor(cfg, eventLog, nil, logger)
+	}
+	return p
+}
+
+// SetMetricsCollector injects a metrics collector into the certificate expiry
+// monitor. It must be called before Start. When called with nil, the monitor
+// emits no metrics.
+func (p *Plugin) SetMetricsCollector(mc ports.MetricsCollector) {
+	if p.monitor != nil {
+		p.monitor.metrics = mc
+	}
 }
 
 // Name returns the canonical plugin identifier "tls".
@@ -61,15 +77,29 @@ func (p *Plugin) Init(_ context.Context) error {
 	return nil
 }
 
-// Start is a no-op for the TLS plugin. TLS lifecycle is managed by Caddy.
-func (p *Plugin) Start(_ context.Context) error { return nil }
+// Start launches the certificate expiry monitor when monitoring is enabled.
+// TLS termination itself is managed by the Caddy runtime.
+func (p *Plugin) Start(ctx context.Context) error {
+	if p.monitor != nil {
+		p.monitor.Start(ctx)
+	}
+	return nil
+}
 
-// Stop is a no-op for the TLS plugin. TLS lifecycle is managed by Caddy.
-func (p *Plugin) Stop(_ context.Context) error { return nil }
+// Stop shuts down the certificate expiry monitor when monitoring is enabled.
+// TLS termination itself is managed by the Caddy runtime.
+func (p *Plugin) Stop(_ context.Context) error {
+	if p.monitor != nil {
+		p.monitor.Stop()
+	}
+	return nil
+}
 
 // Health returns the current health status of the TLS plugin.
 // When TLS is disabled, Health reports healthy with a "tls disabled" message.
-// When TLS is enabled, Health reports healthy with the active provider.
+// When TLS is enabled, Health reports healthy with the active provider, unless
+// the certificate expiry monitor has detected that the certificate is within
+// the critical threshold, in which case Health reports degraded.
 func (p *Plugin) Health() ports.HealthStatus {
 	if !p.cfg.Enabled {
 		return ports.HealthStatus{
@@ -77,6 +107,16 @@ func (p *Plugin) Health() ports.HealthStatus {
 			Message: "tls disabled",
 		}
 	}
+
+	if p.monitor != nil {
+		if degraded, msg := p.monitor.Degraded(); degraded {
+			return ports.HealthStatus{
+				Healthy: false,
+				Message: fmt.Sprintf("tls degraded: %s", msg),
+			}
+		}
+	}
+
 	return ports.HealthStatus{
 		Healthy: true,
 		Message: fmt.Sprintf("tls enabled, provider: %s", p.cfg.Provider),

--- a/internal/plugins/tls/plugin_test.go
+++ b/internal/plugins/tls/plugin_test.go
@@ -23,7 +23,7 @@ type noopWriter struct{}
 func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }
 
 func newPlugin(cfg ports.TLSConfig) *tlsplugin.Plugin {
-	return tlsplugin.New(cfg, discardLogger())
+	return tlsplugin.New(cfg, nil, discardLogger())
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/ports/metrics.go
+++ b/internal/ports/metrics.go
@@ -82,6 +82,12 @@ type MetricsCollector interface {
 	// Parameters:
 	//   - route: the matched egress route name, or "unmatched" when no route matched
 	IncEgressErrorTotal(route string)
+
+	// SetTLSCertExpirySeconds sets the vibewarden_tls_cert_expiry_seconds gauge
+	// to the number of seconds until the monitored TLS certificate expires.
+	// A negative value indicates the certificate has already expired.
+	// The domain label identifies which certificate is being reported.
+	SetTLSCertExpirySeconds(domain string, seconds float64)
 }
 
 // MetricsConfig holds configuration for the metrics subsystem.

--- a/internal/ports/proxy.go
+++ b/internal/ports/proxy.go
@@ -270,6 +270,26 @@ const (
 	TLSProviderExternal TLSProvider = "external"
 )
 
+// TLSCertMonitoringConfig holds configuration for the certificate expiry monitor.
+type TLSCertMonitoringConfig struct {
+	// Enabled toggles the certificate expiry monitor.
+	// Defaults to true when TLS is enabled.
+	Enabled bool
+
+	// CheckInterval is how often the monitor reads the certificate and checks
+	// expiry. Defaults to 6 hours.
+	CheckInterval time.Duration
+
+	// WarningThreshold is the time-before-expiry at which a
+	// tls.cert_expiry_warning event is emitted. Defaults to 30 days.
+	WarningThreshold time.Duration
+
+	// CriticalThreshold is the time-before-expiry at which a
+	// tls.cert_expiry_critical event is emitted and the health check reports
+	// degraded. Defaults to 7 days.
+	CriticalThreshold time.Duration
+}
+
 // TLSConfig holds TLS-specific settings.
 type TLSConfig struct {
 	// Enabled toggles TLS termination.
@@ -295,6 +315,10 @@ type TLSConfig struct {
 	// StoragePath is where Caddy stores ACME certificates on disk.
 	// Uses the Caddy default when empty (applicable to TLSProviderLetsEncrypt only).
 	StoragePath string
+
+	// CertMonitoring holds configuration for the background certificate
+	// expiry monitor. The monitor is only active when TLS is enabled.
+	CertMonitoring TLSCertMonitoringConfig
 }
 
 // SecurityHeadersConfig holds security header settings.

--- a/test/benchmarks/proxy_bench_test.go
+++ b/test/benchmarks/proxy_bench_test.go
@@ -57,6 +57,7 @@ func (noopMetrics) IncWAFDetection(_, _ string)                                 
 func (noopMetrics) IncEgressRequestTotal(_, _, _ string)                         {}
 func (noopMetrics) ObserveEgressDuration(_, _ string, _ time.Duration)           {}
 func (noopMetrics) IncEgressErrorTotal(_ string)                                 {}
+func (noopMetrics) SetTLSCertExpirySeconds(_ string, _ float64)                  {}
 
 // ---------------------------------------------------------------------------
 // Shared helpers


### PR DESCRIPTION
Closes #488

## Summary

- Added `CertMonitor` in `internal/plugins/tls/monitor.go`: a background goroutine that reads the TLS certificate on a configurable interval (default 6 h) and checks its expiry against two thresholds.
- Emits `tls.cert_expiry_warning` (within 30 days) and `tls.cert_expiry_critical` (within 7 days) structured events following the existing schema.
- Added `SetTLSCertExpirySeconds(domain string, seconds float64)` to `ports.MetricsCollector` and implemented it in `OTelAdapter` (as `vibewarden_tls_cert_expiry_seconds` gauge via `Int64UpDownCounter`) and `NoOpMetricsCollector`.
- `Plugin.Health()` returns `Healthy: false` with a degraded message when the cert is within the critical window.
- Config: `tls.cert_monitoring.enabled` (default `true`), `check_interval` (default `6h`), `warning_threshold` (default `720h`/30d), `critical_threshold` (default `168h`/7d).
- `wireTLSMetricsCollector` in `serve_config.go` wires the metrics collector from the metrics plugin into the TLS plugin between `InitAll` and `StartAll`, following the same late-wiring pattern used for `buildEventLogger`.
- Supports all three providers: `letsencrypt`/`self-signed` (via Caddy storage path glob), `external` (via `cert_path`/`key_path` directly).

## Test plan

- `TestApplyMonitorDefaults_*` — defaults and custom value preservation
- `TestCertMonitor_Check_HealthyCert` — no events, metric updated, not degraded
- `TestCertMonitor_Check_WarningThreshold` — `tls.cert_expiry_warning` emitted, not degraded
- `TestCertMonitor_Check_CriticalThreshold` — `tls.cert_expiry_critical` emitted, degraded
- `TestCertMonitor_Check_AlreadyExpired` — critical event, negative seconds metric
- `TestCertMonitor_Check_DegradedClearedOnRecovery` — degraded clears when cert recovers
- `TestCertMonitor_Check_NilEventLog` — no panic with nil event log
- `TestCertMonitor_Check_EventPayloadFields` — all required payload keys present
- `TestFileCertReader_RoundTrip` — round-trip PEM read on temp files
- `TestFileCertReader_InvalidPath` — error on missing path
- `TestCaddyCertReader_External_DelegatesToFileReader` — external provider path
- `TestCertMonitor_StartStop` — goroutine starts and stops cleanly
- `TestOTelAdapter_SetTLSCertExpirySeconds` — metric appears in Prometheus output
