### PR TITLE
docs: clarify first-run and iterative development modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,36 @@ all in a single binary that sits next to your app.
 # macOS / Linux
 curl -sS https://vibewarden.dev/install.sh | sh
 
-# Add VibeWarden to your existing project
-vibew wrap --upstream 3000
-
-# Build your app image
-vibew build
-
-# Start everything
+# Create a new project — multi-stage Dockerfile builds everything automatically
+vibew init --lang go myapp
+cd myapp
 vibew dev
 ```
 
-Your app on port 3000 is now behind VibeWarden at `https://localhost:8443`. Done.
+Your app is now behind VibeWarden at `https://localhost:8443`. Done.
 
 **Windows:**
 
 ```powershell
 irm vibewarden.dev/install.ps1 | iex
-vibew wrap --upstream 3000
-vibew build
+vibew init --lang go myapp
+cd myapp
 vibew dev
 ```
+
+### Faster iteration after the first run
+
+Once the stack is running, build locally for faster rebuilds instead of waiting for
+the full multi-stage Docker build:
+
+```bash
+go build -o bin/myapp ./cmd/myapp   # fast local build (seconds, not minutes)
+vibew build                          # package the artifact into a thin image
+vibew restart                        # restart containers without a full recreate
+```
+
+Use `vibew build` + `vibew restart` whenever you change code. Use `vibew dev` only when
+you add new services or change `vibewarden.yaml`.
 
 Docker images are published to `ghcr.io/vibewarden/vibewarden` as multi-arch manifests
 covering `linux/amd64` and `linux/arm64`. Docker pulls the correct image automatically

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,14 +86,44 @@ AGENTS.md                # AI agent context (generic)
 
 ## Step 3 — Build and start
 
-### 3a — Build the app
+There are two development modes. Choose based on where you are in your workflow.
 
-Build the app binary or artifact using your language's tool:
+---
+
+### Mode 1 — First run (just works)
+
+The generated `Dockerfile` is a multi-stage build. It compiles your app inside
+Docker, so you do not need any language toolchain installed locally. Run:
+
+```bash
+./vibew dev
+```
+
+This command:
+
+1. Runs `vibew generate` to produce `.vibewarden/generated/docker-compose.yml`
+   from your `vibewarden.yaml`.
+2. Runs `docker build` (multi-stage: compiles your app inside the container).
+3. Starts the full stack with `docker compose up`.
+
+Your app is protected at `https://localhost:8443`. Nothing else is required for the
+first run.
+
+---
+
+### Mode 2 — Iterative development (faster rebuilds)
+
+The multi-stage Docker build recompiles from source every time, which can take
+30–60 seconds. For fast iteration, build locally with your language tool and then
+package the resulting artifact into a thin Docker image. This build takes only a
+few seconds.
+
+**Step 3a — Build the app artifact locally**
 
 === "Go"
 
     ```bash
-    go build ./...
+    go build -o bin/myapp ./cmd/myapp
     ```
 
 === "Gradle (Kotlin / Java)"
@@ -108,43 +138,41 @@ Build the app binary or artifact using your language's tool:
     npm run build
     ```
 
-### 3b — Build the Docker image
+**Step 3b — Package into a thin Docker image**
 
 ```bash
 ./vibew build
 ```
 
-This runs `docker build` using the `Dockerfile` in your project root and tags the
-image so the Compose stack can reference it. You can also run
+This runs `docker build` using the thin-image stage in your `Dockerfile` (the
+commented-out section at the bottom). It copies the pre-built artifact instead of
+recompiling, so the image builds in seconds. You can also run
 `docker build -t myapp .` directly if you prefer.
 
-### 3c — `vibew dev`
+**Step 3c — Start or restart the stack**
 
-Start the full local stack:
+On first start:
 
 ```bash
 ./vibew dev
 ```
 
-This command:
-
-1. Runs `vibew generate` to produce `.vibewarden/generated/docker-compose.yml`
-   from your `vibewarden.yaml`.
-2. Starts the stack with `docker compose up`.
-
-Your app is now protected at `https://localhost:8443`.
-
-### Restarting after a code change
-
-After you change application code and rebuild the binary or artifact (step 3a),
-restart the containers without rebuilding the Docker image:
+After subsequent code changes — restart containers without a full `docker compose`
+recreate:
 
 ```bash
 ./vibew restart
 ```
 
