### PR TITLE
feat(#638): check app image exists before vibew dev, restore multi-stage Dockerfiles

### DIFF
--- a/internal/adapters/ops/compose.go
+++ b/internal/adapters/ops/compose.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 
@@ -91,6 +92,33 @@ type composeContainer struct {
 	Service string `json:"Service"`
 	State   string `json:"State"`
 	Health  string `json:"Health"`
+}
+
+// ImageCheckerAdapter implements ports.DockerImageChecker by shelling out to
+// the docker CLI.
+type ImageCheckerAdapter struct{}
+
+// NewImageCheckerAdapter creates a new ImageCheckerAdapter.
+func NewImageCheckerAdapter() *ImageCheckerAdapter {
+	return &ImageCheckerAdapter{}
+}
+
+// ImageExists runs "docker image inspect <name>" and returns true when the
+// exit code is 0 (image found). A non-zero exit code is treated as a missing
+// image, not as an error. Other failures (e.g. daemon unreachable) are
+// returned as errors.
+func (a *ImageCheckerAdapter) ImageExists(ctx context.Context, name string) (bool, error) {
+	args := []string{"image", "inspect", name}
+	cmd := exec.CommandContext(ctx, "docker", args...) //nolint:gosec // args are constructed from caller-supplied image name, not user shell input
+	if err := cmd.Run(); err != nil {
+		// ExitError with code 1 means the image was not found.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return false, nil
+		}
+		return false, fmt.Errorf("docker image inspect: %w", err)
+	}
+	return true, nil
 }
 
 // PS runs "docker compose [-f <composeFile>] ps --format json" and returns one

--- a/internal/adapters/ops/compose_test.go
+++ b/internal/adapters/ops/compose_test.go
@@ -228,6 +228,38 @@ func commandArgs(composeFile string, profiles []string) []string {
 	return args
 }
 
