### PR TITLE
feat(#657): relax secrets.enabled requirement for prod profile

### DIFF
--- a/internal/app/generate/service.go
+++ b/internal/app/generate/service.go
@@ -73,9 +73,11 @@ func (s *Service) Generate(ctx context.Context, cfg *config.Config, outputDir st
 	// Sanitise the caller-supplied output directory to prevent path traversal.
 	outputDir = filepath.Clean(outputDir)
 
-	// Validate prod profile requirements before generating any files.
+	// Warn when prod profile is used without secrets enabled.
+	// OpenBao is strongly recommended for production but is no longer mandatory
+	// so that operators who manage secrets externally are not blocked.
 	if cfg.Profile == "prod" && !cfg.Secrets.Enabled {
-		return fmt.Errorf("prod profile requires secrets.enabled: true (OpenBao is mandatory for production)")
+		slog.Warn("prod profile is running without secrets.enabled: true; OpenBao is strongly recommended for production secret management")
 	}
 
 	// Emit egress-related warnings to stderr via slog.

--- a/internal/app/generate/service_test.go
+++ b/internal/app/generate/service_test.go
@@ -1423,7 +1423,9 @@ func fixedCreds() *gendomain.GeneratedCredentials {
 	}
 }
 
-func TestGenerate_ProdProfile_RequiresSecrets(t *testing.T) {
+func TestGenerate_ProdProfile_SecretsDisabled_Succeeds(t *testing.T) {
+	// Secrets are no longer mandatory for the prod profile; generation must
+	// succeed so that operators who manage secrets externally are not blocked.
 	outputDir := t.TempDir()
 	svc := generate.NewServiceWithCredentials(
 		&fakeRenderer{},
@@ -1434,12 +1436,25 @@ func TestGenerate_ProdProfile_RequiresSecrets(t *testing.T) {
 	cfg.Profile = "prod"
 	cfg.Secrets.Enabled = false
 
-	err := svc.Generate(context.Background(), cfg, outputDir)
-	if err == nil {
-		t.Fatal("Generate() expected error for prod profile without secrets.enabled, got nil")
+	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+		t.Errorf("Generate() unexpected error for prod profile without secrets.enabled: %v", err)
 	}
-	if !strings.Contains(err.Error(), "prod profile requires secrets.enabled") {
-		t.Errorf("Generate() error = %q, want message about prod profile requiring secrets", err.Error())
+}
+
+func TestGenerate_ProdProfile_SecretsDisabled_OpenBaoAbsent(t *testing.T) {
+	// When secrets.enabled is false on a prod profile the openbao service must
+	// not appear in the generated docker-compose.yml.
+	cfg := minimalConfig()
+	cfg.Profile = "prod"
+	cfg.Secrets.Enabled = false
+
+	compose := renderCompose(t, cfg)
+
+	if bytes.Contains(compose, []byte("openbao:")) {
+		t.Error("openbao service must not be present in compose when secrets.enabled is false")
+	}
+	if bytes.Contains(compose, []byte("VIBEWARDEN_SECRETS_OPENBAO_ADDRESS")) {
+		t.Error("VIBEWARDEN_SECRETS_OPENBAO_ADDRESS must not be present in compose when secrets.enabled is false")
 	}
 }
 


### PR DESCRIPTION
Closes #657

## Summary

- Changed the hard `fmt.Errorf` at `internal/app/generate/service.go:77` to an `slog.Warn` so operators who manage secrets externally are not blocked from running `vibewarden generate` with `profile: prod` and `secrets.enabled: false`.
- Generation proceeds normally; the existing compose template already gates the `openbao` and `seed-secrets` services behind `{{ if .Secrets.Enabled }}`, so those containers are absent when secrets are disabled.
- Replaced `TestGenerate_ProdProfile_RequiresSecrets` (which asserted a hard error) with two new tests:
  - `TestGenerate_ProdProfile_SecretsDisabled_Succeeds` — generation returns nil error
  - `TestGenerate_ProdProfile_SecretsDisabled_OpenBaoAbsent` — openbao service is absent from compose output

## Test plan

- [ ] `make check` passes locally (all tests green, lint clean)
- [ ] `TestGenerate_ProdProfile_SecretsDisabled_Succeeds` passes
- [ ] `TestGenerate_ProdProfile_SecretsDisabled_OpenBaoAbsent` passes
- [ ] `TestGenerate_ProdProfile_WithSecretsEnabled_Succeeds` still passes (existing happy path)