-Use `vibew build` followed by `vibew restart` when you also need to update the
-Docker image.
+---
+
+### When to use which mode
+
+| Situation | Command |
+|-----------|---------|
+| First run, no local toolchain needed | `vibew dev` |
+| Code change, want fast feedback | build locally, then `vibew build` + `vibew restart` |
+| Added a new service or changed `vibewarden.yaml` | `vibew dev` (full recreate) |
 
 !!! tip "Trust the self-signed certificate"
     On first run, VibeWarden generates a self-signed CA certificate so your browser

--- a/internal/cli/templates/agents/claude.md.tmpl
+++ b/internal/cli/templates/agents/claude.md.tmpl
@@ -31,23 +31,35 @@ The sidecar handles:
 ## Running the project — CRITICAL RULE
 
 **NEVER start the app directly.** No `go run`, `gradlew run`, `npm start`, `node`, `java -jar`.
-**ALWAYS use the workflow below** — build the app first, then start the full stack via `vibew dev`.
+**ALWAYS use one of the two workflows below.**
+
+### First run (just works)
+
+The generated `Dockerfile` is a multi-stage build — it compiles the app inside Docker,
+so no local toolchain is required:
 
 ```bash
-# 1. Build with your language tool first
-#    Go:         go build ./...
+vibew dev   # generates config, builds image (multi-stage), starts full stack
+```
+
+### Iterative development (faster rebuilds)
+
+Build locally with your language tool, then package into a thin image and restart:
+
+```bash
+# 1. Build the app artifact locally (seconds, not minutes)
+#    Go:         go build -o bin/{{ .ProjectName }} ./cmd/{{ .ProjectName }}
 #    Gradle:     ./gradlew build
 #    npm:        npm run build
 
-# 2. Build the Docker image
-vibew build          # or: docker build -t <app-name> .
+# 2. Package the artifact into a thin Docker image
+vibew build          # or: docker build -t {{ .ProjectName }} .
 
-# 3. Start everything (app + sidecar + dependencies)
-vibew dev
-
-# 4. After a code change, restart containers without a full rebuild
+# 3. Restart containers without a full recreate
 vibew restart
 ```
+
+Use `vibew dev` (full recreate) only when you add new services or change `vibewarden.yaml`.
 
 Additional commands:
 

--- a/internal/cli/templates/go/dev.md.tmpl
+++ b/internal/cli/templates/go/dev.md.tmpl
@@ -6,24 +6,40 @@ the architect's design. You write clean, idiomatic Go code.
 ## Running the project — CRITICAL
 
 **NEVER start the app directly** with `go run`, `go build && ./app`, or any direct execution.
-**ALWAYS use the workflow below** — it builds your app, then starts it behind the VibeWarden
+**ALWAYS use one of the two workflows below** — your app must run behind the VibeWarden
 sidecar with TLS, rate limiting, security headers, and all configured protections active.
 
-### Workflow
+Running the app without the sidecar means NO TLS, NO auth, NO rate limiting, NO WAF.
+This is a security risk even in development.
+
+### First run (just works)
+
+The generated `Dockerfile` is a multi-stage build — it compiles the app inside Docker
+using the Go toolchain baked into the builder image, so no local Go installation is
+required:
 
 ```bash
-# 1. Build the app binary
-go build ./...
+vibew dev   # generates config, builds image (multi-stage), starts full stack
+```
 
-# 2. Build the Docker image (app image must exist before starting the stack)
+### Iterative development (faster rebuilds)
+
+The multi-stage Docker build recompiles from source on every `vibew build`, which can
+take 30–60 seconds. For fast iteration, build locally and copy the binary into a thin
+image instead:
+
+```bash
+# 1. Compile the binary locally (a few seconds)
+go build -o bin/{{ .ProjectName }} ./cmd/{{ .ProjectName }}
+
+# 2. Package the binary into a thin Docker image
 vibew build            # or: docker build -t {{ .ProjectName }} .
 
-# 3. Start the full stack (app + sidecar + dependencies)
-vibew dev
-
-# 4. Restart containers after a code change without a full rebuild
+# 3. Restart containers without a full recreate
 vibew restart
 ```
