### PR TITLE
feat(#607): interactive project description and guided init

### DIFF
--- a/internal/app/scaffold/init_project.go
+++ b/internal/app/scaffold/init_project.go
@@ -111,6 +111,10 @@ type InitProjectOptions struct {
 	// Version is the VibeWarden release version written into .vibewarden-version.
 	// When empty the wrapper falls back to the latest GitHub release at runtime.
 	Version string
+
+	// Description is an optional one-line description of what the project builds.
+	// When set it is included in PROJECT.md and injected into agent templates.
+	Description string
 }
 
 // InitProjectService scaffolds a complete new project from language-specific templates.
@@ -186,6 +190,7 @@ func (s *InitProjectService) InitProject(ctx context.Context, parentDir string, 
 		ModulePath:  opts.ModulePath,
 		Port:        opts.Port,
 		Language:    opts.Language,
+		Description: opts.Description,
 	}
 
 	// Render shared (language-agnostic) agent templates: architect.md, reviewer.md.
@@ -248,6 +253,13 @@ func (s *InitProjectService) InitProject(ctx context.Context, parentDir string, 
 					return fmt.Errorf("creating .gitkeep in %s: %w", d, writeErr)
 				}
 			}
+		}
+	}
+
+	// Write PROJECT.md when a description was supplied.
+	if opts.Description != "" {
+		if err := s.renderProjectMD(projectDir, data, opts.Force); err != nil {
+			return fmt.Errorf("rendering PROJECT.md: %w", err)
 		}
 	}
 
@@ -378,6 +390,20 @@ func (s *InitProjectService) renderTypeScriptFiles(projectDir string, data domai
 			return fmt.Errorf("rendering index.ts: %w", err)
 		}
 		return fmt.Errorf("index.ts already exists; use --force to overwrite: %w", err)
+	}
+	return nil
+}
+
+// renderProjectMD renders PROJECT.md from the shared project-md template into
+// projectDir. PROJECT.md captures the project description so that AI coding
+// assistants always have context about the project's purpose.
+func (s *InitProjectService) renderProjectMD(projectDir string, data any, overwrite bool) error {
+	dest := filepath.Join(projectDir, "PROJECT.md")
+	if err := s.renderer.RenderToFile("agents/project.md.tmpl", data, dest, overwrite); err != nil {
+		if !errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("rendering PROJECT.md: %w", err)
+		}
+		return fmt.Errorf("PROJECT.md already exists; use --force to overwrite: %w", err)
 	}
 	return nil
 }

--- a/internal/app/scaffold/init_project_test.go
+++ b/internal/app/scaffold/init_project_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	scaffoldapp "github.com/vibewarden/vibewarden/internal/app/scaffold"
@@ -409,6 +410,122 @@ func TestInitProject_TypeScript_DefaultsPort(t *testing.T) {
 	}
 
 	mustExist(t, parent, "tsnoport", "vibewarden.yaml")
