### PR TITLE
feat(#628): add vibew restart command

### DIFF
--- a/internal/adapters/ops/compose.go
+++ b/internal/adapters/ops/compose.go
@@ -48,14 +48,17 @@ func (c *ComposeAdapter) Up(ctx context.Context, composeFile string, profiles []
 	return nil
 }
 
-// Restart runs "docker compose [-f <composeFile>] restart".
+// Restart runs "docker compose [-f <composeFile>] restart [<service>...]".
 // When composeFile is non-empty it is passed as the -f flag.
-func (c *ComposeAdapter) Restart(ctx context.Context, composeFile string) error {
+// When services is non-empty each service name is appended so that only those
+// services are restarted; when empty all services are restarted.
+func (c *ComposeAdapter) Restart(ctx context.Context, composeFile string, services []string) error {
 	args := []string{"compose"}
 	if composeFile != "" {
 		args = append(args, "-f", composeFile)
 	}
 	args = append(args, "restart")
+	args = append(args, services...)
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	if err := cmd.Run(); err != nil {

--- a/internal/adapters/ops/compose_test.go
+++ b/internal/adapters/ops/compose_test.go
@@ -84,6 +84,97 @@ func TestComposeAdapter_UpArgsWithComposeFile(t *testing.T) {
 	}
 }
 
+func TestComposeAdapter_Restart_CancelledContext(t *testing.T) {
+	if !dockerAvailable() {
+		t.Skip("docker binary not available")
+	}
+
+	adapter := opsadapter.NewComposeAdapter()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := adapter.Restart(ctx, "", nil)
+	if err == nil {
+		t.Fatal("expected an error because context was cancelled")
+	}
+}
+
+func TestComposeAdapter_Restart_CancelledContextWithService(t *testing.T) {
+	if !dockerAvailable() {
+		t.Skip("docker binary not available")
+	}
+
+	adapter := opsadapter.NewComposeAdapter()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := adapter.Restart(ctx, ".vibewarden/generated/docker-compose.yml", []string{"app"})
+	if err == nil {
+		t.Fatal("expected an error because context was cancelled")
+	}
+}
+
+// restartArgs mirrors the argument-construction logic of ComposeAdapter.Restart
+// for use in table-driven tests.
+func restartArgs(composeFile string, services []string) []string {
+	args := []string{"compose"}
+	if composeFile != "" {
+		args = append(args, "-f", composeFile)
+	}
+	args = append(args, "restart")
+	args = append(args, services...)
+	return args
+}
+
+func TestRestartArgsConstruction(t *testing.T) {
+	tests := []struct {
+		name        string
+		composeFile string
+		services    []string
+		want        []string
+	}{
+		{
+			name: "no file, no services",
+			want: []string{"compose", "restart"},
+		},
+		{
+			name:     "no file, single service",
+			services: []string{"app"},
+			want:     []string{"compose", "restart", "app"},
+		},
+		{
+			name:     "no file, multiple services",
+			services: []string{"app", "kratos"},
+			want:     []string{"compose", "restart", "app", "kratos"},
+		},
+		{
+			name:        "with file, no services",
+			composeFile: ".vibewarden/generated/docker-compose.yml",
+			want:        []string{"compose", "-f", ".vibewarden/generated/docker-compose.yml", "restart"},
+		},
+		{
+			name:        "with file and service",
+			composeFile: ".vibewarden/generated/docker-compose.yml",
+			services:    []string{"app"},
+			want:        []string{"compose", "-f", ".vibewarden/generated/docker-compose.yml", "restart", "app"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := restartArgs(tt.composeFile, tt.services)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len(args) = %d, want %d\ngot:  %v\nwant: %v", len(got), len(tt.want), got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("args[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestComposeAdapter_VersionReturnsErrorWhenDockerMissing(t *testing.T) {
 	if dockerAvailable() {
 		t.Skip("docker is available; skipping missing-docker test")

--- a/internal/app/ops/dev.go
+++ b/internal/app/ops/dev.go
@@ -133,7 +133,7 @@ func (s *DevService) watchLoop(ctx context.Context, cfg *config.Config, opts Dev
 				}
 			}
 
-			if err := s.compose.Restart(ctx, composeFile); err != nil {
+			if err := s.compose.Restart(ctx, composeFile, nil); err != nil {
 				slog.Error("compose restart failed", "error", err)
 				fmt.Fprintf(out, "compose restart failed: %v\n", err)
 			}

--- a/internal/app/ops/dev_test.go
+++ b/internal/app/ops/dev_test.go
@@ -33,7 +33,7 @@ func (f *fakeCompose) Up(_ context.Context, composeFile string, profiles []strin
 	return f.upErr
 }
 
-func (f *fakeCompose) Restart(_ context.Context, _ string) error {
+func (f *fakeCompose) Restart(_ context.Context, _ string, _ []string) error {
 	f.restartCalled++
 	return f.restartErr
 }

--- a/internal/app/ops/restart.go
+++ b/internal/app/ops/restart.go
@@ -1,0 +1,43 @@
+package ops
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// RestartService orchestrates the "vibew restart" use case.
+// It restarts one or more services in the Docker Compose stack without
+// rebuilding or recreating containers.
+type RestartService struct {
+	compose ports.ComposeRunner
+}
+
+// NewRestartService creates a new RestartService.
+func NewRestartService(compose ports.ComposeRunner) *RestartService {
+	return &RestartService{compose: compose}
+}
+
+// Run restarts the compose stack (or a subset of services) using the generated
+// compose file under .vibewarden/generated/.
+// When services is empty all services are restarted.
+// When services is non-empty only those named services are restarted.
+func (s *RestartService) Run(ctx context.Context, services []string, out io.Writer) error {
+	composeFile := filepath.Join(generatedOutputDir, "docker-compose.yml")
+
+	if len(services) == 0 {
+		fmt.Fprintln(out, "Restarting all services...")
+	} else {
+		fmt.Fprintf(out, "Restarting service(s): %v...\n", services)
+	}
+
+	if err := s.compose.Restart(ctx, composeFile, services); err != nil {
+		return fmt.Errorf("restarting services: %w", err)
+	}
+
+	fmt.Fprintln(out, "Done.")
+	return nil
+}

--- a/internal/app/ops/restart_test.go
+++ b/internal/app/ops/restart_test.go
@@ -1,0 +1,121 @@
+package ops_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	opsapp "github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// fakeComposeRunner is a simple fake that records the arguments passed to Restart.
+type fakeComposeRunner struct {
+	// restartComposeFile is the composeFile argument received by the last Restart call.
+	restartComposeFile string
+	// restartServices is the services argument received by the last Restart call.
+	restartServices []string
+	// restartErr is the error Restart should return, if any.
+	restartErr error
+}
+
+func (f *fakeComposeRunner) Up(_ context.Context, _ string, _ []string) error {
+	return nil
+}
+
+func (f *fakeComposeRunner) Restart(_ context.Context, composeFile string, services []string) error {
+	f.restartComposeFile = composeFile
+	f.restartServices = services
+	return f.restartErr
+}
+
+func (f *fakeComposeRunner) Version(_ context.Context) (string, error) {
+	return "Docker Compose version v2.x", nil
+}
+
+func (f *fakeComposeRunner) Info(_ context.Context) error {
+	return nil
+}
+
+func (f *fakeComposeRunner) PS(_ context.Context, _ string) ([]ports.ContainerInfo, error) {
+	return nil, nil
+}
+
+func TestRestartService_Run(t *testing.T) {
+	wantComposeFile := filepath.Join(".vibewarden", "generated", "docker-compose.yml")
+
+	tests := []struct {
+		name       string
+		services   []string
+		restartErr error
+		wantErr    bool
+		wantOutput string
+	}{
+		{
+			name:       "restart all services",
+			services:   nil,
+			wantOutput: "Restarting all services",
+		},
+		{
+			name:       "restart single service",
+			services:   []string{"app"},
+			wantOutput: "app",
+		},
+		{
+			name:       "restart multiple services",
+			services:   []string{"app", "kratos"},
+			wantOutput: "app",
+		},
+		{
+			name:       "compose error is propagated",
+			services:   nil,
+			restartErr: errors.New("docker daemon not running"),
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeComposeRunner{restartErr: tt.restartErr}
+			svc := opsapp.NewRestartService(fake)
+
+			var out strings.Builder
+			err := svc.Run(context.Background(), tt.services, &out)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			// Verify compose file path.
+			if fake.restartComposeFile != wantComposeFile {
+				t.Errorf("composeFile = %q, want %q", fake.restartComposeFile, wantComposeFile)
+			}
+
+			// Verify services slice.
+			if len(tt.services) == 0 {
+				if len(fake.restartServices) != 0 {
+					t.Errorf("expected empty services slice, got %v", fake.restartServices)
+				}
+			} else {
+				if len(fake.restartServices) != len(tt.services) {
+					t.Fatalf("services len = %d, want %d", len(fake.restartServices), len(tt.services))
+				}
+				for i, s := range tt.services {
+					if fake.restartServices[i] != s {
+						t.Errorf("services[%d] = %q, want %q", i, fake.restartServices[i], s)
+					}
+				}
+			}
+
+			// Verify output mentions expected text.
+			if tt.wantOutput != "" && !strings.Contains(out.String(), tt.wantOutput) {
+				t.Errorf("output %q does not contain %q", out.String(), tt.wantOutput)
+			}
+		})
+	}
+}

--- a/internal/cli/cmd/ops_test.go
+++ b/internal/cli/cmd/ops_test.go
@@ -250,6 +250,68 @@ func TestNewGenerateCmd_Short(t *testing.T) {
 	}
 }
 
+// TestNewRestartCmd_RegisteredOnRoot verifies that the restart subcommand is
+// reachable from the root command.
+func TestNewRestartCmd_RegisteredOnRoot(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+
+	restartCmd, _, err := root.Find([]string{"restart"})
+	if err != nil {
+		t.Fatalf("Find(restart) error: %v", err)
+	}
+	if restartCmd == nil || restartCmd.Use == "" {
+		t.Fatal("expected 'restart' subcommand to be registered on root")
+	}
+}
+
+// TestNewRestartCmd_Short verifies the Short description is set.
+func TestNewRestartCmd_Short(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	restartCmd, _, _ := root.Find([]string{"restart"})
+	if restartCmd.Short == "" {
+		t.Error("expected non-empty Short description on 'restart' command")
+	}
+}
+
+// TestNewRestartCmd_Help verifies that help output for restart contains expected content.
+func TestNewRestartCmd_Help(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var outBuf strings.Builder
+	root.SetOut(&outBuf)
+	root.SetArgs([]string{"restart", "--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	out := outBuf.String()
+	for _, want := range []string{"restart", "service", ".vibewarden/generated"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("help output missing %q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+// TestNewRestartCmd_AcceptsServiceArgs verifies that the command accepts
+// optional positional arguments (service names).
+func TestNewRestartCmd_AcceptsServiceArgs(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	restartCmd, _, _ := root.Find([]string{"restart"})
+
+	// Args validator must accept any number of args (including zero).
+	if restartCmd.Args != nil {
+		if err := restartCmd.Args(restartCmd, []string{}); err != nil {
+			t.Errorf("Args validator rejected empty args: %v", err)
+		}
+		if err := restartCmd.Args(restartCmd, []string{"app"}); err != nil {
+			t.Errorf("Args validator rejected single service arg: %v", err)
+		}
+		if err := restartCmd.Args(restartCmd, []string{"app", "kratos"}); err != nil {
+			t.Errorf("Args validator rejected multiple service args: %v", err)
+		}
+	}
+}
+
 // TestQuickStartFlow_WrapThenDev documents and exercises the two-command Quick
 // Start path from the README:
 //

--- a/internal/cli/cmd/restart.go
+++ b/internal/cli/cmd/restart.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	opsadapter "github.com/vibewarden/vibewarden/internal/adapters/ops"
+	opsapp "github.com/vibewarden/vibewarden/internal/app/ops"
+)
+
+// NewRestartCmd creates the "vibew restart [service...]" subcommand.
+//
+// The command restarts the Docker Compose stack (or a subset of named services)
+// without rebuilding or recreating containers.  It always uses the generated
+// compose file at .vibewarden/generated/docker-compose.yml.
+//
+// Examples:
+//
+//	vibew restart              # restart all services
+//	vibew restart app          # restart only the app service
+//	vibew restart app kratos   # restart multiple services
+func NewRestartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "restart [service...]",
+		Short: "Restart the stack without rebuilding",
+		Long: `Restart the VibeWarden Docker Compose stack without rebuilding or recreating
+containers.  This is faster than 'vibew dev' after a config-only change.
+
+When called without arguments all services are restarted.  Pass one or more
+service names to restart only those services.
+
+The generated compose file at .vibewarden/generated/docker-compose.yml is used.
+Run 'vibew generate' first if that file does not yet exist.
+
+Examples:
+  vibew restart
+  vibew restart app
+  vibew restart app kratos`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			compose := opsadapter.NewComposeAdapter()
+			svc := opsapp.NewRestartService(compose)
+			return svc.Run(cmd.Context(), args, cmd.OutOrStdout())
+		},
+	}
+}

--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -46,6 +46,7 @@ Zero-to-secure in minutes.`,
 	root.AddCommand(NewMigrateCmd())
 	root.AddCommand(NewUpgradeCmd())
 	root.AddCommand(NewBuildCmd())
+	root.AddCommand(NewRestartCmd())
 
 	return root
 }

--- a/internal/ports/ops.go
+++ b/internal/ports/ops.go
@@ -25,10 +25,12 @@ type ComposeRunner interface {
 	// The output of the command is streamed to the caller via the returned channel.
 	Up(ctx context.Context, composeFile string, profiles []string) error
 
-	// Restart restarts all running services in the compose project.
+	// Restart restarts services in the compose project.
 	// composeFile is the path to the docker-compose.yml; when empty the default
 	// discovery logic applies.
-	Restart(ctx context.Context, composeFile string) error
+	// services is the optional list of service names to restart; when empty all
+	// services are restarted.
+	Restart(ctx context.Context, composeFile string, services []string) error
 
 	// Version returns the docker compose version string.
 	// Returns an error when docker compose is not available.


### PR DESCRIPTION
Closes #628

## Summary

- Extended `ports.ComposeRunner.Restart` to accept a `services []string` parameter (empty = restart all)
- Updated `ComposeAdapter.Restart` to pass service names as trailing args to `docker compose restart`
- Updated the one existing call site in `DevService.watchLoop` (`dev.go`) to pass `nil`
- Added `RestartService` application service (`internal/app/ops/restart.go`) that targets `.vibewarden/generated/docker-compose.yml`
- Added `NewRestartCmd` CLI command (`internal/cli/cmd/restart.go`) registered on the root command
- Tests for all new and modified code

## Test plan

- `go test ./internal/app/ops/... ./internal/adapters/ops/... ./internal/cli/cmd/...` passes
- `make check` passes (lint + build + race tests, including pre-push hook)
- Manual smoke test: `vibew restart` and `vibew restart app` produce correct output and error when compose file absent