### PR TITLE
fix(#522): document ARM64 multi-arch Docker image support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,9 @@ Single Go binary embedding Caddy. Zero-to-secure in minutes for vibe-coded apps.
 
 - GitHub Actions CI pipeline: build, vet, test on every push and pull request
 - goreleaser configuration with cross-compiled binaries and Docker image publishing
+- Multi-arch Docker images published to `ghcr.io/vibewarden/vibewarden` for
+  `linux/amd64` and `linux/arm64` via OCI manifest lists; works transparently on
+  Apple Silicon, AWS Graviton, and other ARM64 hosts
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Invoke-WebRequest -Uri https://vibewarden.dev/vibew.ps1 -OutFile vibew.ps1
 .\vibew.ps1 dev
 ```
 
+Docker images are published to `ghcr.io/vibewarden/vibewarden` as multi-arch manifests
+covering `linux/amd64` and `linux/arm64`. Docker pulls the correct image automatically
+on both x86-64 servers and ARM64 machines (Apple Silicon, AWS Graviton).
+
 ---
 
 ## What `init` generates
@@ -115,6 +119,7 @@ It never holds external secrets or connects directly to third-party APIs.
 | AI-readable logs | Versioned JSON schema: `schema_version`, `event_type`, `ai_summary`, `payload` |
 | Audit log sinks | JSON file, OTel logs, webhook (HMAC-signed) with retry |
 | Admin API | User management at `/_vibewarden/admin/*` (bearer-token protected) |
+| Docker images | Multi-arch: `linux/amd64` and `linux/arm64` (Apple Silicon, AWS Graviton) |
 | Docker Compose | Profile-based: `--profile observability`, `--profile demo` |
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,6 +10,12 @@ and explains what happens under the hood.
 - **Docker Engine 27+** and **Docker Compose v2+** installed and running.
 - Your app listening on a local port (e.g., `3000`).
 
+!!! note "Multi-architecture support"
+    VibeWarden Docker images are published as multi-arch manifests covering
+    `linux/amd64` and `linux/arm64`. Docker selects the correct image automatically —
+    no extra flags needed on Apple Silicon (M1/M2/M3) or ARM64 servers such as
+    AWS Graviton.
+
 ---
 
 ## Step 1 — Install the `vibew` wrapper


### PR DESCRIPTION
Closes #522

## Summary

- Added a row to the README Feature Matrix noting multi-arch Docker image support (`linux/amd64` + `linux/arm64`).
- Added a paragraph below the Quick Start section explaining that images are published as OCI manifest lists and Docker selects the correct architecture transparently.
- Added an admonition block to `docs/getting-started.md` Prerequisites section calling out ARM64 support for Apple Silicon and AWS Graviton users.
- Added a bullet to the `CI / CD` section of `CHANGELOG.md` under v0.1.0 describing the multi-arch manifest list published via goreleaser.

No code changes — the goreleaser config already builds and pushes both architectures.

## Test plan

- `make check` passes locally (lint, build, all tests green).
- Verify the three changed files render correctly in the GitHub preview.