+}
+
+// TestInitProject_WritesProjectMD verifies that PROJECT.md is created when a
+// description is provided, and omitted when the description is empty.
+func TestInitProject_WritesProjectMD(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		wantFile    bool
+	}{
+		{"with description", "a task management API", true},
+		{"empty description", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			renderer := newFakeRenderer()
+			svc := scaffoldapp.NewInitProjectService(renderer)
+
+			parent := t.TempDir()
+			opts := scaffoldapp.InitProjectOptions{
+				ProjectName: "myapp",
+				Language:    domainscaffold.LanguageGo,
+				Port:        3000,
+				Description: tt.description,
+			}
+
+			if err := svc.InitProject(context.Background(), parent, opts); err != nil {
+				t.Fatalf("InitProject() unexpected error: %v", err)
+			}
+
+			projectMDPath := filepath.Join(parent, "myapp", "PROJECT.md")
+			_, statErr := os.Stat(projectMDPath)
+			exists := statErr == nil
+
+			if exists != tt.wantFile {
+				t.Errorf("PROJECT.md exists=%v, want=%v (description=%q)", exists, tt.wantFile, tt.description)
+			}
+		})
+	}
+}
+
+// TestInitProject_DescriptionInData verifies that InitProjectData carries the
+// description through to the template renderer.
+func TestInitProject_DescriptionInData(t *testing.T) {
+	tracker := newTrackingRenderer()
+	svc := scaffoldapp.NewInitProjectService(tracker)
+
+	parent := t.TempDir()
+	opts := scaffoldapp.InitProjectOptions{
+		ProjectName: "descapp",
+		Language:    domainscaffold.LanguageGo,
+		Port:        3000,
+		Description: "an e-commerce platform",
+	}
+
+	if err := svc.InitProject(context.Background(), parent, opts); err != nil {
+		t.Fatalf("InitProject() unexpected error: %v", err)
+	}
+
+	// PROJECT.md must be rendered.
+	if !containsTemplate(tracker.renderToFileCalls, "agents/project.md.tmpl") {
+		t.Errorf("expected agents/project.md.tmpl to be rendered; RenderToFile calls: %v", tracker.renderToFileCalls)
+	}
+}
+
+// TestInitProject_WithRealFS_Description verifies that the real templates render
+// the description into PROJECT.md, CLAUDE.md, and architect.md.
+func TestInitProject_WithRealFS_Description(t *testing.T) {
+	r := mustBuildRealRenderer(t)
+	svc := scaffoldapp.NewInitProjectService(r)
+
+	parent := t.TempDir()
+	opts := scaffoldapp.InitProjectOptions{
+		ProjectName: "realwithDesc",
+		Language:    domainscaffold.LanguageGo,
+		Port:        3000,
+		Description: "a payment processing service",
+	}
+
+	if err := svc.InitProject(context.Background(), parent, opts); err != nil {
+		t.Fatalf("InitProject() unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		file        string
+		mustContain []string
+	}{
+		{
+			file:        filepath.Join(parent, "realwithDesc", "PROJECT.md"),
+			mustContain: []string{"a payment processing service", "realwithDesc"},
+		},
+		{
+			file:        filepath.Join(parent, "realwithDesc", "CLAUDE.md"),
+			mustContain: []string{"a payment processing service"},
+		},
+		{
+			file:        filepath.Join(parent, "realwithDesc", ".claude", "agents", "architect.md"),
+			mustContain: []string{"a payment processing service"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.file, func(t *testing.T) {
+			raw, err := os.ReadFile(tt.file) //nolint:gosec // test path
+			if err != nil {
+				t.Fatalf("reading %s: %v", tt.file, err)
+			}
+			content := string(raw)
+			for _, want := range tt.mustContain {
+				if !strings.Contains(content, want) {
+					t.Errorf("file %s missing %q\nContent:\n%s", tt.file, want, content)
+				}
+			}
+		})
+	}
 }
 
 // mustExist is a test helper that fails if the file at path does not exist.

--- a/internal/cli/cmd/init.go
+++ b/internal/cli/cmd/init.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -20,28 +21,86 @@ import (
 // Add new entries here as new language templates are introduced.
 var supportedLanguages = []string{"go", "kotlin", "typescript"}
 
+// IsTTY reports whether fd is connected to a terminal.
+// It calls the os.File.Stat method and checks for ModeCharDevice, which is set
+// on UNIX ttys and on Windows console handles.  The function is a package-level
+// variable so that tests can replace it without build-tag gymnastics.
+var IsTTY = func(fd *os.File) bool {
+	info, err := fd.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
+}
+
+// promptString writes prompt to w and reads a single line of input from r.
+// Leading/trailing whitespace is trimmed from the response.
+// If the user just presses Enter, defaultVal is returned.
+func promptString(w *os.File, r *bufio.Reader, prompt, defaultVal string) (string, error) {
+	if defaultVal != "" {
+		fmt.Fprintf(w, "%s [%s]: ", prompt, defaultVal)
+	} else {
+		fmt.Fprintf(w, "%s: ", prompt)
+	}
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("reading input: %w", err)
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return defaultVal, nil
+	}
+	return line, nil
+}
+
+// promptLang prompts the user to choose a language from supportedLanguages.
+// It re-prompts on invalid input.
+func promptLang(w *os.File, r *bufio.Reader) (string, error) {
+	for {
+		fmt.Fprintf(w, "Language (%s): ", strings.Join(supportedLanguages, "/"))
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return "", fmt.Errorf("reading language input: %w", err)
+		}
+		line = strings.TrimSpace(line)
+		for _, l := range supportedLanguages {
+			if strings.EqualFold(line, l) {
+				return l, nil
+			}
+		}
+		fmt.Fprintf(w, "Unknown language %q. Supported: %s\n", line, strings.Join(supportedLanguages, ", "))
+	}
+}
+
 // NewInitCmd creates the `vibewarden init` subcommand.
 //
 // The command scaffolds a complete new project from language-specific templates.
-// It requires --lang to be specified (currently only "go" is supported).
-// When a project name is supplied as a positional argument, a subdirectory with
-// that name is created in the current working directory.  When no argument is
-// given, the current directory name is used as the project name and files are
-// written to the current working directory.
+// In interactive mode (TTY detected and --lang omitted) the user is prompted for
+// language, project name, and description. In non-interactive mode (pipe/CI) --lang
+// is required.
+//
+// When a project name is supplied as a positional argument or via --name, a
+// subdirectory with that name is created inside the current working directory.
+// When neither is given, the current directory name is used and files are written
+// into the current directory.
 //
 // Usage:
 //
 //	vibewarden init --lang go myproject
-//	vibewarden init --lang go              (uses current directory name)
+//	vibewarden init --lang go                (uses current directory name)
 //	vibewarden init --lang go --port 8080 myproject
 //	vibewarden init --lang go --module github.com/org/myproject myproject
+//	vibewarden init --lang go --describe "a task management API" myproject
+//	vibewarden init --name myproject --describe "a task management API"
 func NewInitCmd() *cobra.Command {
 	var (
-		lang    string
-		module  string
-		port    int
-		force   bool
-		version string
+		lang     string
+		module   string
+		port     int
+		force    bool
+		version  string
+		nameFlag string
+		describe string
 	)
 
 	cmd := &cobra.Command{
@@ -55,21 +114,44 @@ The command creates a project directory containing:
   - vibew wrapper scripts (vibew, vibew.ps1, vibew.cmd)
   - .claude/agents/ with architect, developer, and reviewer agent files
   - CLAUDE.md with full vibew CLI reference
+  - PROJECT.md with project description (when --describe is given)
   - Dockerfile
   - .gitignore
+
+In interactive mode (terminal detected, --lang not set) you will be prompted for
+language, project name, and description.  In non-interactive mode (piped/CI) you
+must supply --lang.
 
 Examples:
   vibewarden init --lang go myproject
   vibewarden init --lang go myproject --module github.com/org/myproject
   vibewarden init --lang go myproject --port 8080
-  vibewarden init --lang go --force myproject`,
+  vibewarden init --lang go --describe "a task management API" myproject
+  vibewarden init --lang go --force myproject
+  vibewarden init --name myproject --describe "a task management API"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			interactive := lang == "" && IsTTY(os.Stdin)
+
+			// A single bufio.Reader wraps os.Stdin for the entire interactive
+			// session.  Using multiple readers over the same fd loses buffered
+			// bytes; create one here and pass it to every prompt helper.
+			stdinReader := bufio.NewReader(os.Stdin)
+
+			// Resolve language.
 			if lang == "" {
-				return fmt.Errorf(
-					"--lang is required\n\nSupported languages:\n  %s\n\nExample:\n  vibewarden init --lang go myproject",
-					strings.Join(supportedLanguages, ", "),
-				)
+				if !interactive {
+					return fmt.Errorf(
+						"--lang is required in non-interactive mode\n\nSupported languages:\n  %s\n\nExample:\n  vibewarden init --lang go myproject",
+						strings.Join(supportedLanguages, ", "),
+					)
+				}
+				// Interactive: prompt for language.
+				chosen, err := promptLang(os.Stderr, stdinReader)
+				if err != nil {
+					return fmt.Errorf("prompting for language: %w", err)
+				}
+				lang = chosen
 			}
 
 			language := domainscaffold.Language(lang)
@@ -84,21 +166,42 @@ Examples:
 				)
 			}
 
-			// Determine project name and parent directory.
+			// Determine project name: positional arg > --name flag > interactive prompt > cwd name.
 			var projectName string
 			parentDir := "."
 
 			if len(args) > 0 {
 				projectName = args[0]
+			} else if nameFlag != "" {
+				projectName = nameFlag
+			} else if interactive {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return fmt.Errorf("getting current directory: %w", err)
+				}
+				defaultName := filepath.Base(cwd)
+				chosen, err := promptString(os.Stderr, stdinReader, "Project name", defaultName)
+				if err != nil {
+					return fmt.Errorf("prompting for project name: %w", err)
+				}
+				projectName = chosen
 			} else {
-				// Use the name of the current directory.
+				// Non-interactive, no positional arg, no --name: use cwd name.
 				cwd, err := os.Getwd()
 				if err != nil {
 					return fmt.Errorf("getting current directory: %w", err)
 				}
 				projectName = filepath.Base(cwd)
-				// Write into the current directory rather than creating a subdir.
 				parentDir = filepath.Dir(cwd)
+			}
+
+			// Resolve description: --describe flag > interactive prompt > empty.
+			if describe == "" && interactive {
+				chosen, err := promptString(os.Stderr, stdinReader, "Project description (optional)", "")
+				if err != nil {
+					return fmt.Errorf("prompting for description: %w", err)
+				}
+				describe = chosen
 			}
 
 			renderer := templateadapter.NewRenderer(templates.FS)
@@ -111,6 +214,7 @@ Examples:
 				Language:    language,
 				Force:       force,
 				Version:     version,
+				Description: describe,
 			}
 
 			if err := svc.InitProject(context.Background(), parentDir, opts); err != nil {
@@ -125,11 +229,13 @@ Examples:
 		},
 	}
 
-	cmd.Flags().StringVar(&lang, "lang", "", `programming language (required; supported: "go", "kotlin", "typescript")`)
+	cmd.Flags().StringVar(&lang, "lang", "", `programming language (required in non-interactive mode; supported: "go", "kotlin", "typescript")`)
 	cmd.Flags().StringVar(&module, "module", "", "Go module path (default: project name)")
 	cmd.Flags().IntVar(&port, "port", 3000, "HTTP port the generated app listens on")
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite existing files")
 	cmd.Flags().StringVar(&version, "version", "", "VibeWarden version to pin in .vibewarden-version (default: latest)")
+	cmd.Flags().StringVar(&nameFlag, "name", "", "project name (alternative to positional argument)")
+	cmd.Flags().StringVar(&describe, "describe", "", "one-line description of what the project builds; written to PROJECT.md and injected into agent files")
 
 	return cmd
 }
@@ -140,6 +246,9 @@ func printInitSuccessMessage(cmd *cobra.Command, projectName string, opts scaffo
 
 	fmt.Fprintln(w, "")
 	fmt.Fprintf(w, "Project %q created!\n", projectName)
+	if opts.Description != "" {
+		fmt.Fprintf(w, "Description: %s\n", opts.Description)
+	}
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Files created:")
 
@@ -163,6 +272,9 @@ func printInitSuccessMessage(cmd *cobra.Command, projectName string, opts scaffo
 
 	fmt.Fprintf(w, "  vibewarden.yaml          Security sidecar config\n")
 	fmt.Fprintf(w, "  CLAUDE.md                Project instructions for AI agents\n")
+	if opts.Description != "" {
+		fmt.Fprintf(w, "  PROJECT.md               Project description\n")
+	}
 	fmt.Fprintf(w, "  .claude/agents/          Architect, developer, reviewer agents\n")
 	fmt.Fprintf(w, "  vibew                    Wrapper script (macOS/Linux)\n")
 	fmt.Fprintf(w, "  vibew.ps1                Wrapper script (Windows)\n")

--- a/internal/cli/cmd/init_interactive_test.go
+++ b/internal/cli/cmd/init_interactive_test.go
@@ -1,0 +1,322 @@
+package cmd_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/cli/cmd"
+)
+
+// TestInitCmd_DescribeFlag verifies that --describe writes PROJECT.md and
+// mentions the description in the success message.
+func TestInitCmd_DescribeFlag(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	root := cmd.NewRootCmd("test")
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetArgs([]string{
+		"init", "--lang", "go",
+		"--describe", "a task management API",
+		"describeapp",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("init --describe failed: %v", err)
+	}
+
+	// PROJECT.md must exist.
+	projectMDPath := filepath.Join(dir, "describeapp", "PROJECT.md")
+	data, err := os.ReadFile(projectMDPath) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("PROJECT.md not created: %v", err)
+	}
+	if !strings.Contains(string(data), "a task management API") {
+		t.Errorf("PROJECT.md does not contain description:\n%s", string(data))
+	}
+	if !strings.Contains(string(data), "describeapp") {
+		t.Errorf("PROJECT.md does not contain project name:\n%s", string(data))
+	}
+
+	// Success message must mention the description.
+	if !strings.Contains(out.String(), "a task management API") {
+		t.Errorf("success message does not mention description:\n%s", out.String())
+	}
+	// Success message must mention PROJECT.md.
+	if !strings.Contains(out.String(), "PROJECT.md") {
+		t.Errorf("success message does not mention PROJECT.md:\n%s", out.String())
+	}
+}
+
+// TestInitCmd_DescribeInjectsCLAUDEmd verifies that --describe injects the
+// description into CLAUDE.md.
+func TestInitCmd_DescribeInjectsCLAUDEmd(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	root := cmd.NewRootCmd("test")
+	root.SetOut(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"init", "--lang", "go",
+		"--describe", "an inventory management system",
+		"invapp",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	claudePath := filepath.Join(dir, "invapp", "CLAUDE.md")
+	data, err := os.ReadFile(claudePath) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("CLAUDE.md not found: %v", err)
+	}
+	if !strings.Contains(string(data), "an inventory management system") {
+		t.Errorf("CLAUDE.md does not contain description:\n%s", string(data))
+	}
+}
+
+// TestInitCmd_DescribeInjectsArchitectMD verifies that --describe injects the
+// description into .claude/agents/architect.md.
+func TestInitCmd_DescribeInjectsArchitectMD(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	root := cmd.NewRootCmd("test")
+	root.SetOut(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"init", "--lang", "go",
+		"--describe", "a real-time chat service",
+		"chatapp",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	archPath := filepath.Join(dir, "chatapp", ".claude", "agents", "architect.md")
+	data, err := os.ReadFile(archPath) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("architect.md not found: %v", err)
+	}
+	if !strings.Contains(string(data), "a real-time chat service") {
+		t.Errorf("architect.md does not contain description:\n%s", string(data))
+	}
+}
+
+// TestInitCmd_NoDescribeNoProjectMD verifies that when --describe is omitted,
+// PROJECT.md is not written.
+func TestInitCmd_NoDescribeNoProjectMD(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	root := cmd.NewRootCmd("test")
+	root.SetOut(&bytes.Buffer{})
+	root.SetArgs([]string{"init", "--lang", "go", "nodescapp"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	projectMDPath := filepath.Join(dir, "nodescapp", "PROJECT.md")
+	if _, err := os.Stat(projectMDPath); err == nil {
+		t.Error("PROJECT.md must not exist when --describe is not given")
+	}
+}
+
+// TestInitCmd_NameFlag verifies that --name sets the project name.
+func TestInitCmd_NameFlag(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	root := cmd.NewRootCmd("test")
+	root.SetOut(&bytes.Buffer{})
+	root.SetArgs([]string{"init", "--lang", "go", "--name", "namedproject"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("init --name failed: %v", err)
+	}
+
+	projectDir := filepath.Join(dir, "namedproject")
+	if _, err := os.Stat(projectDir); err != nil {
+		t.Errorf("expected project directory %q to exist: %v", projectDir, err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, "vibewarden.yaml")); err != nil {
+		t.Errorf("vibewarden.yaml not found in --name project: %v", err)
+	}
+}
+
+// TestInitCmd_NameFlagOverriddenByPositionalArg verifies that a positional
+// argument takes priority over --name when both are given.
+func TestInitCmd_NameFlagOverriddenByPositionalArg(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	root := cmd.NewRootCmd("test")
+	root.SetOut(&bytes.Buffer{})
+	// Positional arg "positional" should win over --name "fromflag".
+	root.SetArgs([]string{"init", "--lang", "go", "--name", "fromflag", "positional"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// "positional" directory must exist.
+	if _, err := os.Stat(filepath.Join(dir, "positional")); err != nil {
+		t.Errorf("expected positional/ to exist: %v", err)
+	}
+	// "fromflag" directory must NOT exist.
+	if _, err := os.Stat(filepath.Join(dir, "fromflag")); err == nil {
+		t.Error("fromflag/ must not exist when positional arg is given")
+	}
+}
+
+// TestInitCmd_Interactive simulates an interactive session by temporarily
+// overriding cmd.IsTTY to return true and feeding stdin via a pipe.
+func TestInitCmd_Interactive(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	// Create a pipe to simulate user input.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+
+	// Write: language, project name, description (each terminated by newline).
+	input := "go\ninteractiveapp\na cool interactive project\n"
+	if _, err := w.WriteString(input); err != nil {
+		t.Fatalf("writing to pipe: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing write end: %v", err)
+	}
+
+	// Redirect stdin to the pipe for the duration of this test.
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		_ = r.Close()
+	})
+
+	// Override IsTTY to report interactive.
+	origIsTTY := cmd.IsTTY
+	cmd.IsTTY = func(*os.File) bool { return true }
+	t.Cleanup(func() { cmd.IsTTY = origIsTTY })
+
+	root := cmd.NewRootCmd("test")
+	root.SetOut(&bytes.Buffer{})
+	// No --lang or positional arg — should be filled by interactive prompts.
+	root.SetArgs([]string{"init"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("interactive init failed: %v", err)
+	}
+
+	// Project directory must exist.
+	projectDir := filepath.Join(dir, "interactiveapp")
+	if _, err := os.Stat(projectDir); err != nil {
+		t.Errorf("expected project dir %q: %v", projectDir, err)
+	}
+
+	// PROJECT.md must contain the description.
+	data, err := os.ReadFile(filepath.Join(projectDir, "PROJECT.md")) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("PROJECT.md not found: %v", err)
+	}
+	if !strings.Contains(string(data), "a cool interactive project") {
+		t.Errorf("PROJECT.md missing description:\n%s", string(data))
+	}
+}
+
+// TestInitCmd_InteractiveSkipsDescribeWhenEmpty verifies that when the user
+// provides no description (empty line), PROJECT.md is not written.
+func TestInitCmd_InteractiveSkipsDescribeWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+
+	// Language and name given, empty description.
+	if _, err := w.WriteString("go\nnodescapp2\n\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing write end: %v", err)
+	}
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		_ = r.Close()
+	})
+
+	origIsTTY := cmd.IsTTY
+	cmd.IsTTY = func(*os.File) bool { return true }
+	t.Cleanup(func() { cmd.IsTTY = origIsTTY })
+
+	root := cmd.NewRootCmd("test")
+	root.SetOut(&bytes.Buffer{})
+	root.SetArgs([]string{"init"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("interactive init failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "nodescapp2", "PROJECT.md")); err == nil {
+		t.Error("PROJECT.md must not be written when description is empty")
+	}
+}
+
+// TestInitCmd_NonInteractiveRequiresLang verifies that in non-interactive mode
+// (IsTTY=false, no --lang) an error is returned.
+func TestInitCmd_NonInteractiveRequiresLang(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var errOut bytes.Buffer
+	root.SetErr(&errOut)
+	root.SetArgs([]string{"init", "myproject"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error when --lang missing in non-interactive mode")
+	}
+	if !strings.Contains(err.Error(), "--lang") {
+		t.Errorf("error should mention --lang, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "non-interactive") {
+		t.Errorf("error should mention non-interactive, got: %v", err)
+	}
+}

--- a/internal/cli/cmd/main_test.go
+++ b/internal/cli/cmd/main_test.go
@@ -1,0 +1,18 @@
+package cmd_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/cli/cmd"
+)
+
+// TestMain forces non-interactive mode for all CLI command tests.
+// Tests that want to exercise interactive prompts must override cmd.IsTTY locally
+// and restore it via t.Cleanup.
+func TestMain(m *testing.M) {
+	// In test runs stdin is never a real TTY; force non-interactive mode so that
+	// tests which omit --lang receive a proper error rather than a prompt read.
+	cmd.IsTTY = func(*os.File) bool { return false }
+	os.Exit(m.Run())
+}

--- a/internal/cli/templates/agents/architect.md.tmpl
+++ b/internal/cli/templates/agents/architect.md.tmpl
@@ -2,6 +2,11 @@
 
 You are the software architect for {{ .ProjectName }}. You own technical correctness,
 architectural consistency, and dependency decisions.
+{{ if .Description }}
+## Project description
+
+{{ .Description }}
+{{ end }}
 
 ## Sidecar boundary rule
 

--- a/internal/cli/templates/agents/claude.md.tmpl
+++ b/internal/cli/templates/agents/claude.md.tmpl
@@ -1,5 +1,9 @@
 # {{ .ProjectName }} — Project Instructions
+{{ if .Description }}
+## About this project
 
+{{ .Description }}
+{{ end }}
 ## Architecture
 
 This project follows hexagonal architecture (ports and adapters):

--- a/internal/cli/templates/agents/project.md.tmpl
+++ b/internal/cli/templates/agents/project.md.tmpl
@@ -1,0 +1,19 @@
+# {{ .ProjectName }}
+
+{{ .Description }}
+
+## Overview
+
+This project is secured by VibeWarden sidecar. All TLS, authentication, rate limiting,
+and security headers are handled by the sidecar — application code focuses on business
+logic only.
+
+## Quick start
+
+```bash
+./vibew dev          # Start app + sidecar
+./vibew status       # Check health
+./vibew doctor       # Diagnose issues
+```
+
+Access the app through the sidecar at https://localhost:8443.

--- a/internal/domain/scaffold/types.go
+++ b/internal/domain/scaffold/types.go
@@ -106,6 +106,11 @@ type InitProjectData struct {
 
 	// Language is the target programming language.
 	Language Language
+
+	// Description is an optional one-line description of what the project builds.
+	// When set it is included in PROJECT.md, CLAUDE.md, and agent files so that
+	// AI coding assistants have context about the project's purpose from the start.
+	Description string
 }
 
 // AgentType identifies the target AI coding assistant for context generation.

--- a/internal/domain/scaffold/types_test.go
+++ b/internal/domain/scaffold/types_test.go
@@ -286,6 +286,39 @@ func TestLanguage_Distinctness(t *testing.T) {
 	}
 }
 
+func TestInitProjectData_Description(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+	}{
+		{"empty description", ""},
+		{"non-empty description", "a task management API"},
+		{"multi-word description", "real-time analytics dashboard for small businesses"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := scaffold.InitProjectData{
+				ProjectName: "myproject",
+				ModulePath:  "github.com/org/myproject",
+				Port:        3000,
+				Language:    scaffold.LanguageGo,
+				Description: tt.description,
+			}
+
+			if data.Description != tt.description {
+				t.Errorf("Description = %q, want %q", data.Description, tt.description)
+			}
+
+			// Value object: copy must equal original.
+			copy := data
+			if copy.Description != data.Description {
+				t.Error("Description mismatch after copy")
+			}
+		})
+	}
+}
+
 func TestAgentContextData_Construction(t *testing.T) {
 	acd := scaffold.AgentContextData{
 		UpstreamPort:     8080,


### PR DESCRIPTION
Closes #607

## Summary

- Added `--name` flag as an alternative to the positional argument for setting project name
- Added `--describe` flag to inject a one-line description into `PROJECT.md`, `CLAUDE.md`, and `.claude/agents/architect.md`
- Added TTY detection (`cmd.IsTTY` package-level variable, replaceable in tests) to enable interactive mode when stdin is a terminal and `--lang` is omitted
- In interactive mode: prompts for language, project name, and description using `bufio.Reader` (no external TUI library)
- In non-interactive mode (piped/CI): requires `--lang`, returns a clear error when absent
- Uses a single `bufio.Reader` across all prompts to prevent buffered-byte loss
- `PROJECT.md` is only written when a description is provided
- Extended `InitProjectData` and `InitProjectOptions` with `Description` field
- Added `agents/project.md.tmpl` shared template
- Description conditionally injected into `architect.md.tmpl` and `claude.md.tmpl`

## Test plan

- `TestInitCmd_DescribeFlag` — verifies `--describe` writes `PROJECT.md` and success message
- `TestInitCmd_DescribeInjectsCLAUDEmd` — description appears in `CLAUDE.md`
- `TestInitCmd_DescribeInjectsArchitectMD` — description appears in `architect.md`
- `TestInitCmd_NoDescribeNoProjectMD` — `PROJECT.md` absent when `--describe` omitted
- `TestInitCmd_NameFlag` — `--name` creates the named project directory
- `TestInitCmd_NameFlagOverriddenByPositionalArg` — positional arg wins over `--name`
- `TestInitCmd_Interactive` — full interactive flow via pipe: language, name, description
- `TestInitCmd_InteractiveSkipsDescribeWhenEmpty` — empty description skips `PROJECT.md`
- `TestInitCmd_NonInteractiveRequiresLang` — missing `--lang` returns helpful error
- `TestInitProject_WritesProjectMD` — service writes/skips `PROJECT.md` by description presence
- `TestInitProject_WithRealFS_Description` — real templates embed description in all three files