### PR TITLE
feat(#575): introduce PluginRegistrar extension point and RunServe application service

### DIFF
--- a/cmd/vibewarden/serve.go
+++ b/cmd/vibewarden/serve.go
@@ -2,20 +2,10 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"log/slog"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
 
 	"github.com/spf13/cobra"
 
-	caddyadapter "github.com/vibewarden/vibewarden/internal/adapters/caddy"
-	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
-	"github.com/vibewarden/vibewarden/internal/app/proxy"
-	"github.com/vibewarden/vibewarden/internal/config"
-	"github.com/vibewarden/vibewarden/internal/plugins"
+	appserve "github.com/vibewarden/vibewarden/internal/app/serve"
 )
 
 // newServeCmd creates the serve subcommand.
@@ -30,125 +20,14 @@ func newServeCmd() *cobra.Command {
 Reads configuration from vibewarden.yaml (or the path specified with --config).
 Listens for SIGINT/SIGTERM and performs a graceful shutdown.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runServe(configPath)
+			return appserve.RunServe(context.Background(), appserve.Options{
+				ConfigPath: configPath,
+				Version:    version,
+			})
 		},
 	}
 
 	cmd.Flags().StringVarP(&configPath, "config", "c", "", "path to vibewarden.yaml (default: ./vibewarden.yaml)")
 
 	return cmd
-}
-
-// runServe loads config, builds the plugin registry, wires Caddy via plugin
-// contributors, and runs until a shutdown signal is received.
-func runServe(configPath string) error {
-	cfg, err := config.Load(configPath)
-	if err != nil {
-		return fmt.Errorf("loading config: %w", err)
-	}
-
-	logger := buildLogger(cfg.Log)
-
-	// Migrate legacy metrics: config to telemetry: if needed.
-	config.MigrateLegacyMetrics(cfg, logger)
-
-	logger.Info("VibeWarden starting",
-		slog.String("version", version),
-		slog.String("listen", fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)),
-		slog.String("upstream", fmt.Sprintf("%s:%d", cfg.Upstream.Host, cfg.Upstream.Port)),
-	)
-
-	// Build the plugin registry and register all compiled-in plugins.
-	// At registration time we use a stdout-only event logger. After InitAll,
-	// we upgrade to a multi-handler logger (stdout + OTel) when log export is
-	// enabled. The caddy adapter — the main consumer of the event logger —
-	// is created after StartAll, so it always gets the upgraded logger.
-	initialEventLogger := logadapter.NewSlogEventLogger(os.Stdout)
-
-	registry := plugins.NewRegistry(logger)
-	registerPlugins(registry, cfg, initialEventLogger, logger)
-
-	// Set up OS signal handling before Init/Start so that a slow Init can
-	// still be interrupted.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-
-	go func() {
-		sig := <-sigCh
-		logger.Info("received shutdown signal", slog.String("signal", sig.String()))
-		cancel()
-	}()
-
-	// Initialise all plugins.
-	if err := registry.InitAll(ctx); err != nil {
-		return fmt.Errorf("initialising plugins: %w", err)
-	}
-
-	// After InitAll, retrieve the OTel log handler from the metrics plugin
-	// (if log export is enabled) and build the final event logger.
-	eventLogger := buildEventLogger(registry, logger)
-
-	// Wire the metrics collector into the TLS cert expiry monitor so that
-	// the vibewarden_tls_cert_expiry_seconds gauge is populated. This must
-	// happen after InitAll (metrics provider is ready) and before StartAll
-	// (monitor background goroutine launches on Start).
-	wireTLSMetricsCollector(registry)
-
-	// Start all plugins (background servers, etc.).
-	if err := registry.StartAll(ctx); err != nil {
-		return fmt.Errorf("starting plugins: %w", err)
-	}
-
-	// Ensure StopAll runs on return (normal or error path).
-	defer func() {
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer stopCancel()
-		if stopErr := registry.StopAll(stopCtx); stopErr != nil {
-			logger.Error("stopping plugins", slog.String("error", stopErr.Error()))
-		}
-	}()
-
-	// Build ProxyConfig — base fields that the Caddy adapter uses directly.
-	// Plugin-specific wiring (security headers, rate limiting, auth, admin,
-	// metrics) is now driven by each plugin's CaddyContributor implementation.
-	// The legacy top-level fields are still populated for the existing
-	// BuildCaddyConfig path; a follow-up issue will migrate that fully to
-	// the contributor model.
-	proxyCfg := buildProxyConfig(cfg, registry)
-
-	// Create Caddy adapter and proxy service.
-	adapter := caddyadapter.NewAdapter(proxyCfg, logger, eventLogger)
-	svc := proxy.NewService(adapter, logger)
-
-	if err := svc.Run(ctx); err != nil {
-		return fmt.Errorf("proxy service: %w", err)
-	}
-
-	return nil
-}
-
-// buildLogger creates an slog.Logger from the log configuration.
-func buildLogger(cfg config.LogConfig) *slog.Logger {
-	var level slog.Level
-	switch cfg.Level {
-	case "debug":
-		level = slog.LevelDebug
-	case "warn":
-		level = slog.LevelWarn
-	case "error":
-		level = slog.LevelError
-	default:
-		level = slog.LevelInfo
-	}
-
-	opts := &slog.HandlerOptions{Level: level}
-
-	if cfg.Format == "text" {
-		return slog.New(slog.NewTextHandler(os.Stderr, opts))
-	}
-
-	return slog.New(slog.NewJSONHandler(os.Stderr, opts))
 }

--- a/cmd/vibewarden/serve_test.go
+++ b/cmd/vibewarden/serve_test.go
@@ -2,108 +2,19 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"testing"
 
-	"github.com/vibewarden/vibewarden/internal/config"
+	appserve "github.com/vibewarden/vibewarden/internal/app/serve"
 )
 