+
+Use `vibew dev` (full recreate) only when you add new services or change `vibewarden.yaml`.
 
 Additional commands:
 
@@ -35,9 +51,6 @@ vibew doctor       # Diagnose common issues (run this when something breaks)
 
 The app runs on port {{ .Port }} internally, but **always access it through the sidecar
 at https://localhost:8443**. Never expose port {{ .Port }} directly.
-
-Running the app without the sidecar means NO TLS, NO auth, NO rate limiting, NO WAF.
-This is a security risk even in development.
 
 ## Testing
 
@@ -175,7 +188,7 @@ Rejected: GPL, AGPL, LGPL, CC-BY-SA, proprietary
 1. Add handler function in appropriate package
 2. Register route in `cmd/{{ .ProjectName }}/main.go`
 3. Add test in `*_test.go` next to the handler
-4. Run `go build ./...`, `vibew build`, then `vibew dev` to test
+4. Run `go build -o bin/{{ .ProjectName }} ./cmd/{{ .ProjectName }}`, `vibew build`, then `vibew restart` to test
 
 ### Add a new domain entity
 

--- a/internal/cli/templates/kotlin/dev.md.tmpl
+++ b/internal/cli/templates/kotlin/dev.md.tmpl
@@ -6,24 +6,40 @@ the architect's design. You write clean, idiomatic Kotlin code using Ktor.
 ## Running the project — CRITICAL
 
 **NEVER start the app directly** with `./gradlew run`, `java -jar`, or any direct execution.
-**ALWAYS use the workflow below** — it builds your app, then starts it behind the VibeWarden
+**ALWAYS use one of the two workflows below** — your app must run behind the VibeWarden
 sidecar with TLS, rate limiting, security headers, and all configured protections active.
 
-### Workflow
+Running the app without the sidecar means NO TLS, NO auth, NO rate limiting, NO WAF.
+This is a security risk even in development.
+
+### First run (just works)
+
+The generated `Dockerfile` is a multi-stage build — it compiles the app inside Docker
+using the Gradle wrapper baked into the builder image, so no local JDK installation is
+required:
 
 ```bash
-# 1. Build the app JAR
+vibew dev   # generates config, builds image (multi-stage), starts full stack
+```
+
+### Iterative development (faster rebuilds)
+
+The multi-stage Docker build runs the full Gradle build on every `vibew build`, which
+can take 60+ seconds. For fast iteration, build the fat JAR locally and copy it into a
+thin image instead:
+
+```bash
+# 1. Compile the fat JAR locally
 ./gradlew build
 
-# 2. Build the Docker image (app image must exist before starting the stack)
+# 2. Package the JAR into a thin Docker image
 vibew build            # or: docker build -t {{ .ProjectName }} .
 
-# 3. Start the full stack (app + sidecar + dependencies)
-vibew dev
-
-# 4. Restart containers after a code change without a full rebuild
+# 3. Restart containers without a full recreate
 vibew restart
 ```
+
+Use `vibew dev` (full recreate) only when you add new services or change `vibewarden.yaml`.
 
 Additional commands:
 
@@ -35,9 +51,6 @@ vibew doctor       # Diagnose common issues (run this when something breaks)
 
 The app runs on port {{ .Port }} internally, but **always access it through the sidecar
 at https://localhost:8443**. Never expose port {{ .Port }} directly.
-
-Running the app without the sidecar means NO TLS, NO auth, NO rate limiting, NO WAF.
-This is a security risk even in development.
 
 ## Testing
 