+func TestImageCheckerAdapter_ImageExists_NondexistentImage(t *testing.T) {
+	// Run "docker image inspect" against a clearly non-existent image name.
+	// This verifies that a missing image returns (false, nil) and not an error.
+	if !dockerAvailable() {
+		t.Skip("docker binary not available")
+	}
+
+	adapter := opsadapter.NewImageCheckerAdapter()
+	exists, err := adapter.ImageExists(context.Background(), "vibewarden-test-nonexistent-image:definitely-not-here")
+	if err != nil {
+		t.Fatalf("ImageExists() unexpected error: %v", err)
+	}
+	if exists {
+		t.Error("ImageExists() = true, want false for a non-existent image")
+	}
+}
+
+func TestImageCheckerAdapter_ImageExists_CancelledContext(t *testing.T) {
+	if !dockerAvailable() {
+		t.Skip("docker binary not available")
+	}
+
+	adapter := opsadapter.NewImageCheckerAdapter()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := adapter.ImageExists(ctx, "alpine:latest")
+	if err == nil {
+		t.Fatal("ImageExists() expected error with cancelled context, got nil")
+	}
+}
+
 func TestCommandArgsConstruction(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/app/ops/dev.go
+++ b/internal/app/ops/dev.go
@@ -14,6 +14,15 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
+// buildInstructionsByLang maps known language identifiers (detected from common
+// project files) to human-readable build command examples.
+var buildInstructionsByLang = map[string]string{
+	"go":         "go build -o bin/<project> ./cmd/<project> && vibew build",
+	"kotlin":     "./gradlew buildFatJar && vibew build",
+	"typescript": "npm run build && vibew build",
+	"node":       "npm run build && vibew build",
+}
+
 const generatedOutputDir = ".vibewarden/generated"
 
 // DevService orchestrates the "vibew dev" use case.
@@ -21,9 +30,10 @@ const generatedOutputDir = ".vibewarden/generated"
 // before starting the Docker Compose stack and can watch the config file for
 // changes when --watch is enabled.
 type DevService struct {
-	compose   ports.ComposeRunner
-	generator ports.ConfigGenerator // optional; nil disables generation
-	watcher   ports.ConfigWatcher   // optional; nil disables file watching
+	compose      ports.ComposeRunner
+	generator    ports.ConfigGenerator    // optional; nil disables generation
+	watcher      ports.ConfigWatcher      // optional; nil disables file watching
+	imageChecker ports.DockerImageChecker // optional; nil disables pre-flight image check
 }
 
 // NewDevService creates a new DevService without config generation or file watching.
@@ -46,6 +56,14 @@ func NewDevServiceWithWatcher(compose ports.ComposeRunner, generator ports.Confi
 	return &DevService{compose: compose, generator: generator, watcher: watcher}
 }
 
+// WithImageChecker attaches a DockerImageChecker to the DevService.
+// When set, Run performs a pre-flight check that the app service image exists
+// locally before starting the compose stack.
+func (s *DevService) WithImageChecker(checker ports.DockerImageChecker) *DevService {
+	s.imageChecker = checker
+	return s
+}
+
 // DevOptions holds options for the dev command.
 type DevOptions struct {
 	// Observability enables the "observability" compose profile, which starts
@@ -61,6 +79,11 @@ type DevOptions struct {
 	// ConfigPath is the path to vibewarden.yaml that should be watched.
 	// When empty the default "./vibewarden.yaml" is used.
 	ConfigPath string
+
+	// DetectedLang is the programming language detected in the project directory
+	// (e.g. "go", "kotlin", "typescript"). When non-empty it is used to provide
+	// language-specific build instructions in the pre-flight image-missing error.
+	DetectedLang string
 }
 
 // Run generates runtime config files (when a generator is configured), then
@@ -83,6 +106,11 @@ func (s *DevService) Run(ctx context.Context, cfg *config.Config, opts DevOption
 	composeFile, err := s.resolveComposeFile(ctx, cfg, out)
 	if err != nil {
 		return fmt.Errorf("resolving compose file: %w", err)
+	}
+
+	// Pre-flight: verify the app image exists when using a pre-built image.
+	if err := s.checkAppImage(ctx, cfg, opts, out); err != nil {
+		return err
 	}
 
 	if err := s.compose.Up(ctx, composeFile, profiles); err != nil {
@@ -168,6 +196,59 @@ func (s *DevService) resolveComposeFile(ctx context.Context, cfg *config.Config,
 	// Nothing available — return empty and let docker compose fail with a
 	// clear error message.
 	return "", nil
+}
+
+// checkAppImage verifies that the app service image exists in the local Docker
+// daemon before attempting to start the compose stack.
+//
+// The check is skipped when:
+//   - No imageChecker is wired (s.imageChecker == nil).
+//   - cfg.App.Image is empty (no image configured).
+//   - cfg.App.Build is set (compose will build the image itself).
+//
+// When the image is missing, a descriptive error with language-specific build
+// instructions is returned so the user knows exactly what to do.
+func (s *DevService) checkAppImage(ctx context.Context, cfg *config.Config, opts DevOptions, out io.Writer) error {
+	if s.imageChecker == nil {
+		return nil
+	}
+	if cfg.App.Image == "" || cfg.App.Build != "" {
+		// Nothing to check: no image configured, or compose builds it.
+		return nil
+	}
+
+	image := cfg.App.Image
+	fmt.Fprintf(out, "Checking app image: %s\n", image)
+
+	exists, err := s.imageChecker.ImageExists(ctx, image)
+	if err != nil {
+		return fmt.Errorf("checking app image %q: %w", image, err)
+	}
+	if exists {
+		return nil
+	}
+
+	return buildMissingImageError(image, opts.DetectedLang)
+}
+
+// buildMissingImageError constructs a descriptive error for a missing Docker
+// image, including language-specific instructions when available.
+func buildMissingImageError(image, lang string) error {
+	msg := fmt.Sprintf("app image %q not found in the local Docker daemon.\n", image)
+	msg += "Build the image first, then run `vibew dev` again.\n\n"
+
+	if instructions, ok := buildInstructionsByLang[lang]; ok {
+		msg += fmt.Sprintf("For %s projects:\n  %s\n", lang, instructions)
+	} else {
+		msg += "Build steps:\n"
+		msg += "  1. Build your application binary / artifact.\n"
+		msg += "  2. Run `vibew build` to build the Docker image.\n"
+		msg += "\n"
+		msg += "Tip: set `app.build: \".\"` in vibewarden.yaml to have Compose build the\n"
+		msg += "image automatically on every `vibew dev` run (no pre-build required)."
+	}
+
+	return fmt.Errorf("%s", msg) //nolint:err113 // dynamic user-facing error message
 }
 
 // printServiceURLs writes a human-readable summary of the running services.

--- a/internal/app/ops/dev_test.go
+++ b/internal/app/ops/dev_test.go
@@ -344,3 +344,186 @@ func TestDevService_Watch_WatcherNil_DoesNotBlock(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 }
+
+// fakeImageChecker is a test double for ports.DockerImageChecker.
+type fakeImageChecker struct {
+	exists bool
+	err    error
+}
+
+func (f *fakeImageChecker) ImageExists(_ context.Context, _ string) (bool, error) {
+	return f.exists, f.err
+}
+
+// Ensure fakeImageChecker satisfies the interface at compile time.
+var _ ports.DockerImageChecker = (*fakeImageChecker)(nil)
+
+func TestDevService_ImageCheck_SkippedWhenNoChecker(t *testing.T) {
+	// Without an image checker wired, Run should succeed even when app.image is set.
+	fc := &fakeCompose{}
+	svc := ops.NewDevService(fc)
+	cfg := defaultConfig()
+	cfg.App.Image = "myapp:latest"
+	var buf bytes.Buffer
+
+	if err := svc.Run(context.Background(), cfg, ops.DevOptions{}, &buf); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+}
+
+func TestDevService_ImageCheck_SkippedWhenBuildSet(t *testing.T) {
+	// When app.build is set, compose builds the image — skip the check.
+	fc := &fakeCompose{}
+	fi := &fakeImageChecker{exists: false} // would fail if called
+	svc := ops.NewDevService(fc).WithImageChecker(fi)
+	cfg := defaultConfig()
+	cfg.App.Build = "."
+	cfg.App.Image = "myapp:latest"
+	var buf bytes.Buffer
+
+	if err := svc.Run(context.Background(), cfg, ops.DevOptions{}, &buf); err != nil {
+		t.Fatalf("Run() unexpected error when build is set: %v", err)
+	}
+}
+
+func TestDevService_ImageCheck_SkippedWhenNoImage(t *testing.T) {
+	// When app.image is empty, no check is performed.
+	fc := &fakeCompose{}
+	fi := &fakeImageChecker{exists: false} // would fail if called
+	svc := ops.NewDevService(fc).WithImageChecker(fi)
+	cfg := defaultConfig()
+	cfg.App.Image = ""
+	var buf bytes.Buffer
+
+	if err := svc.Run(context.Background(), cfg, ops.DevOptions{}, &buf); err != nil {
+		t.Fatalf("Run() unexpected error when no image configured: %v", err)
+	}
+}
+
+func TestDevService_ImageCheck_ImageExists_Proceeds(t *testing.T) {
+	// When the image exists, Run proceeds normally.
+	fc := &fakeCompose{}
+	fi := &fakeImageChecker{exists: true}
+	svc := ops.NewDevService(fc).WithImageChecker(fi)
+	cfg := defaultConfig()
+	cfg.App.Image = "myapp:latest"
+	var buf bytes.Buffer
+
+	if err := svc.Run(context.Background(), cfg, ops.DevOptions{}, &buf); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "myapp:latest") {
+		t.Errorf("expected output to mention image name, got:\n%s", out)
+	}
+}
+
+func TestDevService_ImageCheck_ImageMissing_ReturnsError(t *testing.T) {
+	// When the image is absent, Run must return an error before calling compose.
+	fc := &fakeCompose{}
+	fi := &fakeImageChecker{exists: false}
+	svc := ops.NewDevService(fc).WithImageChecker(fi)
+	cfg := defaultConfig()
+	cfg.App.Image = "myapp:latest"
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{}, &buf)
+	if err == nil {
+		t.Fatal("Run() expected error for missing image, got nil")
+	}
+	if !strings.Contains(err.Error(), "myapp:latest") {
+		t.Errorf("error should mention image name, got: %v", err)
+	}
+	// compose.Up must NOT have been called
+	if fc.capturedComposeFile != "" || fc.capturedProfiles != nil {
+		t.Errorf("compose.Up should not have been called when image is missing")
+	}
+}
+
+func TestDevService_ImageCheck_ImageMissing_WithGoLang_ContainsBuildHint(t *testing.T) {
+	// Error message for Go projects should include go build instructions.
+	fc := &fakeCompose{}
+	fi := &fakeImageChecker{exists: false}
+	svc := ops.NewDevService(fc).WithImageChecker(fi)
+	cfg := defaultConfig()
+	cfg.App.Image = "myapp:latest"
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{DetectedLang: "go"}, &buf)
+	if err == nil {
+		t.Fatal("Run() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "go build") {
+		t.Errorf("error should contain 'go build' hint for Go projects, got: %v", err)
+	}
+}
+
+func TestDevService_ImageCheck_ImageMissing_WithKotlinLang_ContainsBuildHint(t *testing.T) {
+	fc := &fakeCompose{}
+	fi := &fakeImageChecker{exists: false}
+	svc := ops.NewDevService(fc).WithImageChecker(fi)
+	cfg := defaultConfig()
+	cfg.App.Image = "myapp:latest"
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{DetectedLang: "kotlin"}, &buf)
+	if err == nil {
+		t.Fatal("Run() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "gradlew") {
+		t.Errorf("error should contain 'gradlew' hint for Kotlin projects, got: %v", err)
+	}
+}
+
+func TestDevService_ImageCheck_ImageMissing_WithTypeScriptLang_ContainsBuildHint(t *testing.T) {
+	fc := &fakeCompose{}
+	fi := &fakeImageChecker{exists: false}
+	svc := ops.NewDevService(fc).WithImageChecker(fi)
+	cfg := defaultConfig()
+	cfg.App.Image = "myapp:latest"
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{DetectedLang: "typescript"}, &buf)
+	if err == nil {
+		t.Fatal("Run() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "npm run build") {
+		t.Errorf("error should contain 'npm run build' hint for TypeScript projects, got: %v", err)
+	}
+}
+
+func TestDevService_ImageCheck_ImageMissing_UnknownLang_ContainsGenericHint(t *testing.T) {
+	fc := &fakeCompose{}
+	fi := &fakeImageChecker{exists: false}
+	svc := ops.NewDevService(fc).WithImageChecker(fi)
+	cfg := defaultConfig()
+	cfg.App.Image = "myapp:latest"
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{DetectedLang: ""}, &buf)
+	if err == nil {
+		t.Fatal("Run() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "vibew build") {
+		t.Errorf("error should mention 'vibew build', got: %v", err)
+	}
+}
+
+func TestDevService_ImageCheck_CheckerError_ReturnsError(t *testing.T) {
+	// When the image checker itself fails (e.g. docker daemon down), Run returns
+	// the wrapped error.
+	fc := &fakeCompose{}
+	fi := &fakeImageChecker{err: errors.New("docker daemon not running")}
+	svc := ops.NewDevService(fc).WithImageChecker(fi)
+	cfg := defaultConfig()
+	cfg.App.Image = "myapp:latest"
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{}, &buf)
+	if err == nil {
+		t.Fatal("Run() expected error when checker fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "docker daemon not running") {
+		t.Errorf("error should wrap checker error, got: %v", err)
+	}
+}

--- a/internal/cli/cmd/dev.go
+++ b/internal/cli/cmd/dev.go
@@ -8,11 +8,13 @@ import (
 
 	credentialsadapter "github.com/vibewarden/vibewarden/internal/adapters/credentials"
 	opsadapter "github.com/vibewarden/vibewarden/internal/adapters/ops"
+	scaffoldadapter "github.com/vibewarden/vibewarden/internal/adapters/scaffold"
 	templateadapter "github.com/vibewarden/vibewarden/internal/adapters/template"
 	generateapp "github.com/vibewarden/vibewarden/internal/app/generate"
 	opsapp "github.com/vibewarden/vibewarden/internal/app/ops"
 	"github.com/vibewarden/vibewarden/internal/config"
 	configtemplates "github.com/vibewarden/vibewarden/internal/config/templates"
+	"github.com/vibewarden/vibewarden/internal/domain/scaffold"
 )
 
 // NewDevCmd creates the "vibew dev" subcommand.
@@ -74,10 +76,19 @@ Examples:
 				svc = opsapp.NewDevServiceWithGenerator(compose, generator)
 			}
 
+			// Wire the image checker so that `vibew dev` fails early with a
+			// helpful message when the app image has not been built yet.
+			svc = svc.WithImageChecker(opsadapter.NewImageCheckerAdapter())
+
+			// Detect the project language to provide language-specific build
+			// instructions when the image is missing.
+			detectedLang := detectProjectLang(".")
+
 			opts := opsapp.DevOptions{
 				Observability: observability,
 				Watch:         watch,
 				ConfigPath:    configPath,
+				DetectedLang:  detectedLang,
 			}
 
 			return svc.Run(cmd.Context(), cfg, opts, cmd.OutOrStdout())
@@ -96,4 +107,39 @@ Examples:
 	}
 
 	return cmd
