### PR TITLE
feat(#626): default generated compose to app.image instead of app.build

### DIFF
--- a/internal/app/scaffold/service.go
+++ b/internal/app/scaffold/service.go
@@ -115,6 +115,7 @@ func (s *Service) Init(_ context.Context, dir string, opts InitOptions) error {
 		TLSEnabled:       opts.TLSEnabled,
 		TLSDomain:        opts.TLSDomain,
 		Version:          opts.Version,
+		ProjectName:      filepath.Base(filepath.Clean(dir)),
 	}
 
 	// Render vibewarden.yaml.

--- a/internal/cli/cmd/init_test.go
+++ b/internal/cli/cmd/init_test.go
@@ -277,6 +277,57 @@ func TestInitCmd_CustomPort(t *testing.T) {
 	}
 }
 
+// TestInitCmd_AppImageDefaultsToProjectName verifies that the generated
+// vibewarden.yaml uses app.image derived from the project name rather than app.build.
+func TestInitCmd_AppImageDefaultsToProjectName(t *testing.T) {
+	tests := []struct {
+		name        string
+		lang        string
+		projectName string
+	}{
+		{"go uses image", "go", "mygoapp"},
+		{"kotlin uses image", "kotlin", "myktapp"},
+		{"typescript uses image", "typescript", "mytsapp"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.Chdir(dir); err != nil {
+				t.Fatalf("chdir: %v", err)
+			}
+
+			root := cmd.NewRootCmd("test")
+			var out bytes.Buffer
+			root.SetOut(&out)
+			root.SetArgs([]string{"init", "--lang", tt.lang, tt.projectName})
+
+			if err := root.Execute(); err != nil {
+				t.Fatalf("init failed: %v", err)
+			}
+
+			vwPath := filepath.Join(dir, tt.projectName, "vibewarden.yaml")
+			data, err := os.ReadFile(vwPath) //nolint:gosec // test path
+			if err != nil {
+				t.Fatalf("reading vibewarden.yaml: %v", err)
+			}
+			content := string(data)
+
+			wantImage := "image: \"" + tt.projectName + ":latest\""
+			if !strings.Contains(content, wantImage) {
+				t.Errorf("vibewarden.yaml missing %q:\n%s", wantImage, content)
+			}
+			// "build:" must not appear as an active (uncommented) directive.
+			for _, line := range strings.Split(content, "\n") {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(trimmed, "build:") {
+					t.Errorf("vibewarden.yaml must not have an active 'build:' directive by default; found: %q\n\nContent:\n%s", line, content)
+				}
+			}
+		})
+	}
+}
+
 // TestInitCmd_KotlinCreatesProject verifies that --lang kotlin scaffolds a project.
 func TestInitCmd_KotlinCreatesProject(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/cli/cmd/wrap_test.go
+++ b/internal/cli/cmd/wrap_test.go
@@ -266,6 +266,11 @@ func TestNewWrapCmd_RenderedYAMLValid(t *testing.T) {
 			args:       []string{},
 			wantInYAML: []string{"overrides"},
 		},
+		{
+			name:       "app.image defaults to project name derived from directory",
+			args:       []string{},
+			wantInYAML: []string{"image:", ":latest"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -292,6 +297,40 @@ func TestNewWrapCmd_RenderedYAMLValid(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestNewWrapCmd_AppImageDerivedFromDirName verifies that the generated
+// vibewarden.yaml defaults to app.image using the directory base name.
+func TestNewWrapCmd_AppImageDerivedFromDirName(t *testing.T) {
+	parent := t.TempDir()
+	projectDir := filepath.Join(parent, "mywebapp")
+	if err := os.MkdirAll(projectDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	root := cmd.NewRootCmd("test")
+	root.SetArgs([]string{"wrap", projectDir})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	yamlBytes, err := os.ReadFile(filepath.Join(projectDir, "vibewarden.yaml"))
+	if err != nil {
+		t.Fatalf("reading vibewarden.yaml: %v", err)
+	}
+	content := string(yamlBytes)
+
+	if !strings.Contains(content, `image: "mywebapp:latest"`) {
+		t.Errorf("vibewarden.yaml does not contain 'image: \"mywebapp:latest\"'\n\nContent:\n%s", content)
+	}
+	// "build:" must not appear as an active (uncommented) directive.
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "build:") {
+			t.Errorf("vibewarden.yaml must not have an active 'build:' directive by default; found: %q\n\nContent:\n%s", line, content)
+		}
 	}
 }
 

--- a/internal/cli/templates/go/vibewarden.yaml.tmpl
+++ b/internal/cli/templates/go/vibewarden.yaml.tmpl
@@ -11,7 +11,8 @@ upstream:
   port: {{ .Port }}
 
 app:
-  build: "."
+  image: "{{ .ProjectName }}:latest"  # overridden at runtime by VIBEWARDEN_APP_IMAGE
+  # build: "."  # uncomment to build from source instead of pulling an image
 
 log:
   level: "info"

--- a/internal/cli/templates/kotlin/vibewarden.yaml.tmpl
+++ b/internal/cli/templates/kotlin/vibewarden.yaml.tmpl
@@ -11,7 +11,8 @@ upstream:
   port: {{ .Port }}
 
 app:
-  build: "."
+  image: "{{ .ProjectName }}:latest"  # overridden at runtime by VIBEWARDEN_APP_IMAGE
+  # build: "."  # uncomment to build from source instead of pulling an image
 
 log:
   level: "info"

--- a/internal/cli/templates/typescript/vibewarden.yaml.tmpl
+++ b/internal/cli/templates/typescript/vibewarden.yaml.tmpl
@@ -11,7 +11,8 @@ upstream:
   port: {{ .Port }}
 
 app:
-  build: "."
+  image: "{{ .ProjectName }}:latest"  # overridden at runtime by VIBEWARDEN_APP_IMAGE
+  # build: "."  # uncomment to build from source instead of pulling an image
 
 log:
   level: "info"

--- a/internal/cli/templates/vibewarden.yaml.tmpl
+++ b/internal/cli/templates/vibewarden.yaml.tmpl
@@ -11,11 +11,11 @@ upstream:
   port: {{ .UpstreamPort }}
 
 # app configures how your application is included in the generated docker-compose.yml.
-# Set app.build to build from source (dev), or app.image to pull a pre-built image (prod).
+# Set app.image to pull a pre-built image (default), or app.build to build from source (opt-in).
 # Remove this section if you manage your app service manually.
 app:
-  build: "."
-  # image: "ghcr.io/your-org/your-app:latest"  # used in prod; overridden by VIBEWARDEN_APP_IMAGE
+  image: "{{ .ProjectName }}:latest"  # overridden at runtime by VIBEWARDEN_APP_IMAGE
+  # build: "."  # uncomment to build from source instead of pulling an image
 
 log:
   level: "info"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,8 +30,10 @@ type Config struct {
 	Upstream UpstreamConfig `mapstructure:"upstream"`
 
 	// App configures how the user's application is included in the generated
-	// Docker Compose file. When neither App.Build nor App.Image is set, no app
-	// service is rendered and the existing host.docker.internal fallback is used.
+	// Docker Compose file. By default, app.image is set to the project name
+	// with ":latest" tag. Set app.build to build from source instead.
+	// When neither is set, no app service is rendered and VibeWarden falls back
+	// to forwarding to host.docker.internal.
 	App AppConfig `mapstructure:"app"`
 
 	// TLS configuration
@@ -325,20 +327,19 @@ type UpstreamHealthConfig struct {
 }
 
 // AppConfig configures the user's application in the generated Docker Compose.
-// Either Build or Image should be set, depending on whether the user wants
-// to build from source (dev) or use a pre-built image (prod).
-// When both are set, Build takes precedence (dev-first workflow).
+// The default is to use a pre-built image (Image field). Build-from-source is
+// opt-in via the Build field. When both are set, Build takes precedence.
 // When neither is set, no app service is rendered and VibeWarden falls back
 // to forwarding to host.docker.internal.
 type AppConfig struct {
 	// Build is the Docker build context path (e.g., "." for the current directory).
-	// Used in dev/tls profiles. When set, the app service is rendered with
-	// a build: context directive.
+	// Opt-in: set this only when you want Compose to build the image from source.
+	// When set, the app service is rendered with a build: context directive.
 	Build string `mapstructure:"build"`
 
-	// Image is the Docker image reference (e.g., "ghcr.io/org/myapp:latest").
-	// Used in prod profile. Can be overridden at runtime via the
-	// VIBEWARDEN_APP_IMAGE environment variable.
+	// Image is the Docker image reference (e.g., "myapp:latest" or "ghcr.io/org/myapp:latest").
+	// Default: derived from the project name by `vibew init`/`vibew wrap` (e.g., "myapp:latest").
+	// Can be overridden at runtime via the VIBEWARDEN_APP_IMAGE environment variable.
 	Image string `mapstructure:"image"`
 
 	// Healthcheck is the Docker healthcheck command for the app container.

--- a/internal/config/templates/env.template.tmpl
+++ b/internal/config/templates/env.template.tmpl
@@ -14,7 +14,7 @@
 VIBEWARDEN_PROFILE={{ .Profile }}
 
 # --------------------------------------------------------------------------
-# App image (prod profile only — dev uses build context)
+# App image — set in vibewarden.yaml (app.image); override here at runtime
 # --------------------------------------------------------------------------
 {{- if .App.Image }}
 

--- a/internal/domain/scaffold/types.go
+++ b/internal/domain/scaffold/types.go
@@ -79,6 +79,10 @@ type TemplateData struct {
 	// Version is the VibeWarden release version to pin in .vibewarden-version.
 	// When empty the wrapper falls back to the latest GitHub release at runtime.
 	Version string
+
+	// ProjectName is the name of the project derived from the directory base name.
+	// Used in vibewarden.yaml to populate the default app.image value.
+	ProjectName string
 }
 
 // Language represents a supported programming language for project scaffolding.

--- a/internal/domain/scaffold/types_test.go
+++ b/internal/domain/scaffold/types_test.go
@@ -194,6 +194,40 @@ func TestTemplateData_ZeroValue(t *testing.T) {
 	if td.TLSDomain != "" {
 		t.Errorf("zero TemplateData.TLSDomain = %q, want empty", td.TLSDomain)
 	}
+	if td.ProjectName != "" {
+		t.Errorf("zero TemplateData.ProjectName = %q, want empty", td.ProjectName)
+	}
+}
+
+func TestTemplateData_ProjectName(t *testing.T) {
+	tests := []struct {
+		name        string
+		projectName string
+	}{
+		{"empty project name", ""},
+		{"simple project name", "myapp"},
+		{"hyphenated project name", "my-cool-app"},
+		{"project name with underscore", "my_app"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			td := scaffold.TemplateData{
+				UpstreamPort: 3000,
+				ProjectName:  tt.projectName,
+			}
+
+			if td.ProjectName != tt.projectName {
+				t.Errorf("ProjectName = %q, want %q", td.ProjectName, tt.projectName)
+			}
+
+			// Value object: copy must equal original.
+			copy := td
+			if copy.ProjectName != td.ProjectName {
+				t.Error("ProjectName mismatch after copy")
+			}
+		})
+	}
 }
 
 func TestAgentType_Constants(t *testing.T) {


### PR DESCRIPTION
Closes #626

## Summary

- `vibew init --lang go|kotlin|typescript` now generates `app.image: "<project-name>:latest"` in `vibewarden.yaml` instead of `app.build: "."`. The `build:` directive is left as an opt-in comment.
- `vibew wrap` derives the image name from the project directory's base name and emits `app.image: "<dir-name>:latest"` by default. Same opt-in comment for `build:`.
- `TemplateData` (used by the wrap command) gains a `ProjectName` field; `Service.Init` populates it from `filepath.Base` of the target directory.
- `AppConfig` godoc updated to reflect image-first semantics; the top-level `App` field comment in `Config` is updated to match.
- `env.template.tmpl` comment updated to remove stale "prod profile only" annotation.

## Test plan

- `TestInitCmd_AppImageDefaultsToProjectName` — table-driven test across go, kotlin, typescript: verifies `image: "<project>:latest"` is present and no active `build:` directive exists.
- `TestNewWrapCmd_AppImageDerivedFromDirName` — verifies that `vibew wrap mywebapp/` generates `image: "mywebapp:latest"`.
- `TestTemplateData_ProjectName` — unit test for the new domain field.
- Existing `TestNewWrapCmd_RenderedYAMLValid` extended with a case that checks `image:` and `:latest` appear in the rendered YAML.
- `make check` passes (lint + build + all tests including demo-app).