### PR TITLE
feat(#652): add MCP deploy tools (prepare_deploy, verify_deploy, get_deploy_logs)

### DIFF
--- a/internal/mcp/deploy.go
+++ b/internal/mcp/deploy.go
@@ -1,0 +1,267 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SidecarImage is the canonical VibeWarden sidecar Docker image reference.
+const SidecarImage = "ghcr.io/vibewarden/vibewarden:latest"
+
+// Platform represents a supported deployment platform.
+type Platform string
+
+const (
+	// PlatformDocker is a generic Docker Compose deployment used with vibew deploy SSH.
+	PlatformDocker Platform = "docker"
+	// PlatformRailway is a Railway.app two-service deployment using internal networking.
+	PlatformRailway Platform = "railway"
+	// PlatformFlyio is a Fly.io deployment using the processes syntax in fly.toml.
+	PlatformFlyio Platform = "flyio"
+)
+
+// SidecarSpec describes the VibeWarden sidecar container in a deployment.
+type SidecarSpec struct {
+	// Image is the container image reference.
+	Image string `json:"image"`
+	// Ports lists the host:container port mappings (Docker syntax).
+	Ports []string `json:"ports"`
+	// Environment lists the required environment variable names (values are placeholders).
+	Environment map[string]string `json:"environment"`
+	// Volumes lists the host:container volume mounts.
+	Volumes []string `json:"volumes"`
+	// Command is the optional override command.
+	Command []string `json:"command,omitempty"`
+}
+
+// DeploySpec is the full deployment specification returned by vibewarden_prepare_deploy.
+type DeploySpec struct {
+	// Platform identifies which platform this spec targets.
+	Platform string `json:"platform"`
+	// AppPort is the port the user's application listens on.
+	AppPort int `json:"app_port"`
+	// Sidecar is the container spec for the VibeWarden sidecar.
+	Sidecar SidecarSpec `json:"sidecar"`
+	// ConfigFileContent is the ready-to-use vibewarden.yaml template.
+	ConfigFileContent string `json:"config_file_content"`
+	// PlatformSpec is a platform-native configuration snippet (Compose YAML,
+	// Railway JSON, or fly.toml TOML depending on the platform).
+	PlatformSpec string `json:"platform_spec"`
+	// HealthCheckURL is the URL agents should poll to verify deployment.
+	HealthCheckURL string `json:"health_check_url"`
+	// Notes contains platform-specific hints and next steps.
+	Notes []string `json:"notes"`
+}
+
+// PrepareDockerSpec builds a generic Docker Compose deployment spec.
+func PrepareDockerSpec(appPort int) DeploySpec {
+	configContent := buildVibewardenYAML(appPort)
+
+	compose := fmt.Sprintf(`services:
+  app:
+    image: your-app-image:latest   # replace with your actual image or build context
+    expose:
+      - "%d"
+    networks:
+      - vibeward
+
+  vibewarden:
+    image: %s
+    ports:
+      - "8443:8443"
+    volumes:
+      - ./vibewarden.yaml:/etc/vibewarden/vibewarden.yaml:ro
+      - vibewarden_data:/data
+    environment:
+      VIBEWARDEN_CONFIG: /etc/vibewarden/vibewarden.yaml
+    depends_on:
+      - app
+    networks:
+      - vibeward
+    restart: unless-stopped
+
+networks:
+  vibeward:
+    driver: bridge
+
+volumes:
+  vibewarden_data:
+`, appPort, SidecarImage)
+
+	return DeploySpec{
+		Platform: string(PlatformDocker),
+		AppPort:  appPort,
+		Sidecar: SidecarSpec{
+			Image: SidecarImage,
+			Ports: []string{"8443:8443"},
+			Environment: map[string]string{
+				"VIBEWARDEN_CONFIG": "/etc/vibewarden/vibewarden.yaml",
+			},
+			Volumes: []string{
+				"./vibewarden.yaml:/etc/vibewarden/vibewarden.yaml:ro",
+				"vibewarden_data:/data",
+			},
+		},
+		ConfigFileContent: configContent,
+		PlatformSpec:      compose,
+		HealthCheckURL:    "https://localhost:8443/_vibewarden/health",
+		Notes: []string{
+			"Replace 'your-app-image:latest' with your actual application image or add a 'build:' key.",
+			"The sidecar listens on port 8443 (HTTPS) and proxies to your app on port " + fmt.Sprintf("%d", appPort) + " within the 'vibeward' network.",
+			"Run 'vibew deploy ssh' to push this Compose file to a remote server.",
+			"Set VIBEWARDEN_ADMIN_TOKEN in your environment or .env file before starting.",
+		},
+	}
+}
+
+// PrepareRailwaySpec builds a Railway.app two-service deployment spec.
+// The sidecar and the app communicate over Railway's private internal network.
+func PrepareRailwaySpec(appPort int) DeploySpec {
+	configContent := buildVibewardenYAML(appPort)
+
+	// railway.toml for the sidecar service.
+	railwaySpec := fmt.Sprintf(`# railway.toml — place this in the vibewarden service root
+
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = ""         # not needed; image is pulled directly
+
+[deploy]
+startCommand = "vibewarden serve --config /etc/vibewarden/vibewarden.yaml"
+
+# Add these environment variables in the Railway dashboard:
+#   VIBEWARDEN_CONFIG       = /etc/vibewarden/vibewarden.yaml
+#   VIBEWARDEN_ADMIN_TOKEN  = <generated secret>
+#   APP_INTERNAL_HOST       = <your-app-service>.railway.internal
+
+# Railway networking notes:
+#   - Services on the same project communicate via <service-name>.railway.internal
+#   - The sidecar upstream.host must be set to your app's internal hostname
+#   - Public traffic hits the sidecar; the app service has no public port
+
+# vibewarden.yaml upstream section for Railway:
+# upstream:
+#   host: your-app-name.railway.internal
+#   port: %d
+`, appPort)
+
+	return DeploySpec{
+		Platform: string(PlatformRailway),
+		AppPort:  appPort,
+		Sidecar: SidecarSpec{
+			Image: SidecarImage,
+			Ports: []string{"8443:8443"},
+			Environment: map[string]string{
+				"VIBEWARDEN_CONFIG":      "/etc/vibewarden/vibewarden.yaml",
+				"VIBEWARDEN_ADMIN_TOKEN": "<generate with: vibew secret generate --admin-token>",
+			},
+			Volumes: []string{},
+		},
+		ConfigFileContent: configContent,
+		PlatformSpec:      railwaySpec,
+		HealthCheckURL:    "https://<your-vibewarden-railway-domain>/_vibewarden/health",
+		Notes: []string{
+			"Deploy the VibeWarden sidecar as a separate Railway service in the same project as your app.",
+			"Set upstream.host in vibewarden.yaml to your app's Railway internal hostname: <app-name>.railway.internal",
+			"Only the vibewarden service needs a public domain; keep your app service internal.",
+			"Store VIBEWARDEN_ADMIN_TOKEN as a Railway secret variable.",
+			"Add vibewarden.yaml as a Railway volume or embed it in a custom Docker image.",
+		},
+	}
+}
+
+// PrepareFlyioSpec builds a Fly.io deployment spec using the processes syntax.
+// The sidecar runs as a separate process group in the same Fly app, sharing the private network.
+func PrepareFlyioSpec(appPort int) DeploySpec {
+	configContent := buildVibewardenYAML(appPort)
+
+	flyToml := fmt.Sprintf(`# fly.toml — Fly.io deployment with VibeWarden sidecar process
+# Place this in your project root and run: fly deploy
+
+app = "your-app-name"        # replace with your Fly app name
+primary_region = "iad"       # replace with your preferred region
+
+# ── App process ──────────────────────────────────────────────────────────────
+[processes]
+  app        = "./your-app-binary"            # replace with your app start command
+  vibewarden = "vibewarden serve --config /etc/vibewarden/vibewarden.yaml"
+
+# ── Services (public ingress via vibewarden) ─────────────────────────────────
+[[services]]
+  processes   = ["vibewarden"]
+  internal_port = 8443
+  protocol      = "tcp"
+
+  [[services.ports]]
+    port     = 443
+    handlers = ["tls", "http"]
+
+  [[services.ports]]
+    port     = 80
+    handlers = ["http"]
+
+  [services.concurrency]
+    type       = "requests"
+    hard_limit = 200
+    soft_limit = 150
+
+# ── App internal service (not exposed publicly) ───────────────────────────────
+[[services]]
+  processes     = ["app"]
+  internal_port = %d
+  protocol      = "tcp"
+  # No public ports — only the sidecar is exposed
+
+# ── Mounts ────────────────────────────────────────────────────────────────────
+[[mounts]]
+  source      = "vibewarden_data"
+  destination = "/data"
+  processes   = ["vibewarden"]
+
+# ── Environment ───────────────────────────────────────────────────────────────
+[env]
+  VIBEWARDEN_CONFIG = "/etc/vibewarden/vibewarden.yaml"
+  # Set VIBEWARDEN_ADMIN_TOKEN as a secret:
+  #   fly secrets set VIBEWARDEN_ADMIN_TOKEN=<value>
+`, appPort)
+
+	return DeploySpec{
+		Platform: string(PlatformFlyio),
+		AppPort:  appPort,
+		Sidecar: SidecarSpec{
+			Image: SidecarImage,
+			Ports: []string{"443:8443"},
+			Environment: map[string]string{
+				"VIBEWARDEN_CONFIG": "/etc/vibewarden/vibewarden.yaml",
+			},
+			Volumes: []string{
+				"vibewarden_data:/data",
+			},
+			Command: []string{"vibewarden", "serve", "--config", "/etc/vibewarden/vibewarden.yaml"},
+		},
+		ConfigFileContent: configContent,
+		PlatformSpec:      flyToml,
+		HealthCheckURL:    "https://<your-app-name>.fly.dev/_vibewarden/health",
+		Notes: []string{
+			"The 'vibewarden' process in [processes] runs the sidecar; the 'app' process runs your application.",
+			"Set the upstream.host in vibewarden.yaml to '0.0.0.0' (localhost within the VM) since both processes share the same Fly machine.",
+			"Run 'fly secrets set VIBEWARDEN_ADMIN_TOKEN=<value>' to store the admin token securely.",
+			"Mount vibewarden.yaml using a Fly volume or bake it into a custom Dockerfile that uses " + SidecarImage + " as base.",
+			"Run 'fly deploy' to deploy. Check health with: fly ssh console -C 'curl http://localhost:8443/_vibewarden/health'",
+		},
+	}
+}
+
+// buildVibewardenYAML generates a minimal vibewarden.yaml template for the given app port.
+func buildVibewardenYAML(appPort int) string {
+	var sb strings.Builder
+	sb.WriteString("# vibewarden.yaml — generated by vibewarden_prepare_deploy\n")
+	sb.WriteString("# Review and adjust before deploying.\n\n")
+	sb.WriteString("server:\n  port: 8443\n\n")
+	fmt.Fprintf(&sb, "upstream:\n  port: %d\n\n", appPort)
+	sb.WriteString("tls:\n  enabled: true\n  provider: self-signed  # change to letsencrypt with a real domain\n\n")
+	sb.WriteString("log:\n  level: info\n  format: json\n\n")
+	sb.WriteString("security_headers:\n  enabled: true\n\n")
+	sb.WriteString("admin:\n  enabled: false  # set to true and provide admin.token to enable user management\n")
+	return sb.String()
+}

--- a/internal/mcp/deploy_test.go
+++ b/internal/mcp/deploy_test.go
@@ -1,0 +1,425 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Deploy spec generators
+// ---------------------------------------------------------------------------
+
+func TestPrepareDockerSpec(t *testing.T) {
+	spec := PrepareDockerSpec(3000)
+
+	if spec.Platform != string(PlatformDocker) {
+		t.Errorf("Platform = %q, want %q", spec.Platform, PlatformDocker)
+	}
+	if spec.AppPort != 3000 {
+		t.Errorf("AppPort = %d, want 3000", spec.AppPort)
+	}
+	if spec.Sidecar.Image != SidecarImage {
+		t.Errorf("Sidecar.Image = %q, want %q", spec.Sidecar.Image, SidecarImage)
+	}
+	if !strings.Contains(spec.ConfigFileContent, "port: 3000") {
+		t.Error("ConfigFileContent does not contain upstream port 3000")
+	}
+	if !strings.Contains(spec.PlatformSpec, "vibewarden:") {
+		t.Error("PlatformSpec does not reference the vibewarden service")
+	}
+	if spec.HealthCheckURL == "" {
+		t.Error("HealthCheckURL must not be empty")
+	}
+	if len(spec.Notes) == 0 {
+		t.Error("Notes must not be empty")
+	}
+	if len(spec.Sidecar.Volumes) == 0 {
+		t.Error("Sidecar.Volumes must not be empty for docker platform")
+	}
+}
+
+func TestPrepareRailwaySpec(t *testing.T) {
+	spec := PrepareRailwaySpec(4000)
+
+	if spec.Platform != string(PlatformRailway) {
+		t.Errorf("Platform = %q, want %q", spec.Platform, PlatformRailway)
+	}
+	if spec.AppPort != 4000 {
+		t.Errorf("AppPort = %d, want 4000", spec.AppPort)
+	}
+	if spec.Sidecar.Image != SidecarImage {
+		t.Errorf("Sidecar.Image = %q, want %q", spec.Sidecar.Image, SidecarImage)
+	}
+	if !strings.Contains(spec.ConfigFileContent, "port: 4000") {
+		t.Error("ConfigFileContent does not contain upstream port 4000")
+	}
+	if !strings.Contains(spec.PlatformSpec, "railway.internal") {
+		t.Error("PlatformSpec does not mention Railway internal networking")
+	}
+	// Railway spec should mention internal networking in notes too.
+	found := false
+	for _, note := range spec.Notes {
+		if strings.Contains(note, "railway.internal") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Notes should mention railway.internal private networking")
+	}
+}
+
+func TestPrepareFlyioSpec(t *testing.T) {
+	spec := PrepareFlyioSpec(8080)
+
+	if spec.Platform != string(PlatformFlyio) {
+		t.Errorf("Platform = %q, want %q", spec.Platform, PlatformFlyio)
+	}
+	if spec.AppPort != 8080 {
+		t.Errorf("AppPort = %d, want 8080", spec.AppPort)
+	}
+	if spec.Sidecar.Image != SidecarImage {
+		t.Errorf("Sidecar.Image = %q, want %q", spec.Sidecar.Image, SidecarImage)
+	}
+	if !strings.Contains(spec.PlatformSpec, "[processes]") {
+		t.Error("fly.toml spec must use processes syntax")
+	}
+	if !strings.Contains(spec.PlatformSpec, "vibewarden") {
+		t.Error("fly.toml spec must reference the vibewarden process")
+	}
+	if len(spec.Sidecar.Command) == 0 {
+		t.Error("Fly.io spec must set Sidecar.Command")
+	}
+}
+
+func TestBuildVibewardenYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		appPort  int
+		contains string
+	}{
+		{"port 3000", 3000, "port: 3000"},
+		{"port 8080", 8080, "port: 8080"},
+		{"tls enabled", 3000, "tls:"},
+		{"security headers enabled", 3000, "security_headers:"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildVibewardenYAML(tt.appPort)
+			if !strings.Contains(got, tt.contains) {
+				t.Errorf("buildVibewardenYAML(%d) does not contain %q", tt.appPort, tt.contains)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parsePort
+// ---------------------------------------------------------------------------
+
+func TestParsePort(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    int
+		wantErr bool
+	}{
+		{"float64 from JSON", float64(3000), 3000, false},
+		{"string numeric", "8080", 8080, false},
+		{"string non-numeric", "abc", 0, true},
+		{"nil", nil, 0, true},
+		{"unexpected type", true, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePort(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parsePort(%v) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parsePort(%v) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handlePrepareDeploy
+// ---------------------------------------------------------------------------
+
+func TestHandlePrepareDeploy(t *testing.T) {
+	tests := []struct {
+		name         string
+		params       map[string]any
+		wantPlatform string
+		wantErr      bool
+	}{
+		{
+			name:         "docker platform string port",
+			params:       map[string]any{"platform": "docker", "app_port": "3000"},
+			wantPlatform: "docker",
+		},
+		{
+			name:         "docker platform numeric port",
+			params:       map[string]any{"platform": "docker", "app_port": float64(3000)},
+			wantPlatform: "docker",
+		},
+		{
+			name:         "railway platform",
+			params:       map[string]any{"platform": "railway", "app_port": "4000"},
+			wantPlatform: "railway",
+		},
+		{
+			name:         "flyio platform",
+			params:       map[string]any{"platform": "flyio", "app_port": "8080"},
+			wantPlatform: "flyio",
+		},
+		{
+			name:    "unsupported platform",
+			params:  map[string]any{"platform": "heroku", "app_port": "3000"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid port",
+			params:  map[string]any{"platform": "docker", "app_port": "notaport"},
+			wantErr: true,
+		},
+		{
+			name:    "port out of range",
+			params:  map[string]any{"platform": "docker", "app_port": "99999"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, _ := json.Marshal(tt.params)
+			items, err := handlePrepareDeploy(context.Background(), raw)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handlePrepareDeploy() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(items) == 0 {
+				t.Fatal("expected at least one content item")
+			}
+			// Decode the JSON spec returned in the text item.
+			var spec DeploySpec
+			if err := json.Unmarshal([]byte(items[0].Text), &spec); err != nil {
+				t.Fatalf("cannot unmarshal spec JSON: %v\nraw: %s", err, items[0].Text)
+			}
+			if spec.Platform != tt.wantPlatform {
+				t.Errorf("spec.Platform = %q, want %q", spec.Platform, tt.wantPlatform)
+			}
+			if spec.Sidecar.Image != SidecarImage {
+				t.Errorf("spec.Sidecar.Image = %q, want %q", spec.Sidecar.Image, SidecarImage)
+			}
+			if spec.HealthCheckURL == "" {
+				t.Error("spec.HealthCheckURL must not be empty")
+			}
+			if spec.ConfigFileContent == "" {
+				t.Error("spec.ConfigFileContent must not be empty")
+			}
+		})
+	}
+}
+
+func TestHandlePrepareDeploy_InvalidArgs(t *testing.T) {
+	_, err := handlePrepareDeploy(context.Background(), json.RawMessage(`{invalid`))
+	if err == nil {
+		t.Error("expected an error for invalid JSON arguments")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleVerifyDeploy
+// ---------------------------------------------------------------------------
+
+func TestHandleVerifyDeploy_Healthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_vibewarden/health" {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"url": srv.URL})
+	items, err := handleVerifyDeploy(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) == 0 {
+		t.Fatal("expected at least one content item")
+	}
+	if !strings.Contains(items[0].Text, "healthy") {
+		t.Errorf("expected 'healthy' in output, got: %s", items[0].Text)
+	}
+}
+
+func TestHandleVerifyDeploy_Unhealthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]string{"url": srv.URL})
+	items, err := handleVerifyDeploy(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) == 0 {
+		t.Fatal("expected at least one content item")
+	}
+	if !strings.Contains(items[0].Text, "not healthy") {
+		t.Errorf("expected 'not healthy' in output, got: %s", items[0].Text)
+	}
+}
+
+func TestHandleVerifyDeploy_Unreachable(t *testing.T) {
+	// Use an address that is guaranteed to be unreachable.
+	params, _ := json.Marshal(map[string]string{"url": "http://127.0.0.1:19999"})
+	items, err := handleVerifyDeploy(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) == 0 {
+		t.Fatal("expected at least one content item")
+	}
+	if !strings.Contains(items[0].Text, "unreachable") {
+		t.Errorf("expected 'unreachable' in output, got: %s", items[0].Text)
+	}
+}
+
+func TestHandleVerifyDeploy_MissingURL(t *testing.T) {
+	params, _ := json.Marshal(map[string]string{})
+	_, err := handleVerifyDeploy(context.Background(), params)
+	if err == nil {
+		t.Error("expected an error when url is missing")
+	}
+}
+
+func TestHandleVerifyDeploy_InvalidArgs(t *testing.T) {
+	_, err := handleVerifyDeploy(context.Background(), json.RawMessage(`{invalid`))
+	if err == nil {
+		t.Error("expected an error for invalid JSON arguments")
+	}
+}
+
+func TestHandleVerifyDeploy_TrailingSlash(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_vibewarden/health" {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Trailing slash in URL should be stripped before appending health path.
+	params, _ := json.Marshal(map[string]string{"url": srv.URL + "/"})
+	items, err := handleVerifyDeploy(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(items[0].Text, "healthy") {
+		t.Errorf("expected 'healthy' in output, got: %s", items[0].Text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleGetDeployLogs
+// ---------------------------------------------------------------------------
+
+func TestHandleGetDeployLogs(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   map[string]string
+		contains []string
+	}{
+		{
+			name:   "no params",
+			params: map[string]string{},
+			contains: []string{
+				"vibew deploy logs",
+				"docker compose logs",
+			},
+		},
+		{
+			name:   "with url and lines",
+			params: map[string]string{"url": "https://my-app.fly.dev", "lines": "100"},
+			contains: []string{
+				"vibew deploy logs",
+				"100",
+				"https://my-app.fly.dev",
+			},
+		},
+		{
+			name:   "fly.io hint included",
+			params: map[string]string{"url": "https://my-app.fly.dev"},
+			contains: []string{
+				"fly logs",
+			},
+		},
+		{
+			name:   "railway hint included",
+			params: map[string]string{},
+			contains: []string{
+				"railway logs",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, _ := json.Marshal(tt.params)
+			items, err := handleGetDeployLogs(context.Background(), raw)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(items) == 0 {
+				t.Fatal("expected at least one content item")
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(items[0].Text, want) {
+					t.Errorf("output does not contain %q\ngot:\n%s", want, items[0].Text)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleGetDeployLogs_InvalidArgs(t *testing.T) {
+	_, err := handleGetDeployLogs(context.Background(), json.RawMessage(`{invalid`))
+	if err == nil {
+		t.Error("expected an error for invalid JSON arguments")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RegisterDefaultTools — ensure deploy tools are included
+// ---------------------------------------------------------------------------
+
+func TestRegisterDefaultTools_IncludesDeployTools(t *testing.T) {
+	srv := newTestServer()
+	RegisterDefaultTools(srv)
+
+	deployTools := []string{
+		"vibewarden_prepare_deploy",
+		"vibewarden_verify_deploy",
+		"vibewarden_get_deploy_logs",
+	}
+
+	for _, name := range deployTools {
+		if _, ok := srv.handlers[name]; !ok {
+			t.Errorf("deploy tool %q not registered", name)
+		}
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -15,13 +15,16 @@ import (
 	"github.com/vibewarden/vibewarden/internal/config"
 )
 
-// RegisterDefaultTools registers the four standard VibeWarden MCP tools onto s.
+// RegisterDefaultTools registers all standard VibeWarden MCP tools onto s.
 // It is a convenience function that wires the tool definitions and handlers together.
 func RegisterDefaultTools(s *Server) {
 	s.RegisterTool(statusToolDef(), handleStatus)
 	s.RegisterTool(doctorToolDef(), handleDoctor)
 	s.RegisterTool(validateToolDef(), handleValidate)
 	s.RegisterTool(explainToolDef(), handleExplain)
+	s.RegisterTool(prepareDeployToolDef(), handlePrepareDeploy)
+	s.RegisterTool(verifyDeployToolDef(), handleVerifyDeploy)
+	s.RegisterTool(getDeployLogsToolDef(), handleGetDeployLogs)
 }
 
 // ---------------------------------------------------------------------------
@@ -380,6 +383,222 @@ func explainConfig(cfg *config.Config, path string) string {
 	}
 
 	return sb.String()
+}
+
+// ---------------------------------------------------------------------------
+// vibewarden_prepare_deploy
+// ---------------------------------------------------------------------------
+
+func prepareDeployToolDef() ToolDefinition {
+	return ToolDefinition{
+		Name:        "vibewarden_prepare_deploy",
+		Description: "Generate a deployment spec for the VibeWarden sidecar on a target platform. Returns a sidecar container spec, a vibewarden.yaml template, a platform-native config snippet, a health check URL, and platform-specific notes.",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"platform": {
+					Type:        "string",
+					Description: "Target platform: 'docker' (generic Docker Compose / SSH), 'railway' (Railway.app), or 'flyio' (Fly.io).",
+				},
+				"app_port": {
+					Type:        "string",
+					Description: "The port your application listens on (e.g. '3000'). Passed as a string because JSON schemas do not enforce integer types in all MCP clients.",
+				},
+				"config_path": {
+					Type:        "string",
+					Description: "Optional path to an existing vibewarden.yaml to read the app_port from. Ignored when app_port is provided.",
+				},
+			},
+			Required: []string{"platform", "app_port"},
+		},
+	}
+}
+
+// prepareDeployArgs holds the arguments for vibewarden_prepare_deploy.
+type prepareDeployArgs struct {
+	Platform   string `json:"platform"`
+	AppPort    any    `json:"app_port"`    // accept string or number
+	ConfigPath string `json:"config_path"` // optional
+}
+
+func handlePrepareDeploy(_ context.Context, params json.RawMessage) ([]ContentItem, error) {
+	var args prepareDeployArgs
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &args); err != nil {
+			return nil, fmt.Errorf("invalid arguments: %w", err)
+		}
+	}
+
+	// Parse app_port — accept both JSON number and quoted string.
+	appPort, err := parsePort(args.AppPort)
+	if err != nil {
+		return nil, fmt.Errorf("app_port: %w", err)
+	}
+	if appPort < 1 || appPort > 65535 {
+		return nil, fmt.Errorf("app_port must be between 1 and 65535, got %d", appPort)
+	}
+
+	var spec DeploySpec
+	switch Platform(args.Platform) {
+	case PlatformDocker:
+		spec = PrepareDockerSpec(appPort)
+	case PlatformRailway:
+		spec = PrepareRailwaySpec(appPort)
+	case PlatformFlyio:
+		spec = PrepareFlyioSpec(appPort)
+	default:
+		return nil, fmt.Errorf("unsupported platform %q — supported values: docker, railway, flyio", args.Platform)
+	}
+
+	out, err := json.MarshalIndent(spec, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshalling deploy spec: %w", err)
+	}
+	return text(string(out)), nil
+}
+
+// parsePort converts an interface{} value (string or float64 from JSON) to int.
+func parsePort(v any) (int, error) {
+	switch val := v.(type) {
+	case float64:
+		return int(val), nil
+	case string:
+		var p int
+		if _, err := fmt.Sscanf(val, "%d", &p); err != nil {
+			return 0, fmt.Errorf("cannot parse %q as a port number", val)
+		}
+		return p, nil
+	case nil:
+		return 0, fmt.Errorf("app_port is required")
+	default:
+		return 0, fmt.Errorf("unexpected type %T for port", v)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// vibewarden_verify_deploy
+// ---------------------------------------------------------------------------
+
+func verifyDeployToolDef() ToolDefinition {
+	return ToolDefinition{
+		Name:        "vibewarden_verify_deploy",
+		Description: "Verify that a deployed VibeWarden sidecar is reachable and healthy by hitting its /_vibewarden/health endpoint. Returns the HTTP status and any warnings.",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"url": {
+					Type:        "string",
+					Description: "Base URL of the deployed sidecar, e.g. 'https://my-app.fly.dev'. The health endpoint is appended automatically.",
+				},
+			},
+			Required: []string{"url"},
+		},
+	}
+}
+
+// verifyDeployArgs holds the arguments for vibewarden_verify_deploy.
+type verifyDeployArgs struct {
+	URL string `json:"url"`
+}
+
+func handleVerifyDeploy(ctx context.Context, params json.RawMessage) ([]ContentItem, error) {
+	var args verifyDeployArgs
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &args); err != nil {
+			return nil, fmt.Errorf("invalid arguments: %w", err)
+		}
+	}
+	if args.URL == "" {
+		return nil, fmt.Errorf("url is required")
+	}
+
+	healthURL := strings.TrimRight(args.URL, "/") + "/_vibewarden/health"
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	checker := opsadapter.NewHTTPHealthChecker(client)
+
+	checkCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	ok, code, err := checker.CheckHealth(checkCtx, healthURL)
+	if err != nil {
+		return text(fmt.Sprintf("sidecar unreachable at %s: %v\nWarning: ensure the sidecar is running and the URL is correct.", healthURL, err)), nil
+	}
+	if !ok {
+		return text(fmt.Sprintf("sidecar returned HTTP %d at %s — not healthy.\nWarning: check the sidecar logs with: vibew deploy logs", code, healthURL)), nil
+	}
+
+	return text(fmt.Sprintf("sidecar is healthy at %s (HTTP %d)", healthURL, code)), nil
+}
+
+// ---------------------------------------------------------------------------
+// vibewarden_get_deploy_logs
+// ---------------------------------------------------------------------------
+
+func getDeployLogsToolDef() ToolDefinition {
+	return ToolDefinition{
+		Name:        "vibewarden_get_deploy_logs",
+		Description: "Retrieve recent sidecar logs from a deployed instance. NOTE: direct remote log retrieval is not available without admin access; this tool explains how to fetch logs using the vibew CLI.",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"url": {
+					Type:        "string",
+					Description: "Base URL of the deployed sidecar (informational only).",
+				},
+				"lines": {
+					Type:        "string",
+					Description: "Number of log lines to retrieve (informational only).",
+				},
+			},
+		},
+	}
+}
+
+// getDeployLogsArgs holds the arguments for vibewarden_get_deploy_logs.
+type getDeployLogsArgs struct {
+	URL   string `json:"url"`
+	Lines string `json:"lines"`
+}
+
+func handleGetDeployLogs(_ context.Context, params json.RawMessage) ([]ContentItem, error) {
+	var args getDeployLogsArgs
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &args); err != nil {
+			return nil, fmt.Errorf("invalid arguments: %w", err)
+		}
+	}
+
+	lines := "50"
+	if args.Lines != "" {
+		lines = args.Lines
+	}
+	target := args.URL
+	if target == "" {
+		target = "<your-sidecar-url>"
+	}
+
+	msg := fmt.Sprintf(`Remote log retrieval is not available via MCP without direct server access.
+
+To fetch sidecar logs, use the vibew CLI on the machine where the sidecar is running:
+
+  # Docker Compose deployments (SSH or local):
+  vibew deploy logs --lines %s
+
+  # Or directly via Docker:
+  docker compose logs vibewarden --tail %s --follow
+
+  # Fly.io:
+  fly logs --app <your-app-name>
+
+  # Railway:
+  railway logs --service vibewarden
+
+Targeted URL was: %s
+If you have SSH access to the host, you can also run:
+  ssh <user>@<host> "docker compose logs vibewarden --tail %s"`, lines, lines, target, lines)
+
+	return text(msg), nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -266,6 +266,9 @@ func TestRegisterDefaultTools(t *testing.T) {
 		"vibewarden_doctor",
 		"vibewarden_validate",
 		"vibewarden_explain",
+		"vibewarden_prepare_deploy",
+		"vibewarden_verify_deploy",
+		"vibewarden_get_deploy_logs",
 	}
 
 	for _, name := range expectedTools {


### PR DESCRIPTION
Closes #652

## Summary

- `vibewarden_prepare_deploy(platform, app_port)` — generates a `DeploySpec` JSON object containing a sidecar container spec, a ready-to-use `vibewarden.yaml` template, a platform-native config snippet, a health check URL, and platform-specific notes. Supports `docker` (Docker Compose), `railway` (Railway.app internal networking), and `flyio` (fly.toml processes syntax).
- `vibewarden_verify_deploy(url)` — hits `<url>/_vibewarden/health` via HTTP and returns the status. Handles unreachable hosts and non-200 responses gracefully as informational messages rather than tool errors.
- `vibewarden_get_deploy_logs(url, lines?)` — not implementable without admin access; returns a clear message with the correct CLI commands for each platform (`vibew deploy logs`, `docker compose logs`, `fly logs`, `railway logs`).

New files:
- `internal/mcp/deploy.go` — `DeploySpec`, `SidecarSpec`, `Platform` types; `PrepareDockerSpec`, `PrepareRailwaySpec`, `PrepareFlyioSpec`, `buildVibewardenYAML`, `parsePort`
- `internal/mcp/deploy_test.go` — table-driven tests for all generators, `parsePort`, and all three tool handlers

`RegisterDefaultTools` in `tools.go` updated to register the three new tools. `tools_test.go` updated to reflect the new tool count (4 to 7).

## Test plan

- [ ] `make check` passes (lint, build, race tests, demo-app) — verified locally
- [ ] `TestHandlePrepareDeploy` covers docker/railway/flyio, string and numeric ports, unsupported platform, invalid port, out-of-range port
- [ ] `TestHandleVerifyDeploy_*` covers healthy, unhealthy (503), unreachable, missing URL, trailing slash normalisation
- [ ] `TestHandleGetDeployLogs` covers all CLI hint paths (vibew, docker, fly, railway)
- [ ] `TestRegisterDefaultTools_IncludesDeployTools` confirms all three tools are registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)