+}
+
+// detectProjectLang uses the scaffold Detector to infer the project language
+// from well-known indicator files in dir. Returns the language string expected
+// by DevOptions.DetectedLang ("go", "kotlin", "typescript", or "").
+func detectProjectLang(dir string) string {
+	d := scaffoldadapter.NewDetector()
+	proj, err := d.Detect(dir)
+	if err != nil {
+		return ""
+	}
+	switch proj.Type {
+	case scaffold.ProjectTypeGo:
+		return "go"
+	case scaffold.ProjectTypeNode:
+		// The scaffold detector uses "node" for all JS/TS projects; map to
+		// "typescript" when a tsconfig.json is present, otherwise "node".
+		if fileExistsAt(dir, "tsconfig.json") {
+			return "typescript"
+		}
+		return "node"
+	default:
+		// Kotlin is not currently detected by the scaffold Detector; fall back
+		// to file-based heuristic.
+		if fileExistsAt(dir, "build.gradle.kts") || fileExistsAt(dir, "build.gradle") {
+			return "kotlin"
+		}
+		return ""
+	}
+}
+
+// fileExistsAt returns true when the named file exists inside dir.
+func fileExistsAt(dir, name string) bool {
+	info, err := os.Stat(fmt.Sprintf("%s/%s", dir, name))
+	return err == nil && !info.IsDir()
 }

