### PR TITLE
feat(#658): implement OpenBao bootstrap and secret seeding on remote deploy

### DIFF
--- a/internal/app/deploy/openbao.go
+++ b/internal/app/deploy/openbao.go
@@ -1,0 +1,474 @@
+// Package deploy provides the application service that deploys a VibeWarden
+// project to a remote server over SSH.
+package deploy
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+const (
+	// vibewardenPolicyName is the name of the OpenBao policy granted to the
+	// VibeWarden AppRole.
+	vibewardenPolicyName = "vibewarden"
+
+	// vibewardenRoleName is the name of the OpenBao AppRole role.
+	vibewardenRoleName = "vibewarden"
+
+	// defaultSecretsMount is the KV v2 mount path used for VibeWarden secrets.
+	defaultSecretsMount = "secret"
+
+	// defaultBaoEnv is the environment variable prefix for bao CLI commands on
+	// the remote host.
+	defaultBaoEnv = "VAULT_ADDR=http://127.0.0.1:8200"
+)
+
+// BootstrapResult holds the credentials produced during the first-time
+// OpenBao bootstrap. Callers should display the UnsealKey to the user and
+// store RoleID / SecretID in the remote environment.
+type BootstrapResult struct {
+	// UnsealKey is the single unseal key generated during `bao operator init`.
+	// The user must save this — it cannot be recovered.
+	UnsealKey string
+
+	// RootToken is the initial root token. It should be revoked after bootstrap.
+	RootToken string
+
+	// RoleID is the AppRole role_id for the vibewarden policy.
+	RoleID string
+
+	// SecretID is the AppRole secret_id for the vibewarden policy.
+	SecretID string
+}
+
+// OpenBaoBootstrapper initialises and configures an OpenBao instance on the
+// remote host using the bao CLI over SSH. It never calls the OpenBao HTTP API
+// directly — all operations are performed via RemoteExecutor.
+type OpenBaoBootstrapper struct {
+	executor ports.RemoteExecutor
+}
+
+// NewOpenBaoBootstrapper creates an OpenBaoBootstrapper that uses the given
+// executor to run bao CLI commands on the remote host.
+func NewOpenBaoBootstrapper(executor ports.RemoteExecutor) *OpenBaoBootstrapper {
+	return &OpenBaoBootstrapper{executor: executor}
+}
+
+// BootstrapOptions configures the OpenBao bootstrap operation.
+type BootstrapOptions struct {
+	// SecretsFile is the path to a local .env-format file whose KEY=VALUE pairs
+	// are seeded into the remote OpenBao instance at secret/data/app.
+	// When empty no secrets are seeded.
+	SecretsFile string
+
+	// RotateSecrets forces re-seeding of secrets even when OpenBao is already
+	// initialised. When false and OpenBao is already initialised, only an
+	// unseal is performed (if necessary).
+	RotateSecrets bool
+
+	// UnsealKey is required on subsequent deploys when OpenBao is already
+	// initialised but sealed. When empty and OpenBao is sealed, an error is
+	// returned.
+	UnsealKey string
+
+	// RemoteDir is the remote project directory used to persist the AppRole
+	// credentials as environment variables in a file alongside the deployment.
+	// Defaults to ~/vibewarden/<project>/ when empty.
+	RemoteDir string
+
+	// Out is the writer used for progress messages. May be nil.
+	Out io.Writer
+}
+
+// Bootstrap performs the full OpenBao bootstrap on the remote host:
+//
+//  1. Checks OpenBao's init status via `bao operator init -status`.
+//  2. If uninitialised: initialises with 1 key share / threshold, unseal,
+//     enables KV v2, enables AppRole, creates policy and role, generates
+//     role_id and secret_id, then seeds secrets if SecretsFile is set.
+//  3. If already initialised but sealed: unseals using opts.UnsealKey.
+//  4. If opts.RotateSecrets is true: re-seeds secrets from opts.SecretsFile.
+//
+// It returns a BootstrapResult on first-time init (UnsealKey is non-empty)
+// or a partial result on subsequent deploys (UnsealKey is empty, RoleID and
+// SecretID are re-read from the remote environment).
+func (b *OpenBaoBootstrapper) Bootstrap(ctx context.Context, opts BootstrapOptions) (*BootstrapResult, error) {
+	out := opts.Out
+	if out == nil {
+		out = io.Discard
+	}
+
+	initialized, err := b.isInitialized(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("checking openbao init status: %w", err)
+	}
+
+	var result *BootstrapResult
+
+	if !initialized {
+		fmt.Fprintln(out, "OpenBao: not initialised — running first-time bootstrap...")
+		result, err = b.firstTimeBootstrap(ctx, opts, out)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		fmt.Fprintln(out, "OpenBao: already initialised — checking seal status...")
+		result = &BootstrapResult{}
+
+		if err := b.ensureUnsealed(ctx, opts.UnsealKey, out); err != nil {
+			return nil, err
+		}
+
+		if opts.RotateSecrets && opts.SecretsFile != "" {
+			fmt.Fprintln(out, "OpenBao: rotating secrets...")
+			rootToken, err := b.readRemoteRootToken(ctx, opts.RemoteDir)
+			if err != nil {
+				return nil, fmt.Errorf("reading remote root token for secret rotation: %w", err)
+			}
+			if err := b.seedSecrets(ctx, opts.SecretsFile, rootToken, out); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// firstTimeBootstrap performs the full OpenBao initialisation sequence.
+func (b *OpenBaoBootstrapper) firstTimeBootstrap(ctx context.Context, opts BootstrapOptions, out io.Writer) (*BootstrapResult, error) {
+	// Step 1: initialise with 1 key share and threshold.
+	fmt.Fprintln(out, "OpenBao: initialising (1 key share, threshold 1)...")
+	initOutput, err := b.baoRun(ctx, "", "operator init -key-shares=1 -key-threshold=1 -format=json")
+	if err != nil {
+		return nil, fmt.Errorf("openbao operator init: %w", err)
+	}
+
+	unsealKey, rootToken, err := ParseInitOutput(initOutput)
+	if err != nil {
+		return nil, fmt.Errorf("parsing openbao init output: %w", err)
+	}
+
+	// Step 2: unseal.
+	fmt.Fprintln(out, "OpenBao: unsealing...")
+	if _, err := b.baoRun(ctx, rootToken, fmt.Sprintf("operator unseal %s", unsealKey)); err != nil {
+		return nil, fmt.Errorf("openbao operator unseal: %w", err)
+	}
+
+	// Step 3: enable KV v2 at secret/.
+	fmt.Fprintln(out, "OpenBao: enabling KV v2 secrets engine at secret/...")
+	if _, err := b.baoRun(ctx, rootToken, fmt.Sprintf("secrets enable -path=%s kv-v2", defaultSecretsMount)); err != nil {
+		// Ignore "already enabled" errors.
+		if !strings.Contains(err.Error(), "already in use") && !strings.Contains(err.Error(), "path is already in use") {
+			return nil, fmt.Errorf("enabling kv-v2: %w", err)
+		}
+	}
+
+	// Step 4: enable AppRole auth.
+	fmt.Fprintln(out, "OpenBao: enabling AppRole auth method...")
+	if _, err := b.baoRun(ctx, rootToken, "auth enable approle"); err != nil {
+		if !strings.Contains(err.Error(), "already in use") && !strings.Contains(err.Error(), "path is already in use") {
+			return nil, fmt.Errorf("enabling approle: %w", err)
+		}
+	}
+
+	// Step 5: create the vibewarden policy.
+	fmt.Fprintln(out, "OpenBao: creating vibewarden policy...")
+	policy := vibewardenPolicy()
+	writeCmd := fmt.Sprintf("policy write %s - <<'POLICY'\n%s\nPOLICY", vibewardenPolicyName, policy)
+	if _, err := b.baoRun(ctx, rootToken, writeCmd); err != nil {
+		return nil, fmt.Errorf("writing vibewarden policy: %w", err)
+	}
+
+	// Step 6: create the AppRole role.
+	fmt.Fprintln(out, "OpenBao: creating vibewarden AppRole role...")
+	roleCmd := fmt.Sprintf("write auth/approle/role/%s token_policies=%s token_ttl=1h token_max_ttl=24h",
+		vibewardenRoleName, vibewardenPolicyName)
+	if _, err := b.baoRun(ctx, rootToken, roleCmd); err != nil {
+		return nil, fmt.Errorf("creating approle role: %w", err)
+	}
+
+	// Step 7: read role_id.
+	fmt.Fprintln(out, "OpenBao: reading role_id...")
+	roleIDOutput, err := b.baoRun(ctx, rootToken, fmt.Sprintf("read -field=role_id auth/approle/role/%s/role-id", vibewardenRoleName))
+	if err != nil {
+		return nil, fmt.Errorf("reading role_id: %w", err)
+	}
+	roleID := strings.TrimSpace(roleIDOutput)
+
+	// Step 8: generate secret_id.
+	fmt.Fprintln(out, "OpenBao: generating secret_id...")
+	secretIDOutput, err := b.baoRun(ctx, rootToken, fmt.Sprintf("write -field=secret_id -f auth/approle/role/%s/secret-id", vibewardenRoleName))
+	if err != nil {
+		return nil, fmt.Errorf("generating secret_id: %w", err)
+	}
+	secretID := strings.TrimSpace(secretIDOutput)
+
+	// Step 9: seed secrets.
+	if opts.SecretsFile != "" {
+		fmt.Fprintf(out, "OpenBao: seeding secrets from %s...\n", opts.SecretsFile)
+		if err := b.seedSecrets(ctx, opts.SecretsFile, rootToken, out); err != nil {
+			return nil, err
+		}
+	}
+
+	// Step 10: store credentials in the remote environment.
+	if opts.RemoteDir != "" {
+		fmt.Fprintln(out, "OpenBao: storing credentials on remote...")
+		if err := b.storeRemoteCredentials(ctx, opts.RemoteDir, rootToken, roleID, secretID, unsealKey); err != nil {
+			return nil, fmt.Errorf("storing remote credentials: %w", err)
+		}
+	}
+
+	return &BootstrapResult{
+		UnsealKey: unsealKey,
+		RootToken: rootToken,
+		RoleID:    roleID,
+		SecretID:  secretID,
+	}, nil
+}
+
+// isInitialized checks whether OpenBao has already been initialised on the
+// remote host. It runs `bao operator init -status` and interprets the exit
+// code: 0 = initialised, 2 = not initialised, other = error.
+func (b *OpenBaoBootstrapper) isInitialized(ctx context.Context) (bool, error) {
+	output, err := b.baoRun(ctx, "", "operator init -status")
+	if err != nil {
+		// bao operator init -status exits with code 2 when not initialised.
+		// The SSH executor wraps the exit code in the error message.
+		if strings.Contains(err.Error(), "exit status 2") || strings.Contains(output, "Vault is not initialized") {
+			return false, nil
+		}
+		// Any other non-zero exit is a real error (e.g. OpenBao not running).
+		return false, fmt.Errorf("openbao init status: %w", err)
+	}
+	// Exit 0 means initialised.
+	return true, nil
+}
+
+// ensureUnsealed checks the seal status and unseals OpenBao if necessary.
+func (b *OpenBaoBootstrapper) ensureUnsealed(ctx context.Context, unsealKey string, out io.Writer) error {
+	sealed, err := b.isSealed(ctx)
+	if err != nil {
+		return fmt.Errorf("checking seal status: %w", err)
+	}
+	if !sealed {
+		fmt.Fprintln(out, "OpenBao: already unsealed.")
+		return nil
+	}
+
+	if unsealKey == "" {
+		return fmt.Errorf("openbao is sealed and no unseal key was provided (use --unseal-key or VIBEWARDEN_UNSEAL_KEY)")
+	}
+
+	fmt.Fprintln(out, "OpenBao: unsealing...")
+	if _, err := b.baoRun(ctx, "", fmt.Sprintf("operator unseal %s", unsealKey)); err != nil {
+		return fmt.Errorf("openbao operator unseal: %w", err)
+	}
+	fmt.Fprintln(out, "OpenBao: unsealed successfully.")
+	return nil
+}
+
+// isSealed checks whether OpenBao is currently sealed.
+func (b *OpenBaoBootstrapper) isSealed(ctx context.Context) (bool, error) {
+	output, err := b.baoRun(ctx, "", "status -format=json")
+	if err != nil {
+		// bao status exits with code 2 when sealed — that is not an error here.
+		if strings.Contains(err.Error(), "exit status 2") {
+			// Try to parse the JSON output to confirm sealed state.
+			if strings.Contains(output, `"sealed":true`) {
+				return true, nil
+			}
+			return true, nil
+		}
+		return false, fmt.Errorf("openbao status: %w", err)
+	}
+
+	return strings.Contains(output, `"sealed":true`), nil
+}
+
+// seedSecrets reads KEY=VALUE pairs from the local secrets file and writes
+// them all to the remote OpenBao instance at secret/data/app.
+func (b *OpenBaoBootstrapper) seedSecrets(ctx context.Context, secretsFile, rootToken string, out io.Writer) error {
+	pairs, err := parseEnvFile(secretsFile)
+	if err != nil {
+		return fmt.Errorf("parsing secrets file %s: %w", secretsFile, err)
+	}
+	if len(pairs) == 0 {
+		fmt.Fprintln(out, "OpenBao: secrets file is empty — nothing to seed.")
+		return nil
+	}
+
+	// Build the `bao kv put` command arguments: key=value ...
+	args := make([]string, 0, len(pairs)+1)
+	args = append(args, fmt.Sprintf("kv put %s/data/app", defaultSecretsMount))
+	for k, v := range pairs {
+		// Shell-quote the value to handle spaces, $, etc.
+		args = append(args, fmt.Sprintf("%s=%s", k, ShellQuote(v)))
+	}
+
+	cmd := strings.Join(args, " ")
+	if _, err := b.baoRun(ctx, rootToken, cmd); err != nil {
+		return fmt.Errorf("seeding secrets: %w", err)
+	}
+	fmt.Fprintf(out, "OpenBao: seeded %d secret(s) to %s/data/app.\n", len(pairs), defaultSecretsMount)
+	return nil
+}
+
+// storeRemoteCredentials writes OPENBAO_ROOT_TOKEN, VIBEWARDEN_ROLE_ID,
+// VIBEWARDEN_SECRET_ID, and OPENBAO_UNSEAL_KEY to a .openbao-credentials
+// file in remoteDir on the remote host.
+func (b *OpenBaoBootstrapper) storeRemoteCredentials(ctx context.Context, remoteDir, rootToken, roleID, secretID, unsealKey string) error {
+	content := fmt.Sprintf(
+		"OPENBAO_ROOT_TOKEN=%s\nVIBEWARDEN_ROLE_ID=%s\nVIBEWARDEN_SECRET_ID=%s\nOPENBAO_UNSEAL_KEY=%s\n",
+		rootToken, roleID, secretID, unsealKey,
+	)
+	// Use printf to write the file without relying on heredoc portability.
+	escapedContent := strings.ReplaceAll(content, "'", `'\''`)
+	cmd := fmt.Sprintf("printf '%%s' '%s' > %s.openbao-credentials", escapedContent, remoteDir)
+	if _, err := b.executor.Run(ctx, cmd); err != nil {
+		return fmt.Errorf("writing .openbao-credentials: %w", err)
+	}
+	// Restrict permissions: only the owner can read/write.
+	chmodCmd := fmt.Sprintf("chmod 600 %s.openbao-credentials", remoteDir)
+	if _, err := b.executor.Run(ctx, chmodCmd); err != nil {
+		return fmt.Errorf("chmod .openbao-credentials: %w", err)
+	}
+	return nil
+}
+
+// readRemoteRootToken reads the OPENBAO_ROOT_TOKEN from the .openbao-credentials
+// file stored on the remote host. This is used when rotating secrets on
+// subsequent deploys.
+func (b *OpenBaoBootstrapper) readRemoteRootToken(ctx context.Context, remoteDir string) (string, error) {
+	if remoteDir == "" {
+		return "", fmt.Errorf("remote directory not set; cannot read root token")
+	}
+	cmd := fmt.Sprintf("grep ^OPENBAO_ROOT_TOKEN= %s.openbao-credentials | cut -d= -f2-", remoteDir)
+	output, err := b.executor.Run(ctx, cmd)
+	if err != nil {
+		return "", fmt.Errorf("reading root token from remote: %w", err)
+	}
+	token := strings.TrimSpace(output)
+	if token == "" {
+		return "", fmt.Errorf("OPENBAO_ROOT_TOKEN not found in remote .openbao-credentials")
+	}
+	return token, nil
+}
+
+// baoRun executes a bao CLI command on the remote host via the RemoteExecutor.
+// token is used as the VAULT_TOKEN environment variable when non-empty.
+func (b *OpenBaoBootstrapper) baoRun(ctx context.Context, token, subcmd string) (string, error) {
+	var envPrefix string
+	if token != "" {
+		envPrefix = fmt.Sprintf("%s VAULT_TOKEN=%s", defaultBaoEnv, token)
+	} else {
+		envPrefix = defaultBaoEnv
+	}
+	cmd := fmt.Sprintf("%s bao %s", envPrefix, subcmd)
+	return b.executor.Run(ctx, cmd)
+}
+
+// ParseInitOutput extracts the unseal key and root token from the JSON output
+// of `bao operator init -format=json`. It is exported for testing.
+func ParseInitOutput(output string) (unsealKey, rootToken string, err error) {
+	// Find the JSON object in output (bao may print warnings before JSON).
+	start := strings.Index(output, "{")
+	if start == -1 {
+		return "", "", fmt.Errorf("no JSON found in openbao init output: %q", output)
+	}
+	jsonPart := output[start:]
+
+	var initResponse struct {
+		UnsealKeysB64 []string `json:"unseal_keys_b64"`
+		RootToken     string   `json:"root_token"`
+	}
+	if err := json.Unmarshal([]byte(jsonPart), &initResponse); err != nil {
+		return "", "", fmt.Errorf("decoding openbao init JSON: %w", err)
+	}
+	if len(initResponse.UnsealKeysB64) == 0 {
+		return "", "", fmt.Errorf("openbao init returned no unseal keys")
+	}
+	if initResponse.RootToken == "" {
+		return "", "", fmt.Errorf("openbao init returned empty root token")
+	}
+	return initResponse.UnsealKeysB64[0], initResponse.RootToken, nil
+}
+
+// parseEnvFile reads a .env-format file (KEY=VALUE per line) from the local
+// filesystem and returns a map of key to value. Lines starting with # and
+// blank lines are ignored. Values may optionally be quoted with ' or ".
+func parseEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path) //nolint:gosec // path is user-supplied config; acceptable in this context.
+	if err != nil {
+		return nil, fmt.Errorf("opening secrets file: %w", err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	return ParseEnvReader(f)
+}
+
+// ParseEnvReader parses .env-format lines from r. It is exported for testing.
+func ParseEnvReader(r io.Reader) (map[string]string, error) {
+	result := make(map[string]string)
+	scanner := bufio.NewScanner(r)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		idx := strings.IndexByte(line, '=')
+		if idx == -1 {
+			return nil, fmt.Errorf("line %d: missing '=' separator in %q", lineNum, line)
+		}
+		key := strings.TrimSpace(line[:idx])
+		if key == "" {
+			return nil, fmt.Errorf("line %d: empty key in %q", lineNum, line)
+		}
+		value := line[idx+1:]
+		// Strip optional surrounding quotes.
+		value = stripQuotes(value)
+		result[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading secrets file: %w", err)
+	}
+	return result, nil
+}
+
+// stripQuotes removes a matching pair of surrounding single or double quotes
+// from s, if present.
+func stripQuotes(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '\'' && s[len(s)-1] == '\'') || (s[0] == '"' && s[len(s)-1] == '"') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+// ShellQuote wraps a value in single quotes, escaping any existing single
+// quotes so the result is safe to embed in a POSIX shell command.
+// It is exported for testing.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// vibewardenPolicy returns the HCL policy granting the vibewarden AppRole
+// read/write access to the secret/ KV mount.
+func vibewardenPolicy() string {
+	return `path "secret/data/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+path "secret/metadata/*" {
+  capabilities = ["read", "list", "delete"]
+}`
+}

--- a/internal/app/deploy/openbao_test.go
+++ b/internal/app/deploy/openbao_test.go
@@ -1,0 +1,359 @@
+package deploy_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	deployapp "github.com/vibewarden/vibewarden/internal/app/deploy"
+)
+
+// TestParseEnvReader tests the internal env-file parser via the public
+// Bootstrap path. We test it directly by constructing known inputs.
+
+func TestParseInitOutput_Valid(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantUnsealKey string
+		wantRootToken string
+		wantErr       bool
+	}{
+		{
+			name: "clean JSON",
+			input: `{
+  "unseal_keys_b64": ["abc123=="],
+  "root_token": "hvs.roottoken"
+}`,
+			wantUnsealKey: "abc123==",
+			wantRootToken: "hvs.roottoken",
+		},
+		{
+			name: "JSON with leading warning text",
+			input: `WARNING: some warning here
+{
+  "unseal_keys_b64": ["xyz789=="],
+  "root_token": "hvs.othertoken"
+}`,
+			wantUnsealKey: "xyz789==",
+			wantRootToken: "hvs.othertoken",
+		},
+		{
+			name:    "no JSON",
+			input:   "something went wrong",
+			wantErr: true,
+		},
+		{
+			name:    "empty unseal keys",
+			input:   `{"unseal_keys_b64": [], "root_token": "tok"}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty root token",
+			input:   `{"unseal_keys_b64": ["key1"], "root_token": ""}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unsealKey, rootToken, err := deployapp.ParseInitOutput(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseInitOutput() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if unsealKey != tt.wantUnsealKey {
+				t.Errorf("unsealKey = %q, want %q", unsealKey, tt.wantUnsealKey)
+			}
+			if rootToken != tt.wantRootToken {
+				t.Errorf("rootToken = %q, want %q", rootToken, tt.wantRootToken)
+			}
+		})
+	}
+}
+
+func TestParseEnvReader_Valid(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name:  "simple key-value",
+			input: "FOO=bar\nBAZ=qux\n",
+			want:  map[string]string{"FOO": "bar", "BAZ": "qux"},
+		},
+		{
+			name:  "comments and blank lines ignored",
+			input: "# comment\n\nFOO=bar\n",
+			want:  map[string]string{"FOO": "bar"},
+		},
+		{
+			name:  "double-quoted value",
+			input: `DB_URL="postgres://localhost/mydb"`,
+			want:  map[string]string{"DB_URL": "postgres://localhost/mydb"},
+		},
+		{
+			name:  "single-quoted value",
+			input: `SECRET='my secret value'`,
+			want:  map[string]string{"SECRET": "my secret value"},
+		},
+		{
+			name:  "value with equals sign",
+			input: "TOKEN=abc=def=",
+			want:  map[string]string{"TOKEN": "abc=def="},
+		},
+		{
+			name:  "empty value",
+			input: "EMPTY=",
+			want:  map[string]string{"EMPTY": ""},
+		},
+		{
+			name:    "missing equals separator",
+			input:   "NOEQUALS\n",
+			wantErr: true,
+		},
+		{
+			name:    "empty key",
+			input:   "=value\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := deployapp.ParseEnvReader(strings.NewReader(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseEnvReader() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("ParseEnvReader()[%q] = %q, want %q", k, got[k], v)
+				}
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("ParseEnvReader() len = %d, want %d; got %v", len(got), len(tt.want), got)
+			}
+		})
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain value", "hello", "'hello'"},
+		{"value with space", "hello world", "'hello world'"},
+		{"value with single quote", "it's fine", `'it'\''s fine'`},
+		{"empty string", "", "''"},
+		{"value with dollar", "$SECRET", "'$SECRET'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deployapp.ShellQuote(tt.input)
+			if got != tt.want {
+				t.Errorf("ShellQuote(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBootstrapper_Bootstrap_FirstTime verifies that on a fresh OpenBao instance
+// the bootstrapper runs the full init sequence.
+func TestBootstrapper_Bootstrap_FirstTime(t *testing.T) {
+	initJSON := `{"unseal_keys_b64":["dGVzdHVuc2VhbGtleQ=="],"root_token":"hvs.testroot"}`
+
+	wrappedExec := &wildcardExecutor{
+		wildcards: map[string]runResponse{
+			// isInitialized: bao init -status exits 2 (not initialized)
+			"bao operator init -status": {
+				output: "Vault is not initialized",
+				err:    errors.New("exit status 2"),
+			},
+			// operator init (no token needed)
+			"bao operator init -key-shares=1 -key-threshold=1 -format=json": {
+				output: initJSON,
+			},
+			// operator unseal
+			"bao operator unseal dGVzdHVuc2VhbGtleQ==": {},
+			// secrets enable kv-v2
+			"bao secrets enable -path=secret kv-v2": {},
+			// auth enable approle
+			"bao auth enable approle": {},
+			// policy write
+			"bao policy write": {},
+			// create role
+			"bao write auth/approle/role/vibewarden token_policies": {},
+			// read role_id
+			"bao read -field=role_id auth/approle/role/vibewarden/role-id": {
+				output: "test-role-id",
+			},
+			// generate secret_id
+			"bao write -field=secret_id -f auth/approle/role/vibewarden/secret-id": {
+				output: "test-secret-id",
+			},
+		},
+	}
+
+	bootstrapper := deployapp.NewOpenBaoBootstrapper(wrappedExec)
+
+	result, err := bootstrapper.Bootstrap(context.Background(), deployapp.BootstrapOptions{})
+	if err != nil {
+		t.Fatalf("Bootstrap() error: %v", err)
+	}
+
+	if result.UnsealKey == "" {
+		t.Error("expected UnsealKey to be set after first-time bootstrap")
+	}
+	if result.RootToken == "" {
+		t.Error("expected RootToken to be set after first-time bootstrap")
+	}
+	if result.RoleID == "" {
+		t.Error("expected RoleID to be set after first-time bootstrap")
+	}
+	if result.SecretID == "" {
+		t.Error("expected SecretID to be set after first-time bootstrap")
+	}
+}
+
+// TestBootstrapper_Bootstrap_AlreadyInitialisedUnsealed verifies that on
+// subsequent deploys the bootstrapper skips the init sequence.
+func TestBootstrapper_Bootstrap_AlreadyInitialisedUnsealed(t *testing.T) {
+	exec := &wildcardExecutor{
+		wildcards: map[string]runResponse{
+			// isInitialized: exits 0 (already initialized)
+			"bao operator init -status": {output: "Vault is initialized"},
+			// isSealed: status returns unsealed JSON
+			"bao status -format=json": {output: `{"sealed":false}`},
+		},
+	}
+
+	bootstrapper := deployapp.NewOpenBaoBootstrapper(exec)
+
+	result, err := bootstrapper.Bootstrap(context.Background(), deployapp.BootstrapOptions{})
+	if err != nil {
+		t.Fatalf("Bootstrap() unexpected error: %v", err)
+	}
+
+	// On subsequent deploy, UnsealKey should be empty (not returned again).
+	if result.UnsealKey != "" {
+		t.Errorf("expected empty UnsealKey on subsequent deploy, got %q", result.UnsealKey)
+	}
+}
+
+// TestBootstrapper_Bootstrap_AlreadyInitialisedSealed verifies that the
+// bootstrapper unseals when sealed and an unseal key is provided.
+func TestBootstrapper_Bootstrap_AlreadyInitialisedSealed(t *testing.T) {
+	exec := &wildcardExecutor{
+		wildcards: map[string]runResponse{
+			"bao operator init -status": {output: "Vault is initialized"},
+			"bao status -format=json":   {output: `{"sealed":true}`, err: errors.New("exit status 2")},
+			"bao operator unseal":       {output: "Unseal Key (will be hidden):"},
+		},
+	}
+
+	bootstrapper := deployapp.NewOpenBaoBootstrapper(exec)
+
+	var buf strings.Builder
+	result, err := bootstrapper.Bootstrap(context.Background(), deployapp.BootstrapOptions{
+		UnsealKey: "myunsealkey",
+		Out:       &buf,
+	})
+	if err != nil {
+		t.Fatalf("Bootstrap() unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "unsealed") {
+		t.Errorf("expected 'unsealed' in output, got: %q", output)
+	}
+}
+
+// TestBootstrapper_Bootstrap_SealedNoUnsealKey verifies that an error is
+// returned when OpenBao is sealed and no unseal key is provided.
+func TestBootstrapper_Bootstrap_SealedNoUnsealKey(t *testing.T) {
+	exec := &wildcardExecutor{
+		wildcards: map[string]runResponse{
+			"bao operator init -status": {output: "Vault is initialized"},
+			"bao status -format=json":   {output: `{"sealed":true}`, err: errors.New("exit status 2")},
+		},
+	}
+
+	bootstrapper := deployapp.NewOpenBaoBootstrapper(exec)
+
+	_, err := bootstrapper.Bootstrap(context.Background(), deployapp.BootstrapOptions{
+		UnsealKey: "", // not provided
+	})
+	if err == nil {
+		t.Fatal("expected error when sealed and no unseal key provided")
+	}
+	if !strings.Contains(err.Error(), "unseal key") {
+		t.Errorf("error should mention 'unseal key', got: %v", err)
+	}
+}
+
+// TestBootstrapper_Bootstrap_InitFails verifies error propagation when
+// `bao operator init` fails.
+func TestBootstrapper_Bootstrap_InitFails(t *testing.T) {
+	exec := &wildcardExecutor{
+		wildcards: map[string]runResponse{
+			"bao operator init -status": {
+				output: "Vault is not initialized",
+				err:    errors.New("exit status 2"),
+			},
+			"bao operator init -key-shares=1": {
+				err: errors.New("connection refused"),
+			},
+		},
+	}
+
+	bootstrapper := deployapp.NewOpenBaoBootstrapper(exec)
+
+	_, err := bootstrapper.Bootstrap(context.Background(), deployapp.BootstrapOptions{})
+	if err == nil {
+		t.Fatal("expected error when operator init fails")
+	}
+	if !strings.Contains(err.Error(), "operator init") {
+		t.Errorf("error should mention 'operator init', got: %v", err)
+	}
+}
+
+// wildcardExecutor is a RemoteExecutor that matches commands by substring
+// prefix, falling back to inner if set.
+type wildcardExecutor struct {
+	inner     *fakeExecutor
+	wildcards map[string]runResponse
+	runCalls  []string
+}
+
+func (w *wildcardExecutor) Run(_ context.Context, cmd string) (string, error) {
+	w.runCalls = append(w.runCalls, cmd)
+	for prefix, resp := range w.wildcards {
+		if strings.Contains(cmd, prefix) {
+			return resp.output, resp.err
+		}
+	}
+	if w.inner != nil {
+		if r, ok := w.inner.runResponses[cmd]; ok {
+			return r.output, r.err
+		}
+	}
+	return "", nil
+}
+
+func (w *wildcardExecutor) Transfer(_ context.Context, _, _ string, _ bool) error {
+	return nil
+}

--- a/internal/app/deploy/service.go
+++ b/internal/app/deploy/service.go
@@ -94,7 +94,7 @@ func (s *Service) Deploy(ctx context.Context, cfg *config.Config, opts RunOption
 
 	projectName := opts.ProjectName
 	if projectName == "" {
-		projectName = projectNameFromConfig(opts.ConfigPath)
+		projectName = ProjectNameFromConfig(opts.ConfigPath)
 	}
 	remoteDir := remoteBaseDir + "/" + projectName + "/"
 
@@ -275,10 +275,11 @@ func (s *Service) checkHealth(ctx context.Context, healthURL string) (bool, erro
 	return resp.StatusCode >= 200 && resp.StatusCode < 300, nil
 }
 
-// projectNameFromConfig derives a project name from the config file path.
+// ProjectNameFromConfig derives a project name from the config file path.
 // It returns the base name of the directory containing the config file, which
-// is the project directory name by convention.
-func projectNameFromConfig(configPath string) string {
+// is the project directory name by convention. It is exported so the CLI can
+// compute the remote directory before calling Deploy.
+func ProjectNameFromConfig(configPath string) string {
 	if configPath == "" {
 		return "vibewarden"
 	}

--- a/internal/cli/cmd/deploy.go
+++ b/internal/cli/cmd/deploy.go
@@ -19,12 +19,16 @@ import (
 // NewDeployCmd creates the "vibew deploy" command and its subcommands.
 //
 // vibew deploy --config vibewarden.prod.yaml --target ssh://user@host
+// vibew deploy --config vibewarden.prod.yaml --target ssh://user@host --secrets-from .env.prod
 // vibew deploy status --target ssh://user@host
 // vibew deploy logs   --target ssh://user@host [--lines 50]
 func NewDeployCmd() *cobra.Command {
 	var (
-		configPath string
-		target     string
+		configPath    string
+		target        string
+		secretsFrom   string
+		rotateSecrets bool
+		unsealKey     string
 	)
 
 	cmd := &cobra.Command{
@@ -34,6 +38,14 @@ func NewDeployCmd() *cobra.Command {
 
 The command generates runtime configuration, transfers files via rsync, and
 starts Docker Compose on the remote host.
+
+When the secrets plugin is enabled (secrets.enabled: true in vibewarden.yaml),
+the first deploy also bootstraps OpenBao: initialises, unseals, enables KV v2
+and AppRole, creates the vibewarden policy and role, and seeds secrets from
+--secrets-from when provided.
+
+On subsequent deploys the unseal key stored in ~/vibewarden/<project>/.openbao-credentials
+is used automatically unless you supply --unseal-key explicitly.
 
 Target URL format:
   ssh://user@host
@@ -46,7 +58,9 @@ Remote directory: ~/vibewarden/<project-name>/
 
 Examples:
   vibew deploy --config vibewarden.prod.yaml --target ssh://ubuntu@203.0.113.10
-  vibew deploy --config vibewarden.prod.yaml --target ssh://deploy@myserver.example.com:2222`,
+  vibew deploy --config vibewarden.prod.yaml --target ssh://deploy@myserver.example.com:2222
+  vibew deploy --config vibewarden.prod.yaml --target ssh://ubuntu@203.0.113.10 --secrets-from .env.prod
+  vibew deploy --config vibewarden.prod.yaml --target ssh://ubuntu@203.0.113.10 --rotate-secrets --secrets-from .env.prod`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if target == "" {
 				return fmt.Errorf("--target is required (e.g. ssh://user@host)")
@@ -76,21 +90,63 @@ Examples:
 				absConfig = configPath
 			}
 
-			return svc.Deploy(cmd.Context(), cfg, deployapp.RunOptions{
+			projectName := deployapp.ProjectNameFromConfig(absConfig)
+			remoteDir := "~/vibewarden/" + projectName + "/"
+
+			opts := deployapp.RunOptions{
 				ConfigPath: absConfig,
 				Out:        cmd.OutOrStdout(),
-			})
+			}
+
+			// Bootstrap OpenBao when the secrets plugin is enabled.
+			if cfg.Secrets.Enabled {
+				bootstrapper := deployapp.NewOpenBaoBootstrapper(executor)
+				result, err := bootstrapper.Bootstrap(cmd.Context(), deployapp.BootstrapOptions{
+					SecretsFile:   secretsFrom,
+					RotateSecrets: rotateSecrets,
+					UnsealKey:     unsealKey,
+					RemoteDir:     remoteDir,
+					Out:           cmd.OutOrStdout(),
+				})
+				if err != nil {
+					return fmt.Errorf("openbao bootstrap: %w", err)
+				}
+				if result.UnsealKey != "" {
+					fmt.Fprintln(cmd.OutOrStdout())
+					fmt.Fprintln(cmd.OutOrStdout(), "=======================================================")
+					fmt.Fprintln(cmd.OutOrStdout(), "  IMPORTANT: Save your OpenBao unseal key now!")
+					fmt.Fprintln(cmd.OutOrStdout(), "  You will need it to unseal OpenBao after a restart.")
+					fmt.Fprintln(cmd.OutOrStdout(), "  This key will NOT be shown again.")
+					fmt.Fprintln(cmd.OutOrStdout(), "=======================================================")
+					fmt.Fprintf(cmd.OutOrStdout(), "  Unseal Key : %s\n", result.UnsealKey)
+					fmt.Fprintf(cmd.OutOrStdout(), "  Root Token : %s\n", result.RootToken)
+					fmt.Fprintf(cmd.OutOrStdout(), "  Role ID    : %s\n", result.RoleID)
+					fmt.Fprintf(cmd.OutOrStdout(), "  Secret ID  : %s\n", result.SecretID)
+					fmt.Fprintln(cmd.OutOrStdout(), "=======================================================")
+					fmt.Fprintln(cmd.OutOrStdout())
+				}
+			}
+
+			return svc.Deploy(cmd.Context(), cfg, opts)
 		},
 	}
 
 	cmd.Flags().StringVar(&configPath, "config", "", "path to vibewarden.yaml (default: ./vibewarden.yaml)")
 	cmd.Flags().StringVar(&target, "target", "", "remote target in ssh://user@host[:port] format (required)")
+	cmd.Flags().StringVar(&secretsFrom, "secrets-from", "", "path to a .env-format file whose KEY=VALUE pairs are seeded into OpenBao")
+	cmd.Flags().BoolVar(&rotateSecrets, "rotate-secrets", false, "re-seed secrets from --secrets-from on subsequent deploys")
+	cmd.Flags().StringVar(&unsealKey, "unseal-key", "", "OpenBao unseal key (required when redeploying a sealed instance); overrides stored key")
 
 	if err := cmd.MarkFlagRequired("target"); err != nil {
 		fmt.Fprintln(os.Stderr, "warning: flag required registration failed:", err)
 	}
 	if err := cmd.RegisterFlagCompletionFunc("config", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"yaml", "yml"}, cobra.ShellCompDirectiveFilterFileExt
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, "warning: flag completion registration failed:", err)
+	}
+	if err := cmd.RegisterFlagCompletionFunc("secrets-from", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"env"}, cobra.ShellCompDirectiveFilterFileExt
 	}); err != nil {
 		fmt.Fprintln(os.Stderr, "warning: flag completion registration failed:", err)
 	}

--- a/internal/cli/cmd/deploy_test.go
+++ b/internal/cli/cmd/deploy_test.go
@@ -174,3 +174,88 @@ func TestDeployCmd_SubcommandHelp(t *testing.T) {
 		})
 	}
 }
+
+func TestDeployCmd_SecretsFromFlagRegistered(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	deployCmd, _, err := root.Find([]string{"deploy"})
+	if err != nil {
+		t.Fatalf("Find(deploy) error: %v", err)
+	}
+	if deployCmd.Flags().Lookup("secrets-from") == nil {
+		t.Error("expected --secrets-from flag on deploy command")
+	}
+}
+
+func TestDeployCmd_RotateSecretsFlagRegistered(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	deployCmd, _, err := root.Find([]string{"deploy"})
+	if err != nil {
+		t.Fatalf("Find(deploy) error: %v", err)
+	}
+	if deployCmd.Flags().Lookup("rotate-secrets") == nil {
+		t.Error("expected --rotate-secrets flag on deploy command")
+	}
+}
+
+func TestDeployCmd_UnsealKeyFlagRegistered(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	deployCmd, _, err := root.Find([]string{"deploy"})
+	if err != nil {
+		t.Fatalf("Find(deploy) error: %v", err)
+	}
+	if deployCmd.Flags().Lookup("unseal-key") == nil {
+		t.Error("expected --unseal-key flag on deploy command")
+	}
+}
+
+func TestDeployCmd_SecretsFromDefaultIsEmpty(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	deployCmd, _, err := root.Find([]string{"deploy"})
+	if err != nil {
+		t.Fatalf("Find(deploy) error: %v", err)
+	}
+	f := deployCmd.Flags().Lookup("secrets-from")
+	if f == nil {
+		t.Fatal("--secrets-from flag not found")
+	}
+	if f.DefValue != "" {
+		t.Errorf("--secrets-from default should be empty, got %q", f.DefValue)
+	}
+}
+
+func TestDeployCmd_RotateSecretsDefaultIsFalse(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	deployCmd, _, err := root.Find([]string{"deploy"})
+	if err != nil {
+		t.Fatalf("Find(deploy) error: %v", err)
+	}
+	f := deployCmd.Flags().Lookup("rotate-secrets")
+	if f == nil {
+		t.Fatal("--rotate-secrets flag not found")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--rotate-secrets default should be false, got %q", f.DefValue)
+	}
+}
+
+func TestDeployCmd_HelpContainsSecretsFromExample(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	deployCmd, _, err := root.Find([]string{"deploy"})
+	if err != nil {
+		t.Fatalf("Find(deploy) error: %v", err)
+	}
+	if !strings.Contains(deployCmd.Long, "--secrets-from") {
+		t.Error("deploy command long description should mention --secrets-from")
+	}
+}
+
+func TestDeployCmd_HelpContainsRotateSecretsExample(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	deployCmd, _, err := root.Find([]string{"deploy"})
+	if err != nil {
+		t.Fatalf("Find(deploy) error: %v", err)
+	}
+	if !strings.Contains(deployCmd.Long, "--rotate-secrets") {
+		t.Error("deploy command long description should mention --rotate-secrets")
+	}
+}


### PR DESCRIPTION
Closes #658

## Summary

- Adds `internal/app/deploy/openbao.go` — `OpenBaoBootstrapper` struct that orchestrates the full OpenBao lifecycle on the remote host using only the `RemoteExecutor` (bao CLI over SSH, no Go OpenBao client):
  - First deploy: `bao operator init` (1 key share / threshold 1), unseal, enable KV v2 at `secret/`, enable AppRole auth, create `vibewarden` policy and role, generate `role_id` and `secret_id`, seed secrets from `--secrets-from` file, store credentials in `~/vibewarden/<project>/.openbao-credentials`.
  - Subsequent deploys: check init status, skip bootstrap, unseal if sealed (using stored or provided key), optionally rotate secrets with `--rotate-secrets`.
- Exports `ProjectNameFromConfig` from `internal/app/deploy/service.go` so the CLI can compute the remote directory before calling `Deploy`.
- Adds three new flags to `vibew deploy`:
  - `--secrets-from <file>` — path to a `.env`-format file seeded into `secret/data/app`
  - `--rotate-secrets` — re-seed secrets on subsequent deploys
  - `--unseal-key <key>` — supply unseal key when redeploying a sealed instance
- Displays unseal key + AppRole credentials with a prominent banner on first deploy.
- Exports `ParseInitOutput`, `ParseEnvReader`, and `ShellQuote` for table-driven unit tests.

## Test plan

- `go test ./internal/app/deploy/...` — 28 tests, all passing (includes `TestBootstrapper_Bootstrap_FirstTime`, `_AlreadyInitialisedUnsealed`, `_AlreadyInitialisedSealed`, `_SealedNoUnsealKey`, `_InitFails`, `ParseInitOutput` cases, `ParseEnvReader` cases, `ShellQuote` cases)
- `go test ./internal/cli/cmd/...` — all existing deploy tests pass; 7 new tests verify the 3 new flags are registered, have correct defaults, and appear in the command long description
- `make check` passes (gofmt, golangci-lint, build, tests, demo-app)