@@ -179,7 +192,7 @@ dependencies {
 1. Add route in `configureRouting()` inside `Application.kt`
 2. Create a data class for request/response if needed
 3. Add test in `ApplicationTest.kt`
-4. Run `./gradlew build`, `vibew build`, then `vibew dev` to test
+4. Run `./gradlew build`, `vibew build`, then `vibew restart` to test
 
 ### Add a new domain entity
 

--- a/internal/cli/templates/typescript/dev.md.tmpl
+++ b/internal/cli/templates/typescript/dev.md.tmpl
@@ -6,24 +6,39 @@ the architect's design. You write clean, idiomatic TypeScript using Express.
 ## Running the project — CRITICAL
 
 **NEVER start the app directly** with `npm start`, `npx ts-node`, `node dist/index.js`, or any direct execution.
-**ALWAYS use the workflow below** — it builds your app, then starts it behind the VibeWarden
+**ALWAYS use one of the two workflows below** — your app must run behind the VibeWarden
 sidecar with TLS, rate limiting, security headers, and all configured protections active.
 
-### Workflow
+Running the app without the sidecar means NO TLS, NO auth, NO rate limiting, NO WAF.
+This is a security risk even in development.
+
+### First run (just works)
+
+The generated `Dockerfile` is a multi-stage build — it installs dependencies and
+compiles TypeScript inside Docker, so no local Node.js installation is required:
 
 ```bash
-# 1. Build the app
+vibew dev   # generates config, builds image (multi-stage), starts full stack
+```
+
+### Iterative development (faster rebuilds)
+
+The multi-stage Docker build runs `npm ci` + `npm run build` on every `vibew build`,
+which can be slow. For fast iteration, build the `dist/` output locally and copy it
+into a thin image instead:
+
+```bash
+# 1. Compile TypeScript locally
 npm run build
 
-# 2. Build the Docker image (app image must exist before starting the stack)
+# 2. Package the dist/ output into a thin Docker image
 vibew build            # or: docker build -t {{ .ProjectName }} .
 
-# 3. Start the full stack (app + sidecar + dependencies)
-vibew dev
-
-# 4. Restart containers after a code change without a full rebuild
+# 3. Restart containers without a full recreate
 vibew restart
 ```
+
+Use `vibew dev` (full recreate) only when you add new services or change `vibewarden.yaml`.
 
 Additional commands:
 
@@ -35,9 +50,6 @@ vibew doctor       # Diagnose common issues (run this when something breaks)
 
 The app runs on port {{ .Port }} internally, but **always access it through the sidecar
 at https://localhost:8443**. Never expose port {{ .Port }} directly.
-
-Running the app without the sidecar means NO TLS, NO auth, NO rate limiting, NO WAF.
-This is a security risk even in development.
 
 ## Testing
 
@@ -206,7 +218,7 @@ npm install --save-dev <package>  # Dev-only dependency
 1. Add route handler in `src/index.ts` (or extract to a router module)
 2. Define request/response types as TypeScript interfaces
 3. Add test in `src/index.test.ts`
-4. Run `npm run build`, `vibew build`, then `vibew dev` to test
+4. Run `npm run build`, `vibew build`, then `vibew restart` to test
 
 ### Add a new domain entity
 


### PR DESCRIPTION
## Summary

- **README quick start** now shows `vibew init` + `vibew dev` as the first-run flow, followed by a "faster iteration" section explaining `vibew build` + `vibew restart`.
- **`docs/getting-started.md`** restructured Step 3 into two named modes: "First run (just works)" and "Iterative development (faster rebuilds)", with a decision table at the end.
- **`internal/cli/templates/agents/claude.md.tmpl`** and all three `dev.md.tmpl` templates (go, kotlin, typescript) now explain both flows clearly — `vibew dev` alone for first run, local build + `vibew build` + `vibew restart` for iteration.
- "Common tasks" sections in all dev templates updated to use `vibew restart` (not `vibew dev`) for the rebuild-and-test loop.

## Test plan

- [ ] `make check` passes (confirmed locally — all 80+ packages green, lint clean)
- [ ] README quick start reads cleanly end-to-end: install, `vibew init`, `vibew dev`, done
- [ ] `docs/getting-started.md` "When to use which mode" table covers all three scenarios
- [ ] Agent templates generated by `vibew init --lang go`, `--lang kotlin`, `--lang typescript` contain both workflow sections