### PR TITLE
fix: deploy docs to docs/vibewarden/ instead of docs/

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,6 @@ jobs:
           external_repository: vibewarden/vibewarden.dev
           publish_branch: main
           publish_dir: ./_site/docs
-          destination_dir: docs
+          destination_dir: docs/vibewarden
           keep_files: true
           commit_message: "docs: sync from vibewarden/vibewarden@${{ github.sha }}"


### PR DESCRIPTION
## Summary
- Change `destination_dir` from `docs` to `docs/vibewarden` in the docs deploy workflow

## Test plan
- [ ] Docs deploy to correct path on vibewarden.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)