### PR TITLE
fix: remaining vibewarden→vibew in app layer

### DIFF
--- a/internal/app/ops/dev.go
+++ b/internal/app/ops/dev.go
@@ -16,7 +16,7 @@ import (
 
 const generatedOutputDir = ".vibewarden/generated"
 
-// DevService orchestrates the "vibewarden dev" use case.
+// DevService orchestrates the "vibew dev" use case.
 // It optionally generates runtime configuration files from vibewarden.yaml
 // before starting the Docker Compose stack and can watch the config file for
 // changes when --watch is enabled.
@@ -193,5 +193,5 @@ func printServiceURLs(cfg *config.Config, opts DevOptions, out io.Writer) {
 		fmt.Fprintf(out, "  Grafana:             http://localhost:3000\n")
 	}
 	fmt.Fprintln(out, "")
-	fmt.Fprintln(out, "Tip: run 'vibewarden status' to check component health.")
+	fmt.Fprintln(out, "Tip: run 'vibew status' to check component health.")
 }

--- a/internal/app/ops/dev_test.go
+++ b/internal/app/ops/dev_test.go
@@ -96,7 +96,7 @@ func TestDevService_Run(t *testing.T) {
 			wantOutputContains: []string{
 				"Proxy (VibeWarden):",
 				"https://localhost:8443",
-				"vibewarden status",
+				"vibew status",
 			},
 		},
 		{

--- a/internal/app/ops/doctor.go
+++ b/internal/app/ops/doctor.go
@@ -40,7 +40,7 @@ type CheckResult struct {
 // OK returns true when the check severity is OK.
 func (c CheckResult) OK() bool { return c.Severity == SeverityOK }
 
-// DoctorService orchestrates the "vibewarden doctor" use case.
+// DoctorService orchestrates the "vibew doctor" use case.
 // Every check runs independently — a failing check does not stop subsequent ones.
 type DoctorService struct {
 	compose       ports.ComposeRunner
@@ -222,7 +222,7 @@ func checkGeneratedFiles(composePath string) CheckResult {
 		return CheckResult{
 			Name:     "Generated files",
 			Severity: SeverityWarn,
-			Detail:   fmt.Sprintf("%s not found — run 'vibewarden generate' first", composePath),
+			Detail:   fmt.Sprintf("%s not found — run 'vibew generate' first", composePath),
 		}
 	}
 	return CheckResult{
@@ -251,7 +251,7 @@ func (s *DoctorService) checkContainerHealth(ctx context.Context, composePath st
 		return CheckResult{
 			Name:     "Container health",
 			Severity: SeverityWarn,
-			Detail:   "no containers found — run 'vibewarden dev' to start the stack",
+			Detail:   "no containers found — run 'vibew dev' to start the stack",
 		}
 	}
 

--- a/internal/app/ops/status.go
+++ b/internal/app/ops/status.go
@@ -22,7 +22,7 @@ type ComponentStatus struct {
 	Detail string
 }
 
-// StatusService orchestrates the "vibewarden status" use case.
+// StatusService orchestrates the "vibew status" use case.
 // It queries each component and returns a structured summary.
 type StatusService struct {
 	health ports.HealthChecker

--- a/internal/app/scaffold/add_feature.go
+++ b/internal/app/scaffold/add_feature.go
@@ -9,7 +9,7 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
-// AddFeatureService orchestrates the `vibewarden add <feature>` flow:
+// AddFeatureService orchestrates the `vibew add <feature>` flow:
 //  1. Check vibewarden.yaml exists.
 //  2. Check feature not already enabled (returns ErrFeatureAlreadyEnabled).
 //  3. Enable the feature in vibewarden.yaml.
@@ -24,7 +24,7 @@ func NewAddFeatureService(toggler ports.FeatureToggler, renderer ports.TemplateR
 	return &AddFeatureService{toggler: toggler, renderer: renderer}
 }
 
-// AddFeatureOptions carries options for a single `vibewarden add` invocation.
+// AddFeatureOptions carries options for a single `vibew add` invocation.
 type AddFeatureOptions struct {
 	// Feature is the feature to enable.
 	Feature domainscaffold.Feature

--- a/internal/app/scaffold/service.go
+++ b/internal/app/scaffold/service.go
@@ -33,7 +33,7 @@ const (
 )
 
 // InitOptions carries the options supplied by the user when running
-// `vibewarden wrap`.
+// `vibew wrap`.
 type InitOptions struct {
 	// UpstreamPort is the port of the protected application.
 	UpstreamPort int


### PR DESCRIPTION
Fixes tip/hint messages and test assertions still saying vibewarden instead of vibew.