### PR TITLE
fix(#644): upgrade installs to the running binary's location

### DIFF
--- a/internal/app/upgrade/service.go
+++ b/internal/app/upgrade/service.go
@@ -1,12 +1,19 @@
 // Package upgrade provides the application service for the `vibew upgrade`
 // command. It fetches the latest (or a pinned) VibeWarden release from GitHub,
-// verifies the SHA-256 checksum, replaces the running binary (or installs to
-// ~/.vibewarden/bin/), updates .vibewarden-version when found, and regenerates
-// wrapper scripts when they exist.
+// verifies the SHA-256 checksum, replaces the running binary (resolved via
+// os.Executable + filepath.EvalSymlinks), updates .vibewarden-version when
+// found, and regenerates wrapper scripts when they exist.
+//
+// Install path resolution order:
+//  1. opts.InstallDir — explicit override (--install-dir flag).
+//  2. opts.ExecutablePath — the directory that contains the currently running
+//     binary, populated by the CLI layer via ResolveExecutablePath.
+//  3. ~/.vibewarden/bin — last resort fallback when os.Executable fails.
 package upgrade
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
@@ -16,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -45,9 +53,17 @@ type Options struct {
 	// When empty the service resolves the latest GitHub release.
 	Version string
 
-	// InstallDir is where the binary is written.
-	// Defaults to ~/.vibewarden/bin when the running binary is not writable.
+	// InstallDir is an explicit override for where the binary is written.
+	// When set it takes priority over ExecutablePath.
+	// Corresponds to the --install-dir CLI flag.
 	InstallDir string
+
+	// ExecutablePath is the absolute, symlink-resolved path of the currently
+	// running binary, populated by the CLI layer via ResolveExecutablePath.
+	// When InstallDir is empty the service installs over this path (i.e. it
+	// replaces the binary that is currently running).  When ExecutablePath is
+	// also empty the service falls back to ~/.vibewarden/bin/.
+	ExecutablePath string
 
 	// DryRun prints what would happen without downloading or writing any files.
 	DryRun bool
@@ -58,6 +74,25 @@ type Options struct {
 	// GOOS / GOARCH override the detected platform (useful in tests).
 	GOOS   string
 	GOARCH string
+}
+
+// ResolveExecutablePath returns the absolute, symlink-resolved path of the
+// currently running binary.  Call this in the CLI layer and pass the result to
+// Options.ExecutablePath so that the upgrade service can replace the correct
+// binary.
+//
+// Returns an empty string (and a non-nil error) when os.Executable fails; the
+// caller should fall back to the default install directory in that case.
+func ResolveExecutablePath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolving executable path: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return "", fmt.Errorf("evaluating symlinks for %q: %w", exe, err)
+	}
+	return resolved, nil
 }
 
 // githubRelease is the subset of the GitHub releases API response that the
@@ -132,20 +167,32 @@ func (s *Service) Run(ctx context.Context, opts Options) error {
 	archiveURL := fmt.Sprintf("%s/%s", baseURL, archiveName)
 	checksumsURL := fmt.Sprintf("%s/%s", baseURL, checksumsName)
 
-	// Resolve install directory.
-	installDir := opts.InstallDir
-	if installDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("resolving home directory: %w", err)
-		}
-		installDir = filepath.Join(home, ".vibewarden", "bin")
-	}
+	// Resolve install path.
+	//
+	// Priority:
+	//  1. --install-dir flag  (opts.InstallDir)
+	//  2. Directory of the running binary  (opts.ExecutablePath)
+	//  3. ~/.vibewarden/bin  (fallback)
 	binaryName := "vibew"
 	if goos == "windows" {
 		binaryName = "vibew.exe"
 	}
