### PR TITLE
fix(#691): default app section to build instead of image

### DIFF
--- a/internal/cli/cmd/init_test.go
+++ b/internal/cli/cmd/init_test.go
@@ -276,17 +276,17 @@ func TestInitCmd_CustomPort(t *testing.T) {
 	}
 }
 
-// TestInitCmd_AppImageDefaultsToProjectName verifies that the generated
-// vibewarden.yaml uses app.image derived from the project name rather than app.build.
-func TestInitCmd_AppImageDefaultsToProjectName(t *testing.T) {
+// TestInitCmd_AppBuildDefaultsToCurrentDir verifies that the generated
+// vibewarden.yaml uses app.build = "." by default rather than app.image.
+func TestInitCmd_AppBuildDefaultsToCurrentDir(t *testing.T) {
 	tests := []struct {
 		name        string
 		lang        string
 		projectName string
 	}{
-		{"go uses image", "go", "mygoapp"},
-		{"kotlin uses image", "kotlin", "myktapp"},
-		{"typescript uses image", "typescript", "mytsapp"},
+		{"go uses build", "go", "mygoapp"},
+		{"kotlin uses build", "kotlin", "myktapp"},
+		{"typescript uses build", "typescript", "mytsapp"},
 	}
 
 	for _, tt := range tests {
@@ -312,15 +312,15 @@ func TestInitCmd_AppImageDefaultsToProjectName(t *testing.T) {
 			}
 			content := string(data)
 
-			wantImage := "image: \"" + tt.projectName + ":latest\""
-			if !strings.Contains(content, wantImage) {
-				t.Errorf("vibewarden.yaml missing %q:\n%s", wantImage, content)
+			// app.build must be the active directive.
+			if !strings.Contains(content, `build: "."`) {
+				t.Errorf("vibewarden.yaml missing active 'build: \".\"':\n%s", content)
 			}
-			// "build:" must not appear as an active (uncommented) directive.
+			// app.image must not appear as an active (uncommented) directive.
 			for _, line := range strings.Split(content, "\n") {
 				trimmed := strings.TrimSpace(line)
-				if strings.HasPrefix(trimmed, "build:") {
-					t.Errorf("vibewarden.yaml must not have an active 'build:' directive by default; found: %q\n\nContent:\n%s", line, content)
+				if strings.HasPrefix(trimmed, "image:") {
+					t.Errorf("vibewarden.yaml must not have an active 'image:' directive by default; found: %q\n\nContent:\n%s", line, content)
 				}
 			}
 		})

--- a/internal/cli/cmd/wrap_test.go
+++ b/internal/cli/cmd/wrap_test.go
@@ -267,9 +267,9 @@ func TestNewWrapCmd_RenderedYAMLValid(t *testing.T) {
 			wantInYAML: []string{"overrides"},
 		},
 		{
-			name:       "app.image defaults to project name derived from directory",
+			name:       "app.build defaults to current directory",
 			args:       []string{},
-			wantInYAML: []string{"image:", ":latest"},
+			wantInYAML: []string{`build: "."`},
 		},
 	}
 
@@ -300,9 +300,9 @@ func TestNewWrapCmd_RenderedYAMLValid(t *testing.T) {
 	}
 }
 
-// TestNewWrapCmd_AppImageDerivedFromDirName verifies that the generated
-// vibewarden.yaml defaults to app.image using the directory base name.
-func TestNewWrapCmd_AppImageDerivedFromDirName(t *testing.T) {
+// TestNewWrapCmd_AppBuildDefaultsToDot verifies that the generated
+// vibewarden.yaml defaults to app.build = "." rather than app.image.
+func TestNewWrapCmd_AppBuildDefaultsToDot(t *testing.T) {
 	parent := t.TempDir()
 	projectDir := filepath.Join(parent, "mywebapp")
 	if err := os.MkdirAll(projectDir, 0o750); err != nil {
@@ -322,14 +322,14 @@ func TestNewWrapCmd_AppImageDerivedFromDirName(t *testing.T) {
 	}
 	content := string(yamlBytes)
 
-	if !strings.Contains(content, `image: "mywebapp:latest"`) {
-		t.Errorf("vibewarden.yaml does not contain 'image: \"mywebapp:latest\"'\n\nContent:\n%s", content)
+	if !strings.Contains(content, `build: "."`) {
+		t.Errorf("vibewarden.yaml does not contain active 'build: \".\"'\n\nContent:\n%s", content)
 	}
-	// "build:" must not appear as an active (uncommented) directive.
+	// "image:" must not appear as an active (uncommented) directive.
 	for _, line := range strings.Split(content, "\n") {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "build:") {
-			t.Errorf("vibewarden.yaml must not have an active 'build:' directive by default; found: %q\n\nContent:\n%s", line, content)
+		if strings.HasPrefix(trimmed, "image:") {
+			t.Errorf("vibewarden.yaml must not have an active 'image:' directive by default; found: %q\n\nContent:\n%s", line, content)
 		}
 	}
 }

--- a/internal/cli/templates/go/vibewarden.yaml.tmpl
+++ b/internal/cli/templates/go/vibewarden.yaml.tmpl
@@ -12,8 +12,8 @@ upstream:
   port: {{ .Port }}
 
 app:
-  image: "{{ .ProjectName }}:latest"  # overridden at runtime by VIBEWARDEN_APP_IMAGE
-  # build: "."  # uncomment to build from source instead of pulling an image
+  build: "."
+  # image: "{{ .ProjectName }}:latest"  # use in production instead of build
 
 log:
   level: "info"

--- a/internal/cli/templates/kotlin/vibewarden.yaml.tmpl
+++ b/internal/cli/templates/kotlin/vibewarden.yaml.tmpl
@@ -12,8 +12,8 @@ upstream:
   port: {{ .Port }}
 
 app:
-  image: "{{ .ProjectName }}:latest"  # overridden at runtime by VIBEWARDEN_APP_IMAGE
-  # build: "."  # uncomment to build from source instead of pulling an image
+  build: "."
+  # image: "{{ .ProjectName }}:latest"  # use in production instead of build
 
 log:
   level: "info"

--- a/internal/cli/templates/typescript/vibewarden.yaml.tmpl
+++ b/internal/cli/templates/typescript/vibewarden.yaml.tmpl
@@ -12,8 +12,8 @@ upstream:
   port: {{ .Port }}
 
 app:
-  image: "{{ .ProjectName }}:latest"  # overridden at runtime by VIBEWARDEN_APP_IMAGE
-  # build: "."  # uncomment to build from source instead of pulling an image
+  build: "."
+  # image: "{{ .ProjectName }}:latest"  # use in production instead of build
 
 log:
   level: "info"

--- a/internal/cli/templates/vibewarden.yaml.tmpl
+++ b/internal/cli/templates/vibewarden.yaml.tmpl
@@ -12,11 +12,11 @@ upstream:
   port: {{ .UpstreamPort }}
 
 # app configures how your application is included in the generated docker-compose.yml.
-# Set app.image to pull a pre-built image (default), or app.build to build from source (opt-in).
+# Set app.build to build from source (default), or app.image to pull a pre-built image (production).
 # Remove this section if you manage your app service manually.
 app:
-  image: "{{ .ProjectName }}:latest"  # overridden at runtime by VIBEWARDEN_APP_IMAGE
-  # build: "."  # uncomment to build from source instead of pulling an image
+  build: "."
+  # image: "{{ .ProjectName }}:latest"  # use in production instead of build
 
 log:
   level: "info"


### PR DESCRIPTION
Closes #691

## Summary

- All four `vibewarden.yaml` templates (`vibewarden.yaml.tmpl`, `go/`, `kotlin/`, `typescript/`) now emit `app.build: "."` as the active directive by default
- `app.image` is moved to a comment with a note to use it in production instead of `build`
- The comment above the `app:` block in the base template is updated to reflect the new default
- Tests in `init_test.go` and `wrap_test.go` updated to assert `build: "."` is present and no active `image:` directive exists

## Test plan

- `make check` passes locally (formatting, golangci-lint, build, full test suite)
- `TestInitCmd_AppBuildDefaultsToCurrentDir` verifies the three language-specific templates emit `build: "."`
- `TestNewWrapCmd_AppBuildDefaultsToDot` verifies the base template emits `build: "."`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>