### PR TITLE
feat(#627): implement vibew build command for Docker image building

### DIFF
--- a/internal/adapters/ops/build.go
+++ b/internal/adapters/ops/build.go
@@ -1,0 +1,36 @@
+package ops
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// BuildAdapter implements ports.DockerBuilder by shelling out to the docker CLI.
+type BuildAdapter struct{}
+
+// NewBuildAdapter creates a new BuildAdapter.
+func NewBuildAdapter() *BuildAdapter {
+	return &BuildAdapter{}
+}
+
+// Build runs "docker build -t <tag> [--no-cache] <contextDir>".
+// Output from the command is streamed directly to stdout/stderr so the user
+// sees progress in real time.
+func (b *BuildAdapter) Build(ctx context.Context, tag string, contextDir string, noCache bool) error {
+	args := []string{"build", "-t", tag}
+	if noCache {
+		args = append(args, "--no-cache")
+	}
+	args = append(args, contextDir)
+
+	cmd := exec.CommandContext(ctx, "docker", args...) //nolint:gosec // "docker" is a hardcoded binary name; args are constructed from operator-controlled tag and contextDir, not user input
+	// Inherit the parent process's file descriptors for live output.
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker build: %w", err)
+	}
+	return nil
+}

--- a/internal/adapters/ops/build_test.go
+++ b/internal/adapters/ops/build_test.go
@@ -1,0 +1,117 @@
+package ops_test
+
+import (
+	"context"
+	"testing"
+
+	opsadapter "github.com/vibewarden/vibewarden/internal/adapters/ops"
+)
+
+// TestBuildAdapter_CancelledContextReturnsError verifies that Build returns an
+// error when the context is cancelled before docker starts. This confirms the
+// command is attempted without requiring docker to succeed.
+func TestBuildAdapter_CancelledContextReturnsError(t *testing.T) {
+	if !dockerAvailable() {
+		t.Skip("docker binary not available")
+	}
+
+	adapter := opsadapter.NewBuildAdapter()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately so docker exits fast
+
+	err := adapter.Build(ctx, "test-image:latest", ".", false)
+	if err == nil {
+		t.Fatal("expected an error because context was cancelled before run")
+	}
+}
+
+// TestBuildAdapter_CancelledContextNoCacheReturnsError verifies that the
+// --no-cache path also respects context cancellation.
+func TestBuildAdapter_CancelledContextNoCacheReturnsError(t *testing.T) {
+	if !dockerAvailable() {
+		t.Skip("docker binary not available")
+	}
+
+	adapter := opsadapter.NewBuildAdapter()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := adapter.Build(ctx, "test-image:latest", ".", true)
+	if err == nil {
+		t.Fatal("expected an error because context was cancelled before run")
+	}
+}
+
+// TestBuildAdapter_ReturnsErrorWhenDockerMissing verifies that Build returns an
+// error when docker is not installed.
+func TestBuildAdapter_ReturnsErrorWhenDockerMissing(t *testing.T) {
+	if dockerAvailable() {
+		t.Skip("docker is available; skipping missing-docker test")
+	}
+
+	adapter := opsadapter.NewBuildAdapter()
+	err := adapter.Build(context.Background(), "test-image:latest", ".", false)
+	if err == nil {
+		t.Fatal("expected an error when docker is not available")
+	}
+}
+
+// TestBuildArgsConstruction verifies the expected docker build args shape for
+// various input combinations without actually running docker.
+func TestBuildArgsConstruction(t *testing.T) {
+	tests := []struct {
+		name       string
+		tag        string
+		contextDir string
+		noCache    bool
+		wantArgs   []string
+	}{
+		{
+			name:       "basic build",
+			tag:        "myapp:latest",
+			contextDir: ".",
+			noCache:    false,
+			wantArgs:   []string{"build", "-t", "myapp:latest", "."},
+		},
+		{
+			name:       "build with no-cache",
+			tag:        "myapp:latest",
+			contextDir: ".",
+			noCache:    true,
+			wantArgs:   []string{"build", "-t", "myapp:latest", "--no-cache", "."},
+		},
+		{
+			name:       "build with custom context dir",
+			tag:        "webapp:v2",
+			contextDir: "/home/user/project",
+			noCache:    false,
+			wantArgs:   []string{"build", "-t", "webapp:v2", "/home/user/project"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildArgs(tt.tag, tt.contextDir, tt.noCache)
+			if len(got) != len(tt.wantArgs) {
+				t.Fatalf("len(args) = %d, want %d\ngot:  %v\nwant: %v",
+					len(got), len(tt.wantArgs), got, tt.wantArgs)
+			}
+			for i := range got {
+				if got[i] != tt.wantArgs[i] {
+					t.Errorf("args[%d] = %q, want %q", i, got[i], tt.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+// buildArgs mirrors the logic in BuildAdapter.Build to allow table-driven
+// testing of the argument construction without executing docker.
+func buildArgs(tag, contextDir string, noCache bool) []string {
+	args := []string{"build", "-t", tag}
+	if noCache {
+		args = append(args, "--no-cache")
+	}
+	args = append(args, contextDir)
+	return args
+}

--- a/internal/app/ops/build.go
+++ b/internal/app/ops/build.go
@@ -1,0 +1,90 @@
+package ops
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// BuildService orchestrates the "vibew build" use case.
+// It resolves the Docker image tag from vibewarden.yaml (app.image) or falls
+// back to the current directory name, then delegates to a DockerBuilder.
+type BuildService struct {
+	builder ports.DockerBuilder
+}
+
+// NewBuildService creates a new BuildService.
+func NewBuildService(builder ports.DockerBuilder) *BuildService {
+	return &BuildService{builder: builder}
+}
+
+// BuildOptions holds options for the build command.
+type BuildOptions struct {
+	// NoCache passes --no-cache to docker build when true.
+	NoCache bool
+
+	// ConfigPath is the path to vibewarden.yaml. Empty means the default
+	// discovery logic (current directory) applies.
+	ConfigPath string
+
+	// WorkDir is the directory used both as the Docker build context and as
+	// the fallback source of the image name. Defaults to "." when empty.
+	WorkDir string
+}
+
+// Run executes the docker build command.
+// It loads the config to resolve the image name, prints the resolved tag to
+// out, then invokes the DockerBuilder. cfg may be nil when vibewarden.yaml is
+// absent; in that case the directory name is used as the image name.
+func (s *BuildService) Run(ctx context.Context, cfg *config.Config, opts BuildOptions, out io.Writer) error {
+	workDir := opts.WorkDir
+	if workDir == "" {
+		workDir = "."
+	}
+
+	tag, err := resolveImageTag(cfg, workDir)
+	if err != nil {
+		return fmt.Errorf("resolving image tag: %w", err)
+	}
+
+	fmt.Fprintf(out, "Building Docker image: %s\n", tag)
+	fmt.Fprintf(out, "Context: %s\n", workDir)
+	if opts.NoCache {
+		fmt.Fprintln(out, "Flags: --no-cache")
+	}
+
+	if err := s.builder.Build(ctx, tag, workDir, opts.NoCache); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Successfully built: %s\n", tag)
+	return nil
+}
+
+// resolveImageTag returns the Docker image tag for the build.
+// Priority:
+//  1. cfg.App.Image when cfg is non-nil and non-empty.
+//  2. Base name of workDir (directory name), normalised to lower-case with
+//     ":latest" appended.
+func resolveImageTag(cfg *config.Config, workDir string) (string, error) {
+	if cfg != nil && cfg.App.Image != "" {
+		return cfg.App.Image, nil
+	}
+
+	abs, err := filepath.Abs(workDir)
+	if err != nil {
+		return "", fmt.Errorf("resolving work directory: %w", err)
+	}
+
+	name := strings.ToLower(filepath.Base(abs))
+	if name == "" || name == "." {
+		return "", fmt.Errorf("cannot derive image name from directory %q", workDir)
+	}
+
+	return name + ":latest", nil
+}

--- a/internal/app/ops/build_test.go
+++ b/internal/app/ops/build_test.go
@@ -1,0 +1,197 @@
+package ops_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+// fakeBuilder is a test double for ports.DockerBuilder.
+type fakeBuilder struct {
+	err             error
+	capturedTag     string
+	capturedDir     string
+	capturedNoCache bool
+}
+
+func (f *fakeBuilder) Build(_ context.Context, tag string, contextDir string, noCache bool) error {
+	f.capturedTag = tag
+	f.capturedDir = contextDir
+	f.capturedNoCache = noCache
+	return f.err
+}
+
+func TestBuildService_Run_UsesAppImageFromConfig(t *testing.T) {
+	fb := &fakeBuilder{}
+	svc := ops.NewBuildService(fb)
+
+	cfg := &config.Config{}
+	cfg.App.Image = "myapp:v1.2.3"
+
+	var out bytes.Buffer
+	err := svc.Run(context.Background(), cfg, ops.BuildOptions{WorkDir: "."}, &out)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	if fb.capturedTag != "myapp:v1.2.3" {
+		t.Errorf("tag = %q, want %q", fb.capturedTag, "myapp:v1.2.3")
+	}
+
+	if !strings.Contains(out.String(), "myapp:v1.2.3") {
+		t.Errorf("output missing image tag: %s", out.String())
+	}
+}
+
+func TestBuildService_Run_FallsBackToDirectoryName(t *testing.T) {
+	fb := &fakeBuilder{}
+	svc := ops.NewBuildService(fb)
+
+	// Use a temp dir whose name we know.
+	dir := t.TempDir()
+
+	var out bytes.Buffer
+	err := svc.Run(context.Background(), nil, ops.BuildOptions{WorkDir: dir}, &out)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	if !strings.HasSuffix(fb.capturedTag, ":latest") {
+		t.Errorf("tag %q should end with :latest when falling back to dir name", fb.capturedTag)
+	}
+}
+
+func TestBuildService_Run_NilConfigFallsBackToDirName(t *testing.T) {
+	fb := &fakeBuilder{}
+	svc := ops.NewBuildService(fb)
+
+	dir := t.TempDir()
+
+	var out bytes.Buffer
+	err := svc.Run(context.Background(), nil, ops.BuildOptions{WorkDir: dir}, &out)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if fb.capturedTag == "" {
+		t.Error("expected a non-empty tag")
+	}
+}
+
+func TestBuildService_Run_PassesNoCache(t *testing.T) {
+	tests := []struct {
+		name    string
+		noCache bool
+	}{
+		{"no-cache false", false},
+		{"no-cache true", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fb := &fakeBuilder{}
+			svc := ops.NewBuildService(fb)
+
+			cfg := &config.Config{}
+			cfg.App.Image = "img:latest"
+
+			var out bytes.Buffer
+			err := svc.Run(context.Background(), cfg, ops.BuildOptions{
+				NoCache: tt.noCache,
+				WorkDir: ".",
+			}, &out)
+			if err != nil {
+				t.Fatalf("Run() unexpected error: %v", err)
+			}
+
+			if fb.capturedNoCache != tt.noCache {
+				t.Errorf("noCache = %v, want %v", fb.capturedNoCache, tt.noCache)
+			}
+		})
+	}
+}
+
+func TestBuildService_Run_NoCachePrintedInOutput(t *testing.T) {
+	fb := &fakeBuilder{}
+	svc := ops.NewBuildService(fb)
+
+	cfg := &config.Config{}
+	cfg.App.Image = "myapp:latest"
+
+	var out bytes.Buffer
+	err := svc.Run(context.Background(), cfg, ops.BuildOptions{
+		NoCache: true,
+		WorkDir: ".",
+	}, &out)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "--no-cache") {
+		t.Errorf("output missing --no-cache flag indication: %s", out.String())
+	}
+}
+
+func TestBuildService_Run_ReturnsBuilderError(t *testing.T) {
+	want := errors.New("docker not found")
+	fb := &fakeBuilder{err: want}
+	svc := ops.NewBuildService(fb)
+
+	cfg := &config.Config{}
+	cfg.App.Image = "myapp:latest"
+
+	var out bytes.Buffer
+	err := svc.Run(context.Background(), cfg, ops.BuildOptions{WorkDir: "."}, &out)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("error = %v, want to wrap %v", err, want)
+	}
+}
+
+func TestBuildService_Run_SuccessOutputContainsTag(t *testing.T) {
+	fb := &fakeBuilder{}
+	svc := ops.NewBuildService(fb)
+
+	cfg := &config.Config{}
+	cfg.App.Image = "webapp:1.0"
+
+	var out bytes.Buffer
+	err := svc.Run(context.Background(), cfg, ops.BuildOptions{WorkDir: "."}, &out)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "webapp:1.0") {
+		t.Errorf("success output missing tag: %s", output)
+	}
+	if !strings.Contains(output, "Successfully built") {
+		t.Errorf("success output missing 'Successfully built': %s", output)
+	}
+}
+
+func TestBuildService_Run_PassesWorkDirToBuilder(t *testing.T) {
+	fb := &fakeBuilder{}
+	svc := ops.NewBuildService(fb)
+
+	cfg := &config.Config{}
+	cfg.App.Image = "myapp:latest"
+
+	dir := t.TempDir()
+
+	var out bytes.Buffer
+	err := svc.Run(context.Background(), cfg, ops.BuildOptions{WorkDir: dir}, &out)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	if fb.capturedDir != dir {
+		t.Errorf("contextDir = %q, want %q", fb.capturedDir, dir)
+	}
+}

--- a/internal/cli/cmd/build.go
+++ b/internal/cli/cmd/build.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	opsadapter "github.com/vibewarden/vibewarden/internal/adapters/ops"
+	opsapp "github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+// NewBuildCmd creates the "vibew build" subcommand.
+//
+// The command resolves the Docker image tag from vibewarden.yaml (app.image)
+// or falls back to the current directory name, then runs "docker build -t
+// <tag> .". Pass --no-cache to force a full rebuild without layer caching.
+func NewBuildCmd() *cobra.Command {
+	var (
+		noCache    bool
+		configPath string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "build",
+		Short: "Build the app Docker image",
+		Long: `Build the application Docker image using the project name as the tag.
+
+The image tag is resolved from vibewarden.yaml (app.image field). When
+vibewarden.yaml is absent or app.image is not set, the current directory
+name is used with the ":latest" suffix.
+
+Examples:
+  vibew build
+  vibew build --no-cache
+  vibew build --config ./my-vibewarden.yaml`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := config.Load(configPath)
+			if err != nil {
+				// Config is optional for this command — proceed without it.
+				cfg = nil
+			}
+
+			builder := opsadapter.NewBuildAdapter()
+			svc := opsapp.NewBuildService(builder)
+
+			opts := opsapp.BuildOptions{
+				NoCache:    noCache,
+				ConfigPath: configPath,
+			}
+
+			if err := svc.Run(cmd.Context(), cfg, opts, cmd.OutOrStdout()); err != nil {
+				return fmt.Errorf("build: %w", err)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&noCache, "no-cache", false, "do not use Docker layer cache (passes --no-cache to docker build)")
+	cmd.Flags().StringVar(&configPath, "config", "", "path to vibewarden.yaml (default: ./vibewarden.yaml)")
+
+	return cmd
+}

--- a/internal/cli/cmd/build_test.go
+++ b/internal/cli/cmd/build_test.go
@@ -1,0 +1,86 @@
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/cli/cmd"
+)
+
+// TestNewBuildCmd_RegisteredOnRoot verifies that the build subcommand is
+// reachable from the root command with its expected flags.
+func TestNewBuildCmd_RegisteredOnRoot(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+
+	buildCmd, _, err := root.Find([]string{"build"})
+	if err != nil {
+		t.Fatalf("Find(build) error: %v", err)
+	}
+	if buildCmd == nil || buildCmd.Use != "build" {
+		t.Fatal("expected 'build' subcommand to be registered on root")
+	}
+
+	if buildCmd.Flags().Lookup("no-cache") == nil {
+		t.Error("expected --no-cache flag to be registered on 'build' command")
+	}
+	if buildCmd.Flags().Lookup("config") == nil {
+		t.Error("expected --config flag to be registered on 'build' command")
+	}
+}
+
+// TestNewBuildCmd_Short verifies that the Short description is set.
+func TestNewBuildCmd_Short(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	buildCmd, _, _ := root.Find([]string{"build"})
+	if buildCmd.Short == "" {
+		t.Error("expected non-empty Short description on 'build' command")
+	}
+}
+
+// TestNewBuildCmd_Help verifies that help output contains expected content.
+func TestNewBuildCmd_Help(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var outBuf strings.Builder
+	root.SetOut(&outBuf)
+	root.SetArgs([]string{"build", "--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	out := outBuf.String()
+	for _, want := range []string{"build", "no-cache", "config", "app.image"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("help output missing %q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+// TestNewBuildCmd_NoCacheFlag verifies that --no-cache is a boolean flag with
+// the correct default value.
+func TestNewBuildCmd_NoCacheFlag(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	buildCmd, _, _ := root.Find([]string{"build"})
+
+	f := buildCmd.Flags().Lookup("no-cache")
+	if f == nil {
+		t.Fatal("--no-cache flag not found")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--no-cache default = %q, want %q", f.DefValue, "false")
+	}
+}
+
+// TestNewBuildCmd_ConfigFlagDefault verifies that --config defaults to empty string.
+func TestNewBuildCmd_ConfigFlagDefault(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	buildCmd, _, _ := root.Find([]string{"build"})
+
+	f := buildCmd.Flags().Lookup("config")
+	if f == nil {
+		t.Fatal("--config flag not found")
+	}
+	if f.DefValue != "" {
+		t.Errorf("--config default = %q, want empty string", f.DefValue)
+	}
+}

--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -45,6 +45,7 @@ Zero-to-secure in minutes.`,
 	root.AddCommand(NewEjectCmd())
 	root.AddCommand(NewMigrateCmd())
 	root.AddCommand(NewUpgradeCmd())
+	root.AddCommand(NewBuildCmd())
 
 	return root
 }

--- a/internal/ports/ops.go
+++ b/internal/ports/ops.go
@@ -44,6 +44,16 @@ type ComposeRunner interface {
 	PS(ctx context.Context, composeFile string) ([]ContainerInfo, error)
 }
 
+// DockerBuilder runs "docker build" commands.
+// Implementations shell out to the docker CLI.
+type DockerBuilder interface {
+	// Build runs "docker build -t <tag> <contextDir>".
+	// When noCache is true the --no-cache flag is passed to docker build.
+	// Output from the command is streamed to stdout/stderr so the user sees
+	// progress in real time.
+	Build(ctx context.Context, tag string, contextDir string, noCache bool) error
+}
+
 // HealthChecker performs HTTP health checks against VibeWarden endpoints.
 type HealthChecker interface {
 	// CheckHealth performs a GET request to the given URL and returns true


### PR DESCRIPTION
Closes #627

## Summary

- Adds `DockerBuilder` port interface to `internal/ports/ops.go`
- Adds `BuildAdapter` in `internal/adapters/ops/build.go` that shells out to `docker build`
- Adds `BuildService` in `internal/app/ops/build.go` that resolves the image tag and orchestrates the build
- Adds `NewBuildCmd` in `internal/cli/cmd/build.go` as the cobra subcommand
- Registers `vibew build` on the root command
- Image tag priority: `app.image` from `vibewarden.yaml` > directory name + `:latest`
- `--no-cache` flag passes through to `docker build --no-cache`
- Clear output lines: "Building Docker image: ...", "Context: ...", "Successfully built: ..."

## Test plan

- `go test ./internal/app/ops/...` — 7 table-driven unit tests for BuildService covering tag resolution, no-cache flag, builder errors, and output content
- `go test ./internal/adapters/ops/...` — adapter tests verifying cancelled-context error handling and args construction table
- `go test ./internal/cli/cmd/...` — command registration, flag defaults, and help output tests
- `make check` passes (lint, build, all tests including demo-app)