-	destPath := filepath.Join(installDir, binaryName)
+
+	var destPath string
+	switch {
+	case opts.InstallDir != "":
+		destPath = filepath.Join(opts.InstallDir, binaryName)
+	case opts.ExecutablePath != "":
+		destPath = opts.ExecutablePath
+	default:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("resolving home directory: %w", err)
+		}
+		destPath = filepath.Join(home, ".vibewarden", "bin", binaryName)
+	}
+
+	installDir := filepath.Dir(destPath)
 
 	fmt.Fprintf(w, "Install path:   %s\n", destPath)
 
@@ -197,7 +244,7 @@ func (s *Service) Run(ctx context.Context, opts Options) error {
 	if err := os.MkdirAll(installDir, permExec); err != nil {
 		return fmt.Errorf("creating install directory %q: %w", installDir, err)
 	}
-	if err := atomicReplace(extractedBin, destPath, permExec); err != nil {
+	if err := installBinary(extractedBin, destPath, permExec, w); err != nil {
 		return fmt.Errorf("installing binary: %w", err)
 	}
 	fmt.Fprintf(w, "Installed: %s\n", destPath)
@@ -382,6 +429,39 @@ func extractTarGz(archivePath, destDir, targetFile string) error {
 		return nil
 	}
 	return fmt.Errorf("%q not found in archive %q", targetFile, archivePath)
+}
+
+// installBinary installs the binary at src to dest. It first attempts a direct
+// atomicReplace. When the target directory is not writable on a Unix-like
+// system it retries via `sudo install -m 755 src dest` so that users who
+// installed to /usr/local/bin without a writable permission can still upgrade
+// without manually re-running with sudo.
+//
+// The sudo retry only happens on non-Windows platforms and only when the
+// initial attempt fails with a permission error.
+func installBinary(src, dest string, mode os.FileMode, w io.Writer) error {
+	err := atomicReplace(src, dest, mode)
+	if err == nil {
+		return nil
+	}
+
+	// Only attempt sudo on non-Windows and only for permission errors.
+	if runtime.GOOS == "windows" || !os.IsPermission(err) {
+		return err
+	}
+
+	fmt.Fprintf(w, "No write permission for %s — retrying with sudo...\n", filepath.Dir(dest))
+
+	// Use `sudo install` which handles atomic replacement correctly.
+	sudoArgs := []string{"install", "-m", fmt.Sprintf("%04o", mode.Perm()), src, dest}
+	//nolint:gosec // sudo path is controlled by the OS, arguments are from internal sources
+	cmd := exec.Command("sudo", sudoArgs...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if sudoErr := cmd.Run(); sudoErr != nil {
+		return fmt.Errorf("sudo install failed (%w); stderr: %s", sudoErr, stderr.String())
+	}
+	return nil
 }
 
 // atomicReplace installs src to dest atomically using a temp file in the same

--- a/internal/app/upgrade/service_test.go
+++ b/internal/app/upgrade/service_test.go
@@ -341,6 +341,195 @@ func TestService_Run_UpdatesVersionFile(t *testing.T) {
 	}
 }
 
+// TestResolveExecutablePath verifies that ResolveExecutablePath returns a
+// non-empty, absolute path that actually exists on disk.
+func TestResolveExecutablePath(t *testing.T) {
+	got, err := upgrade.ResolveExecutablePath()
+	if err != nil {
+		t.Fatalf("ResolveExecutablePath() unexpected error: %v", err)
+	}
+	if got == "" {
+		t.Fatal("ResolveExecutablePath() returned empty string")
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("ResolveExecutablePath() returned non-absolute path: %q", got)
+	}
+	if _, statErr := os.Stat(got); statErr != nil {
+		t.Errorf("ResolveExecutablePath() returned path that does not exist: %q (%v)", got, statErr)
+	}
+}
+
+// TestService_Run_UsesExecutablePath verifies that when ExecutablePath is set
+// (and InstallDir is empty) the service installs the binary to that exact
+// path rather than ~/.vibewarden/bin.
+func TestService_Run_UsesExecutablePath(t *testing.T) {
+	version := "v0.8.0"
+	goos := "linux"
+	goarch := "amd64"
+	cleanVersion := "0.8.0"
+	archiveName := fmt.Sprintf("vibewarden_%s_%s_%s.tar.gz", cleanVersion, goos, goarch)
+
+	archiveBytes, checksumHex := buildFakeArchive(t, "vibew", "#!/bin/sh\necho vibewarden")
+	checksumBytes := buildChecksums(archiveName, checksumHex)
+
+	baseURL := fmt.Sprintf("https://github.com/vibewarden/vibewarden/releases/download/%s", version)
+	client := &fakeHTTPClient{
+		responses: map[string]fakeResponse{
+			baseURL + "/" + archiveName: {status: http.StatusOK, body: archiveBytes},
+			baseURL + "/checksums.txt":  {status: http.StatusOK, body: checksumBytes},
+		},
+	}
+	svc := upgrade.NewService(client)
+
+	// Simulate the running binary living at a custom path (e.g. /usr/local/bin/vibew).
+	customBinDir := t.TempDir()
+	// Pre-create the "running" binary so the path exists.
+	customBinPath := filepath.Join(customBinDir, "vibew")
+	if err := os.WriteFile(customBinPath, []byte("old binary"), 0o755); err != nil {
+		t.Fatalf("creating fake running binary: %v", err)
+	}
+
+	var out strings.Builder
+	opts := upgrade.Options{
+		Version:        version,
+		ExecutablePath: customBinPath, // no InstallDir — should use this
+		Stdout:         &out,
+		GOOS:           goos,
+		GOARCH:         goarch,
+	}
+
+	if err := svc.Run(context.Background(), opts); err != nil {
+		t.Fatalf("Run() unexpected error: %v\nOutput:\n%s", err, out.String())
+	}
+
+	// Binary must be replaced at the exact ExecutablePath.
+	info, err := os.Stat(customBinPath)
+	if err != nil {
+		t.Fatalf("binary not found at %s: %v", customBinPath, err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Errorf("binary not executable, mode=%v", info.Mode())
+	}
+
+	content, err := os.ReadFile(customBinPath)
+	if err != nil {
+		t.Fatalf("reading installed binary: %v", err)
+	}
+	if string(content) == "old binary" {
+		t.Error("binary was not replaced: still contains old content")
+	}
+
+	// Output must mention the resolved path.
+	if !strings.Contains(out.String(), customBinPath) {
+		t.Errorf("expected install path %s in output, got:\n%s", customBinPath, out.String())
+	}
+}
+
+// TestService_Run_InstallDirTakesPriorityOverExecutablePath verifies that
+// --install-dir overrides ExecutablePath when both are set.
+func TestService_Run_InstallDirTakesPriorityOverExecutablePath(t *testing.T) {
+	version := "v0.8.1"
+	goos := "linux"
+	goarch := "amd64"
+	cleanVersion := "0.8.1"
+	archiveName := fmt.Sprintf("vibewarden_%s_%s_%s.tar.gz", cleanVersion, goos, goarch)
+
+	archiveBytes, checksumHex := buildFakeArchive(t, "vibew", "#!/bin/sh")
+	checksumBytes := buildChecksums(archiveName, checksumHex)
+
+	baseURL := fmt.Sprintf("https://github.com/vibewarden/vibewarden/releases/download/%s", version)
+	client := &fakeHTTPClient{
+		responses: map[string]fakeResponse{
+			baseURL + "/" + archiveName: {status: http.StatusOK, body: archiveBytes},
+			baseURL + "/checksums.txt":  {status: http.StatusOK, body: checksumBytes},
+		},
+	}
+	svc := upgrade.NewService(client)
+
+	explicitDir := t.TempDir()
+	exeDir := t.TempDir()
+	exePath := filepath.Join(exeDir, "vibew")
+	if err := os.WriteFile(exePath, []byte("exe"), 0o755); err != nil {
+		t.Fatalf("creating fake exe: %v", err)
+	}
+
+	opts := upgrade.Options{
+		Version:        version,
+		InstallDir:     explicitDir,
+		ExecutablePath: exePath,
+		Stdout:         io.Discard,
+		GOOS:           goos,
+		GOARCH:         goarch,
+	}
+
+	if err := svc.Run(context.Background(), opts); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	// Binary must land in explicitDir, not exeDir.
+	expectedPath := filepath.Join(explicitDir, "vibew")
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Fatalf("expected binary at %s: %v", expectedPath, err)
+	}
+	if _, err := os.Stat(exePath); err == nil {
+		// exePath content should be the old "exe" stub, not replaced.
+		content, _ := os.ReadFile(exePath)
+		if string(content) != "exe" {
+			t.Error("InstallDir did not take priority: ExecutablePath was modified")
+		}
+	}
+}
+
+// TestService_Run_FallsBackToHomeDirWhenNoExecutablePath verifies that when
+// both InstallDir and ExecutablePath are empty the binary is installed to
+// ~/.vibewarden/bin/vibew.
+func TestService_Run_FallsBackToHomeDirWhenNoExecutablePath(t *testing.T) {
+	version := "v0.8.2"
+	goos := "linux"
+	goarch := "amd64"
+	cleanVersion := "0.8.2"
+	archiveName := fmt.Sprintf("vibewarden_%s_%s_%s.tar.gz", cleanVersion, goos, goarch)
+
+	archiveBytes, checksumHex := buildFakeArchive(t, "vibew", "#!/bin/sh")
+	checksumBytes := buildChecksums(archiveName, checksumHex)
+
+	baseURL := fmt.Sprintf("https://github.com/vibewarden/vibewarden/releases/download/%s", version)
+	client := &fakeHTTPClient{
+		responses: map[string]fakeResponse{
+			baseURL + "/" + archiveName: {status: http.StatusOK, body: archiveBytes},
+			baseURL + "/checksums.txt":  {status: http.StatusOK, body: checksumBytes},
+		},
+	}
+	svc := upgrade.NewService(client)
+
+	// Override HOME so we can check the fallback path without touching the
+	// real home directory.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	var out strings.Builder
+	opts := upgrade.Options{
+		Version: version,
+		// InstallDir and ExecutablePath intentionally empty.
+		Stdout: &out,
+		GOOS:   goos,
+		GOARCH: goarch,
+	}
+
+	if err := svc.Run(context.Background(), opts); err != nil {
+		t.Fatalf("Run() unexpected error: %v\nOutput:\n%s", err, out.String())
+	}
+
+	expectedPath := filepath.Join(fakeHome, ".vibewarden", "bin", "vibew")
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Fatalf("expected binary at fallback path %s: %v", expectedPath, err)
+	}
+
+	if !strings.Contains(out.String(), expectedPath) {
+		t.Errorf("expected fallback path %s in output, got:\n%s", expectedPath, out.String())
+	}
+}
+
 func TestService_Run_RegeneratesWrappers(t *testing.T) {
 	version := "v0.7.0"
 	goos := "linux"

--- a/internal/cli/cmd/upgrade.go
+++ b/internal/cli/cmd/upgrade.go
@@ -13,10 +13,12 @@ import (
 // NewUpgradeCmd creates the `vibew upgrade` subcommand.
 //
 // The command downloads the specified (or latest) VibeWarden release from
-// GitHub Releases, verifies its SHA-256 checksum, installs the binary to
-// ~/.vibewarden/bin/, updates .vibewarden-version when found in the current
-// or a parent directory, and touches the vibew wrapper scripts so tooling
-// knows they were considered.
+// GitHub Releases, verifies its SHA-256 checksum, and replaces the currently
+// running binary in-place. The destination path is resolved by calling
+// os.Executable followed by filepath.EvalSymlinks so that symlinked
+// installations are handled correctly. When the target directory is not
+// writable, the service automatically retries via sudo (Unix only).
+// ~/.vibewarden/bin is used as a last resort if executable resolution fails.
 func NewUpgradeCmd() *cobra.Command {
 	var (
 		dryRun     bool
@@ -36,9 +38,15 @@ The command:
   1. Resolves the target version (latest or the supplied tag).
   2. Downloads the binary archive for the current OS and architecture.
   3. Verifies the SHA-256 checksum.
-  4. Installs the binary to ~/.vibewarden/bin/ (or --install-dir).
+  4. Replaces the currently running binary in-place (resolved via
+     os.Executable + symlink evaluation).
+     Use --install-dir to override the destination directory.
+     Falls back to ~/.vibewarden/bin when executable resolution fails.
   5. Updates .vibewarden-version if found in the current or a parent directory.
   6. Touches vibew, vibew.ps1, vibew.cmd in the current directory when present.
+
+If the target directory is not writable (e.g. /usr/local/bin without sudo),
+the command automatically retries the file installation with sudo.
 
 Use --dry-run to see what would happen without writing any files.
 
@@ -54,14 +62,23 @@ Examples:
 				version = args[0]
 			}
 
+			// Resolve the path of the running binary so the service can
+			// replace it in-place.  A failure here is non-fatal: the service
+			// will fall back to ~/.vibewarden/bin.
+			exePath, err := upgradeapp.ResolveExecutablePath()
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not resolve executable path (%v); falling back to ~/.vibewarden/bin\n", err)
+			}
+
 			client := &http.Client{Timeout: 60 * time.Second}
 			svc := upgradeapp.NewService(client)
 
 			opts := upgradeapp.Options{
-				Version:    version,
-				InstallDir: installDir,
-				DryRun:     dryRun,
-				Stdout:     cmd.OutOrStdout(),
+				Version:        version,
+				InstallDir:     installDir,
+				ExecutablePath: exePath,
+				DryRun:         dryRun,
+				Stdout:         cmd.OutOrStdout(),
 			}
 
 			if err := svc.Run(cmd.Context(), opts); err != nil {
@@ -72,7 +89,7 @@ Examples:
 	}
 
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would happen without writing any files")
-	cmd.Flags().StringVar(&installDir, "install-dir", "", "directory to install the binary into (default: ~/.vibewarden/bin)")
+	cmd.Flags().StringVar(&installDir, "install-dir", "", "directory to install the binary into (default: path of running binary)")
 
 	return cmd
 }


### PR DESCRIPTION
Closes #644

## Summary

- `ResolveExecutablePath()` (new exported helper in `internal/app/upgrade`) calls `os.Executable()` then `filepath.EvalSymlinks` to obtain the absolute, symlink-resolved path of the running binary.
- `Options` gains an `ExecutablePath` field. The CLI layer populates it before calling `svc.Run`; a warning (not a fatal error) is printed if resolution fails and the service falls back to `~/.vibewarden/bin`.
- Install-path priority in `Run`:
  1. `opts.InstallDir` — explicit `--install-dir` flag, highest priority.
  2. `opts.ExecutablePath` — path of the running binary (the normal case).
  3. `~/.vibewarden/bin/vibew` — last-resort fallback.
- `installBinary` (new helper) wraps `atomicReplace`. On a permission error on non-Windows it retries via `sudo install -m 0755 src dest`, so users with a binary in `/usr/local/bin` can upgrade without re-running as root.
- `--install-dir` flag help text updated to reflect the new default behaviour.

## Test plan

- `TestResolveExecutablePath` — verifies the helper returns a non-empty absolute path that exists on disk.
- `TestService_Run_UsesExecutablePath` — service installs to `ExecutablePath` when `InstallDir` is empty.
- `TestService_Run_InstallDirTakesPriorityOverExecutablePath` — `InstallDir` wins when both are set.
- `TestService_Run_FallsBackToHomeDirWhenNoExecutablePath` — fallback to `~/.vibewarden/bin` when both fields are empty; uses `t.Setenv("HOME", …)` to avoid touching the real home directory.
- All pre-existing tests continue to pass.
- `make check` (format + lint + build + test --race) passes locally.