### PR TITLE
feat(#630): update docs and agent templates for new build/dev/restart workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ curl -sS https://vibewarden.dev/install.sh | sh
 # Add VibeWarden to your existing project
 vibew wrap --upstream 3000
 
+# Build your app image
+vibew build
+
 # Start everything
 vibew dev
 ```
@@ -40,6 +43,7 @@ Your app on port 3000 is now behind VibeWarden at `https://localhost:8443`. Done
 ```powershell
 irm vibewarden.dev/install.ps1 | iex
 vibew wrap --upstream 3000
+vibew build
 vibew dev
 ```
 
@@ -197,7 +201,9 @@ If you need a general-purpose load balancer or a CDN edge, use the right tool fo
 | `vibew add tls --domain example.com` | Enable TLS |
 | `vibew add metrics` | Enable Prometheus metrics |
 | `vibew generate` | Regenerate `docker-compose.yml` from config |
+| `vibew build` | Build the Docker image for the app |
 | `vibew dev` | Start local dev environment |
+| `vibew restart` | Restart containers without rebuilding the image |
 | `vibew status` | Show health of all components |
 | `vibew doctor` | Diagnose common issues |
 | `vibew logs` | Pretty-print structured logs |
@@ -230,12 +236,14 @@ Regenerate after config changes:
 
 ```bash
 cd examples/demo-app
+./vibew build
 ./vibew dev
 # Open https://localhost:8443
 ```
 
-`vibew dev` generates the runtime configuration under `.vibewarden/generated/`
-and starts the full Docker Compose stack automatically.
+`vibew build` builds the demo app Docker image. `vibew dev` then generates the
+runtime configuration under `.vibewarden/generated/` and starts the full Docker
+Compose stack.
 
 The demo includes a Vulnerability Lab with live SQLi, XSS, and path traversal
 examples — and shows VibeWarden blocking them.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,7 +84,41 @@ AGENTS.md                # AI agent context (generic)
 
 ---
 
-## Step 3 — `vibew dev`
+## Step 3 — Build and start
+
+### 3a — Build the app
+
+Build the app binary or artifact using your language's tool:
+
+=== "Go"
+
+    ```bash
+    go build ./...
+    ```
+
+=== "Gradle (Kotlin / Java)"
+
+    ```bash
+    ./gradlew build
+    ```
+
+=== "npm (TypeScript / Node.js)"
+
+    ```bash
+    npm run build
+    ```
+
+### 3b — Build the Docker image
+
+```bash
+./vibew build
+```
+
+This runs `docker build` using the `Dockerfile` in your project root and tags the
+image so the Compose stack can reference it. You can also run
+`docker build -t myapp .` directly if you prefer.
+
+### 3c — `vibew dev`
 
 Start the full local stack:
 
@@ -99,6 +133,18 @@ This command:
 2. Starts the stack with `docker compose up`.
 
 Your app is now protected at `https://localhost:8443`.
+
+### Restarting after a code change
+
+After you change application code and rebuild the binary or artifact (step 3a),
+restart the containers without rebuilding the Docker image:
+
+```bash
+./vibew restart
+```
+
+Use `vibew build` followed by `vibew restart` when you also need to update the
+Docker image.
 
 !!! tip "Trust the self-signed certificate"
     On first run, VibeWarden generates a self-signed CA certificate so your browser
@@ -213,6 +259,7 @@ examples with Auth0, Keycloak, Firebase, Cognito, Okta, Supabase, and Kratos.
 
 ```bash
 ./vibew add metrics
+./vibew build
 ./vibew dev
 ```
 

--- a/internal/cli/templates/agents/claude.md.tmpl
+++ b/internal/cli/templates/agents/claude.md.tmpl
@@ -31,10 +31,27 @@ The sidecar handles:
 ## Running the project — CRITICAL RULE
 
 **NEVER start the app directly.** No `go run`, `gradlew run`, `npm start`, `node`, `java -jar`.
-**ALWAYS use `vibew dev`** — it starts the app AND the sidecar together.
+**ALWAYS use the workflow below** — build the app first, then start the full stack via `vibew dev`.
 
 ```bash
-vibew dev          # Start everything (app + sidecar + dependencies)
+# 1. Build with your language tool first
+#    Go:         go build ./...
+#    Gradle:     ./gradlew build
+#    npm:        npm run build
+
+# 2. Build the Docker image
+vibew build          # or: docker build -t <app-name> .
+
+# 3. Start everything (app + sidecar + dependencies)
+vibew dev
+
+# 4. After a code change, restart containers without a full rebuild
+vibew restart
+```
+
+Additional commands:
+
+```bash
 vibew dev --watch  # Start with hot reload on config changes
 vibew status       # Check component health
 vibew doctor       # Diagnose common issues
@@ -69,8 +86,10 @@ Access secrets in code via environment variables — vibew injects them at runti
 
 | Command | Description |
 |---------|-------------|
+| `vibew build` | Build the Docker image for the app |
 | `vibew dev` | Start dev environment (generates config, starts stack) |
 | `vibew dev --watch` | Start with file watching and hot reload |
+| `vibew restart` | Restart containers without rebuilding the image |
 | `vibew status` | Show health of all components |
 | `vibew logs` | Tail logs from all services |
 | `vibew logs app` | Tail logs from app only |

--- a/internal/cli/templates/claude.md.tmpl
+++ b/internal/cli/templates/claude.md.tmpl
@@ -71,15 +71,27 @@ Use `/_vibewarden/health` as the liveness probe in Docker Compose or Kubernetes.
 
 ## Running the dev environment
 
-Start everything with:
+Use this workflow every time:
 
-```
+```bash
+# 1. Build the app with your language tool
+#    Go:       go build ./...
+#    Gradle:   ./gradlew build
+#    npm:      npm run build
+
+# 2. Build the Docker image
+vibew build          # or: docker build -t <app-name> .
+
+# 3. Start the full stack
 vibew dev
+
+# 4. After a code change, restart without a full rebuild
+vibew restart
 ```
 
-This generates all runtime config (Kratos, Docker Compose) into `.vibewarden/generated/`
-and starts the full stack. Do not run `docker compose up` directly — use `vibew dev`
-so that config is generated from `vibewarden.yaml` first.
+`vibew dev` generates all runtime config (Kratos, Docker Compose) into
+`.vibewarden/generated/` and starts the full stack. Do not run `docker compose up`
+directly — use `vibew dev` so that config is always generated from `vibewarden.yaml` first.
 
 ## Configuration reference
 

--- a/internal/cli/templates/go/dev.md.tmpl
+++ b/internal/cli/templates/go/dev.md.tmpl
@@ -6,11 +6,28 @@ the architect's design. You write clean, idiomatic Go code.
 ## Running the project — CRITICAL
 
 **NEVER start the app directly** with `go run`, `go build && ./app`, or any direct execution.
-**ALWAYS use `vibew dev`** — it starts the app behind the VibeWarden sidecar with TLS,
-rate limiting, security headers, and all configured protections active.
+**ALWAYS use the workflow below** — it builds your app, then starts it behind the VibeWarden
+sidecar with TLS, rate limiting, security headers, and all configured protections active.
+
+### Workflow
 
 ```bash
-vibew dev          # Start dev environment (app + sidecar + dependencies)
+# 1. Build the app binary
+go build ./...
+
+# 2. Build the Docker image (app image must exist before starting the stack)
+vibew build            # or: docker build -t {{ .ProjectName }} .
+
+# 3. Start the full stack (app + sidecar + dependencies)
+vibew dev
+
+# 4. Restart containers after a code change without a full rebuild
+vibew restart
+```
+
+Additional commands:
+
+```bash
 vibew dev --watch  # Start with hot reload on config changes
 vibew status       # Check component health
 vibew doctor       # Diagnose common issues (run this when something breaks)
@@ -131,8 +148,10 @@ Rejected: GPL, AGPL, LGPL, CC-BY-SA, proprietary
 
 | Command | Description |
 |---------|-------------|
+| `vibew build` | Build the Docker image for the app |
 | `vibew dev` | Start dev environment (generates config, starts stack) |
 | `vibew dev --watch` | Start with file watching and hot reload |
+| `vibew restart` | Restart containers without rebuilding the image |
 | `vibew status` | Show health of all components |
 | `vibew logs` | Tail logs from all services |
 | `vibew logs app` | Tail logs from app only |
@@ -156,7 +175,7 @@ Rejected: GPL, AGPL, LGPL, CC-BY-SA, proprietary
 1. Add handler function in appropriate package
 2. Register route in `cmd/{{ .ProjectName }}/main.go`
 3. Add test in `*_test.go` next to the handler
-4. Run `vibew dev` to test
+4. Run `go build ./...`, `vibew build`, then `vibew dev` to test
 
 ### Add a new domain entity
 

--- a/internal/cli/templates/kotlin/dev.md.tmpl
+++ b/internal/cli/templates/kotlin/dev.md.tmpl
@@ -6,11 +6,28 @@ the architect's design. You write clean, idiomatic Kotlin code using Ktor.
 ## Running the project — CRITICAL
 
 **NEVER start the app directly** with `./gradlew run`, `java -jar`, or any direct execution.
-**ALWAYS use `vibew dev`** — it starts the app behind the VibeWarden sidecar with TLS,
-rate limiting, security headers, and all configured protections active.
+**ALWAYS use the workflow below** — it builds your app, then starts it behind the VibeWarden
+sidecar with TLS, rate limiting, security headers, and all configured protections active.
+
+### Workflow
 
 ```bash
-vibew dev          # Start dev environment (app + sidecar + dependencies)
+# 1. Build the app JAR
+./gradlew build
+
+# 2. Build the Docker image (app image must exist before starting the stack)
+vibew build            # or: docker build -t {{ .ProjectName }} .
+
+# 3. Start the full stack (app + sidecar + dependencies)
+vibew dev
+
+# 4. Restart containers after a code change without a full rebuild
+vibew restart
+```
+
+Additional commands:
+
+```bash
 vibew dev --watch  # Start with hot reload on config changes
 vibew status       # Check component health
 vibew doctor       # Diagnose common issues (run this when something breaks)
@@ -135,8 +152,10 @@ dependencies {
 
 | Command | Description |
 |---------|-------------|
+| `vibew build` | Build the Docker image for the app |
 | `vibew dev` | Start dev environment (generates config, starts stack) |
 | `vibew dev --watch` | Start with file watching and hot reload |
+| `vibew restart` | Restart containers without rebuilding the image |
 | `vibew status` | Show health of all components |
 | `vibew logs` | Tail logs from all services |
 | `vibew logs app` | Tail logs from app only |
@@ -160,7 +179,7 @@ dependencies {
 1. Add route in `configureRouting()` inside `Application.kt`
 2. Create a data class for request/response if needed
 3. Add test in `ApplicationTest.kt`
-4. Run `vibew dev` to test
+4. Run `./gradlew build`, `vibew build`, then `vibew dev` to test
 
 ### Add a new domain entity
 

--- a/internal/cli/templates/typescript/dev.md.tmpl
+++ b/internal/cli/templates/typescript/dev.md.tmpl
@@ -6,11 +6,28 @@ the architect's design. You write clean, idiomatic TypeScript using Express.
 ## Running the project — CRITICAL
 
 **NEVER start the app directly** with `npm start`, `npx ts-node`, `node dist/index.js`, or any direct execution.
-**ALWAYS use `vibew dev`** — it starts the app behind the VibeWarden sidecar with TLS,
-rate limiting, security headers, and all configured protections active.
+**ALWAYS use the workflow below** — it builds your app, then starts it behind the VibeWarden
+sidecar with TLS, rate limiting, security headers, and all configured protections active.
+
+### Workflow
 
 ```bash
-vibew dev          # Start dev environment (app + sidecar + dependencies)
+# 1. Build the app
+npm run build
+
+# 2. Build the Docker image (app image must exist before starting the stack)
+vibew build            # or: docker build -t {{ .ProjectName }} .
+
+# 3. Start the full stack (app + sidecar + dependencies)
+vibew dev
+
+# 4. Restart containers after a code change without a full rebuild
+vibew restart
+```
+
+Additional commands:
+
+```bash
 vibew dev --watch  # Start with hot reload on config changes
 vibew status       # Check component health
 vibew doctor       # Diagnose common issues (run this when something breaks)
@@ -162,8 +179,10 @@ npm install --save-dev <package>  # Dev-only dependency
 
 | Command | Description |
 |---------|-------------|
+| `vibew build` | Build the Docker image for the app |
 | `vibew dev` | Start dev environment (generates config, starts stack) |
 | `vibew dev --watch` | Start with file watching and hot reload |
+| `vibew restart` | Restart containers without rebuilding the image |
 | `vibew status` | Show health of all components |
 | `vibew logs` | Tail logs from all services |
 | `vibew logs app` | Tail logs from app only |
@@ -187,7 +206,7 @@ npm install --save-dev <package>  # Dev-only dependency
 1. Add route handler in `src/index.ts` (or extract to a router module)
 2. Define request/response types as TypeScript interfaces
 3. Add test in `src/index.test.ts`
-4. Run `vibew dev` to test
+4. Run `npm run build`, `vibew build`, then `vibew dev` to test
 
 ### Add a new domain entity
 


### PR DESCRIPTION
Closes #630

## Summary

- **Agent templates** (`go/dev.md.tmpl`, `kotlin/dev.md.tmpl`, `typescript/dev.md.tmpl`, `agents/claude.md.tmpl`, `claude.md.tmpl`): added explicit 4-step workflow — build with language tool, `vibew build`, `vibew dev`, `vibew restart`; added `vibew build` and `vibew restart` rows to the CLI reference table in each template.
- **README.md**: added `vibew build` step to both the macOS/Linux and Windows quick start snippets; added `vibew build` and `vibew restart` to the CLI Reference table; updated the Demo section.
- **docs/getting-started.md**: expanded Step 3 into sub-steps 3a (language build), 3b (`vibew build`), 3c (`vibew dev`), plus a "Restarting after a code change" block; updated the observability snippet.

## Test plan

- `make check` passes (build, lint, tests, demo-app — all green).
- Reviewed each template change to confirm the new workflow is consistent across all three language stacks (Go, Kotlin, TypeScript).
- README and getting-started quick-start flows match the 4-step pattern described in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)