-func TestBuildLogger_Level(t *testing.T) {
-	tests := []struct {
-		name      string
-		cfg       config.LogConfig
-		wantLevel slog.Level
-	}{
-		{
-			name:      "debug level",
-			cfg:       config.LogConfig{Level: "debug", Format: "json"},
-			wantLevel: slog.LevelDebug,
-		},
-		{
-			name:      "info level",
-			cfg:       config.LogConfig{Level: "info", Format: "json"},
-			wantLevel: slog.LevelInfo,
-		},
-		{
-			name:      "warn level",
-			cfg:       config.LogConfig{Level: "warn", Format: "json"},
-			wantLevel: slog.LevelWarn,
-		},
-		{
-			name:      "error level",
-			cfg:       config.LogConfig{Level: "error", Format: "json"},
-			wantLevel: slog.LevelError,
-		},
-		{
-			name:      "unknown level defaults to info",
-			cfg:       config.LogConfig{Level: "verbose", Format: "json"},
-			wantLevel: slog.LevelInfo,
-		},
-		{
-			name:      "empty level defaults to info",
-			cfg:       config.LogConfig{Level: "", Format: "json"},
-			wantLevel: slog.LevelInfo,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			logger := buildLogger(tt.cfg)
-			if logger == nil {
-				t.Fatal("buildLogger() returned nil logger")
-			}
-			if !logger.Enabled(context.TODO(), tt.wantLevel) {
-				t.Errorf("buildLogger(%q) logger does not enable level %v", tt.cfg.Level, tt.wantLevel)
-			}
-			// Verify that one level below is disabled (except for debug which has nothing below)
-			if tt.wantLevel > slog.LevelDebug {
-				lowerLevel := tt.wantLevel - 4
-				if logger.Enabled(context.TODO(), lowerLevel) {
-					t.Errorf("buildLogger(%q) unexpectedly enables level %v (below minimum %v)", tt.cfg.Level, lowerLevel, tt.wantLevel)
-				}
-			}
-		})
-	}
-}
-
-func TestBuildLogger_Format(t *testing.T) {
-	tests := []struct {
-		name    string
-		cfg     config.LogConfig
-		wantNil bool
-	}{
-		{
-			name:    "json format returns a logger",
-			cfg:     config.LogConfig{Level: "info", Format: "json"},
-			wantNil: false,
-		},
-		{
-			name:    "text format returns a logger",
-			cfg:     config.LogConfig{Level: "info", Format: "text"},
-			wantNil: false,
-		},
-		{
-			name:    "unknown format falls back to json and returns a logger",
-			cfg:     config.LogConfig{Level: "info", Format: "unknown"},
-			wantNil: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			logger := buildLogger(tt.cfg)
-			if (logger == nil) != tt.wantNil {
-				t.Errorf("buildLogger() = %v, wantNil %v", logger, tt.wantNil)
-			}
-		})
-	}
-}
-
 func TestRunServe_MissingConfig(t *testing.T) {
-	// runServe should return an error when given a path to a non-existent config file
-	// that is not a standard search path (explicit path forces a load attempt).
-	err := runServe("/nonexistent/path/to/vibewarden.yaml")
+	// RunServe should return an error when given a path to a non-existent config
+	// file that is not a standard search path (explicit path forces a load attempt).
+	err := appserve.RunServe(context.Background(), appserve.Options{
+		ConfigPath: "/nonexistent/path/to/vibewarden.yaml",
+		Version:    "test",
+	})
 	if err == nil {
-		t.Error("runServe() expected error for missing explicit config file, got nil")
+		t.Error("RunServe() expected error for missing explicit config file, got nil")
 	}
 }

