### PR TITLE
feat(#474): implement input validation middleware

### DIFF
--- a/cmd/vibewarden/serve_plugins.go
+++ b/cmd/vibewarden/serve_plugins.go
@@ -11,6 +11,7 @@ import (
 	authplugin "github.com/vibewarden/vibewarden/internal/plugins/auth"
 	bodysizeplugin "github.com/vibewarden/vibewarden/internal/plugins/bodysize"
 	corsplugin "github.com/vibewarden/vibewarden/internal/plugins/cors"
+	inputvalidationplugin "github.com/vibewarden/vibewarden/internal/plugins/inputvalidation"
 	ipfilterplugin "github.com/vibewarden/vibewarden/internal/plugins/ipfilter"
 	maintenanceplugin "github.com/vibewarden/vibewarden/internal/plugins/maintenance"
 	metricsplugin "github.com/vibewarden/vibewarden/internal/plugins/metrics"
@@ -59,6 +60,10 @@ func registerPlugins(
 		AllowCredentials: cfg.CORS.AllowCredentials,
 		MaxAge:           cfg.CORS.MaxAge,
 	}, logger))
+
+	// Input validation — priority 18 (before WAF at 25; catches oversized inputs
+	// before regex scanning begins).
+	registry.Register(buildInputValidationPlugin(cfg, logger))
 
 	// WAF — priority 25 (after security headers at 20, before admin auth at 30)
 	registry.Register(wafplugin.New(wafplugin.Config{
@@ -337,4 +342,29 @@ func buildTLSPlugin(cfg *config.Config, eventLogger ports.EventLogger, logger *s
 		StoragePath:    cfg.TLS.StoragePath,
 		CertMonitoring: monCfg,
 	}, eventLogger, logger)
+}
+
+// buildInputValidationPlugin constructs the input validation plugin from cfg.
+func buildInputValidationPlugin(cfg *config.Config, logger *slog.Logger) *inputvalidationplugin.Plugin {
+	iv := cfg.InputValidation
+
+	pluginCfg := inputvalidationplugin.Config{
+		Enabled:              iv.Enabled,
+		MaxURLLength:         iv.MaxURLLength,
+		MaxQueryStringLength: iv.MaxQueryStringLength,
+		MaxHeaderCount:       iv.MaxHeaderCount,
+		MaxHeaderSize:        iv.MaxHeaderSize,
+	}
+
+	for _, ov := range iv.PathOverrides {
+		pluginCfg.PathOverrides = append(pluginCfg.PathOverrides, inputvalidationplugin.PathOverrideConfig{
+			Path:                 ov.Path,
+			MaxURLLength:         ov.MaxURLLength,
+			MaxQueryStringLength: ov.MaxQueryStringLength,
+			MaxHeaderCount:       ov.MaxHeaderCount,
+			MaxHeaderSize:        ov.MaxHeaderSize,
+		})
+	}
+
+	return inputvalidationplugin.New(pluginCfg, logger)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,6 +99,9 @@ type Config struct {
 	// WAF configures the Web Application Firewall plugins.
 	WAF WAFConfig `mapstructure:"waf"`
 
+	// InputValidation configures request input size limit enforcement.
+	InputValidation InputValidationConfig `mapstructure:"input_validation"`
+
 	// Egress configures the egress proxy plugin for outbound API call control.
 	Egress EgressConfig `mapstructure:"egress"`
 
@@ -852,6 +855,58 @@ type ContentTypeValidationConfig struct {
 	// Requests with a Content-Type not in this list receive 415 Unsupported Media Type.
 	// Default: ["application/json", "application/x-www-form-urlencoded", "multipart/form-data"]
 	Allowed []string `mapstructure:"allowed"`
+}
+
+// InputValidationConfig holds request input size limit settings.
+type InputValidationConfig struct {
+	// Enabled toggles the input validation middleware (default: false).
+	Enabled bool `mapstructure:"enabled"`
+
+	// MaxURLLength is the maximum allowed length of the raw request URI in bytes
+	// (path + query string). Default: 2048. Zero disables this check.
+	MaxURLLength int `mapstructure:"max_url_length"`
+
+	// MaxQueryStringLength is the maximum allowed query string length in bytes,
+	// not including the leading "?". Default: 2048. Zero disables this check.
+	MaxQueryStringLength int `mapstructure:"max_query_string_length"`
+
+	// MaxHeaderCount is the maximum number of request headers allowed.
+	// Default: 100. Zero disables this check.
+	MaxHeaderCount int `mapstructure:"max_header_count"`
+
+	// MaxHeaderSize is the maximum allowed byte length of any single header
+	// value. Default: 8192. Zero disables this check.
+	MaxHeaderSize int `mapstructure:"max_header_size"`
+
+	// PathOverrides defines per-path limit overrides.
+	// The first entry whose Path glob pattern (path.Match syntax) matches the
+	// request URL path wins. Non-zero fields in the matching entry override the
+	// global limits.
+	PathOverrides []InputValidationPathOverrideConfig `mapstructure:"path_overrides"`
+}
+
+// InputValidationPathOverrideConfig defines per-path limit overrides for the
+// input validation middleware.
+type InputValidationPathOverrideConfig struct {
+	// Path is a glob pattern (path.Match syntax) matched against the request
+	// URL path (e.g. "/api/upload", "/static/*").
+	Path string `mapstructure:"path"`
+
+	// MaxURLLength overrides the global limit for matching paths.
+	// Zero means inherit the global value.
+	MaxURLLength int `mapstructure:"max_url_length"`
+
+	// MaxQueryStringLength overrides the global limit for matching paths.
+	// Zero means inherit the global value.
+	MaxQueryStringLength int `mapstructure:"max_query_string_length"`
+
+	// MaxHeaderCount overrides the global limit for matching paths.
+	// Zero means inherit the global value.
+	MaxHeaderCount int `mapstructure:"max_header_count"`
+
+	// MaxHeaderSize overrides the global limit for matching paths.
+	// Zero means inherit the global value.
+	MaxHeaderSize int `mapstructure:"max_header_size"`
 }
 
 // CORSConfig holds Cross-Origin Resource Sharing settings.
@@ -2018,6 +2073,12 @@ func Load(configPath string) (*Config, error) {
 	v.SetDefault("observability.prometheus_port", 9090)
 	v.SetDefault("observability.loki_port", 3100)
 	v.SetDefault("observability.retention_days", 7)
+	v.SetDefault("input_validation.enabled", false)
+	v.SetDefault("input_validation.max_url_length", 2048)
+	v.SetDefault("input_validation.max_query_string_length", 2048)
+	v.SetDefault("input_validation.max_header_count", 100)
+	v.SetDefault("input_validation.max_header_size", 8192)
+	v.SetDefault("input_validation.path_overrides", []InputValidationPathOverrideConfig{})
 	v.SetDefault("waf.content_type_validation.enabled", false)
 	v.SetDefault("waf.content_type_validation.allowed", []string{
 		"application/json",

--- a/internal/middleware/input_validation.go
+++ b/internal/middleware/input_validation.go
@@ -1,0 +1,195 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"path"
+)
+
+// InputValidationConfig holds configuration for the InputValidation middleware.
+// Limits are applied globally; per-path overrides can narrow or widen them for
+// specific URL paths.
+type InputValidationConfig struct {
+	// Enabled toggles the middleware. When false the handler is a no-op.
+	Enabled bool
+
+	// MaxURLLength is the maximum allowed length of the raw request URI
+	// (path + query string). Default: 2048. Zero disables this check.
+	MaxURLLength int
+
+	// MaxQueryStringLength is the maximum allowed length of the query string
+	// component of the URL, not including the leading "?". Default: 2048.
+	// Zero disables this check.
+	MaxQueryStringLength int
+
+	// MaxHeaderCount is the maximum number of request headers allowed.
+	// Default: 100. Zero disables this check.
+	MaxHeaderCount int
+
+	// MaxHeaderSize is the maximum allowed byte length of any single header
+	// value. Default: 8192. Zero disables this check.
+	MaxHeaderSize int
+
+	// PathOverrides allows per-path configuration. The first entry whose Path
+	// glob pattern (path.Match syntax) matches the request URL path wins. If no
+	// override matches, the top-level limits apply.
+	PathOverrides []InputValidationPathOverride
+}
+
+// InputValidationPathOverride defines per-path limit overrides.
+// Only non-zero fields override the global values.
+type InputValidationPathOverride struct {
+	// Path is a glob pattern (path.Match syntax) matched against the request
+	// URL path (e.g. "/api/upload", "/static/*").
+	Path string
+
+	// MaxURLLength overrides the global limit. Zero means use the global value.
+	MaxURLLength int
+
+	// MaxQueryStringLength overrides the global limit. Zero means use the
+	// global value.
+	MaxQueryStringLength int
+
+	// MaxHeaderCount overrides the global limit. Zero means use the global
+	// value.
+	MaxHeaderCount int
+
+	// MaxHeaderSize overrides the global limit. Zero means use the global
+	// value.
+	MaxHeaderSize int
+}
+
+// inputValidationLimits holds the effective per-request limits after override
+// resolution.
+type inputValidationLimits struct {
+	maxURLLength         int
+	maxQueryStringLength int
+	maxHeaderCount       int
+	maxHeaderSize        int
+}
+
+// InputValidation returns an HTTP middleware that enforces request input size
+// limits. It is designed to run before the WAF so that oversized inputs are
+// rejected early, before regex scanning begins.
+//
+// Behaviour:
+//   - When disabled (cfg.Enabled == false) the middleware is a transparent
+//     pass-through.
+//   - The /_vibewarden/* prefix is always exempt from validation.
+//   - Limit resolution: for each request the first PathOverride whose glob
+//     pattern matches the request path wins; any zero-valued field in the
+//     override falls back to the corresponding global limit.
+//   - Violations produce 400 Bad Request with a structured JSON body using
+//     error code "input_validation_failed".
+//
+// Checks are applied in this order:
+//  1. URL length (len(r.RequestURI))
+//  2. Query string length (len(r.URL.RawQuery))
+//  3. Header count (len(r.Header))
+//  4. Per-header value size (any single header value exceeding MaxHeaderSize)
+func InputValidation(cfg InputValidationConfig) func(http.Handler) http.Handler {
+	if !cfg.Enabled {
+		return func(next http.Handler) http.Handler { return next }
+	}
+
+	// Pre-validate all override patterns at construction time so the error is
+	// surfaced immediately rather than silently on the first matching request.
+	type validatedOverride struct {
+		pattern string
+		limits  InputValidationPathOverride
+	}
+
+	overrides := make([]validatedOverride, 0, len(cfg.PathOverrides))
+	for _, ov := range cfg.PathOverrides {
+		if _, err := path.Match(ov.Path, ""); err != nil {
+			// Invalid pattern: skip. The misconfiguration is visible at startup
+			// because Init() validates the config before calling this function.
+			continue
+		}
+		overrides = append(overrides, validatedOverride{pattern: ov.Path, limits: ov})
+	}
+
+	// Exempt matcher covers /_vibewarden/* only.
+	exemptMatcher, _ := NewExemptPathMatcher(nil) //nolint:errcheck // nil is always valid
+
+	resolve := func(requestPath string) inputValidationLimits {
+		l := inputValidationLimits{
+			maxURLLength:         cfg.MaxURLLength,
+			maxQueryStringLength: cfg.MaxQueryStringLength,
+			maxHeaderCount:       cfg.MaxHeaderCount,
+			maxHeaderSize:        cfg.MaxHeaderSize,
+		}
+		for _, ov := range overrides {
+			matched, err := path.Match(ov.pattern, requestPath)
+			if err != nil || !matched {
+				continue
+			}
+			if ov.limits.MaxURLLength != 0 {
+				l.maxURLLength = ov.limits.MaxURLLength
+			}
+			if ov.limits.MaxQueryStringLength != 0 {
+				l.maxQueryStringLength = ov.limits.MaxQueryStringLength
+			}
+			if ov.limits.MaxHeaderCount != 0 {
+				l.maxHeaderCount = ov.limits.MaxHeaderCount
+			}
+			if ov.limits.MaxHeaderSize != 0 {
+				l.maxHeaderSize = ov.limits.MaxHeaderSize
+			}
+			break
+		}
+		return l
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Always exempt /_vibewarden/* paths.
+			if exemptMatcher.Matches(r.URL.Path) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			limits := resolve(r.URL.Path)
+
+			// 1. URL length check.
+			if limits.maxURLLength > 0 && len(r.RequestURI) > limits.maxURLLength {
+				WriteErrorResponse(w, r, http.StatusBadRequest, "input_validation_failed",
+					fmt.Sprintf("request URI length %d exceeds maximum %d",
+						len(r.RequestURI), limits.maxURLLength))
+				return
+			}
+
+			// 2. Query string length check.
+			if limits.maxQueryStringLength > 0 && len(r.URL.RawQuery) > limits.maxQueryStringLength {
+				WriteErrorResponse(w, r, http.StatusBadRequest, "input_validation_failed",
+					fmt.Sprintf("query string length %d exceeds maximum %d",
+						len(r.URL.RawQuery), limits.maxQueryStringLength))
+				return
+			}
+
+			// 3. Header count check.
+			if limits.maxHeaderCount > 0 && len(r.Header) > limits.maxHeaderCount {
+				WriteErrorResponse(w, r, http.StatusBadRequest, "input_validation_failed",
+					fmt.Sprintf("header count %d exceeds maximum %d",
+						len(r.Header), limits.maxHeaderCount))
+				return
+			}
+
+			// 4. Per-header value size check.
+			if limits.maxHeaderSize > 0 {
+				for name, values := range r.Header {
+					for _, v := range values {
+						if len(v) > limits.maxHeaderSize {
+							WriteErrorResponse(w, r, http.StatusBadRequest, "input_validation_failed",
+								fmt.Sprintf("header %q value length %d exceeds maximum %d",
+									name, len(v), limits.maxHeaderSize))
+							return
+						}
+					}
+				}
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middleware/input_validation_test.go
+++ b/internal/middleware/input_validation_test.go
@@ -1,0 +1,628 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// newInputValidationRequest builds an httptest.Request with the given method,
+// URL (path+query) and optional headers. It also sets RequestURI to simulate
+// the full raw URI the server sees.
+func newInputValidationRequest(t *testing.T, method, rawURL string, headers map[string]string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(method, rawURL, nil)
+	// httptest.NewRequest populates URL but not RequestURI for non-server use.
+	// Set it explicitly so URL-length checks work correctly.
+	req.RequestURI = rawURL
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	return req
+}
+
+// inputValidationBody decodes the JSON error response body from the recorder.
+func inputValidationBody(t *testing.T, rec *httptest.ResponseRecorder) ErrorResponse {
+	t.Helper()
+	var resp ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding error response: %v", err)
+	}
+	return resp
+}
+
+// noopHandler is a simple handler that records it was called.
+func noopHandlerFunc(called *bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		*called = true
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Disabled middleware
+// ---------------------------------------------------------------------------
+
+func TestInputValidation_Disabled(t *testing.T) {
+	called := false
+	handler := InputValidation(InputValidationConfig{Enabled: false})(noopHandlerFunc(&called))
+
+	req := newInputValidationRequest(t, http.MethodGet, "/api?"+strings.Repeat("a", 5000), nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Error("expected next handler to be called when middleware is disabled")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Exempt paths
+// ---------------------------------------------------------------------------
+
+func TestInputValidation_ExemptVibewardenPaths(t *testing.T) {
+	cfg := InputValidationConfig{
+		Enabled:      true,
+		MaxURLLength: 10, // tiny limit
+	}
+
+	called := false
+	handler := InputValidation(cfg)(noopHandlerFunc(&called))
+
+	// /_vibewarden/health has a very long fake URI but must pass through.
+	req := newInputValidationRequest(t, http.MethodGet, "/_vibewarden/health?x=1", nil)
+	// Artificially lengthen the RequestURI to exceed the limit.
+	req.RequestURI = "/_vibewarden/health?" + strings.Repeat("x", 100)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Error("expected /_vibewarden/* to be exempt from input validation")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// URL length
+// ---------------------------------------------------------------------------
+
+func TestInputValidation_URLLength(t *testing.T) {
+	tests := []struct {
+		name         string
+		maxURLLength int
+		rawURI       string
+		wantStatus   int
+	}{
+		{
+			name:         "within limit",
+			maxURLLength: 2048,
+			rawURI:       "/api?" + strings.Repeat("a", 10),
+			wantStatus:   http.StatusOK,
+		},
+		{
+			name:         "at limit",
+			maxURLLength: 20,
+			rawURI:       strings.Repeat("a", 20),
+			wantStatus:   http.StatusOK,
+		},
+		{
+			name:         "exceeds limit",
+			maxURLLength: 20,
+			rawURI:       strings.Repeat("a", 21),
+			wantStatus:   http.StatusBadRequest,
+		},
+		{
+			name:         "zero disables check",
+			maxURLLength: 0,
+			rawURI:       "/" + strings.Repeat("a", 10000),
+			wantStatus:   http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := InputValidationConfig{
+				Enabled:      true,
+				MaxURLLength: tt.maxURLLength,
+			}
+			called := false
+			handler := InputValidation(cfg)(noopHandlerFunc(&called))
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RequestURI = tt.rawURI
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("got status %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if tt.wantStatus == http.StatusBadRequest {
+				body := inputValidationBody(t, rec)
+				if body.Error != "input_validation_failed" {
+					t.Errorf("expected error code 'input_validation_failed', got %q", body.Error)
+				}
+				if called {
+					t.Error("next handler must not be called when validation fails")
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Query string length
+// ---------------------------------------------------------------------------
+
+func TestInputValidation_QueryStringLength(t *testing.T) {
+	tests := []struct {
+		name                 string
+		maxQueryStringLength int
+		query                string
+		wantStatus           int
+	}{
+		{
+			name:                 "within limit",
+			maxQueryStringLength: 2048,
+			query:                strings.Repeat("a", 100),
+			wantStatus:           http.StatusOK,
+		},
+		{
+			name:                 "at limit",
+			maxQueryStringLength: 50,
+			query:                strings.Repeat("b", 50),
+			wantStatus:           http.StatusOK,
+		},
+		{
+			name:                 "exceeds limit",
+			maxQueryStringLength: 50,
+			query:                strings.Repeat("b", 51),
+			wantStatus:           http.StatusBadRequest,
+		},
+		{
+			name:                 "zero disables check",
+			maxQueryStringLength: 0,
+			query:                strings.Repeat("z", 99999),
+			wantStatus:           http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := InputValidationConfig{
+				Enabled:              true,
+				MaxQueryStringLength: tt.maxQueryStringLength,
+			}
+			called := false
+			handler := InputValidation(cfg)(noopHandlerFunc(&called))
+
+			req := httptest.NewRequest(http.MethodGet, "/path?"+tt.query, nil)
+			req.RequestURI = "/path?" + tt.query
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("got status %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if tt.wantStatus == http.StatusBadRequest {
+				body := inputValidationBody(t, rec)
+				if body.Error != "input_validation_failed" {
+					t.Errorf("expected error code 'input_validation_failed', got %q", body.Error)
+				}
+				if called {
+					t.Error("next handler must not be called when validation fails")
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Header count
+// ---------------------------------------------------------------------------
+
+func TestInputValidation_HeaderCount(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxHeaderCount int
+		headerCount    int
+		wantStatus     int
+	}{
+		{
+			name:           "within limit",
+			maxHeaderCount: 100,
+			headerCount:    5,
+			wantStatus:     http.StatusOK,
+		},
+		{
+			name:           "at limit",
+			maxHeaderCount: 3,
+			headerCount:    3,
+			wantStatus:     http.StatusOK,
+		},
+		{
+			name:           "exceeds limit",
+			maxHeaderCount: 3,
+			headerCount:    4,
+			wantStatus:     http.StatusBadRequest,
+		},
+		{
+			name:           "zero disables check",
+			maxHeaderCount: 0,
+			headerCount:    500,
+			wantStatus:     http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := InputValidationConfig{
+				Enabled:        true,
+				MaxHeaderCount: tt.maxHeaderCount,
+			}
+			called := false
+			handler := InputValidation(cfg)(noopHandlerFunc(&called))
+
+			req := httptest.NewRequest(http.MethodGet, "/path", nil)
+			req.RequestURI = "/path"
+			// Clear headers set by httptest so we control the count exactly.
+			req.Header = make(http.Header)
+			for i := 0; i < tt.headerCount; i++ {
+				req.Header.Set("X-Test-"+strings.Repeat(string(rune('A'+i%26)), i+1), "value")
+			}
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("got status %d, want %d (headerCount=%d, max=%d)",
+					rec.Code, tt.wantStatus, tt.headerCount, tt.maxHeaderCount)
+			}
+			if tt.wantStatus == http.StatusBadRequest {
+				body := inputValidationBody(t, rec)
+				if body.Error != "input_validation_failed" {
+					t.Errorf("expected error code 'input_validation_failed', got %q", body.Error)
+				}
+				if called {
+					t.Error("next handler must not be called when validation fails")
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Header value size
+// ---------------------------------------------------------------------------
+
+func TestInputValidation_HeaderSize(t *testing.T) {
+	tests := []struct {
+		name          string
+		maxHeaderSize int
+		headerValue   string
+		wantStatus    int
+	}{
+		{
+			name:          "within limit",
+			maxHeaderSize: 8192,
+			headerValue:   strings.Repeat("x", 100),
+			wantStatus:    http.StatusOK,
+		},
+		{
+			name:          "at limit",
+			maxHeaderSize: 50,
+			headerValue:   strings.Repeat("y", 50),
+			wantStatus:    http.StatusOK,
+		},
+		{
+			name:          "exceeds limit",
+			maxHeaderSize: 50,
+			headerValue:   strings.Repeat("y", 51),
+			wantStatus:    http.StatusBadRequest,
+		},
+		{
+			name:          "zero disables check",
+			maxHeaderSize: 0,
+			headerValue:   strings.Repeat("z", 100000),
+			wantStatus:    http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := InputValidationConfig{
+				Enabled:       true,
+				MaxHeaderSize: tt.maxHeaderSize,
+			}
+			called := false
+			handler := InputValidation(cfg)(noopHandlerFunc(&called))
+
+			req := httptest.NewRequest(http.MethodGet, "/path", nil)
+			req.RequestURI = "/path"
+			req.Header.Set("X-Big-Header", tt.headerValue)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("got status %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if tt.wantStatus == http.StatusBadRequest {
+				body := inputValidationBody(t, rec)
+				if body.Error != "input_validation_failed" {
+					t.Errorf("expected error code 'input_validation_failed', got %q", body.Error)
+				}
+				if called {
+					t.Error("next handler must not be called when validation fails")
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Path overrides
+// ---------------------------------------------------------------------------
+
+func TestInputValidation_PathOverrides(t *testing.T) {
+	cfg := InputValidationConfig{
+		Enabled:              true,
+		MaxURLLength:         100,
+		MaxQueryStringLength: 50,
+		MaxHeaderCount:       10,
+		MaxHeaderSize:        200,
+		PathOverrides: []InputValidationPathOverride{
+			{
+				// /api/upload gets a relaxed query string limit.
+				Path:                 "/api/upload",
+				MaxQueryStringLength: 5000,
+			},
+			{
+				// /strict/* gets a tighter URL limit.
+				Path:         "/strict/*",
+				MaxURLLength: 20,
+			},
+		},
+	}
+
+	handler := InputValidation(cfg)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	t.Run("override relaxes query string limit on matching path", func(t *testing.T) {
+		// Query is 60 chars — exceeds global limit (50) but under override (5000).
+		// The URI is "/api/upload?" + 60 q's = 72 chars, which is under the global
+		// MaxURLLength of 100, so only the query string check is relevant.
+		longQuery := strings.Repeat("q", 60)
+		req := httptest.NewRequest(http.MethodGet, "/api/upload?"+longQuery, nil)
+		req.RequestURI = "/api/upload?" + longQuery
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200 on overridden path, got %d", rec.Code)
+		}
+	})
+
+	t.Run("global query string limit applies on non-matching path", func(t *testing.T) {
+		longQuery := strings.Repeat("q", 51) // exceeds global 50
+		req := httptest.NewRequest(http.MethodGet, "/other?"+longQuery, nil)
+		req.RequestURI = "/other?" + longQuery
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected 400 on non-matching path, got %d", rec.Code)
+		}
+	})
+
+	t.Run("override tightens URL limit on wildcard path", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/strict/foo", nil)
+		req.RequestURI = "/strict/" + strings.Repeat("a", 20) // exceeds override 20
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected 400 on strict path with long URI, got %d", rec.Code)
+		}
+	})
+
+	t.Run("first matching override wins", func(t *testing.T) {
+		// /api/upload matches the first override (MaxQueryStringLength=5000).
+		// Query is 55 chars — exceeds global limit (50) but under override (5000).
+		// URI "/api/upload?" + 55 q's = 67 chars, under global MaxURLLength of 100.
+		mediumQuery := strings.Repeat("q", 55)
+		req := httptest.NewRequest(http.MethodGet, "/api/upload?"+mediumQuery, nil)
+		req.RequestURI = "/api/upload?" + mediumQuery
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200 (first override wins), got %d", rec.Code)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Error response structure
+// ---------------------------------------------------------------------------
+
+func TestInputValidation_ErrorResponseStructure(t *testing.T) {
+	cfg := InputValidationConfig{
+		Enabled:      true,
+		MaxURLLength: 5,
+	}
+	handler := InputValidation(cfg)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/toolong", nil)
+	req.RequestURI = "/toolong"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+
+	ct := rec.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+
+	body := inputValidationBody(t, rec)
+	if body.Error != "input_validation_failed" {
+		t.Errorf("expected error code 'input_validation_failed', got %q", body.Error)
+	}
+	if body.Status != http.StatusBadRequest {
+		t.Errorf("expected status 400 in body, got %d", body.Status)
+	}
+	if body.Message == "" {
+		t.Error("expected non-empty message in error response")
+	}
+	// Must have a correlation ID (either trace_id or request_id).
+	if body.TraceID == "" && body.RequestID == "" {
+		t.Error("expected trace_id or request_id in error response")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// All checks pass — next handler is called
+// ---------------------------------------------------------------------------
+
+func TestInputValidation_AllCheckPass(t *testing.T) {
+	cfg := InputValidationConfig{
+		Enabled:              true,
+		MaxURLLength:         2048,
+		MaxQueryStringLength: 2048,
+		MaxHeaderCount:       100,
+		MaxHeaderSize:        8192,
+	}
+
+	called := false
+	handler := InputValidation(cfg)(noopHandlerFunc(&called))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/data?foo=bar", nil)
+	req.RequestURI = "/api/data?foo=bar"
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Error("expected next handler to be called when all checks pass")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Default limits
+// ---------------------------------------------------------------------------
+
+func TestInputValidation_DefaultLimits(t *testing.T) {
+	// Build a config that matches the defaults described in the issue.
+	cfg := InputValidationConfig{
+		Enabled:              true,
+		MaxURLLength:         2048,
+		MaxQueryStringLength: 2048,
+		MaxHeaderCount:       100,
+		MaxHeaderSize:        8192,
+	}
+
+	tests := []struct {
+		name       string
+		setup      func(*http.Request)
+		wantStatus int
+	}{
+		{
+			name: "URL at default limit",
+			setup: func(r *http.Request) {
+				r.RequestURI = "/" + strings.Repeat("a", 2047) // 2048 total
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "URL exceeds default limit",
+			setup: func(r *http.Request) {
+				r.RequestURI = "/" + strings.Repeat("a", 2048) // 2049 total
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "query string at default limit",
+			setup: func(r *http.Request) {
+				// Set RawQuery to exactly the default limit (2048 chars).
+				// Keep RequestURI short so the URL-length check (also 2048) does
+				// not fire before the query-string check.
+				r.URL.RawQuery = strings.Repeat("q", 2048)
+				r.RequestURI = "/"
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "query string exceeds default limit",
+			setup: func(r *http.Request) {
+				// 2049 chars — one over the default limit.
+				r.URL.RawQuery = strings.Repeat("q", 2049)
+				r.RequestURI = "/"
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "header count at default limit",
+			setup: func(r *http.Request) {
+				r.Header = make(http.Header)
+				for i := 0; i < 100; i++ {
+					r.Header.Set("X-H-"+strings.Repeat("A", i+1), "v")
+				}
+				r.RequestURI = "/"
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "header count exceeds default limit",
+			setup: func(r *http.Request) {
+				r.Header = make(http.Header)
+				for i := 0; i < 101; i++ {
+					r.Header.Set("X-H-"+strings.Repeat("A", i+1), "v")
+				}
+				r.RequestURI = "/"
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "header value at default size limit",
+			setup: func(r *http.Request) {
+				r.RequestURI = "/"
+				r.Header.Set("X-Big", strings.Repeat("v", 8192))
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "header value exceeds default size limit",
+			setup: func(r *http.Request) {
+				r.RequestURI = "/"
+				r.Header.Set("X-Big", strings.Repeat("v", 8193))
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			handler := InputValidation(cfg)(noopHandlerFunc(&called))
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			tt.setup(req)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("got status %d, want %d", rec.Code, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/internal/plugins/catalog.go
+++ b/internal/plugins/catalog.go
@@ -35,6 +35,31 @@ var Catalog = []PluginDescriptor{
     message: "Scheduled maintenance — back in 30 minutes"`,
 	},
 	{
+		Name:        "input-validation",
+		Description: "Input validation: enforce URL length, query string length, header count, and header value size limits before WAF scanning",
+		ConfigSchema: map[string]string{
+			"enabled":                                  "Enable the input validation middleware (default: false)",
+			"max_url_length":                           "Maximum allowed raw request URI length in bytes (default: 2048; 0 disables)",
+			"max_query_string_length":                  "Maximum allowed query string length in bytes (default: 2048; 0 disables)",
+			"max_header_count":                         "Maximum number of request headers allowed (default: 100; 0 disables)",
+			"max_header_size":                          "Maximum allowed byte length of any single header value (default: 8192; 0 disables)",
+			"path_overrides[].path":                    "URL path glob pattern (path.Match syntax) for this override",
+			"path_overrides[].max_url_length":          "Override max URL length for matching paths (0 inherits global value)",
+			"path_overrides[].max_query_string_length": "Override max query string length for matching paths (0 inherits global value)",
+			"path_overrides[].max_header_count":        "Override max header count for matching paths (0 inherits global value)",
+			"path_overrides[].max_header_size":         "Override max header value size for matching paths (0 inherits global value)",
+		},
+		Example: `  input_validation:
+    enabled: true
+    max_url_length: 2048
+    max_query_string_length: 2048
+    max_header_count: 100
+    max_header_size: 8192
+    path_overrides:
+      - path: /api/upload
+        max_query_string_length: 8192`,
+	},
+	{
 		Name:        "waf",
 		Description: "WAF: Content-Type validation blocks body requests with missing or disallowed media types",
 		ConfigSchema: map[string]string{

--- a/internal/plugins/inputvalidation/config.go
+++ b/internal/plugins/inputvalidation/config.go
@@ -1,0 +1,66 @@
+// Package inputvalidation implements the VibeWarden input validation plugin.
+//
+// The plugin enforces request input size limits at the sidecar boundary before
+// any other processing occurs (it runs at priority 18, before the WAF at 25).
+// Oversized inputs are rejected with 400 Bad Request before regex scanning
+// starts, reducing CPU load and protecting against resource-exhaustion attacks.
+//
+// Configurable limits (all with sensible defaults):
+//   - max_url_length (default 2048)
+//   - max_query_string_length (default 2048)
+//   - max_header_count (default 100)
+//   - max_header_size (default 8192 bytes per header value)
+//
+// Each limit can be overridden per URL path via the path_overrides list.
+package inputvalidation
+
+// PathOverrideConfig defines per-path limit overrides.
+// Only non-zero fields override the global values.
+type PathOverrideConfig struct {
+	// Path is a glob pattern (path.Match syntax) matched against the request
+	// URL path (e.g. "/api/upload", "/static/*").
+	Path string
+
+	// MaxURLLength overrides the global limit for matching paths.
+	// Zero means inherit the global value.
+	MaxURLLength int
+
+	// MaxQueryStringLength overrides the global limit for matching paths.
+	// Zero means inherit the global value.
+	MaxQueryStringLength int
+
+	// MaxHeaderCount overrides the global limit for matching paths.
+	// Zero means inherit the global value.
+	MaxHeaderCount int
+
+	// MaxHeaderSize overrides the global limit for matching paths.
+	// Zero means inherit the global value.
+	MaxHeaderSize int
+}
+
+// Config holds all settings for the input validation plugin.
+// It maps to the input_validation: section of vibewarden.yaml.
+type Config struct {
+	// Enabled toggles the plugin. Default: false.
+	Enabled bool
+
+	// MaxURLLength is the maximum allowed length of the raw request URI
+	// (path + query string). Default: 2048. Zero disables this check.
+	MaxURLLength int
+
+	// MaxQueryStringLength is the maximum allowed length of the query string,
+	// not including the leading "?". Default: 2048. Zero disables this check.
+	MaxQueryStringLength int
+
+	// MaxHeaderCount is the maximum number of request headers allowed.
+	// Default: 100. Zero disables this check.
+	MaxHeaderCount int
+
+	// MaxHeaderSize is the maximum allowed byte length of any single header
+	// value. Default: 8192. Zero disables this check.
+	MaxHeaderSize int
+
+	// PathOverrides defines per-path limit overrides.
+	// The first entry whose Path pattern matches the request URL path wins.
+	PathOverrides []PathOverrideConfig
+}

--- a/internal/plugins/inputvalidation/meta.go
+++ b/internal/plugins/inputvalidation/meta.go
@@ -1,0 +1,38 @@
+package inputvalidation
+
+// Description returns a short description of the input validation plugin.
+func (p *Plugin) Description() string {
+	return "Input validation: enforce URL length, query string length, header count, and header value size limits before WAF scanning"
+}
+
+// ConfigSchema returns the configuration field descriptions for the input
+// validation plugin.
+func (p *Plugin) ConfigSchema() map[string]string {
+	return map[string]string{
+		"enabled":                                  "Enable the input validation middleware (default: false)",
+		"max_url_length":                           "Maximum allowed raw request URI length in bytes (default: 2048; 0 disables)",
+		"max_query_string_length":                  "Maximum allowed query string length in bytes (default: 2048; 0 disables)",
+		"max_header_count":                         "Maximum number of request headers allowed (default: 100; 0 disables)",
+		"max_header_size":                          "Maximum allowed byte length of any single header value (default: 8192; 0 disables)",
+		"path_overrides[].path":                    "URL path glob pattern (path.Match syntax) for this override",
+		"path_overrides[].max_url_length":          "Override max URL length for matching paths (0 inherits global value)",
+		"path_overrides[].max_query_string_length": "Override max query string length for matching paths (0 inherits global value)",
+		"path_overrides[].max_header_count":        "Override max header count for matching paths (0 inherits global value)",
+		"path_overrides[].max_header_size":         "Override max header value size for matching paths (0 inherits global value)",
+	}
+}
+
+// Example returns an example YAML configuration for the input validation plugin.
+func (p *Plugin) Example() string {
+	return `  input_validation:
+    enabled: true
+    max_url_length: 2048
+    max_query_string_length: 2048
+    max_header_count: 100
+    max_header_size: 8192
+    path_overrides:
+      - path: /api/upload
+        max_query_string_length: 8192
+      - path: /api/search
+        max_query_string_length: 4096`
+}

--- a/internal/plugins/inputvalidation/plugin.go
+++ b/internal/plugins/inputvalidation/plugin.go
@@ -1,0 +1,220 @@
+package inputvalidation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"path"
+
+	"github.com/vibewarden/vibewarden/internal/middleware"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// Plugin is the input validation plugin for VibeWarden.
+// It implements ports.Plugin and ports.CaddyContributor.
+//
+// The plugin enforces request input size limits (URL length, query string
+// length, header count, per-header value size) at priority 18 — before the
+// WAF (priority 25) — so that oversized inputs are rejected early, before
+// any regex scanning begins.
+//
+// Start and Stop are no-ops; the plugin is fully stateless. Health reports
+// whether the plugin is enabled.
+type Plugin struct {
+	cfg    Config
+	logger *slog.Logger
+}
+
+// New creates a new input validation Plugin.
+func New(cfg Config, logger *slog.Logger) *Plugin {
+	return &Plugin{cfg: cfg, logger: logger}
+}
+
+// Name returns the canonical plugin identifier "input-validation".
+func (p *Plugin) Name() string { return "input-validation" }
+
+// Priority returns 18 — input validation runs after security headers (20) is
+// incorrect; it must run before the WAF (25). We use 18 so it slots between
+// CORS/IP-filter (10-15) and the WAF (25), with security headers at 20 also
+// running first since headers are added to the response, not inspecting the
+// request.
+func (p *Plugin) Priority() int { return 18 }
+
+// Init validates the plugin configuration. It verifies that all path override
+// patterns are syntactically valid path.Match expressions.
+func (p *Plugin) Init(_ context.Context) error {
+	if !p.cfg.Enabled {
+		return nil
+	}
+
+	for i, ov := range p.cfg.PathOverrides {
+		if ov.Path == "" {
+			return fmt.Errorf("input_validation: path_overrides[%d].path must not be empty", i)
+		}
+		if _, err := path.Match(ov.Path, ""); err != nil {
+			return fmt.Errorf("input_validation: path_overrides[%d].path %q is not a valid path.Match pattern: %w",
+				i, ov.Path, err)
+		}
+	}
+
+	p.logger.Info("input validation plugin initialised",
+		slog.Int("max_url_length", p.cfg.MaxURLLength),
+		slog.Int("max_query_string_length", p.cfg.MaxQueryStringLength),
+		slog.Int("max_header_count", p.cfg.MaxHeaderCount),
+		slog.Int("max_header_size", p.cfg.MaxHeaderSize),
+		slog.Int("path_overrides", len(p.cfg.PathOverrides)),
+	)
+	return nil
+}
+
+// Start is a no-op for the input validation plugin.
+func (p *Plugin) Start(_ context.Context) error { return nil }
+
+// Stop is a no-op for the input validation plugin.
+func (p *Plugin) Stop(_ context.Context) error { return nil }
+
+// Health returns the current health status of the input validation plugin.
+func (p *Plugin) Health() ports.HealthStatus {
+	if !p.cfg.Enabled {
+		return ports.HealthStatus{
+			Healthy: true,
+			Message: "input-validation disabled",
+		}
+	}
+	return ports.HealthStatus{
+		Healthy: true,
+		Message: fmt.Sprintf(
+			"input-validation active (max_url=%d, max_qs=%d, max_headers=%d, max_header_size=%d, overrides=%d)",
+			p.cfg.MaxURLLength,
+			p.cfg.MaxQueryStringLength,
+			p.cfg.MaxHeaderCount,
+			p.cfg.MaxHeaderSize,
+			len(p.cfg.PathOverrides),
+		),
+	}
+}
+
+// ContributeCaddyRoutes returns nil. The input validation plugin does not add
+// named routes.
+func (p *Plugin) ContributeCaddyRoutes() []ports.CaddyRoute { return nil }
+
+// ContributeCaddyHandlers returns a single Caddy handler fragment for the
+// input validation middleware at priority 18. Returns an empty slice when the
+// plugin is disabled.
+func (p *Plugin) ContributeCaddyHandlers() []ports.CaddyHandler {
+	if !p.cfg.Enabled {
+		return nil
+	}
+
+	handlerJSON, err := buildHandlerJSON(p.cfg)
+	if err != nil {
+		p.logger.Error("input validation plugin: building handler JSON",
+			slog.String("err", err.Error()))
+		return nil
+	}
+
+	return []ports.CaddyHandler{
+		{
+			Handler:  handlerJSON,
+			Priority: 18,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Internal builders — pure functions, no side effects.
+// ---------------------------------------------------------------------------
+
+// handlerConfig is the JSON-serialisable configuration sent to the
+// vibewarden_input_validation Caddy module.
+type handlerConfig struct {
+	// MaxURLLength is the maximum allowed raw URI length.
+	MaxURLLength int `json:"max_url_length"`
+
+	// MaxQueryStringLength is the maximum allowed query string length.
+	MaxQueryStringLength int `json:"max_query_string_length"`
+
+	// MaxHeaderCount is the maximum number of request headers.
+	MaxHeaderCount int `json:"max_header_count"`
+
+	// MaxHeaderSize is the maximum per-header value byte size.
+	MaxHeaderSize int `json:"max_header_size"`
+
+	// PathOverrides defines per-path limit overrides.
+	PathOverrides []pathOverrideHandlerConfig `json:"path_overrides,omitempty"`
+}
+
+// pathOverrideHandlerConfig is the JSON representation of a single per-path
+// override sent to the Caddy module.
+type pathOverrideHandlerConfig struct {
+	Path                 string `json:"path"`
+	MaxURLLength         int    `json:"max_url_length,omitempty"`
+	MaxQueryStringLength int    `json:"max_query_string_length,omitempty"`
+	MaxHeaderCount       int    `json:"max_header_count,omitempty"`
+	MaxHeaderSize        int    `json:"max_header_size,omitempty"`
+}
+
+// buildHandlerJSON serialises cfg into the Caddy handler JSON map expected by
+// the vibewarden_input_validation module.
+func buildHandlerJSON(cfg Config) (map[string]any, error) {
+	hcfg := handlerConfig{
+		MaxURLLength:         cfg.MaxURLLength,
+		MaxQueryStringLength: cfg.MaxQueryStringLength,
+		MaxHeaderCount:       cfg.MaxHeaderCount,
+		MaxHeaderSize:        cfg.MaxHeaderSize,
+	}
+
+	for _, ov := range cfg.PathOverrides {
+		hcfg.PathOverrides = append(hcfg.PathOverrides, pathOverrideHandlerConfig(ov))
+	}
+
+	cfgBytes, err := json.Marshal(hcfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling input validation handler config: %w", err)
+	}
+
+	return map[string]any{
+		"handler": "vibewarden_input_validation",
+		"config":  json.RawMessage(cfgBytes),
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Middleware accessor — used by the Caddy adapter to build the handler chain.
+// ---------------------------------------------------------------------------
+
+// Middleware returns the compiled net/http middleware function for the plugin.
+// It is used by adapters that construct the middleware chain directly (e.g.
+// the Caddy adapter) rather than via Caddy JSON config contribution.
+func (p *Plugin) Middleware() func(http.Handler) http.Handler {
+	ovs := make([]middleware.InputValidationPathOverride, 0, len(p.cfg.PathOverrides))
+	for _, ov := range p.cfg.PathOverrides {
+		ovs = append(ovs, middleware.InputValidationPathOverride{
+			Path:                 ov.Path,
+			MaxURLLength:         ov.MaxURLLength,
+			MaxQueryStringLength: ov.MaxQueryStringLength,
+			MaxHeaderCount:       ov.MaxHeaderCount,
+			MaxHeaderSize:        ov.MaxHeaderSize,
+		})
+	}
+
+	return middleware.InputValidation(middleware.InputValidationConfig{
+		Enabled:              p.cfg.Enabled,
+		MaxURLLength:         p.cfg.MaxURLLength,
+		MaxQueryStringLength: p.cfg.MaxQueryStringLength,
+		MaxHeaderCount:       p.cfg.MaxHeaderCount,
+		MaxHeaderSize:        p.cfg.MaxHeaderSize,
+		PathOverrides:        ovs,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Interface guards.
+// ---------------------------------------------------------------------------
+
+var (
+	_ ports.Plugin           = (*Plugin)(nil)
+	_ ports.CaddyContributor = (*Plugin)(nil)
+)

--- a/internal/plugins/inputvalidation/plugin_test.go
+++ b/internal/plugins/inputvalidation/plugin_test.go
@@ -1,0 +1,366 @@
+package inputvalidation_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/plugins/inputvalidation"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type noopWriter struct{}
+
+func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(noopWriter{}, nil))
+}
+
+func defaultConfig() inputvalidation.Config {
+	return inputvalidation.Config{
+		Enabled:              true,
+		MaxURLLength:         2048,
+		MaxQueryStringLength: 2048,
+		MaxHeaderCount:       100,
+		MaxHeaderSize:        8192,
+	}
+}
+
+func newPlugin(cfg inputvalidation.Config) *inputvalidation.Plugin {
+	return inputvalidation.New(cfg, discardLogger())
+}
+
+// ---------------------------------------------------------------------------
+// Name / Priority
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Name(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if got := p.Name(); got != "input-validation" {
+		t.Errorf("Name() = %q, want %q", got, "input-validation")
+	}
+}
+
+func TestPlugin_Priority(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if got := p.Priority(); got != 18 {
+		t.Errorf("Priority() = %d, want 18", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Init(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     inputvalidation.Config
+		wantErr bool
+	}{
+		{
+			name:    "disabled — no validation",
+			cfg:     inputvalidation.Config{Enabled: false},
+			wantErr: false,
+		},
+		{
+			name:    "enabled with valid config",
+			cfg:     defaultConfig(),
+			wantErr: false,
+		},
+		{
+			name: "enabled with valid path override",
+			cfg: inputvalidation.Config{
+				Enabled:      true,
+				MaxURLLength: 2048,
+				PathOverrides: []inputvalidation.PathOverrideConfig{
+					{Path: "/api/*", MaxURLLength: 4096},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "enabled with empty path override path",
+			cfg: inputvalidation.Config{
+				Enabled:      true,
+				MaxURLLength: 2048,
+				PathOverrides: []inputvalidation.PathOverrideConfig{
+					{Path: ""},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "enabled with invalid path override pattern",
+			cfg: inputvalidation.Config{
+				Enabled:      true,
+				MaxURLLength: 2048,
+				PathOverrides: []inputvalidation.PathOverrideConfig{
+					{Path: "[invalid"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			err := p.Init(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Start / Stop — no-ops
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Start_IsNoop(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if err := p.Start(context.Background()); err != nil {
+		t.Errorf("Start() unexpected error: %v", err)
+	}
+}
+
+func TestPlugin_Stop_IsNoop(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if err := p.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Health(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            inputvalidation.Config
+		wantHealthy    bool
+		wantMsgContain string
+	}{
+		{
+			name:           "disabled",
+			cfg:            inputvalidation.Config{Enabled: false},
+			wantHealthy:    true,
+			wantMsgContain: "disabled",
+		},
+		{
+			name:           "enabled",
+			cfg:            defaultConfig(),
+			wantHealthy:    true,
+			wantMsgContain: "active",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			h := p.Health()
+			if h.Healthy != tt.wantHealthy {
+				t.Errorf("Health().Healthy = %v, want %v", h.Healthy, tt.wantHealthy)
+			}
+			if !strings.Contains(h.Message, tt.wantMsgContain) {
+				t.Errorf("Health().Message = %q, want it to contain %q", h.Message, tt.wantMsgContain)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyRoutes
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyRoutes_AlwaysEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  inputvalidation.Config
+	}{
+		{"disabled", inputvalidation.Config{Enabled: false}},
+		{"enabled", defaultConfig()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.cfg)
+			if routes := p.ContributeCaddyRoutes(); len(routes) != 0 {
+				t.Errorf("ContributeCaddyRoutes() = %v, want empty", routes)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ContributeCaddyHandlers
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ContributeCaddyHandlers_DisabledReturnsNil(t *testing.T) {
+	p := newPlugin(inputvalidation.Config{Enabled: false})
+	if handlers := p.ContributeCaddyHandlers(); len(handlers) != 0 {
+		t.Errorf("ContributeCaddyHandlers() = %v, want empty when disabled", handlers)
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_EnabledReturnsOneHandler(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 1 {
+		t.Fatalf("ContributeCaddyHandlers() len = %d, want 1", len(handlers))
+	}
+
+	h := handlers[0]
+	if h.Priority != 18 {
+		t.Errorf("handler priority = %d, want 18", h.Priority)
+	}
+	if h.Handler["handler"] != "vibewarden_input_validation" {
+		t.Errorf("handler name = %v, want \"vibewarden_input_validation\"", h.Handler["handler"])
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_ConfigContainsLimits(t *testing.T) {
+	cfg := inputvalidation.Config{
+		Enabled:              true,
+		MaxURLLength:         1024,
+		MaxQueryStringLength: 512,
+		MaxHeaderCount:       50,
+		MaxHeaderSize:        4096,
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 1 {
+		t.Fatalf("expected 1 handler, got %d", len(handlers))
+	}
+
+	rawCfg, ok := handlers[0].Handler["config"].(json.RawMessage)
+	if !ok {
+		t.Fatalf("expected json.RawMessage under \"config\" key, got %T", handlers[0].Handler["config"])
+	}
+
+	var hcfg struct {
+		MaxURLLength         int `json:"max_url_length"`
+		MaxQueryStringLength int `json:"max_query_string_length"`
+		MaxHeaderCount       int `json:"max_header_count"`
+		MaxHeaderSize        int `json:"max_header_size"`
+	}
+	if err := json.Unmarshal(rawCfg, &hcfg); err != nil {
+		t.Fatalf("json.Unmarshal config: %v", err)
+	}
+
+	if hcfg.MaxURLLength != 1024 {
+		t.Errorf("max_url_length = %d, want 1024", hcfg.MaxURLLength)
+	}
+	if hcfg.MaxQueryStringLength != 512 {
+		t.Errorf("max_query_string_length = %d, want 512", hcfg.MaxQueryStringLength)
+	}
+	if hcfg.MaxHeaderCount != 50 {
+		t.Errorf("max_header_count = %d, want 50", hcfg.MaxHeaderCount)
+	}
+	if hcfg.MaxHeaderSize != 4096 {
+		t.Errorf("max_header_size = %d, want 4096", hcfg.MaxHeaderSize)
+	}
+}
+
+func TestPlugin_ContributeCaddyHandlers_PathOverridesInConfig(t *testing.T) {
+	cfg := inputvalidation.Config{
+		Enabled:      true,
+		MaxURLLength: 2048,
+		PathOverrides: []inputvalidation.PathOverrideConfig{
+			{
+				Path:         "/api/upload",
+				MaxURLLength: 8192,
+			},
+		},
+	}
+	p := newPlugin(cfg)
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 1 {
+		t.Fatalf("expected 1 handler, got %d", len(handlers))
+	}
+
+	rawCfg, ok := handlers[0].Handler["config"].(json.RawMessage)
+	if !ok {
+		t.Fatalf("expected json.RawMessage under \"config\" key, got %T", handlers[0].Handler["config"])
+	}
+
+	var hcfg struct {
+		PathOverrides []struct {
+			Path         string `json:"path"`
+			MaxURLLength int    `json:"max_url_length"`
+		} `json:"path_overrides"`
+	}
+	if err := json.Unmarshal(rawCfg, &hcfg); err != nil {
+		t.Fatalf("json.Unmarshal config: %v", err)
+	}
+	if len(hcfg.PathOverrides) != 1 {
+		t.Fatalf("path_overrides count = %d, want 1", len(hcfg.PathOverrides))
+	}
+	if hcfg.PathOverrides[0].Path != "/api/upload" {
+		t.Errorf("path_overrides[0].path = %q, want \"/api/upload\"", hcfg.PathOverrides[0].Path)
+	}
+	if hcfg.PathOverrides[0].MaxURLLength != 8192 {
+		t.Errorf("path_overrides[0].max_url_length = %d, want 8192", hcfg.PathOverrides[0].MaxURLLength)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+
+func TestPlugin_Description_NonEmpty(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if p.Description() == "" {
+		t.Error("Description() must not be empty")
+	}
+}
+
+func TestPlugin_ConfigSchema_HasExpectedKeys(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	schema := p.ConfigSchema()
+
+	required := []string{
+		"enabled",
+		"max_url_length",
+		"max_query_string_length",
+		"max_header_count",
+		"max_header_size",
+		"path_overrides[].path",
+	}
+	for _, key := range required {
+		if _, ok := schema[key]; !ok {
+			t.Errorf("ConfigSchema() missing key %q", key)
+		}
+	}
+}
+
+func TestPlugin_Example_NonEmpty(t *testing.T) {
+	p := newPlugin(defaultConfig())
+	if p.Example() == "" {
+		t.Error("Example() must not be empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Interface compliance
+// ---------------------------------------------------------------------------
+
+func TestPlugin_ImplementsPortsPlugin(t *testing.T) {
+	var _ ports.Plugin = (*inputvalidation.Plugin)(nil)
+}
+
+func TestPlugin_ImplementsCaddyContributor(t *testing.T) {
+	var _ ports.CaddyContributor = (*inputvalidation.Plugin)(nil)
+}
+
+func TestPlugin_ImplementsPluginMeta(t *testing.T) {
+	var _ ports.PluginMeta = (*inputvalidation.Plugin)(nil)
+}


### PR DESCRIPTION
Closes #474

## Summary

- New `InputValidation` middleware in `internal/middleware/input_validation.go` that enforces four configurable request input size limits: URL length, query string length, header count, and per-header value size.
- Middleware runs at priority 18 — before the WAF (priority 25) — so oversized inputs are rejected before regex scanning begins.
- Returns 400 Bad Request with structured JSON (`error: "input_validation_failed"`) plus a trace/request correlation ID on any violation.
- The `/_vibewarden/*` prefix is always exempt.
- Per-path overrides via `path_overrides` list (first-match wins; non-zero fields override the global value).
- New `internal/plugins/inputvalidation` plugin package (`config.go`, `plugin.go`, `meta.go`) wires the middleware into the plugin registry as `"input-validation"`.
- Defaults match the issue spec: `max_url_length=2048`, `max_query_string_length=2048`, `max_header_count=100`, `max_header_size=8192`.
- `internal/config/config.go` gains `InputValidation InputValidationConfig` and matching `SetDefault` calls.
- `internal/plugins/catalog.go` gains the `"input-validation"` descriptor.
- `cmd/vibewarden/serve_plugins.go` registers the plugin via `buildInputValidationPlugin`.

## Test plan

- `internal/middleware/input_validation_test.go`: table-driven tests covering disabled state, `/_vibewarden/*` exemption, URL length at/over limit, query string length at/over limit, header count at/over limit, header value size at/over limit, per-path overrides (relax, tighten, first-match-wins), error response structure (JSON, Content-Type, correlation ID), and all-checks-pass flow.
- `internal/plugins/inputvalidation/plugin_test.go`: Name/Priority, Init (valid/invalid config, empty path, invalid pattern), Start/Stop no-ops, Health (disabled/enabled), ContributeCaddyRoutes (always empty), ContributeCaddyHandlers (disabled returns nil, enabled returns one handler at priority 18 with correct Caddy module name and serialised limits), path overrides in config, PluginMeta interface (Description/ConfigSchema/Example).
- `make check` passes (formatting, golangci-lint 0 issues, build, race-enabled test suite).
