### PR TITLE
fix: Kotlin package names — sanitize hyphens, add --group flag

### DIFF
--- a/internal/app/scaffold/init_project.go
+++ b/internal/app/scaffold/init_project.go
@@ -115,6 +115,10 @@ type InitProjectOptions struct {
 	// Description is an optional one-line description of what the project builds.
 	// When set it is included in PROJECT.md and injected into agent templates.
 	Description string
+
+	// GroupID is the JVM group identifier (e.g., "com.mycompany").
+	// Used for Kotlin/JVM package paths. Defaults to sanitized project name.
+	GroupID string
 }
 
 // InitProjectService scaffolds a complete new project from language-specific templates.
@@ -185,9 +189,17 @@ func (s *InitProjectService) InitProject(ctx context.Context, parentDir string, 
 		return fmt.Errorf("creating project directory: %w", err)
 	}
 
+	pkgName := domainscaffold.SanitizePackageName(opts.ProjectName)
+	groupID := opts.GroupID
+	if groupID == "" {
+		groupID = pkgName // simple default: project name as group
+	}
+
 	data := domainscaffold.InitProjectData{
 		ProjectName: opts.ProjectName,
 		ModulePath:  opts.ModulePath,
+		PackageName: pkgName,
+		GroupID:     groupID,
 		Port:        opts.Port,
 		Language:    opts.Language,
 		Description: opts.Description,
@@ -354,10 +366,12 @@ func (s *InitProjectService) renderKotlinFiles(projectDir string, data domainsca
 	}
 
 	// Render Application.kt into the standard Gradle source set path.
+	// GroupID "com.mycompany" → "com/mycompany", PackageName "my_app" → "my_app"
+	groupParts := filepath.Join(strings.Split(data.GroupID, ".")...)
 	appPath := filepath.Join(
 		projectDir,
 		"src", "main", "kotlin",
-		"com", "example", data.ProjectName,
+		groupParts, data.PackageName,
 		"Application.kt",
 	)
 	if err := s.renderer.RenderToFile("kotlin/Application.kt.tmpl", data, appPath, overwrite); err != nil {

--- a/internal/app/scaffold/init_project_shared_templates_test.go
+++ b/internal/app/scaffold/init_project_shared_templates_test.go
@@ -307,7 +307,7 @@ func TestInitProject_KotlinWithRealFS(t *testing.T) {
 			},
 		},
 		{
-			file: filepath.Join(parent, "ktreal", "src", "main", "kotlin", "com", "example", "ktreal", "Application.kt"),
+			file: filepath.Join(parent, "ktreal", "src", "main", "kotlin", "ktreal", "ktreal", "Application.kt"),
 			mustContain: []string{
 				"ktreal",
 				"fun main()",

--- a/internal/app/scaffold/init_project_test.go
+++ b/internal/app/scaffold/init_project_test.go
@@ -258,7 +258,8 @@ func TestInitProject_Kotlin_CreatesStructure(t *testing.T) {
 	mustExist(t, parent, "myktapp", "CLAUDE.md")
 
 	// Verify Application.kt at the Gradle source path.
-	mustExist(t, parent, "myktapp", "src", "main", "kotlin", "com", "example", "myktapp", "Application.kt")
+	// GroupID defaults to sanitized project name; package path is <groupID>/<packageName>/
+	mustExist(t, parent, "myktapp", "src", "main", "kotlin", "myktapp", "myktapp", "Application.kt")
 
 	// Verify agent files.
 	mustExist(t, parent, "myktapp", ".claude", "agents", "architect.md")

--- a/internal/cli/cmd/init.go
+++ b/internal/cli/cmd/init.go
@@ -101,6 +101,7 @@ func NewInitCmd() *cobra.Command {
 		version  string
 		nameFlag string
 		describe string
+		group    string
 	)
 
 	cmd := &cobra.Command{
@@ -215,6 +216,7 @@ Examples:
 				Force:       force,
 				Version:     version,
 				Description: describe,
+				GroupID:     group,
 			}
 
 			if err := svc.InitProject(context.Background(), parentDir, opts); err != nil {
@@ -236,6 +238,7 @@ Examples:
 	cmd.Flags().StringVar(&version, "version", "", "VibeWarden version to pin in .vibewarden-version (default: latest)")
 	cmd.Flags().StringVar(&nameFlag, "name", "", "project name (alternative to positional argument)")
 	cmd.Flags().StringVar(&describe, "describe", "", "one-line description of what the project builds; written to PROJECT.md and injected into agent files")
+	cmd.Flags().StringVar(&group, "group", "", "JVM group identifier for Kotlin projects (e.g., com.mycompany); defaults to sanitized project name")
 
 	return cmd
 }

--- a/internal/cli/cmd/init_test.go
+++ b/internal/cli/cmd/init_test.go
@@ -310,7 +310,7 @@ func TestInitCmd_KotlinCreatesProject(t *testing.T) {
 		filepath.Join("ktapp", "vibew.ps1"),
 		filepath.Join("ktapp", "vibew.cmd"),
 		filepath.Join("ktapp", ".vibewarden-version"),
-		filepath.Join("ktapp", "src", "main", "kotlin", "com", "example", "ktapp", "Application.kt"),
+		filepath.Join("ktapp", "src", "main", "kotlin", "ktapp", "ktapp", "Application.kt"),
 	}
 
 	for _, rel := range expectedFiles {

--- a/internal/cli/templates/kotlin/Application.kt.tmpl
+++ b/internal/cli/templates/kotlin/Application.kt.tmpl
@@ -1,4 +1,4 @@
-package com.example.{{ .ProjectName }}
+package {{ .GroupID }}.{{ .PackageName }}
 
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*

--- a/internal/cli/templates/kotlin/build.gradle.kts.tmpl
+++ b/internal/cli/templates/kotlin/build.gradle.kts.tmpl
@@ -9,11 +9,11 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
 }
 
-group = "com.example.{{ .ProjectName }}"
+group = "{{ .GroupID }}.{{ .PackageName }}"
 version = "0.0.1"
 
 application {
-    mainClass.set("com.example.{{ .ProjectName }}.ApplicationKt")
+    mainClass.set("{{ .GroupID }}.{{ .PackageName }}.ApplicationKt")
 
     val isDevelopment: Boolean = project.ext.has("development")
     applicationDefaultJvmArgs = listOf("-Dio.ktor.development=$isDevelopment")

--- a/internal/domain/scaffold/types.go
+++ b/internal/domain/scaffold/types.go
@@ -93,6 +93,25 @@ const (
 	LanguageTypeScript Language = "typescript"
 )
 
+// SanitizePackageName converts a project name into a valid JVM/TypeScript package
+// identifier by replacing hyphens and dots with underscores and lowercasing.
+func SanitizePackageName(name string) string {
+	var b []byte
+	for _, c := range []byte(name) {
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '_':
+			b = append(b, c)
+		case c >= 'A' && c <= 'Z':
+			b = append(b, c+32) // lowercase
+		case c == '-', c == '.':
+			b = append(b, '_')
+		default:
+			b = append(b, '_')
+		}
+	}
+	return string(b)
+}
+
 // InitProjectData is the data passed to project scaffold templates when rendering.
 type InitProjectData struct {
 	// ProjectName is the name of the project (directory name, used in go.mod).
@@ -100,6 +119,14 @@ type InitProjectData struct {
 
 	// ModulePath is the Go module path (e.g., "github.com/user/myproject").
 	ModulePath string
+
+	// PackageName is the sanitized project name safe for JVM/TypeScript package identifiers.
+	// Hyphens are replaced with underscores, everything is lowercased.
+	PackageName string
+
+	// GroupID is the JVM group identifier (e.g., "com.mycompany").
+	// Defaults to the sanitized project name when not specified.
+	GroupID string
 
 	// Port is the HTTP port the generated app listens on.
 	Port int


### PR DESCRIPTION
Fixes invalid Kotlin package names when project name has hyphens (e.g. vibew-demo1 → vibew_demo1). Drops com.example default — group defaults to sanitized project name. Adds --group flag for custom JVM group identifier.