--- a/internal/cli/templates/go/dockerfile.tmpl
+++ b/internal/cli/templates/go/dockerfile.tmpl
@@ -1,7 +1,20 @@
-# Build your app first, then build this image.
-# Example: go build -o bin/{{ .ProjectName }} ./cmd/{{ .ProjectName }}
+# Multi-stage build — works out of the box with `vibew dev` (no pre-build needed).
+FROM golang:1.24-alpine AS build
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /bin/app ./cmd/{{ .ProjectName }}
+
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates wget
-COPY bin/{{ .ProjectName }} /app
+COPY --from=build /bin/app /app
 EXPOSE {{ .Port }}
 CMD ["/app"]
+
+# Thin-image alternative (requires pre-built binary; faster rebuilds):
+# FROM alpine:3.21
+# RUN apk add --no-cache ca-certificates wget
+# COPY bin/{{ .ProjectName }} /app
+# EXPOSE {{ .Port }}
+# CMD ["/app"]

--- a/internal/cli/templates/kotlin/dockerfile.tmpl
+++ b/internal/cli/templates/kotlin/dockerfile.tmpl
@@ -1,7 +1,19 @@
-# Build your app first, then build this image.
-# Example: ./gradlew buildFatJar
+# Multi-stage build — works out of the box with `vibew dev` (no pre-build needed).
+FROM gradle:8.13-jdk21-alpine AS build
+WORKDIR /app
+COPY build.gradle.kts settings.gradle.kts ./
+COPY src ./src
+RUN gradle buildFatJar --no-daemon
+
 FROM eclipse-temurin:21-jre-alpine
 RUN apk add --no-cache wget
