### PR TITLE
fix(#496): align wrapper scripts with GoReleaser archive naming

### DIFF
--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -1,0 +1,45 @@
+name: Release dry-run
+
+on:
+  pull_request:
+    paths:
+      - ".goreleaser.yml"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/release-dryrun.yml"
+      - "scripts/wrapper/vibew"
+      - "scripts/wrapper/vibew.ps1"
+      - "Dockerfile.goreleaser"
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    name: GoReleaser snapshot
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Validate GoReleaser config
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: check
+
+      - name: Run GoReleaser snapshot
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --skip=publish --clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -156,7 +156,7 @@ release:
     docker pull ghcr.io/vibewarden/vibewarden:{{ .Version }}
 
     # Binary install
-    curl -fsSL https://vibewarden.dev/install.sh | sh
+    curl -fsSL https://vibewarden.dev/vibew -o vibew && chmod +x vibew
     ```
   footer: |
     **Full Changelog**: https://github.com/vibewarden/vibewarden/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/scripts/wrapper/vibew
+++ b/scripts/wrapper/vibew
@@ -60,6 +60,12 @@ detect_platform() {
         ;;
     esac
 }
+check_dependencies() {
+    if ! command -v tar >/dev/null 2>&1; then
+        echo "error: tar is required to extract the archive" >&2
+        exit 1
+    fi
+}
 download() {
     url="$1"
     dest="$2"
@@ -105,21 +111,24 @@ verify_checksum() {
     fi
 }
 detect_platform
+check_dependencies
 VERSION=$(resolve_version)
-BINARY_NAME="vibewarden-${VERSION}-${OS}-${ARCH}"
-CACHED_BIN="${CACHE_DIR}/${BINARY_NAME}"
+CLEAN_VERSION="${VERSION#v}"
+ARCHIVE_NAME="vibewarden_${CLEAN_VERSION}_${OS}_${ARCH}.tar.gz"
+CACHED_BIN="${CACHE_DIR}/vibewarden-${VERSION}"
 if [ ! -x "${CACHED_BIN}" ]; then
     BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
-    CHECKSUMS_URL="${BASE_URL}/vibewarden-${VERSION}-checksums.txt"
-    BINARY_URL="${BASE_URL}/${BINARY_NAME}"
+    CHECKSUMS_URL="${BASE_URL}/checksums.txt"
+    ARCHIVE_URL="${BASE_URL}/${ARCHIVE_NAME}"
     TMP_DIR=$(mktemp -d)
     trap 'rm -rf "${TMP_DIR}"' EXIT
     echo "Downloading VibeWarden ${VERSION} (${OS}/${ARCH})..." >&2
-    download "${BINARY_URL}" "${TMP_DIR}/${BINARY_NAME}"
+    download "${ARCHIVE_URL}" "${TMP_DIR}/${ARCHIVE_NAME}"
     download "${CHECKSUMS_URL}" "${TMP_DIR}/checksums.txt"
-    verify_checksum "${TMP_DIR}/${BINARY_NAME}" "${TMP_DIR}/checksums.txt"
+    verify_checksum "${TMP_DIR}/${ARCHIVE_NAME}" "${TMP_DIR}/checksums.txt"
+    tar -xzf "${TMP_DIR}/${ARCHIVE_NAME}" -C "${TMP_DIR}" vibewarden
     mkdir -p "${CACHE_DIR}"
-    mv "${TMP_DIR}/${BINARY_NAME}" "${CACHED_BIN}"
+    mv "${TMP_DIR}/vibewarden" "${CACHED_BIN}"
     chmod +x "${CACHED_BIN}"
 fi
 exec "${CACHED_BIN}" "$@"

--- a/scripts/wrapper/vibew.ps1
+++ b/scripts/wrapper/vibew.ps1
@@ -1,15 +1,16 @@
 # vibew.ps1 — zero-install wrapper for the VibeWarden CLI (Windows PowerShell)
 #
-# Usage: irm https://get.vibewarden.dev/vibew.ps1 | iex
+# Usage: irm https://vibewarden.dev/vibew.ps1 | iex
 #   Or: copy this file into your project and commit it.
 #
 # The script:
 #   1. Reads the required version from .vibewarden-version (or queries the
 #      GitHub API for the latest release).
-#   2. Downloads vibewarden-<version>-windows-amd64.exe from GitHub Releases.
+#   2. Downloads vibewarden_<version>_windows_amd64.zip from GitHub Releases.
 #   3. Downloads the checksum file and verifies the SHA256 hash.
-#   4. Caches the binary at %USERPROFILE%\.vibewarden\bin\vibewarden-<version>.exe
-#   5. Forwards all arguments and preserves the exit code.
+#   4. Extracts the binary from the archive.
+#   5. Caches the binary at %USERPROFILE%\.vibewarden\bin\vibewarden-<version>.exe
+#   6. Forwards all arguments and preserves the exit code.
 #
 # Environment variables:
 #   GITHUB_TOKEN — optional; avoids GitHub API rate limits.
@@ -93,30 +94,33 @@ function Confirm-Checksum {
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
-$Version    = Resolve-Version
-$BinaryName = "vibewarden-$Version-windows-amd64.exe"
-$CachedBin  = Join-Path $CacheDir $BinaryName
+$Version      = Resolve-Version
+$CleanVersion = $Version -replace '^v', ''
+$ArchiveName  = "vibewarden_${CleanVersion}_windows_amd64.zip"
+$CachedBin    = Join-Path $CacheDir "vibewarden-$Version.exe"
 
 if (-not (Test-Path $CachedBin)) {
-    $BaseUrl       = "https://github.com/$Repo/releases/download/$Version"
-    $BinaryUrl     = "$BaseUrl/$BinaryName"
-    $ChecksumsUrl  = "$BaseUrl/vibewarden-$Version-checksums.txt"
+    $BaseUrl      = "https://github.com/$Repo/releases/download/$Version"
+    $ArchiveUrl   = "$BaseUrl/$ArchiveName"
+    $ChecksumsUrl = "$BaseUrl/checksums.txt"
 
     $TmpDir = [System.IO.Path]::GetTempPath() + [System.IO.Path]::GetRandomFileName()
     New-Item -ItemType Directory -Path $TmpDir | Out-Null
 
     try {
         Write-Host "Downloading VibeWarden $Version (windows/amd64)..." -ForegroundColor Cyan
-        Get-File -Url $BinaryUrl    -Dest (Join-Path $TmpDir $BinaryName)
+        Get-File -Url $ArchiveUrl   -Dest (Join-Path $TmpDir $ArchiveName)
         Get-File -Url $ChecksumsUrl -Dest (Join-Path $TmpDir 'checksums.txt')
 
-        Confirm-Checksum -FilePath (Join-Path $TmpDir $BinaryName) `
+        Confirm-Checksum -FilePath (Join-Path $TmpDir $ArchiveName) `
                          -ChecksumsPath (Join-Path $TmpDir 'checksums.txt')
+
+        Expand-Archive -Path (Join-Path $TmpDir $ArchiveName) -DestinationPath $TmpDir -Force
 
         if (-not (Test-Path $CacheDir)) {
             New-Item -ItemType Directory -Path $CacheDir | Out-Null
         }
-        Move-Item (Join-Path $TmpDir $BinaryName) $CachedBin
+        Move-Item (Join-Path $TmpDir 'vibewarden.exe') $CachedBin
     } finally {
         Remove-Item $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
     }

--- a/scripts/wrapper/vibew_test.sh
+++ b/scripts/wrapper/vibew_test.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# vibew_test.sh — unit tests for vibew wrapper script URL construction logic.
+#
+# Validates that the wrapper constructs correct GoReleaser-compatible archive
+# names and download URLs. Run with: sh scripts/wrapper/vibew_test.sh
+set -e
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    label="$1"
+    expected="$2"
+    actual="$3"
+    if [ "${expected}" = "${actual}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}" >&2
+        echo "  expected: ${expected}" >&2
+        echo "  actual:   ${actual}" >&2
+    fi
+}
+
+REPO="vibewarden/vibewarden"
+
+test_version_prefix_stripping() {
+    VERSION="v1.0.0"
+    CLEAN_VERSION="${VERSION#v}"
+    assert_eq "strip v prefix from v1.0.0" "1.0.0" "${CLEAN_VERSION}"
+
+    VERSION="v2.3.4-beta.1"
+    CLEAN_VERSION="${VERSION#v}"
+    assert_eq "strip v prefix from v2.3.4-beta.1" "2.3.4-beta.1" "${CLEAN_VERSION}"
+
+    VERSION="1.0.0"
+    CLEAN_VERSION="${VERSION#v}"
+    assert_eq "no-op when no v prefix" "1.0.0" "${CLEAN_VERSION}"
+}
+
+test_archive_name_construction() {
+    VERSION="v1.0.0"
+    CLEAN_VERSION="${VERSION#v}"
+    OS="linux"
+    ARCH="amd64"
+    ARCHIVE_NAME="vibewarden_${CLEAN_VERSION}_${OS}_${ARCH}.tar.gz"
+    assert_eq "linux amd64 archive name" "vibewarden_1.0.0_linux_amd64.tar.gz" "${ARCHIVE_NAME}"
+
+    OS="darwin"
+    ARCH="arm64"
+    ARCHIVE_NAME="vibewarden_${CLEAN_VERSION}_${OS}_${ARCH}.tar.gz"
+    assert_eq "darwin arm64 archive name" "vibewarden_1.0.0_darwin_arm64.tar.gz" "${ARCHIVE_NAME}"
+}
+
+test_download_urls() {
+    VERSION="v1.0.0"
+    CLEAN_VERSION="${VERSION#v}"
+    OS="linux"
+    ARCH="amd64"
+    ARCHIVE_NAME="vibewarden_${CLEAN_VERSION}_${OS}_${ARCH}.tar.gz"
+    BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+    ARCHIVE_URL="${BASE_URL}/${ARCHIVE_NAME}"
+    CHECKSUMS_URL="${BASE_URL}/checksums.txt"
+
+    assert_eq "archive URL" \
+        "https://github.com/vibewarden/vibewarden/releases/download/v1.0.0/vibewarden_1.0.0_linux_amd64.tar.gz" \
+        "${ARCHIVE_URL}"
+
+    assert_eq "checksums URL" \
+        "https://github.com/vibewarden/vibewarden/releases/download/v1.0.0/checksums.txt" \
+        "${CHECKSUMS_URL}"
+}
+
+test_cached_binary_name() {
+    VERSION="v1.0.0"
+    CACHE_DIR="${HOME}/.vibewarden/bin"
+    CACHED_BIN="${CACHE_DIR}/vibewarden-${VERSION}"
+    assert_eq "cached binary path" "${HOME}/.vibewarden/bin/vibewarden-v1.0.0" "${CACHED_BIN}"
+}
+
+test_version_prefix_stripping
+test_archive_name_construction
+test_download_urls
+test_cached_binary_name
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [ "${FAIL}" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
Closes #496

## Summary
- Fixed `scripts/wrapper/vibew` to strip the `v` prefix from version, use underscores in archive names (`vibewarden_1.0.0_linux_amd64.tar.gz`), download `.tar.gz` archives and extract the binary with `tar`, and use `checksums.txt` as the checksums filename
- Fixed `scripts/wrapper/vibew.ps1` with the same naming fixes for Windows, using `.zip` archives and `Expand-Archive` for extraction
- Updated `.goreleaser.yml` release header to reference `vibew` instead of `install.sh`
- Added `.github/workflows/release-dryrun.yml` CI workflow that runs `goreleaser check` and `goreleaser release --snapshot` on PRs touching release-related files
- Added `scripts/wrapper/vibew_test.sh` with unit tests validating URL construction, version prefix stripping, and archive naming

## Test plan
- [ ] Run `sh scripts/wrapper/vibew_test.sh` -- all 8 assertions pass
- [ ] `go build ./...` passes (no Go source changes)
- [ ] `go test ./...` passes (no Go source changes)
- [ ] Verify `vibew` script constructs URLs matching GoReleaser output: `vibewarden_<version>_<os>_<arch>.tar.gz`
- [ ] Verify `vibew.ps1` constructs URLs matching GoReleaser output: `vibewarden_<version>_windows_amd64.zip`
- [ ] Verify `.goreleaser.yml` release header references `vibew` not `install.sh`
- [ ] Verify `release-dryrun.yml` triggers on PRs touching `.goreleaser.yml`, wrapper scripts, or release workflow
