### PR TITLE
feat(#578): deploy mkdocs to vibewarden.dev repo

### DIFF
--- a/.github/workflows/docs.yml.disabled
+++ b/.github/workflows/docs.yml.disabled
@@ -1,4 +1,4 @@
-name: Deploy docs
+name: Deploy docs to vibewarden.dev
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   deploy:
@@ -34,10 +34,16 @@ jobs:
             mkdocs-minify-plugin \
             pymdown-extensions
 
-      - name: Configure git for gh-pages push
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Build docs
+        run: mkdocs build --strict --site-dir _site/docs
 
-      - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+      - name: Deploy to vibewarden.dev repo
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          deploy_key: ${{ secrets.DOCS_DEPLOY_KEY }}
+          external_repository: vibewarden/vibewarden.dev
+          publish_branch: main
+          publish_dir: ./_site/docs
+          destination_dir: docs
+          keep_files: true
+          commit_message: "docs: sync from vibewarden/vibewarden@${{ github.sha }}"


### PR DESCRIPTION
## Summary
- Redirects mkdocs deployment from gh-pages branch to the `vibewarden/vibewarden.dev` repo's `docs/` directory
- Uses `peaceiris/actions-gh-pages` with a deploy key for cross-repo push
- `keep_files: true` preserves the landing page and other static content in vibewarden.dev
- Narrows permissions from `contents: write` to `contents: read` (deploy key handles writes)
- Adds `--strict` flag to mkdocs build to catch broken links

## Setup required before merging
1. Generate SSH deploy key pair: `ssh-keygen -t ed25519 -C "docs-deploy" -f docs-deploy-key -N ""`
2. Add **private key** as repo secret `DOCS_DEPLOY_KEY` in vibewarden/vibewarden
3. Add **public key** as deploy key (with write access) in vibewarden/vibewarden.dev

## Test plan
- [ ] Generate and configure deploy keys (manual)
- [ ] Trigger workflow manually via `workflow_dispatch` after merge
- [ ] Verify docs appear at vibewarden.dev/docs/ (after Pages is enabled)
- [ ] Verify landing page and other files in vibewarden.dev are preserved

Closes #578
See also: vibewarden/vibewarden.dev#7
