### PR TITLE
fix: last vibewarden→vibew references in comments

### DIFF
--- a/internal/app/ops/logs.go
+++ b/internal/app/ops/logs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
-// LogsOptions holds the options passed to the "vibewarden logs" command.
+// LogsOptions holds the options passed to the "vibew logs" command.
 type LogsOptions struct {
 	// Follow tails the log stream in real time (docker compose logs -f).
 	Follow bool
@@ -21,7 +21,7 @@ type LogsOptions struct {
 	Stdin io.Reader
 }
 
-// LogsService orchestrates the "vibewarden logs" use case.
+// LogsService orchestrates the "vibew logs" use case.
 // It reads structured log lines from docker compose (or stdin) and delegates
 // formatting to a LogPrinter.
 type LogsService struct {

--- a/internal/plugins/catalog.go
+++ b/internal/plugins/catalog.go
@@ -11,7 +11,7 @@ type PluginDescriptor struct {
 	Description string
 
 	// ConfigSchema maps configuration field names to their descriptions.
-	// Used by "vibewarden plugins show <name>".
+	// Used by "vibew plugins show <name>".
 	ConfigSchema map[string]string
 
 	// Example is a minimal YAML snippet illustrating an enabled configuration.
@@ -20,7 +20,7 @@ type PluginDescriptor struct {
 }
 
 // Catalog is the static list of all plugins compiled into the VibeWarden binary.
-// It is the authoritative source of truth for "vibewarden plugins" output.
+// It is the authoritative source of truth for "vibew plugins" output.
 // The order reflects the recommended initialisation priority.
 var Catalog = []PluginDescriptor{
 	{

--- a/internal/plugins/responseheaders/meta.go
+++ b/internal/plugins/responseheaders/meta.go
@@ -6,7 +6,7 @@ func (p *Plugin) Description() string {
 }
 
 // ConfigSchema returns the configuration field descriptions for the
-// response-headers plugin, used by "vibewarden plugins show response-headers".
+// response-headers plugin, used by "vibew plugins show response-headers".
 func (p *Plugin) ConfigSchema() map[string]string {
 	return map[string]string{
 		"set":    "Map of header names to values that overwrite any existing value (or create the header). Values support ${ENV_VAR} substitution.",

--- a/internal/ports/plugin.go
+++ b/internal/ports/plugin.go
@@ -205,7 +205,7 @@ type PluginMeta interface {
 	Description() string
 
 	// ConfigSchema returns a map of field name to field description for use
-	// in "vibewarden plugins show <name>" output. Fields should be listed in
+	// in "vibew plugins show <name>" output. Fields should be listed in
 	// logical order; the caller is responsible for display ordering.
 	ConfigSchema() map[string]string
 


### PR DESCRIPTION
Cleans up remaining vibewarden command references in Go comments.