### PR TITLE
docs(#633): add dev/prod auth split pattern

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -38,6 +38,23 @@ The open-source core is Apache 2.0 — free forever. A Pro tier (fleet dashboard
 
 Yes, as a sidecar container in the same pod as your application. A Helm chart is planned. For now, deploy the Docker image directly.
 
+## Can I use a different auth provider in dev vs prod?
+
+Yes. This is the recommended pattern. Use `auth.mode: kratos` locally for a
+full self-contained auth loop (registration, login, password reset — no
+internet required), and `auth.mode: jwt` in production to validate tokens from
+your cloud IAM (Cognito, Auth0, Azure AD, etc.).
+
+Your application code does not change between environments. VibeWarden injects
+the same `X-User-Id`, `X-User-Email`, and `X-User-Verified` headers in both
+modes. Only the VibeWarden config differs.
+
+Switch between them with `vibewarden start --config vibewarden.dev.yaml` or
+via environment variable interpolation in a single shared config file.
+
+See the [Dev/Prod auth split](identity-providers.md#devprod-auth-split) section
+in the identity providers guide for full examples.
+
 ## Where do I report security vulnerabilities?
 
 See [SECURITY.md](https://github.com/vibewarden/vibewarden/blob/main/SECURITY.md). Use GitHub Security Advisories or email security@vibewarden.dev.

--- a/docs/identity-providers.md
+++ b/docs/identity-providers.md
@@ -496,6 +496,166 @@ If you started with `auth.mode: kratos` and want to move to JWT/OIDC:
 
 ---
 
+## Dev/Prod auth split
+
+Your application code never needs to know which auth provider is active. The
+app reads the same `X-User-Id`, `X-User-Email`, and `X-User-Verified` headers
+in every environment. Only the VibeWarden config changes between development
+and production.
+
+### The pattern
+
+| Environment | Auth mode | Why |
+|-------------|-----------|-----|
+| `dev` | `kratos` | Local login/registration/password-reset flows without cloud accounts or internet access |
+| `prod` | `jwt` | Validate tokens from your cloud IAM — no extra infrastructure to run |
+
+### Development config (`vibewarden.dev.yaml`)
+
+Use Kratos for a fully local auth loop. Kratos handles registration, login,
+password reset, and email verification inside your Docker Compose stack.
+
+```yaml
+# vibewarden.dev.yaml
+server:
+  upstream: "http://localhost:3000"
+  listen: ":8080"
+
+auth:
+  mode: kratos
+
+kratos:
+  public_url: "http://127.0.0.1:4433"
+  admin_url: "http://127.0.0.1:4434"
+  # external: false  — VibeWarden starts Kratos for you (default)
+
+plugins:
+  user-management:
+    enabled: true
+    adapter: postgres
+```
+
+No cloud accounts, no API keys, no internet access required.
+
+### Production config (`vibewarden.yaml`)
+
+Validate JWTs from your cloud IAM. Pick the example that matches your provider.
+
+**Amazon Cognito:**
+
+```yaml
+# vibewarden.yaml
+server:
+  upstream: "http://localhost:3000"
+  listen: ":8080"
+
+auth:
+  mode: jwt
+  jwt:
+    jwks_url: "https://cognito-idp.<region>.amazonaws.com/<user-pool-id>/.well-known/jwks.json"
+    issuer: "https://cognito-idp.<region>.amazonaws.com/<user-pool-id>"
+    audience: "<app-client-id>"
+    claims_to_headers:
+      sub: X-User-Id
+      email: X-User-Email
+      email_verified: X-User-Verified
+```
+
+**Auth0:**
+
+```yaml
+auth:
+  mode: jwt
+  jwt:
+    jwks_url: "https://<tenant>.us.auth0.com/.well-known/jwks.json"
+    issuer: "https://<tenant>.us.auth0.com/"
+    audience: "https://api.your-app.com"
+    claims_to_headers:
+      sub: X-User-Id
+      email: X-User-Email
+      email_verified: X-User-Verified
+```
+
+**Azure AD (Microsoft Entra ID):**
+
+```yaml
+auth:
+  mode: jwt
+  jwt:
+    jwks_url: "https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys"
+    issuer: "https://login.microsoftonline.com/<tenant-id>/v2.0"
+    audience: "<application-client-id>"
+    claims_to_headers:
+      sub: X-User-Id
+      email: X-User-Email
+      name: X-User-Name
+```
+
+Replace the angle-bracket placeholders with your real values. The JWKS URLs
+above are the canonical patterns published by each provider — they do not
+change unless you migrate regions or tenants.
+
+### Switching via the `--config` flag
+
+Pass the config file at startup. No code changes, no environment variables
+required:
+
+```bash
+# development
+vibewarden start --config vibewarden.dev.yaml
+
+# production (default name picked up automatically)
+vibewarden start
+```
+
+Keep both files in version control. Do not commit secrets — use environment
+variable interpolation for sensitive values (see below).
+
+### Switching via environment variables
+
+VibeWarden interpolates `${VAR}` placeholders in the config file. Set a
+single env var to select the provider, and override only the fields that
+change between environments:
+
+```yaml
+# vibewarden.yaml — works in dev and prod
+auth:
+  mode: jwt
+  jwt:
+    jwks_url: "${AUTH_JWKS_URL}"
+    issuer: "${AUTH_ISSUER}"
+    audience: "${AUTH_AUDIENCE}"
+    claims_to_headers:
+      sub: X-User-Id
+      email: X-User-Email
+      email_verified: X-User-Verified
+```
+
+Then export the appropriate values per environment:
+
+```bash
+# .env.dev
+AUTH_JWKS_URL=http://127.0.0.1:4433/.well-known/jwks.json
+AUTH_ISSUER=http://127.0.0.1:4433
+AUTH_AUDIENCE=vibewarden-dev
+
+# .env.prod
+AUTH_JWKS_URL=https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_XXXXXX/.well-known/jwks.json
+AUTH_ISSUER=https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_XXXXXX
+AUTH_AUDIENCE=6rp8xxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+### Key message
+
+**Same app code. Same headers. Only config changes.**
+
+Your upstream receives `X-User-Id`, `X-User-Email`, and `X-User-Verified`
+regardless of whether VibeWarden is running in Kratos mode locally or
+validating Cognito JWTs in production. The auth split is entirely a
+deployment-time concern.
+
+---
+
 ## AI-agent-readable summary
 
 ```json
@@ -513,6 +673,12 @@ If you started with `auth.mode: kratos` and want to move to JWT/OIDC:
   },
   "provider_examples": ["auth0", "keycloak", "firebase", "cognito", "okta", "supabase"],
   "kratos_use_cases": ["browser_flows", "mfa", "social_login", "self_hosted_accounts"],
-  "api_key_use_cases": ["machine_to_machine", "ci_cd", "service_accounts"]
+  "api_key_use_cases": ["machine_to_machine", "ci_cd", "service_accounts"],
+  "dev_prod_split": {
+    "dev_mode": "kratos",
+    "prod_mode": "jwt",
+    "switching_mechanisms": ["--config flag", "env var interpolation"],
+    "upstream_headers_unchanged": true
+  }
 }
 ```


### PR DESCRIPTION
Closes #633

## Summary

- Adds a **Dev/Prod Auth Split** section to `docs/identity-providers.md` covering:
  - Dev: `auth.mode: kratos` for fully local auth (registration, login, password reset, no internet required)
  - Prod: `auth.mode: jwt` validating tokens from cloud IAM (Cognito, Auth0, Azure AD)
  - Complete `vibewarden.yaml` examples for each provider with real JWKS URL patterns
  - How to switch using `--config` flag or `${ENV_VAR}` interpolation in a single shared config file
  - Key message callout: same app code, same upstream headers, only config changes
- Updates the AI-agent-readable summary JSON at the bottom of the file to include the new pattern
- Adds a FAQ entry in `docs/faq.md` pointing to the new section

## Test plan

- [ ] Read `docs/identity-providers.md` and verify the new section renders correctly in a Markdown viewer
- [ ] Confirm JWKS URL patterns for Cognito, Auth0, and Azure AD match provider documentation
- [ ] Read `docs/faq.md` and verify the new entry links correctly to the new section
- [ ] `make check` passes (lint, build, tests — confirmed locally)