-COPY build/libs/{{ .ProjectName }}-all.jar /app.jar
+COPY --from=build /app/build/libs/{{ .ProjectName }}-all.jar /app.jar
 EXPOSE {{ .Port }}
 CMD ["java", "-jar", "/app.jar"]
+
+# Thin-image alternative (requires pre-built fat JAR; faster rebuilds):
+# FROM eclipse-temurin:21-jre-alpine
+# RUN apk add --no-cache wget
+# COPY build/libs/{{ .ProjectName }}-all.jar /app.jar
+# EXPOSE {{ .Port }}
+# CMD ["java", "-jar", "/app.jar"]

--- a/internal/cli/templates/typescript/dockerfile.tmpl
+++ b/internal/cli/templates/typescript/dockerfile.tmpl
@@ -1,9 +1,25 @@
-# Build your app first, then build this image.
-# Example: npm run build
+# Multi-stage build — works out of the box with `vibew dev` (no pre-build needed).
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
 FROM node:22-alpine
 WORKDIR /app
-COPY dist/ ./dist/
+COPY --from=build /app/dist ./dist
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 EXPOSE {{ .Port }}
 CMD ["node", "dist/index.js"]
+
+# Thin-image alternative (requires pre-built dist/; faster rebuilds):
+# FROM node:22-alpine
+# WORKDIR /app
+# COPY dist/ ./dist/
+# COPY package.json package-lock.json ./
+# RUN npm ci --omit=dev
+# EXPOSE {{ .Port }}
+# CMD ["node", "dist/index.js"]

