### PR TITLE
feat(#654): add --config flag to validate command

### DIFF
--- a/internal/cli/cmd/validate.go
+++ b/internal/cli/cmd/validate.go
@@ -39,11 +39,16 @@ var validFrameOptions = map[string]bool{
 
 // NewValidateCmd creates the `vibew validate` subcommand.
 //
-// The command loads vibewarden.yaml (or the path supplied as the first
-// positional argument), runs semantic validation rules beyond what YAML
-// parsing provides, and reports any errors. It exits with code 0 when the
-// configuration is valid and code 1 otherwise.
+// The command loads vibewarden.yaml (or the path supplied via --config or as
+// the first positional argument), runs semantic validation rules beyond what
+// YAML parsing provides, and reports any errors. It exits with code 0 when
+// the configuration is valid and code 1 otherwise.
+//
+// When both --config and a positional argument are provided, --config takes
+// precedence. The positional argument is kept for backward compatibility.
 func NewValidateCmd() *cobra.Command {
+	var configFlag string
+
 	cmd := &cobra.Command{
 		Use:   "validate [config-file]",
 		Short: "Validate vibewarden.yaml configuration",
@@ -68,11 +73,13 @@ Exits with code 0 when configuration is valid, code 1 when invalid.
 
 Examples:
   vibew validate
-  vibew validate ./path/to/vibewarden.yaml`,
+  vibew validate ./path/to/vibewarden.yaml
+  vibew validate --config ./my-vibewarden.yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			configPath := ""
-			if len(args) > 0 {
+			// --config takes precedence over the positional argument.
+			configPath := configFlag
+			if configPath == "" && len(args) > 0 {
 				configPath = args[0]
 			}
 
@@ -112,6 +119,15 @@ Examples:
 			fmt.Fprintf(cmd.OutOrStdout(), "Configuration valid (%s)\n", displayPath)
 			return nil
 		},
+	}
+
+	cmd.Flags().StringVar(&configFlag, "config", "", "path to vibewarden.yaml (default: ./vibewarden.yaml)")
+
+	if err := cmd.RegisterFlagCompletionFunc("config", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"yaml", "yml"}, cobra.ShellCompDirectiveFilterFileExt
+	}); err != nil {
+		// registration can only fail when called on a non-existent flag; safe to ignore
+		fmt.Fprintln(os.Stderr, "warning: flag completion registration failed:", err)
 	}
 
 	return cmd

--- a/internal/cli/cmd/validate_test.go
+++ b/internal/cli/cmd/validate_test.go
@@ -446,3 +446,118 @@ upstream:
 		t.Errorf("Execute() unexpected error for minimal valid config: %v\nstderr: %s", err, errBuf.String())
 	}
 }
+
+// TestValidateCmd_ConfigFlag verifies that --config <path> works as an
+// alternative to the positional argument.
+func TestValidateCmd_ConfigFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{
+			name: "valid config via flag",
+			yaml: `
+server:
+  port: 8080
+upstream:
+  port: 3000
+tls:
+  enabled: false
+  provider: self-signed
+log:
+  level: info
+  format: json
+`,
+			wantErr: false,
+		},
+		{
+			name: "invalid config via flag",
+			yaml: `
+server:
+  port: 0
+upstream:
+  port: 3000
+`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeConfig(t, tt.yaml)
+
+			root := cmd.NewRootCmd("test")
+			var outBuf, errBuf bytes.Buffer
+			root.SetOut(&outBuf)
+			root.SetErr(&errBuf)
+			root.SetArgs([]string{"validate", "--config", path})
+
+			err := root.Execute()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Execute() error = %v, wantErr %v\nstderr: %s", err, tt.wantErr, errBuf.String())
+			}
+		})
+	}
+}
+
+// TestValidateCmd_ConfigFlagNotFound verifies that --config with a
+// non-existent path returns a clear "not found" error.
+func TestValidateCmd_ConfigFlagNotFound(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"validate", "--config", "/nonexistent/path/vibewarden.yaml"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Error("Execute() expected error for nonexistent --config path, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}
+
+// TestValidateCmd_ConfigFlagPrecedenceOverPositional verifies that --config
+// takes precedence over the positional argument when both are provided.
+func TestValidateCmd_ConfigFlagPrecedenceOverPositional(t *testing.T) {
+	// Write a valid config for the flag and an invalid one for the positional arg.
+	validPath := writeConfig(t, `
+server:
+  port: 8080
+upstream:
+  port: 3000
+`)
+	invalidPath := writeConfig(t, `
+server:
+  port: 0
+upstream:
+  port: 3000
+`)
+
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	// --config points to the valid file; positional arg points to the invalid one.
+	root.SetArgs([]string{"validate", "--config", validPath, invalidPath})
+
+	err := root.Execute()
+	if err != nil {
+		t.Errorf("Execute() expected success (--config takes precedence), got: %v\nstderr: %s", err, errBuf.String())
+	}
+}
+
+// TestValidateCmd_ConfigFlagRegistered verifies that --config is registered
+// on the validate subcommand.
+func TestValidateCmd_ConfigFlagRegistered(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	validateCmd, _, err := root.Find([]string{"validate"})
+	if err != nil {
+		t.Fatalf("Find(validate) error: %v", err)
+	}
+	if validateCmd.Flags().Lookup("config") == nil {
+		t.Error("expected --config flag to be registered on 'validate' command")
+	}
+}


### PR DESCRIPTION
Closes #654

## Summary

- `vibew validate` previously only accepted the config path as a positional argument (`vibew validate ./path/to/vibewarden.yaml`).
- Added `--config <path>` flag to `validate`, making it consistent with `generate`, `dev`, and `doctor` which already had the flag.
- The flag takes precedence over the positional argument when both are provided; the positional arg is retained for backward compatibility.
- Shell completion for `.yaml`/`.yml` extensions is registered on the new flag, matching the pattern used by the other commands.
- Three additional test cases added to `validate_test.go`: flag with valid config, flag with nonexistent path (clear error), and flag-takes-precedence-over-positional.

## Test plan

- [ ] `vibew validate --config ./vibewarden.yaml` validates the file
- [ ] `vibew validate --config /nonexistent.yaml` returns "config file not found: ..." error
- [ ] `vibew validate --config valid.yaml invalid.yaml` uses the flag path (valid), not the positional arg (invalid)
- [ ] `vibew validate ./vibewarden.yaml` still works (positional arg, backward compat)
- [ ] `go test ./internal/cli/cmd/...` passes
- [ ] `make check` passes