--- a/internal/app/serve/config.go
+++ b/internal/app/serve/config.go
@@ -1,16 +1,13 @@
-package main
+package serve
 
 import (
 	"fmt"
 	"log/slog"
-	"os"
 	"time"
 
-	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
 	"github.com/vibewarden/vibewarden/internal/config"
 	"github.com/vibewarden/vibewarden/internal/domain/csp"
 	"github.com/vibewarden/vibewarden/internal/plugins"
-	egressplugin "github.com/vibewarden/vibewarden/internal/plugins/egress"
 	metricsplugin "github.com/vibewarden/vibewarden/internal/plugins/metrics"
 	tlsplugin "github.com/vibewarden/vibewarden/internal/plugins/tls"
 	"github.com/vibewarden/vibewarden/internal/ports"
@@ -18,9 +15,10 @@ import (
 
 // buildProxyConfig constructs the ports.ProxyConfig that the Caddy adapter
 // uses to build its JSON configuration. Plugin-specific fields are read from
-// the running plugins where possible (e.g. metrics internal address after
-// Start).
-func buildProxyConfig(cfg *config.Config, registry *plugins.Registry) *ports.ProxyConfig {
+// the running plugins where possible (e.g. metrics internal address after Start).
+//
+// version is the binary version string injected at build time.
+func buildProxyConfig(cfg *config.Config, registry *plugins.Registry, version string) *ports.ProxyConfig {
 	// Collect internal addresses from started InternalServerPlugin instances.
 	var metricsCfg ports.MetricsProxyConfig
 	var adminCfg ports.AdminProxyConfig
@@ -300,99 +298,26 @@ func buildResiliencePortsConfig(cfg *config.Config) ports.ResilienceConfig {
 	return result
 }
 
-// buildEgressPlugin constructs the egress proxy plugin from config, parsing
-// duration strings into time.Duration values. Falls back to plugin defaults
-// on parse errors (config.Validate does not validate egress duration strings
-// since they are optional and have sensible defaults).
-func buildEgressPlugin(cfg *config.Config, eventLogger ports.EventLogger, logger *slog.Logger) *egressplugin.Plugin {
-	ec := cfg.Egress
+// wireTLSMetricsCollector injects the MetricsCollector from the metrics plugin
+// into the TLS plugin's certificate expiry monitor. It must be called after
+// InitAll (so the metrics provider is ready) and before StartAll (so the
+// monitor goroutine receives the collector before it first runs).
+func wireTLSMetricsCollector(registry *plugins.Registry) {
+	var collector ports.MetricsCollector
+	var tlsPlugin *tlsplugin.Plugin
 
-	defaultTimeout, err := time.ParseDuration(ec.DefaultTimeout)
-	if err != nil && ec.DefaultTimeout != "" {
-		logger.Warn("egress.default_timeout parse error — using default 30s",
-			slog.String("error", err.Error()),
-			slog.String("value", ec.DefaultTimeout),
-		)
-	}
-
-	defaultBodySizeBytes, err := config.ParseBodySize(ec.DefaultBodySizeLimit)
-	if err != nil && ec.DefaultBodySizeLimit != "" {
-		logger.Warn("egress.default_body_size_limit parse error — disabling global body size limit",
-			slog.String("error", err.Error()),
-		)
-		defaultBodySizeBytes = 0
-	}
-
-	defaultResponseSizeBytes, err := config.ParseBodySize(ec.DefaultResponseSizeLimit)
-	if err != nil && ec.DefaultResponseSizeLimit != "" {
-		logger.Warn("egress.default_response_size_limit parse error — disabling global response size limit",
-			slog.String("error", err.Error()),
-		)
-		defaultResponseSizeBytes = 0
-	}
-
-	pluginCfg := egressplugin.Config{
-		Enabled:                  ec.Enabled,
-		Listen:                   ec.Listen,
-		DefaultPolicy:            ec.DefaultPolicy,
-		AllowInsecure:            ec.AllowInsecure,
-		DefaultTimeout:           defaultTimeout,
-		DefaultBodySizeLimit:     defaultBodySizeBytes,
-		DefaultResponseSizeLimit: defaultResponseSizeBytes,
-		BlockPrivate:             ec.DNS.BlockPrivate,
-		AllowedPrivate:           ec.DNS.AllowedPrivate,
-	}
-
-	// Map route configs.
-	for _, rc := range ec.Routes {
-		routeTimeout, routeErr := time.ParseDuration(rc.Timeout)
-		if routeErr != nil && rc.Timeout != "" {
-			logger.Warn("egress route timeout parse error — using global default",
-				slog.String("route", rc.Name),
-				slog.String("error", routeErr.Error()),
-			)
+	for _, p := range registry.Plugins() {
+		switch v := p.(type) {
+		case *metricsplugin.Plugin:
+			collector = v.Collector()
+		case *tlsplugin.Plugin:
+			tlsPlugin = v
 		}
-
-		cbResetAfter, cbErr := time.ParseDuration(rc.CircuitBreaker.ResetAfter)
-		if cbErr != nil && rc.CircuitBreaker.ResetAfter != "" {
-			logger.Warn("egress route circuit_breaker.reset_after parse error — disabling circuit breaker for route",
-				slog.String("route", rc.Name),
-				slog.String("error", cbErr.Error()),
-			)
-		}
-
-		bodySizeBytes, _ := config.ParseBodySize(rc.BodySizeLimit)
-		responseSizeBytes, _ := config.ParseBodySize(rc.ResponseSizeLimit)
-
-		pluginCfg.Routes = append(pluginCfg.Routes, egressplugin.RouteConfig{
-			Name:              rc.Name,
-			Pattern:           rc.Pattern,
-			Methods:           rc.Methods,
-			Timeout:           routeTimeout,
-			Secret:            rc.Secret,
-			SecretHeader:      rc.SecretHeader,
-			SecretFormat:      rc.SecretFormat,
-			RateLimit:         rc.RateLimit,
-			BodySizeLimit:     bodySizeBytes,
-			ResponseSizeLimit: responseSizeBytes,
-			AllowInsecure:     rc.AllowInsecure,
-			CircuitBreaker: egressplugin.CircuitBreakerConfig{
-				Threshold:  rc.CircuitBreaker.Threshold,
-				ResetAfter: cbResetAfter,
-			},
-			Retries: egressplugin.RetryConfig{
-				Max:     rc.Retries.Max,
-				Methods: rc.Retries.Methods,
-				Backoff: rc.Retries.Backoff,
-			},
-			ValidateResponse: egressplugin.ResponseValidationConfig{
-				StatusCodes:  rc.ValidateResponse.StatusCodes,
-				ContentTypes: rc.ValidateResponse.ContentTypes,
-			},
-		})
 	}
 
-	return egressplugin.New(pluginCfg, eventLogger, logger)
+	if tlsPlugin != nil && collector != nil {
+		tlsPlugin.SetMetricsCollector(collector)
+	}
 }
 
 // resolveCSP returns the Content-Security-Policy header value to use.
@@ -420,43 +345,4 @@ func resolveCSP(cfg *config.Config) string {
 		FrameAncestors: cfg.SecurityHeaders.CSP.FrameAncestors,
 		BaseURI:        cfg.SecurityHeaders.CSP.BaseURI,
 	})
-}
-
-// buildEventLogger constructs the event logger used by the caddy adapter and
-// other consumers. When the metrics plugin has an OTel log handler available,
-// the logger fans out to both stdout JSON and OTel via a MultiHandler.
-// Falls back to stdout-only when log export is disabled or unavailable.
-func buildEventLogger(registry *plugins.Registry, logger *slog.Logger) ports.EventLogger {
-	for _, p := range registry.Plugins() {
-		if mp, ok := p.(*metricsplugin.Plugin); ok {
-			if h := mp.LogHandler(); h != nil {
-				logger.Info("event logger: OTel log export enabled")
-				return logadapter.NewSlogEventLogger(os.Stdout, h)
-			}
-			break
-		}
-	}
-	return logadapter.NewSlogEventLogger(os.Stdout)
-}
-
-// wireTLSMetricsCollector injects the MetricsCollector from the metrics plugin
-// into the TLS plugin's certificate expiry monitor. It must be called after
-// InitAll (so the metrics provider is ready) and before StartAll (so the
-// monitor goroutine receives the collector before it first runs).
-func wireTLSMetricsCollector(registry *plugins.Registry) {
-	var collector ports.MetricsCollector
-	var tlsPlugin *tlsplugin.Plugin
-
-	for _, p := range registry.Plugins() {
-		switch v := p.(type) {
-		case *metricsplugin.Plugin:
-			collector = v.Collector()
-		case *tlsplugin.Plugin:
-			tlsPlugin = v
-		}
-	}
-
-	if tlsPlugin != nil && collector != nil {
-		tlsPlugin.SetMetricsCollector(collector)
-	}
 }

--- a/internal/app/serve/config_test.go
+++ b/internal/app/serve/config_test.go
@@ -1,4 +1,4 @@
-package main
+package serve
 
 import (
 	"testing"

--- a/internal/app/serve/logger.go
+++ b/internal/app/serve/logger.go
@@ -1,0 +1,55 @@
+// Package serve provides the RunServe application service that orchestrates the
+// VibeWarden startup sequence: config loading, plugin registration, Caddy wiring,
+// and graceful shutdown. It is importable by both the OSS binary and the Pro binary.
+package serve
+
+import (
+	"log/slog"
+	"os"
+
+	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
+	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/plugins"
+	metricsplugin "github.com/vibewarden/vibewarden/internal/plugins/metrics"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// buildLogger creates an slog.Logger from the log configuration.
+func buildLogger(cfg config.LogConfig) *slog.Logger {
+	var level slog.Level
+	switch cfg.Level {
+	case "debug":
+		level = slog.LevelDebug
+	case "warn":
+		level = slog.LevelWarn
+	case "error":
+		level = slog.LevelError
+	default:
+		level = slog.LevelInfo
+	}
+
+	opts := &slog.HandlerOptions{Level: level}
+
+	if cfg.Format == "text" {
+		return slog.New(slog.NewTextHandler(os.Stderr, opts))
+	}
+
+	return slog.New(slog.NewJSONHandler(os.Stderr, opts))
+}
+
+// buildEventLogger constructs the event logger used by the caddy adapter and
+// other consumers. When the metrics plugin has an OTel log handler available,
+// the logger fans out to both stdout JSON and OTel via a MultiHandler.
+// Falls back to stdout-only when log export is disabled or unavailable.
+func buildEventLogger(registry *plugins.Registry, logger *slog.Logger) ports.EventLogger {
+	for _, p := range registry.Plugins() {
+		if mp, ok := p.(*metricsplugin.Plugin); ok {
+			if h := mp.LogHandler(); h != nil {
+				logger.Info("event logger: OTel log export enabled")
+				return logadapter.NewSlogEventLogger(os.Stdout, h)
+			}
+			break
+		}
+	}
+	return logadapter.NewSlogEventLogger(os.Stdout)
+}

--- a/internal/app/serve/logger_test.go
+++ b/internal/app/serve/logger_test.go
@@ -1,0 +1,100 @@
+package serve
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+func TestBuildLogger_Level(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       config.LogConfig
+		wantLevel slog.Level
+	}{
+		{
+			name:      "debug level",
+			cfg:       config.LogConfig{Level: "debug", Format: "json"},
+			wantLevel: slog.LevelDebug,
+		},
+		{
+			name:      "info level",
+			cfg:       config.LogConfig{Level: "info", Format: "json"},
+			wantLevel: slog.LevelInfo,
+		},
+		{
+			name:      "warn level",
+			cfg:       config.LogConfig{Level: "warn", Format: "json"},
+			wantLevel: slog.LevelWarn,
+		},
+		{
+			name:      "error level",
+			cfg:       config.LogConfig{Level: "error", Format: "json"},
+			wantLevel: slog.LevelError,
+		},
+		{
+			name:      "unknown level defaults to info",
+			cfg:       config.LogConfig{Level: "verbose", Format: "json"},
+			wantLevel: slog.LevelInfo,
+		},
+		{
+			name:      "empty level defaults to info",
+			cfg:       config.LogConfig{Level: "", Format: "json"},
+			wantLevel: slog.LevelInfo,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := buildLogger(tt.cfg)
+			if logger == nil {
+				t.Fatal("buildLogger() returned nil logger")
+			}
+			if !logger.Enabled(context.TODO(), tt.wantLevel) {
+				t.Errorf("buildLogger(%q) logger does not enable level %v", tt.cfg.Level, tt.wantLevel)
+			}
+			// Verify that one level below is disabled (except for debug which has nothing below)
+			if tt.wantLevel > slog.LevelDebug {
+				lowerLevel := tt.wantLevel - 4
+				if logger.Enabled(context.TODO(), lowerLevel) {
+					t.Errorf("buildLogger(%q) unexpectedly enables level %v (below minimum %v)", tt.cfg.Level, lowerLevel, tt.wantLevel)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildLogger_Format(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config.LogConfig
+		wantNil bool
+	}{
+		{
+			name:    "json format returns a logger",
+			cfg:     config.LogConfig{Level: "info", Format: "json"},
+			wantNil: false,
+		},
+		{
+			name:    "text format returns a logger",
+			cfg:     config.LogConfig{Level: "info", Format: "text"},
+			wantNil: false,
+		},
+		{
+			name:    "unknown format falls back to json and returns a logger",
+			cfg:     config.LogConfig{Level: "info", Format: "unknown"},
+			wantNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := buildLogger(tt.cfg)
+			if (logger == nil) != tt.wantNil {
+				t.Errorf("buildLogger() = %v, wantNil %v", logger, tt.wantNil)
+			}
+		})
+	}
+}

--- a/internal/app/serve/serve.go
+++ b/internal/app/serve/serve.go
@@ -1,0 +1,135 @@
+package serve
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	caddyadapter "github.com/vibewarden/vibewarden/internal/adapters/caddy"
+	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
+	"github.com/vibewarden/vibewarden/internal/app/proxy"
+	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/plugins"
+)
+
+// Options configures the RunServe function behavior.
+type Options struct {
+	// ConfigPath is the path to vibewarden.yaml. An empty string causes the
+	// default search paths to be used (current directory and /etc/vibewarden).
+	ConfigPath string
+
+	// Version is the binary version string, typically set via -ldflags at build
+	// time. It is embedded in the ProxyConfig for observability.
+	Version string
+}
+
+// RunServe loads config, builds the plugin registry, wires Caddy via plugin
+// contributors, and runs until a shutdown signal is received or the context is
+// cancelled.
+//
+// Additional plugins can be contributed by passing PluginRegistrar functions via
+// extraPlugins. They are called after plugins.RegisterBuiltinPlugins, allowing
+// Pro or custom binaries to extend the registry without forking the OSS code.
+//
+// Signal handling: RunServe installs SIGINT/SIGTERM handlers that cancel the
+// context and trigger graceful shutdown.
+func RunServe(ctx context.Context, opts Options, extraPlugins ...plugins.PluginRegistrar) error {
+	cfg, err := config.Load(opts.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	logger := buildLogger(cfg.Log)
+
+	// Migrate legacy metrics: config to telemetry: if needed.
+	config.MigrateLegacyMetrics(cfg, logger)
+
+	logger.Info("VibeWarden starting",
+		slog.String("version", opts.Version),
+		slog.String("listen", fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)),
+		slog.String("upstream", fmt.Sprintf("%s:%d", cfg.Upstream.Host, cfg.Upstream.Port)),
+	)
+
+	// Build the plugin registry and register all compiled-in plugins.
+	// At registration time we use a stdout-only event logger. After InitAll,
+	// we upgrade to a multi-handler logger (stdout + OTel) when log export is
+	// enabled. The caddy adapter — the main consumer of the event logger —
+	// is created after StartAll, so it always gets the upgraded logger.
+	initialEventLogger := logadapter.NewSlogEventLogger(os.Stdout)
+
+	registry := plugins.NewRegistry(logger)
+
+	// Register built-in OSS plugins.
+	plugins.RegisterBuiltinPlugins(registry, cfg, initialEventLogger, logger)
+
+	// Register any additional plugins supplied by the caller (e.g. Pro plugins).
+	for _, reg := range extraPlugins {
+		reg(registry, cfg, initialEventLogger, logger)
+	}
+
+	// Set up OS signal handling before Init/Start so that a slow Init can
+	// still be interrupted.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	go func() {
+		select {
+		case sig := <-sigCh:
+			logger.Info("received shutdown signal", slog.String("signal", sig.String()))
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	// Initialise all plugins.
+	if err := registry.InitAll(ctx); err != nil {
+		return fmt.Errorf("initialising plugins: %w", err)
+	}
+
+	// After InitAll, retrieve the OTel log handler from the metrics plugin
+	// (if log export is enabled) and build the final event logger.
+	eventLogger := buildEventLogger(registry, logger)
+
+	// Wire the metrics collector into the TLS cert expiry monitor so that
+	// the vibewarden_tls_cert_expiry_seconds gauge is populated. This must
+	// happen after InitAll (metrics provider is ready) and before StartAll
+	// (monitor background goroutine launches on Start).
+	wireTLSMetricsCollector(registry)
+
+	// Start all plugins (background servers, etc.).
+	if err := registry.StartAll(ctx); err != nil {
+		return fmt.Errorf("starting plugins: %w", err)
+	}
+
+	// Ensure StopAll runs on return (normal or error path).
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		if stopErr := registry.StopAll(stopCtx); stopErr != nil {
+			logger.Error("stopping plugins", slog.String("error", stopErr.Error()))
+		}
+	}()
+
+	// Build ProxyConfig — base fields that the Caddy adapter uses directly.
+	// Plugin-specific wiring (security headers, rate limiting, auth, admin,
+	// metrics) is now driven by each plugin's CaddyContributor implementation.
+	proxyCfg := buildProxyConfig(cfg, registry, opts.Version)
+
+	// Create Caddy adapter and proxy service.
+	adapter := caddyadapter.NewAdapter(proxyCfg, logger, eventLogger)
+	svc := proxy.NewService(adapter, logger)
+
+	if err := svc.Run(ctx); err != nil {
+		return fmt.Errorf("proxy service: %w", err)
+	}
+
+	return nil
+}

--- a/internal/plugins/builtin.go
+++ b/internal/plugins/builtin.go
@@ -1,33 +1,32 @@
-package main
+package plugins
 
 import (
 	"log/slog"
-	"time"
 
 	jwtadapter "github.com/vibewarden/vibewarden/internal/adapters/jwt"
 	ratelimitadapter "github.com/vibewarden/vibewarden/internal/adapters/ratelimit"
 	"github.com/vibewarden/vibewarden/internal/config"
-	"github.com/vibewarden/vibewarden/internal/plugins"
 	authplugin "github.com/vibewarden/vibewarden/internal/plugins/auth"
 	bodysizeplugin "github.com/vibewarden/vibewarden/internal/plugins/bodysize"
 	corsplugin "github.com/vibewarden/vibewarden/internal/plugins/cors"
-	inputvalidationplugin "github.com/vibewarden/vibewarden/internal/plugins/inputvalidation"
 	ipfilterplugin "github.com/vibewarden/vibewarden/internal/plugins/ipfilter"
 	maintenanceplugin "github.com/vibewarden/vibewarden/internal/plugins/maintenance"
 	metricsplugin "github.com/vibewarden/vibewarden/internal/plugins/metrics"
 	ratelimitplugin "github.com/vibewarden/vibewarden/internal/plugins/ratelimit"
-	secretsplugin "github.com/vibewarden/vibewarden/internal/plugins/secrets"
 	sechdrs "github.com/vibewarden/vibewarden/internal/plugins/securityheaders"
-	tlsplugin "github.com/vibewarden/vibewarden/internal/plugins/tls"
 	usermgmtplugin "github.com/vibewarden/vibewarden/internal/plugins/usermgmt"
 	wafplugin "github.com/vibewarden/vibewarden/internal/plugins/waf"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
-// registerPlugins creates each compiled-in plugin from cfg and registers it
-// with the registry. Registration order matches plugin priority (low → high).
-func registerPlugins(
-	registry *plugins.Registry,
+// RegisterBuiltinPlugins registers all OSS compiled-in plugins with the registry
+// based on the provided configuration. Plugin registration order matches plugin
+// priority (low number → runs first in the request chain).
+//
+// This function is called automatically by internal/app/serve.RunServe and should
+// not be called directly unless composing a custom startup sequence.
+func RegisterBuiltinPlugins(
+	registry *Registry,
 	cfg *config.Config,
 	eventLogger ports.EventLogger,
 	logger *slog.Logger,
@@ -214,157 +213,4 @@ func registerPlugins(
 
 	// Egress proxy — priority 80 (independent listener; registered last)
 	registry.Register(buildEgressPlugin(cfg, eventLogger, logger))
-}
-
-// buildSecretsPlugin constructs the secrets plugin from config, parsing
-// duration strings into time.Duration values. Falls back to plugin defaults
-// on parse errors (config.Validate does not validate duration strings here
-// since they are optional and have sensible defaults).
-func buildSecretsPlugin(cfg *config.Config, eventLogger ports.EventLogger, logger *slog.Logger) *secretsplugin.Plugin {
-	secretsCfg := secretsplugin.Config{
-		Enabled:  cfg.Secrets.Enabled,
-		Provider: cfg.Secrets.Provider,
-		OpenBao: secretsplugin.OpenBaoConfig{
-			Address:   cfg.Secrets.OpenBao.Address,
-			MountPath: cfg.Secrets.OpenBao.MountPath,
-			Auth: secretsplugin.OpenBaoAuthConfig{
-				Method:   cfg.Secrets.OpenBao.Auth.Method,
-				Token:    cfg.Secrets.OpenBao.Auth.Token,
-				RoleID:   cfg.Secrets.OpenBao.Auth.RoleID,
-				SecretID: cfg.Secrets.OpenBao.Auth.SecretID,
-			},
-		},
-		Dynamic: secretsplugin.DynamicConfig{
-			Postgres: secretsplugin.DynamicPostgresConfig{
-				Enabled: cfg.Secrets.Dynamic.Postgres.Enabled,
-			},
-		},
-		Inject: secretsplugin.InjectConfig{
-			EnvFile: cfg.Secrets.Inject.EnvFile,
-		},
-		Health: secretsplugin.HealthConfig{
-			WeakPatterns: cfg.Secrets.Health.WeakPatterns,
-		},
-	}
-
-	// Parse optional duration strings.
-	if cfg.Secrets.CacheTTL != "" {
-		if d, err := time.ParseDuration(cfg.Secrets.CacheTTL); err != nil {
-			logger.Warn("secrets.cache_ttl parse error — using default", slog.String("error", err.Error()))
-		} else {
-			secretsCfg.CacheTTL = d
-		}
-	}
-	if cfg.Secrets.Health.CheckInterval != "" {
-		if d, err := time.ParseDuration(cfg.Secrets.Health.CheckInterval); err != nil {
-			logger.Warn("secrets.health.check_interval parse error — using default", slog.String("error", err.Error()))
-		} else {
-			secretsCfg.Health.CheckInterval = d
-		}
-	}
-	if cfg.Secrets.Health.MaxStaticAge != "" {
-		if d, err := time.ParseDuration(cfg.Secrets.Health.MaxStaticAge); err != nil {
-			logger.Warn("secrets.health.max_static_age parse error — using default", slog.String("error", err.Error()))
-		} else {
-			secretsCfg.Health.MaxStaticAge = d
-		}
-	}
-
-	// Map header injections.
-	for _, inj := range cfg.Secrets.Inject.Headers {
-		secretsCfg.Inject.Headers = append(secretsCfg.Inject.Headers, secretsplugin.HeaderInjection{
-			SecretPath: inj.SecretPath,
-			SecretKey:  inj.SecretKey,
-			Header:     inj.Header,
-		})
-	}
-
-	// Map env injections.
-	for _, inj := range cfg.Secrets.Inject.Env {
-		secretsCfg.Inject.Env = append(secretsCfg.Inject.Env, secretsplugin.EnvInjection{
-			SecretPath: inj.SecretPath,
-			SecretKey:  inj.SecretKey,
-			EnvVar:     inj.EnvVar,
-		})
-	}
-
-	// Map dynamic postgres roles.
-	for _, role := range cfg.Secrets.Dynamic.Postgres.Roles {
-		secretsCfg.Dynamic.Postgres.Roles = append(secretsCfg.Dynamic.Postgres.Roles, secretsplugin.DynamicRole{
-			Name:           role.Name,
-			EnvVarUser:     role.EnvVarUser,
-			EnvVarPassword: role.EnvVarPassword,
-		})
-	}
-
-	return secretsplugin.New(secretsCfg, eventLogger, logger)
-}
-
-// buildTLSPlugin constructs the TLS plugin from cfg, parsing the optional
-// cert_monitoring duration strings into time.Duration values. Falls back to
-// plugin defaults on parse errors.
-func buildTLSPlugin(cfg *config.Config, eventLogger ports.EventLogger, logger *slog.Logger) *tlsplugin.Plugin {
-	monCfg := ports.TLSCertMonitoringConfig{
-		Enabled: cfg.TLS.CertMonitoring.Enabled,
-	}
-
-	if cfg.TLS.CertMonitoring.CheckInterval != "" {
-		if d, err := time.ParseDuration(cfg.TLS.CertMonitoring.CheckInterval); err != nil {
-			logger.Warn("tls.cert_monitoring.check_interval parse error — using default",
-				slog.String("error", err.Error()))
-		} else {
-			monCfg.CheckInterval = d
-		}
-	}
-	if cfg.TLS.CertMonitoring.WarningThreshold != "" {
-		if d, err := time.ParseDuration(cfg.TLS.CertMonitoring.WarningThreshold); err != nil {
-			logger.Warn("tls.cert_monitoring.warning_threshold parse error — using default",
-				slog.String("error", err.Error()))
-		} else {
-			monCfg.WarningThreshold = d
-		}
-	}
-	if cfg.TLS.CertMonitoring.CriticalThreshold != "" {
-		if d, err := time.ParseDuration(cfg.TLS.CertMonitoring.CriticalThreshold); err != nil {
-			logger.Warn("tls.cert_monitoring.critical_threshold parse error — using default",
-				slog.String("error", err.Error()))
-		} else {
-			monCfg.CriticalThreshold = d
-		}
-	}
-
-	return tlsplugin.New(ports.TLSConfig{
-		Enabled:        cfg.TLS.Enabled,
-		Provider:       ports.TLSProvider(cfg.TLS.Provider),
-		Domain:         cfg.TLS.Domain,
-		CertPath:       cfg.TLS.CertPath,
-		KeyPath:        cfg.TLS.KeyPath,
-		StoragePath:    cfg.TLS.StoragePath,
-		CertMonitoring: monCfg,
-	}, eventLogger, logger)
-}
-
-// buildInputValidationPlugin constructs the input validation plugin from cfg.
-func buildInputValidationPlugin(cfg *config.Config, logger *slog.Logger) *inputvalidationplugin.Plugin {
-	iv := cfg.InputValidation
-
-	pluginCfg := inputvalidationplugin.Config{
-		Enabled:              iv.Enabled,
-		MaxURLLength:         iv.MaxURLLength,
-		MaxQueryStringLength: iv.MaxQueryStringLength,
-		MaxHeaderCount:       iv.MaxHeaderCount,
-		MaxHeaderSize:        iv.MaxHeaderSize,
-	}
-
-	for _, ov := range iv.PathOverrides {
-		pluginCfg.PathOverrides = append(pluginCfg.PathOverrides, inputvalidationplugin.PathOverrideConfig{
-			Path:                 ov.Path,
-			MaxURLLength:         ov.MaxURLLength,
-			MaxQueryStringLength: ov.MaxQueryStringLength,
-			MaxHeaderCount:       ov.MaxHeaderCount,
-			MaxHeaderSize:        ov.MaxHeaderSize,
-		})
-	}
-
-	return inputvalidationplugin.New(pluginCfg, logger)
 }

--- a/internal/plugins/builtin_helpers.go
+++ b/internal/plugins/builtin_helpers.go
@@ -1,0 +1,289 @@
+package plugins
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/domain/csp"
+	egressplugin "github.com/vibewarden/vibewarden/internal/plugins/egress"
+	inputvalidationplugin "github.com/vibewarden/vibewarden/internal/plugins/inputvalidation"
+	secretsplugin "github.com/vibewarden/vibewarden/internal/plugins/secrets"
+	tlsplugin "github.com/vibewarden/vibewarden/internal/plugins/tls"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// buildSecretsPlugin constructs the secrets plugin from config, parsing
+// duration strings into time.Duration values. Falls back to plugin defaults
+// on parse errors (config.Validate does not validate duration strings here
+// since they are optional and have sensible defaults).
+func buildSecretsPlugin(cfg *config.Config, eventLogger ports.EventLogger, logger *slog.Logger) *secretsplugin.Plugin {
+	secretsCfg := secretsplugin.Config{
+		Enabled:  cfg.Secrets.Enabled,
+		Provider: cfg.Secrets.Provider,
+		OpenBao: secretsplugin.OpenBaoConfig{
+			Address:   cfg.Secrets.OpenBao.Address,
+			MountPath: cfg.Secrets.OpenBao.MountPath,
+			Auth: secretsplugin.OpenBaoAuthConfig{
+				Method:   cfg.Secrets.OpenBao.Auth.Method,
+				Token:    cfg.Secrets.OpenBao.Auth.Token,
+				RoleID:   cfg.Secrets.OpenBao.Auth.RoleID,
+				SecretID: cfg.Secrets.OpenBao.Auth.SecretID,
+			},
+		},
+		Dynamic: secretsplugin.DynamicConfig{
+			Postgres: secretsplugin.DynamicPostgresConfig{
+				Enabled: cfg.Secrets.Dynamic.Postgres.Enabled,
+			},
+		},
+		Inject: secretsplugin.InjectConfig{
+			EnvFile: cfg.Secrets.Inject.EnvFile,
+		},
+		Health: secretsplugin.HealthConfig{
+			WeakPatterns: cfg.Secrets.Health.WeakPatterns,
+		},
+	}
+
+	// Parse optional duration strings.
+	if cfg.Secrets.CacheTTL != "" {
+		if d, err := time.ParseDuration(cfg.Secrets.CacheTTL); err != nil {
+			logger.Warn("secrets.cache_ttl parse error — using default", slog.String("error", err.Error()))
+		} else {
+			secretsCfg.CacheTTL = d
+		}
+	}
+	if cfg.Secrets.Health.CheckInterval != "" {
+		if d, err := time.ParseDuration(cfg.Secrets.Health.CheckInterval); err != nil {
+			logger.Warn("secrets.health.check_interval parse error — using default", slog.String("error", err.Error()))
+		} else {
+			secretsCfg.Health.CheckInterval = d
+		}
+	}
+	if cfg.Secrets.Health.MaxStaticAge != "" {
+		if d, err := time.ParseDuration(cfg.Secrets.Health.MaxStaticAge); err != nil {
+			logger.Warn("secrets.health.max_static_age parse error — using default", slog.String("error", err.Error()))
+		} else {
+			secretsCfg.Health.MaxStaticAge = d
+		}
+	}
+
+	// Map header injections.
+	for _, inj := range cfg.Secrets.Inject.Headers {
+		secretsCfg.Inject.Headers = append(secretsCfg.Inject.Headers, secretsplugin.HeaderInjection{
+			SecretPath: inj.SecretPath,
+			SecretKey:  inj.SecretKey,
+			Header:     inj.Header,
+		})
+	}
+
+	// Map env injections.
+	for _, inj := range cfg.Secrets.Inject.Env {
+		secretsCfg.Inject.Env = append(secretsCfg.Inject.Env, secretsplugin.EnvInjection{
+			SecretPath: inj.SecretPath,
+			SecretKey:  inj.SecretKey,
+			EnvVar:     inj.EnvVar,
+		})
+	}
+
+	// Map dynamic postgres roles.
+	for _, role := range cfg.Secrets.Dynamic.Postgres.Roles {
+		secretsCfg.Dynamic.Postgres.Roles = append(secretsCfg.Dynamic.Postgres.Roles, secretsplugin.DynamicRole{
+			Name:           role.Name,
+			EnvVarUser:     role.EnvVarUser,
+			EnvVarPassword: role.EnvVarPassword,
+		})
+	}
+
+	return secretsplugin.New(secretsCfg, eventLogger, logger)
+}
+
+// buildTLSPlugin constructs the TLS plugin from cfg, parsing the optional
+// cert_monitoring duration strings into time.Duration values. Falls back to
+// plugin defaults on parse errors.
+func buildTLSPlugin(cfg *config.Config, eventLogger ports.EventLogger, logger *slog.Logger) *tlsplugin.Plugin {
+	monCfg := ports.TLSCertMonitoringConfig{
+		Enabled: cfg.TLS.CertMonitoring.Enabled,
+	}
+
+	if cfg.TLS.CertMonitoring.CheckInterval != "" {
+		if d, err := time.ParseDuration(cfg.TLS.CertMonitoring.CheckInterval); err != nil {
+			logger.Warn("tls.cert_monitoring.check_interval parse error — using default",
+				slog.String("error", err.Error()))
+		} else {
+			monCfg.CheckInterval = d
+		}
+	}
+	if cfg.TLS.CertMonitoring.WarningThreshold != "" {
+		if d, err := time.ParseDuration(cfg.TLS.CertMonitoring.WarningThreshold); err != nil {
+			logger.Warn("tls.cert_monitoring.warning_threshold parse error — using default",
+				slog.String("error", err.Error()))
+		} else {
+			monCfg.WarningThreshold = d
+		}
+	}
+	if cfg.TLS.CertMonitoring.CriticalThreshold != "" {
+		if d, err := time.ParseDuration(cfg.TLS.CertMonitoring.CriticalThreshold); err != nil {
+			logger.Warn("tls.cert_monitoring.critical_threshold parse error — using default",
+				slog.String("error", err.Error()))
+		} else {
+			monCfg.CriticalThreshold = d
+		}
+	}
+
+	return tlsplugin.New(ports.TLSConfig{
+		Enabled:        cfg.TLS.Enabled,
+		Provider:       ports.TLSProvider(cfg.TLS.Provider),
+		Domain:         cfg.TLS.Domain,
+		CertPath:       cfg.TLS.CertPath,
+		KeyPath:        cfg.TLS.KeyPath,
+		StoragePath:    cfg.TLS.StoragePath,
+		CertMonitoring: monCfg,
+	}, eventLogger, logger)
+}
+
+// buildInputValidationPlugin constructs the input validation plugin from cfg.
+func buildInputValidationPlugin(cfg *config.Config, logger *slog.Logger) *inputvalidationplugin.Plugin {
+	iv := cfg.InputValidation
+
+	pluginCfg := inputvalidationplugin.Config{
+		Enabled:              iv.Enabled,
+		MaxURLLength:         iv.MaxURLLength,
+		MaxQueryStringLength: iv.MaxQueryStringLength,
+		MaxHeaderCount:       iv.MaxHeaderCount,
+		MaxHeaderSize:        iv.MaxHeaderSize,
+	}
+
+	for _, ov := range iv.PathOverrides {
+		pluginCfg.PathOverrides = append(pluginCfg.PathOverrides, inputvalidationplugin.PathOverrideConfig{
+			Path:                 ov.Path,
+			MaxURLLength:         ov.MaxURLLength,
+			MaxQueryStringLength: ov.MaxQueryStringLength,
+			MaxHeaderCount:       ov.MaxHeaderCount,
+			MaxHeaderSize:        ov.MaxHeaderSize,
+		})
+	}
+
+	return inputvalidationplugin.New(pluginCfg, logger)
+}
+
+// buildEgressPlugin constructs the egress proxy plugin from config, parsing
+// duration strings into time.Duration values. Falls back to plugin defaults
+// on parse errors (config.Validate does not validate egress duration strings
+// since they are optional and have sensible defaults).
+func buildEgressPlugin(cfg *config.Config, eventLogger ports.EventLogger, logger *slog.Logger) *egressplugin.Plugin {
+	ec := cfg.Egress
+
+	defaultTimeout, err := time.ParseDuration(ec.DefaultTimeout)
+	if err != nil && ec.DefaultTimeout != "" {
+		logger.Warn("egress.default_timeout parse error — using default 30s",
+			slog.String("error", err.Error()),
+			slog.String("value", ec.DefaultTimeout),
+		)
+	}
+
+	defaultBodySizeBytes, err := config.ParseBodySize(ec.DefaultBodySizeLimit)
+	if err != nil && ec.DefaultBodySizeLimit != "" {
+		logger.Warn("egress.default_body_size_limit parse error — disabling global body size limit",
+			slog.String("error", err.Error()),
+		)
+		defaultBodySizeBytes = 0
+	}
+
+	defaultResponseSizeBytes, err := config.ParseBodySize(ec.DefaultResponseSizeLimit)
+	if err != nil && ec.DefaultResponseSizeLimit != "" {
+		logger.Warn("egress.default_response_size_limit parse error — disabling global response size limit",
+			slog.String("error", err.Error()),
+		)
+		defaultResponseSizeBytes = 0
+	}
+
+	pluginCfg := egressplugin.Config{
+		Enabled:                  ec.Enabled,
+		Listen:                   ec.Listen,
+		DefaultPolicy:            ec.DefaultPolicy,
+		AllowInsecure:            ec.AllowInsecure,
+		DefaultTimeout:           defaultTimeout,
+		DefaultBodySizeLimit:     defaultBodySizeBytes,
+		DefaultResponseSizeLimit: defaultResponseSizeBytes,
+		BlockPrivate:             ec.DNS.BlockPrivate,
+		AllowedPrivate:           ec.DNS.AllowedPrivate,
+	}
+
+	// Map route configs.
+	for _, rc := range ec.Routes {
+		routeTimeout, routeErr := time.ParseDuration(rc.Timeout)
+		if routeErr != nil && rc.Timeout != "" {
+			logger.Warn("egress route timeout parse error — using global default",
+				slog.String("route", rc.Name),
+				slog.String("error", routeErr.Error()),
+			)
+		}
+
+		cbResetAfter, cbErr := time.ParseDuration(rc.CircuitBreaker.ResetAfter)
+		if cbErr != nil && rc.CircuitBreaker.ResetAfter != "" {
+			logger.Warn("egress route circuit_breaker.reset_after parse error — disabling circuit breaker for route",
+				slog.String("route", rc.Name),
+				slog.String("error", cbErr.Error()),
+			)
+		}
+
+		bodySizeBytes, _ := config.ParseBodySize(rc.BodySizeLimit)
+		responseSizeBytes, _ := config.ParseBodySize(rc.ResponseSizeLimit)
+
+		pluginCfg.Routes = append(pluginCfg.Routes, egressplugin.RouteConfig{
+			Name:              rc.Name,
+			Pattern:           rc.Pattern,
+			Methods:           rc.Methods,
+			Timeout:           routeTimeout,
+			Secret:            rc.Secret,
+			SecretHeader:      rc.SecretHeader,
+			SecretFormat:      rc.SecretFormat,
+			RateLimit:         rc.RateLimit,
+			BodySizeLimit:     bodySizeBytes,
+			ResponseSizeLimit: responseSizeBytes,
+			AllowInsecure:     rc.AllowInsecure,
+			CircuitBreaker: egressplugin.CircuitBreakerConfig{
+				Threshold:  rc.CircuitBreaker.Threshold,
+				ResetAfter: cbResetAfter,
+			},
+			Retries: egressplugin.RetryConfig{
+				Max:     rc.Retries.Max,
+				Methods: rc.Retries.Methods,
+				Backoff: rc.Retries.Backoff,
+			},
+			ValidateResponse: egressplugin.ResponseValidationConfig{
+				StatusCodes:  rc.ValidateResponse.StatusCodes,
+				ContentTypes: rc.ValidateResponse.ContentTypes,
+			},
+		})
+	}
+
+	return egressplugin.New(pluginCfg, eventLogger, logger)
+}
+
+// resolveCSP returns the Content-Security-Policy header value to use.
+// The raw content_security_policy string takes precedence for backward
+// compatibility. When it is empty, the structured csp block is passed to
+// csp.Build and the generated string is returned instead.
+func resolveCSP(cfg *config.Config) string {
+	if cfg.SecurityHeaders.ContentSecurityPolicy != "" {
+		return cfg.SecurityHeaders.ContentSecurityPolicy
+	}
+	return csp.Build(csp.Config{
+		DefaultSrc:     cfg.SecurityHeaders.CSP.DefaultSrc,
+		ScriptSrc:      cfg.SecurityHeaders.CSP.ScriptSrc,
+		StyleSrc:       cfg.SecurityHeaders.CSP.StyleSrc,
+		ImgSrc:         cfg.SecurityHeaders.CSP.ImgSrc,
+		ConnectSrc:     cfg.SecurityHeaders.CSP.ConnectSrc,
+		FontSrc:        cfg.SecurityHeaders.CSP.FontSrc,
+		FrameSrc:       cfg.SecurityHeaders.CSP.FrameSrc,
+		MediaSrc:       cfg.SecurityHeaders.CSP.MediaSrc,
+		ObjectSrc:      cfg.SecurityHeaders.CSP.ObjectSrc,
+		ManifestSrc:    cfg.SecurityHeaders.CSP.ManifestSrc,
+		WorkerSrc:      cfg.SecurityHeaders.CSP.WorkerSrc,
+		ChildSrc:       cfg.SecurityHeaders.CSP.ChildSrc,
+		FormAction:     cfg.SecurityHeaders.CSP.FormAction,
+		FrameAncestors: cfg.SecurityHeaders.CSP.FrameAncestors,
+		BaseURI:        cfg.SecurityHeaders.CSP.BaseURI,
+	})
+}

--- a/internal/plugins/registrar.go
+++ b/internal/plugins/registrar.go
@@ -1,0 +1,24 @@
+// Package plugins provides the plugin registry and lifecycle management for
+// VibeWarden. It initialises, starts, stops, and health-checks all registered
+// plugins in the correct order.
+package plugins
+
+import (
+	"log/slog"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// PluginRegistrar is a function that registers plugins with a Registry.
+// It is called during serve startup to allow external packages to contribute
+// additional plugins alongside the built-in OSS catalog.
+//
+// The Pro binary uses this to register proprietary plugins without forking the
+// OSS codebase. See internal/app/serve.RunServe for how registrars are invoked.
+type PluginRegistrar func(
+	registry *Registry,
+	cfg *config.Config,
+	eventLogger ports.EventLogger,
+	logger *slog.Logger,
+)


### PR DESCRIPTION
Closes #575

## Summary

- Introduces `plugins.PluginRegistrar` function type in `internal/plugins/registrar.go` — the extension hook the Pro binary uses to add plugins without forking
- Moves all compiled-in plugin registrations from `cmd/vibewarden/serve_plugins.go` to `internal/plugins/builtin.go` as the exported `RegisterBuiltinPlugins` function
- Moves plugin builder helpers (`buildTLSPlugin`, `buildSecretsPlugin`, `buildEgressPlugin`, `buildInputValidationPlugin`, `resolveCSP`) from `cmd/vibewarden/serve_config.go` to `internal/plugins/builtin_helpers.go` (package-private)
- Creates `internal/app/serve/` package with three files:
  - `serve.go` — exports `RunServe(ctx, Options, ...PluginRegistrar)` — the new importable serve orchestration entry point
  - `logger.go` — `buildLogger` and `buildEventLogger` helpers (moved from `cmd/vibewarden/serve.go`)
  - `config.go` — ProxyConfig construction helpers moved from `cmd/vibewarden/serve_config.go`
- Thins `cmd/vibewarden/serve.go` to a ~30-line cobra command that calls `appserve.RunServe`
- Deletes `cmd/vibewarden/serve_plugins.go` and `cmd/vibewarden/serve_config.go`
- Migrates tests into the new packages

Pure refactor — no behavior change.

## Test plan

- [x] `make check` passes (formatting, golangci-lint, build, race tests, demo-app)
- [x] All existing tests pass with no modifications to assertions
- [x] `go vet ./...` clean