--- a/internal/ports/ops.go
+++ b/internal/ports/ops.go
@@ -69,3 +69,13 @@ type PortChecker interface {
 	// host:port address.
 	IsPortAvailable(ctx context.Context, host string, port int) (bool, error)
 }
+
+// DockerImageChecker checks whether a Docker image exists in the local daemon.
+// Implementations shell out to the docker CLI.
+type DockerImageChecker interface {
+	// ImageExists returns true when the named image is present in the local
+	// Docker image store. name is a full image reference such as "myapp:latest".
+	// Returns an error only for unexpected failures (e.g. docker daemon
+	// unreachable); a missing image is not an error — it returns (false, nil).
+	ImageExists(ctx context.Context, name string) (bool, error)
+}


### PR DESCRIPTION
Closes #638

## Summary

- **Pre-flight image check**: `DevService` now calls `checkAppImage` before `compose.Up`. When `app.image` is set and `app.build` is absent, it runs `docker image inspect <name>` via the new `DockerImageChecker` port. If the image is missing, it returns a clear error with language-specific build instructions (Go, Kotlin, TypeScript/Node) or a generic hint for unknown languages. The check is fully skipped when no checker is wired (preserving backward compatibility for callers that don't need it) or when `app.build` is set (compose handles the build).

- **`DockerImageChecker` port** added to `internal/ports/ops.go`.

- **`ImageCheckerAdapter`** added to `internal/adapters/ops/compose.go`, shelling out to `docker image inspect`. Missing image returns `(false, nil)`; daemon errors are wrapped and returned.

- **`DevOptions.DetectedLang`** field added. The CLI command detects the project language from the filesystem (go.mod, package.json + tsconfig.json, build.gradle.kts) and passes it to `DevOptions` so the error message can include the right build command.

- **Multi-stage Dockerfiles restored** for Go, Kotlin, and TypeScript so `vibew init → vibew dev` works out of the box without a pre-build step. The thin-image alternatives are kept as commented blocks for users who prefer faster rebuilds.

## Test plan

- `go test -race ./internal/app/ops/...` — 14 new tests covering all skip conditions, happy path, language-specific error messages, and checker failure.
- `go test -race ./internal/adapters/ops/...` — 2 new tests for `ImageCheckerAdapter` (non-existent image returns false without error; cancelled context returns error).
- `make check` passes (gofmt, golangci-lint, build, all tests including demo-app).

To verify manually:
1. `vibew init --lang go myapp && cd myapp`
2. `vibew dev` → fails immediately with "app image not found" and Go build hint (image not built yet).
3. `vibew build && vibew dev` → proceeds normally.
4. Set `app.build: "."` in `vibewarden.yaml` → `vibew dev` skips the check and compose builds the image.