### PR TITLE
feat(#606): improve --lang omission error with supported languages list

### DIFF
--- a/docs/claude-md-snippet.md
+++ b/docs/claude-md-snippet.md
@@ -26,4 +26,12 @@ the network layer. Do not implement any of the following in application code:
 **When asked to add security features**, check `vibewarden.yaml` first.
 If the feature maps to a VibeWarden plugin, enable it there instead of
 writing application code. Plugin docs: https://vibewarden.dev/docs
+
+**When scaffolding a new project with `vibewarden init`**, always pass
+`--lang` explicitly. The flag is required — omitting it returns an error.
+Supported values: `go`. Example:
+
+```sh
+vibewarden init --lang go myproject
+```
 ```

--- a/internal/cli/cmd/init.go
+++ b/internal/cli/cmd/init.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -14,6 +15,10 @@ import (
 	"github.com/vibewarden/vibewarden/internal/cli/templates"
 	domainscaffold "github.com/vibewarden/vibewarden/internal/domain/scaffold"
 )
+
+// supportedLanguages lists every language the init command accepts.
+// Add new entries here as new language templates are introduced.
+var supportedLanguages = []string{"go"}
 
 // NewInitCmd creates the `vibewarden init` subcommand.
 //
@@ -61,12 +66,19 @@ Examples:
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if lang == "" {
-				return fmt.Errorf("flag --lang is required (supported: go)")
+				return fmt.Errorf(
+					"--lang is required\n\nSupported languages:\n  %s\n\nExample:\n  vibewarden init --lang go myproject",
+					strings.Join(supportedLanguages, ", "),
+				)
 			}
 
 			language := domainscaffold.Language(lang)
 			if language != domainscaffold.LanguageGo {
-				return fmt.Errorf("unsupported language %q (supported: go)", lang)
+				return fmt.Errorf(
+					"unsupported language %q\n\nSupported languages:\n  %s\n\nExample:\n  vibewarden init --lang go myproject",
+					lang,
+					strings.Join(supportedLanguages, ", "),
+				)
 			}
 
 			// Determine project name and parent directory.

--- a/internal/cli/cmd/init_test.go
+++ b/internal/cli/cmd/init_test.go
@@ -10,35 +10,85 @@ import (
 	"github.com/vibewarden/vibewarden/internal/cli/cmd"
 )
 
-// TestInitCmd_RequiresLang verifies that omitting --lang returns an error.
+// TestInitCmd_RequiresLang verifies that omitting --lang returns a helpful error.
 func TestInitCmd_RequiresLang(t *testing.T) {
-	root := cmd.NewRootCmd("test")
-	var errOut bytes.Buffer
-	root.SetErr(&errOut)
-	root.SetArgs([]string{"init", "myproject"})
-
-	err := root.Execute()
-	if err == nil {
-		t.Fatal("expected error when --lang is missing, got nil")
+	tests := []struct {
+		name        string
+		wantInError []string
+	}{
+		{
+			name: "mentions --lang flag",
+			wantInError: []string{
+				"--lang",
+				"go",
+				"vibewarden init --lang go",
+			},
+		},
 	}
-	if !strings.Contains(err.Error(), "--lang") {
-		t.Errorf("expected error to mention --lang, got: %v", err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := cmd.NewRootCmd("test")
+			var errOut bytes.Buffer
+			root.SetErr(&errOut)
+			root.SetArgs([]string{"init", "myproject"})
+
+			err := root.Execute()
+			if err == nil {
+				t.Fatal("expected error when --lang is missing, got nil")
+			}
+			for _, want := range tt.wantInError {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("expected error to contain %q, got: %v", want, err)
+				}
+			}
+		})
 	}
 }
 
-// TestInitCmd_RejectsUnknownLang verifies an unsupported language is rejected.
+// TestInitCmd_RejectsUnknownLang verifies an unsupported language is rejected with a helpful error.
 func TestInitCmd_RejectsUnknownLang(t *testing.T) {
-	root := cmd.NewRootCmd("test")
-	var errOut bytes.Buffer
-	root.SetErr(&errOut)
-	root.SetArgs([]string{"init", "--lang", "typescript", "myproject"})
-
-	err := root.Execute()
-	if err == nil {
-		t.Fatal("expected error for unknown lang, got nil")
+	tests := []struct {
+		name        string
+		lang        string
+		wantInError []string
+	}{
+		{
+			name: "unknown language typescript",
+			lang: "typescript",
+			wantInError: []string{
+				"typescript",
+				"go",
+				"vibewarden init --lang go",
+			},
+		},
+		{
+			name: "unknown language python",
+			lang: "python",
+			wantInError: []string{
+				"python",
+				"go",
+			},
+		},
 	}
-	if !strings.Contains(err.Error(), "typescript") {
-		t.Errorf("expected error to mention 'typescript', got: %v", err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := cmd.NewRootCmd("test")
+			var errOut bytes.Buffer
+			root.SetErr(&errOut)
+			root.SetArgs([]string{"init", "--lang", tt.lang, "myproject"})
+
+			err := root.Execute()
+			if err == nil {
+				t.Fatalf("expected error for unknown lang %q, got nil", tt.lang)
+			}
+			for _, want := range tt.wantInError {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("expected error to contain %q, got: %v", want, err)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #606

## Summary

- When `--lang` is omitted from `vibewarden init`, the error now reads:
  ```
  --lang is required

  Supported languages:
    go

  Example:
    vibewarden init --lang go myproject
  ```
- The same language list and example are shown when an unsupported language is given.
- Introduced `supportedLanguages` package-level slice so the list is defined once and shared by both error paths. Adding a new language template in the future requires updating only that one slice.
- `docs/claude-md-snippet.md` gains a "When scaffolding a new project" paragraph so AI agents know to always pass `--lang`.
- `init_test.go` tests are expanded to table-driven form verifying that error messages contain the language list and usage example.

## Test plan

- [ ] `make check` passes (all tests green, lint clean)
- [ ] Run `vibewarden init myproject` without `--lang` and confirm the helpful error message is printed
- [ ] Run `vibewarden init --lang rust myproject` and confirm the unsupported-language message lists `go` and shows the example
- [ ] Run `vibewarden init --lang go myproject` and confirm normal scaffolding still works