### PR TITLE
feat(#584): add network-level egress isolation in generated Docker Compose

### DIFF
--- a/internal/app/generate/service.go
+++ b/internal/app/generate/service.go
@@ -83,6 +83,12 @@ func (s *Service) Generate(ctx context.Context, cfg *config.Config, outputDir st
 		slog.Warn(w)
 	}
 
+	// Warn when network isolation is enabled but the app is not containerized.
+	// A host-mode app bypasses Docker network isolation entirely.
+	if cfg.Egress.IsNetworkIsolationEnabled() && cfg.App.Build == "" && cfg.App.Image == "" {
+		slog.Warn("Network isolation is enabled but app.build and app.image are both empty: host-mode app bypasses Docker network isolation")
+	}
+
 	// kratosMode is true only when auth is enabled and mode is "kratos" and
 	// the Kratos instance is not managed externally.
 	// An empty mode string is also treated as Kratos for defensive backwards

--- a/internal/app/generate/service_test.go
+++ b/internal/app/generate/service_test.go
@@ -1882,3 +1882,114 @@ func TestGenerate_Compose_ExternalKratosSkipsKratosFiles(t *testing.T) {
 		t.Errorf("docker-compose.yml should exist: %v", err)
 	}
 }
+
+// TestGenerate_EgressIsolationOn verifies that when egress is enabled with
+// network isolation on (the default), the generated docker-compose.yml uses
+// the dual-network topology: vibewarden-internal (internal: true) and
+// vibewarden-external, with the app on the internal network only and
+// vibewarden bridging both.
+func TestGenerate_EgressIsolationOn(t *testing.T) {
+	cfg := &config.Config{
+		Server:   config.ServerConfig{Host: "127.0.0.1", Port: 8080},
+		Upstream: config.UpstreamConfig{Host: "127.0.0.1", Port: 3000},
+		App:      config.AppConfig{Build: "."},
+		Egress: config.EgressConfig{
+			Enabled: true,
+			Listen:  "127.0.0.1:8081",
+		},
+	}
+
+	compose := renderCompose(t, cfg)
+
+	mustContain := []string{
+		"vibewarden-internal:",
+		"internal: true",
+		"vibewarden-external:",
+		"HTTP_PROXY=http://vibewarden:8081",
+		"HTTPS_PROXY=http://vibewarden:8081",
+		"NO_PROXY=localhost,127.0.0.1,vibewarden",
+		"VIBEWARDEN_EGRESS_LISTEN=0.0.0.0:8081",
+	}
+	for _, want := range mustContain {
+		if !bytes.Contains(compose, []byte(want)) {
+			t.Errorf("isolation-on compose missing %q", want)
+		}
+	}
+
+	// The single "vibewarden:" network definition should NOT appear as a
+	// top-level network (it will appear as a service name, so check the
+	// networks: section specifically).
+	if bytes.Contains(compose, []byte("\n  vibewarden:\n    driver: bridge\n")) {
+		t.Error("isolation-on compose should not have single 'vibewarden' network")
+	}
+}
+
+// TestGenerate_EgressIsolationOff verifies that when egress is enabled but
+// network isolation is explicitly disabled, the generated docker-compose.yml
+// uses a single bridge network and still injects proxy environment variables
+// and VIBEWARDEN_EGRESS_LISTEN.
+func TestGenerate_EgressIsolationOff(t *testing.T) {
+	isolationOff := false
+	cfg := &config.Config{
+		Server:   config.ServerConfig{Host: "127.0.0.1", Port: 8080},
+		Upstream: config.UpstreamConfig{Host: "127.0.0.1", Port: 3000},
+		App:      config.AppConfig{Build: "."},
+		Egress: config.EgressConfig{
+			Enabled:          true,
+			Listen:           "127.0.0.1:8081",
+			NetworkIsolation: &isolationOff,
+		},
+	}
+
+	compose := renderCompose(t, cfg)
+
+	mustContain := []string{
+		"HTTP_PROXY=http://vibewarden:8081",
+		"HTTPS_PROXY=http://vibewarden:8081",
+		"NO_PROXY=localhost,127.0.0.1,vibewarden",
+		"VIBEWARDEN_EGRESS_LISTEN=0.0.0.0:8081",
+	}
+	for _, want := range mustContain {
+		if !bytes.Contains(compose, []byte(want)) {
+			t.Errorf("isolation-off compose missing %q", want)
+		}
+	}
+
+	// Single network topology: "vibewarden" network, no "vibewarden-internal"
+	// or "vibewarden-external".
+	mustNotContain := []string{
+		"vibewarden-internal:",
+		"vibewarden-external:",
+		"internal: true",
+	}
+	for _, absent := range mustNotContain {
+		if bytes.Contains(compose, []byte(absent)) {
+			t.Errorf("isolation-off compose should not contain %q", absent)
+		}
+	}
+}
+
+// TestGenerate_EgressDisabledNoProxyVars verifies that when egress is disabled,
+// no proxy environment variables or VIBEWARDEN_EGRESS_LISTEN are injected.
+func TestGenerate_EgressDisabledNoProxyVars(t *testing.T) {
+	cfg := &config.Config{
+		Server:   config.ServerConfig{Host: "127.0.0.1", Port: 8080},
+		Upstream: config.UpstreamConfig{Host: "127.0.0.1", Port: 3000},
+		App:      config.AppConfig{Build: "."},
+		Egress:   config.EgressConfig{Enabled: false},
+	}
+
+	compose := renderCompose(t, cfg)
+
+	mustNotContain := []string{
+		"HTTP_PROXY=",
+		"HTTPS_PROXY=",
+		"NO_PROXY=",
+		"VIBEWARDEN_EGRESS_LISTEN=",
+	}
+	for _, absent := range mustNotContain {
+		if bytes.Contains(compose, []byte(absent)) {
+			t.Errorf("egress-disabled compose should not contain %q", absent)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,7 +135,7 @@ func (c *Config) InternalNetworkName() string {
 // localhost and the vibewarden service name. Additional services are appended
 // based on configuration flags (e.g., kratos, openbao, redis).
 func (c *Config) EgressNoProxy() string {
-	parts := []string{"localhost", "vibewarden"}
+	parts := []string{"localhost", "127.0.0.1", "vibewarden"}
 
 	kratosMode := c.Auth.Enabled && c.Auth.Mode == AuthModeKratos && !c.Kratos.External
 	if kratosMode {

--- a/internal/config/egress.go
+++ b/internal/config/egress.go
@@ -1,6 +1,6 @@
 package config
 
-import "strings"
+import "net"
 
 // EgressConfig holds configuration for the egress proxy plugin.
 // When enabled, the egress proxy listens on a separate port and forwards
@@ -191,8 +191,8 @@ func (e EgressConfig) ListenPort() string {
 	if e.Listen == "" {
 		return "8081"
 	}
-	_, port, found := strings.Cut(e.Listen, ":")
-	if !found || port == "" {
+	_, port, err := net.SplitHostPort(e.Listen)
+	if err != nil || port == "" {
 		return "8081"
 	}
 	return port

--- a/internal/config/egress_test.go
+++ b/internal/config/egress_test.go
@@ -614,6 +614,8 @@ func TestListenPort(t *testing.T) {
 		{"empty defaults to 8081", "", "8081"},
 		{"no colon defaults to 8081", "localhost", "8081"},
 		{"colon but no port defaults to 8081", "localhost:", "8081"},
+		{"IPv6 loopback with port", "[::1]:9090", "9090"},
+		{"IPv6 all interfaces with port", "[::]:8081", "8081"},
 	}
 
 	for _, tt := range tests {
@@ -735,16 +737,16 @@ func TestEgressNoProxy(t *testing.T) {
 		want string
 	}{
 		{
-			name: "minimal — only localhost and vibewarden",
+			name: "minimal — localhost, 127.0.0.1, and vibewarden",
 			cfg:  config.Config{},
-			want: "localhost,vibewarden",
+			want: "localhost,127.0.0.1,vibewarden",
 		},
 		{
 			name: "with kratos (local db)",
 			cfg: config.Config{
 				Auth: config.AuthConfig{Enabled: true, Mode: config.AuthModeKratos},
 			},
-			want: "localhost,vibewarden,kratos,kratos-db",
+			want: "localhost,127.0.0.1,vibewarden,kratos,kratos-db",
 		},
 		{
 			name: "with kratos (external db)",
@@ -752,28 +754,28 @@ func TestEgressNoProxy(t *testing.T) {
 				Auth:     config.AuthConfig{Enabled: true, Mode: config.AuthModeKratos},
 				Database: config.DatabaseConfig{ExternalURL: "postgres://ext:5432/kratos"},
 			},
-			want: "localhost,vibewarden,kratos",
+			want: "localhost,127.0.0.1,vibewarden,kratos",
 		},
 		{
 			name: "with secrets",
 			cfg: config.Config{
 				Secrets: config.SecretsConfig{Enabled: true},
 			},
-			want: "localhost,vibewarden,openbao",
+			want: "localhost,127.0.0.1,vibewarden,openbao",
 		},
 		{
 			name: "with redis rate limiting",
 			cfg: config.Config{
 				RateLimit: config.RateLimitConfig{Store: "redis"},
 			},
-			want: "localhost,vibewarden,redis",
+			want: "localhost,127.0.0.1,vibewarden,redis",
 		},
 		{
 			name: "with observability",
 			cfg: config.Config{
 				Observability: config.ObservabilityConfig{Enabled: true},
 			},
-			want: "localhost,vibewarden,prometheus,loki,promtail,otel-collector,jaeger,grafana",
+			want: "localhost,127.0.0.1,vibewarden,prometheus,loki,promtail,otel-collector,jaeger,grafana",
 		},
 		{
 			name: "all services enabled",
@@ -783,7 +785,7 @@ func TestEgressNoProxy(t *testing.T) {
 				RateLimit:     config.RateLimitConfig{Store: "redis"},
 				Observability: config.ObservabilityConfig{Enabled: true},
 			},
-			want: "localhost,vibewarden,kratos,kratos-db,openbao,redis,prometheus,loki,promtail,otel-collector,jaeger,grafana",
+			want: "localhost,127.0.0.1,vibewarden,kratos,kratos-db,openbao,redis,prometheus,loki,promtail,otel-collector,jaeger,grafana",
 		},
 	}
 

--- a/internal/config/templates/docker-compose.yml.tmpl
+++ b/internal/config/templates/docker-compose.yml.tmpl
@@ -98,7 +98,7 @@ services:
       - VIBEWARDEN_TELEMETRY_OTLP_ENDPOINT=http://otel-collector:4318
       - VIBEWARDEN_TELEMETRY_LOGS_OTLP=true
 {{- end }}
-{{- if .Egress.IsNetworkIsolationEnabled }}
+{{- if .Egress.Enabled }}
       - VIBEWARDEN_EGRESS_LISTEN=0.0.0.0:{{ .Egress.ListenPort }}
 {{- end }}
 {{- if not (or .App.Build .App.Image) }}


### PR DESCRIPTION
Closes #584

## Summary

- Added `NetworkIsolation *bool` field to `EgressConfig` with nil-defaults-to-true semantics when egress is enabled
- Added helper methods: `IsNetworkIsolationEnabled()`, `ListenPort()`, `EgressWarnings()` on `EgressConfig`; `InternalNetworkName()`, `EgressNoProxy()` on `Config`
- Updated `docker-compose.yml.tmpl` to generate a dual-network topology (`vibewarden-internal` with `internal: true` + `vibewarden-external`) when isolation is on
- All infrastructure/observability services placed on internal network only; VibeWarden bridges both networks
- App service gets `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` env vars when egress is enabled
- VibeWarden service gets `VIBEWARDEN_EGRESS_LISTEN=0.0.0.0:<port>` when isolation is on (binds all interfaces inside container)
- Generation service logs warnings via `slog.Warn` when isolation is disabled or has no effect
- When `network_isolation: false`, generates backward-compatible single-network layout

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 50+ existing test files)
- [x] `go vet ./...` passes
- [x] Table-driven tests for `IsNetworkIsolationEnabled` (6 cases: nil/true/false x enabled/disabled)
- [x] Table-driven tests for `ListenPort` (5 cases including edge cases)
- [x] Table-driven tests for `EgressWarnings` (5 cases covering all warning/no-warning paths)
- [x] Table-driven tests for `InternalNetworkName` (3 cases)
- [x] Table-driven tests for `EgressNoProxy` (7 cases covering all service combinations)
