### PR TITLE
fix(#695): generate AGENTS-VIBEWARDEN.md and append reference to AGENTS.md

### DIFF
--- a/internal/app/scaffold/agent_context.go
+++ b/internal/app/scaffold/agent_context.go
@@ -2,8 +2,11 @@ package scaffold
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 
 	domainscaffold "github.com/vibewarden/vibewarden/internal/domain/scaffold"
 	"github.com/vibewarden/vibewarden/internal/ports"
@@ -21,16 +24,16 @@ type agentSpec struct {
 }
 
 // agentSpecs defines the template and output path for each supported agent type.
+// AgentTypeGeneric is handled separately: it generates AGENTS-VIBEWARDEN.md and
+// then calls ensureAgentsMD to create or update AGENTS.md with a reference.
 var agentSpecs = map[domainscaffold.AgentType]agentSpec{
 	domainscaffold.AgentTypeClaude:  {templateName: "claude.md.tmpl", outputPath: filepath.Join(".claude", "CLAUDE.md")},
-	domainscaffold.AgentTypeCursor:  {templateName: "cursor-rules.tmpl", outputPath: filepath.Join(".cursor", "rules")},
-	domainscaffold.AgentTypeGeneric: {templateName: "agents.md.tmpl", outputPath: "AGENTS.md"},
+	domainscaffold.AgentTypeGeneric: {templateName: "agents.md.tmpl", outputPath: "AGENTS-VIBEWARDEN.md"},
 }
 
 // allAgentTypes is the ordered slice used when AgentTypeAll is requested.
 var allAgentTypes = []domainscaffold.AgentType{
 	domainscaffold.AgentTypeClaude,
-	domainscaffold.AgentTypeCursor,
 	domainscaffold.AgentTypeGeneric,
 }
 
@@ -50,7 +53,12 @@ func NewAgentContextService(renderer ports.TemplateRenderer) *AgentContextServic
 // When agentType is AgentTypeAll, context files for all supported agent types
 // are generated. Returns the list of file paths written.
 //
-// Files that already exist are skipped unless opts.Force is true.
+// For AgentTypeGeneric: AGENTS-VIBEWARDEN.md is always overwritten (it is
+// vibew-owned). AGENTS.md is then created from template when absent, or the
+// reference line is appended when it is missing from an existing file.
+//
+// Files other than AGENTS-VIBEWARDEN.md that already exist are skipped unless
+// opts.Force is true.
 func (s *AgentContextService) GenerateAgentContext(
 	_ context.Context,
 	dir string,
@@ -76,10 +84,26 @@ func (s *AgentContextService) GenerateAgentContext(
 		}
 
 		outPath := filepath.Join(dir, spec.outputPath)
-		if err := s.renderer.RenderToFile(spec.templateName, data, outPath, opts.Force); err != nil {
-			return nil, fmt.Errorf("generating context for agent %q: %w", at, err)
+
+		if at == domainscaffold.AgentTypeGeneric {
+			// AGENTS-VIBEWARDEN.md is always overwritten (vibew-owned).
+			if err := s.renderer.RenderToFile(spec.templateName, data, outPath, true); err != nil {
+				return nil, fmt.Errorf("generating context for agent %q: %w", at, err)
+			}
+			written = append(written, outPath)
+
+			// Ensure AGENTS.md exists and contains a reference to AGENTS-VIBEWARDEN.md.
+			agentsMDPath := filepath.Join(dir, "AGENTS.md")
+			if err := ensureAgentsMD(s.renderer, agentsMDPath); err != nil {
+				return nil, fmt.Errorf("ensuring AGENTS.md: %w", err)
+			}
+			written = append(written, agentsMDPath)
+		} else {
+			if err := s.renderer.RenderToFile(spec.templateName, data, outPath, opts.Force); err != nil {
+				return nil, fmt.Errorf("generating context for agent %q: %w", at, err)
+			}
+			written = append(written, outPath)
 		}
-		written = append(written, outPath)
 	}
 
 	return written, nil
@@ -92,4 +116,46 @@ func resolveAgentTypes(agentType domainscaffold.AgentType) []domainscaffold.Agen
 		return allAgentTypes
 	}
 	return []domainscaffold.AgentType{agentType}
+}
+
+// ensureAgentsMD ensures AGENTS.md at dest exists and contains a reference to
+// AGENTS-VIBEWARDEN.md.
+//
+// Behaviour:
+//   - If AGENTS.md does not exist, it is created from agents/agents.md.tmpl.
+//   - If AGENTS.md exists but does not contain a reference to AGENTS-VIBEWARDEN.md,
+//     the reference line is appended.
+//   - If AGENTS.md already contains the reference, it is left unchanged.
+//
+// The reference detection uses a simple substring match for "AGENTS-VIBEWARDEN.md".
+func ensureAgentsMD(renderer ports.TemplateRenderer, dest string) error {
+	existing, err := os.ReadFile(dest) //nolint:gosec // path is constructed from trusted inputs
+	if errors.Is(err, os.ErrNotExist) {
+		// Create from template.
+		if createErr := renderer.RenderToFile("agents/agents.md.tmpl", nil, dest, false); createErr != nil {
+			return fmt.Errorf("creating AGENTS.md: %w", createErr)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading AGENTS.md: %w", err)
+	}
+
+	// File exists — check whether the reference is already present.
+	if strings.Contains(string(existing), "AGENTS-VIBEWARDEN.md") {
+		return nil
+	}
+
+	// Append reference.
+	f, err := os.OpenFile(dest, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // path is trusted
+	if err != nil {
+		return fmt.Errorf("opening AGENTS.md for append: %w", err)
+	}
+	defer f.Close() //nolint:errcheck // best-effort close on read path
+
+	const referenceBlock = "\n\nSee [AGENTS-VIBEWARDEN.md](./AGENTS-VIBEWARDEN.md) for VibeWarden sidecar instructions.\n"
+	if _, writeErr := f.WriteString(referenceBlock); writeErr != nil {
+		return fmt.Errorf("appending reference to AGENTS.md: %w", writeErr)
+	}
+	return nil
 }

--- a/internal/app/scaffold/agent_context_test.go
+++ b/internal/app/scaffold/agent_context_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	scaffoldapp "github.com/vibewarden/vibewarden/internal/app/scaffold"
@@ -70,33 +71,26 @@ func TestAgentContextService_GenerateAgentContext(t *testing.T) {
 			wantTemplates: []string{"claude.md.tmpl"},
 		},
 		{
-			name:          "cursor generates .cursor/rules",
-			agentType:     domainscaffold.AgentTypeCursor,
-			opts:          baseOpts,
-			wantPaths:     []string{filepath.Join(".cursor", "rules")},
-			wantTemplates: []string{"cursor-rules.tmpl"},
-		},
-		{
-			name:          "generic generates AGENTS.md",
+			name:          "generic generates AGENTS-VIBEWARDEN.md and creates AGENTS.md",
 			agentType:     domainscaffold.AgentTypeGeneric,
 			opts:          baseOpts,
-			wantPaths:     []string{"AGENTS.md"},
-			wantTemplates: []string{"agents.md.tmpl"},
+			wantPaths:     []string{"AGENTS-VIBEWARDEN.md", "AGENTS.md"},
+			wantTemplates: []string{"agents.md.tmpl", "agents/agents.md.tmpl"},
 		},
 		{
-			name:      "all generates three files",
+			name:      "all generates two agent type file sets",
 			agentType: domainscaffold.AgentTypeAll,
 			opts:      baseOpts,
 			wantPaths: []string{
 				filepath.Join(".claude", "CLAUDE.md"),
-				filepath.Join(".cursor", "rules"),
+				"AGENTS-VIBEWARDEN.md",
 				"AGENTS.md",
 			},
-			wantTemplates: []string{"claude.md.tmpl", "cursor-rules.tmpl", "agents.md.tmpl"},
+			wantTemplates: []string{"claude.md.tmpl", "agents.md.tmpl", "agents/agents.md.tmpl"},
 		},
 		{
-			name:      "force false does not overwrite existing file",
-			agentType: domainscaffold.AgentTypeGeneric,
+			name:      "force false does not overwrite existing claude file",
+			agentType: domainscaffold.AgentTypeClaude,
 			opts: scaffoldapp.InitOptions{
 				UpstreamPort: 3000,
 				Force:        false,
@@ -110,10 +104,13 @@ func TestAgentContextService_GenerateAgentContext(t *testing.T) {
 			dir := t.TempDir()
 			renderer := newFakeAgentRenderer()
 
-			// Pre-create AGENTS.md to trigger the overwrite-false error case.
-			if tt.name == "force false does not overwrite existing file" {
-				agentsPath := filepath.Join(dir, "AGENTS.md")
-				if err := os.WriteFile(agentsPath, []byte("existing"), 0o644); err != nil {
+			// Pre-create .claude/CLAUDE.md to trigger the overwrite-false error case.
+			if tt.name == "force false does not overwrite existing claude file" {
+				claudePath := filepath.Join(dir, ".claude", "CLAUDE.md")
+				if err := os.MkdirAll(filepath.Dir(claudePath), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(claudePath, []byte("existing"), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -148,12 +145,12 @@ func TestAgentContextService_GenerateAgentContext(t *testing.T) {
 	}
 }
 
-func TestAgentContextService_GenerateAgentContext_ForceOverwrites(t *testing.T) {
+func TestAgentContextService_GenerateAgentContext_GenericAlwaysOverwrites(t *testing.T) {
 	dir := t.TempDir()
 
-	// Pre-create AGENTS.md with old content.
-	agentsPath := filepath.Join(dir, "AGENTS.md")
-	if err := os.WriteFile(agentsPath, []byte("old content"), 0o644); err != nil {
+	// Pre-create AGENTS-VIBEWARDEN.md with old content.
+	vibewardenPath := filepath.Join(dir, "AGENTS-VIBEWARDEN.md")
+	if err := os.WriteFile(vibewardenPath, []byte("old content"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -162,23 +159,89 @@ func TestAgentContextService_GenerateAgentContext_ForceOverwrites(t *testing.T) 
 
 	opts := scaffoldapp.InitOptions{
 		UpstreamPort: 3000,
-		Force:        true,
+		Force:        false, // Force=false must NOT prevent AGENTS-VIBEWARDEN.md overwrite.
 	}
 
 	written, err := svc.GenerateAgentContext(context.Background(), dir, domainscaffold.AgentTypeGeneric, opts)
 	if err != nil {
 		t.Fatalf("GenerateAgentContext() unexpected error: %v", err)
 	}
-	if len(written) != 1 {
-		t.Fatalf("expected 1 written path, got %d", len(written))
+	// Expect both AGENTS-VIBEWARDEN.md and AGENTS.md to be returned.
+	const wantCount = 2
+	if len(written) != wantCount {
+		t.Fatalf("expected %d written paths, got %d", wantCount, len(written))
 	}
 
-	got, err := os.ReadFile(agentsPath)
+	got, err := os.ReadFile(vibewardenPath)
+	if err != nil {
+		t.Fatalf("reading AGENTS-VIBEWARDEN.md: %v", err)
+	}
+	if string(got) == "old content" {
+		t.Error("expected AGENTS-VIBEWARDEN.md to be overwritten, but old content remains")
+	}
+}
+
+func TestAgentContextService_GenerateAgentContext_ExistingAGENTSMDGetsReference(t *testing.T) {
+	dir := t.TempDir()
+
+	// Pre-create AGENTS.md without any reference to AGENTS-VIBEWARDEN.md.
+	agentsMDPath := filepath.Join(dir, "AGENTS.md")
+	original := "# My project agent instructions\n\nDo stuff.\n"
+	if err := os.WriteFile(agentsMDPath, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	renderer := newFakeAgentRenderer()
+	svc := scaffoldapp.NewAgentContextService(renderer)
+
+	opts := scaffoldapp.InitOptions{UpstreamPort: 3000}
+	_, err := svc.GenerateAgentContext(context.Background(), dir, domainscaffold.AgentTypeGeneric, opts)
+	if err != nil {
+		t.Fatalf("GenerateAgentContext() unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(agentsMDPath)
 	if err != nil {
 		t.Fatalf("reading AGENTS.md: %v", err)
 	}
-	if string(got) == "old content" {
-		t.Error("expected AGENTS.md to be overwritten, but old content remains")
+	content := string(got)
+
+	// Original content must be preserved.
+	if !strings.Contains(content, "My project agent instructions") {
+		t.Error("existing AGENTS.md content was lost")
+	}
+	// Reference must have been appended.
+	if !strings.Contains(content, "AGENTS-VIBEWARDEN.md") {
+		t.Errorf("expected AGENTS.md to contain reference to AGENTS-VIBEWARDEN.md, got:\n%s", content)
+	}
+}
+
+func TestAgentContextService_GenerateAgentContext_ExistingAGENTSMDWithReferenceUnchanged(t *testing.T) {
+	dir := t.TempDir()
+
+	// Pre-create AGENTS.md that already has the reference.
+	agentsMDPath := filepath.Join(dir, "AGENTS.md")
+	original := "# Instructions\n\nSee [AGENTS-VIBEWARDEN.md](./AGENTS-VIBEWARDEN.md) for VibeWarden sidecar instructions.\n"
+	if err := os.WriteFile(agentsMDPath, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	renderer := newFakeAgentRenderer()
+	svc := scaffoldapp.NewAgentContextService(renderer)
+
+	opts := scaffoldapp.InitOptions{UpstreamPort: 3000}
+	_, err := svc.GenerateAgentContext(context.Background(), dir, domainscaffold.AgentTypeGeneric, opts)
+	if err != nil {
+		t.Fatalf("GenerateAgentContext() unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(agentsMDPath)
+	if err != nil {
+		t.Fatalf("reading AGENTS.md: %v", err)
+	}
+	// Content should be unchanged — reference not duplicated.
+	if string(got) != original {
+		t.Errorf("AGENTS.md was modified unnecessarily.\nWant:\n%s\nGot:\n%s", original, string(got))
 	}
 }
 
@@ -197,8 +260,8 @@ func TestAgentContextService_GenerateAgentContext_RenderError(t *testing.T) {
 }
 
 func TestResolveAgentTypes_AllExpands(t *testing.T) {
-	// Verify AgentTypeAll resolves to all three individual types by calling
-	// GenerateAgentContext and checking all three files are created.
+	// Verify AgentTypeAll resolves to all individual types by calling
+	// GenerateAgentContext and checking all expected files are created.
 	dir := t.TempDir()
 	renderer := newFakeAgentRenderer()
 	svc := scaffoldapp.NewAgentContextService(renderer)
@@ -209,6 +272,7 @@ func TestResolveAgentTypes_AllExpands(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	// claude produces 1 file; generic produces 2 (AGENTS-VIBEWARDEN.md + AGENTS.md).
 	const wantCount = 3
 	if len(written) != wantCount {
 		t.Errorf("AgentTypeAll produced %d files, want %d", len(written), wantCount)

--- a/internal/app/scaffold/init_project.go
+++ b/internal/app/scaffold/init_project.go
@@ -388,47 +388,11 @@ func (s *InitProjectService) renderAgentsVibewardenMD(
 }
 
 // ensureAgentsMD ensures AGENTS.md exists and contains a reference to
-// AGENTS-VIBEWARDEN.md.
-//
-// Behaviour:
-//   - If AGENTS.md does not exist, it is created from agents/agents.md.tmpl.
-//   - If AGENTS.md exists but does not contain a reference to AGENTS-VIBEWARDEN.md,
-//     the reference line is appended.
-//   - If AGENTS.md already contains the reference, it is left unchanged.
-//
-// The reference detection uses a simple substring match for "AGENTS-VIBEWARDEN.md".
+// AGENTS-VIBEWARDEN.md. It delegates to the package-level ensureAgentsMD
+// function so that the same logic is shared with AgentContextService.
 func (s *InitProjectService) ensureAgentsMD(projectDir string) error {
 	dest := filepath.Join(projectDir, "AGENTS.md")
-
-	existing, err := os.ReadFile(dest) //nolint:gosec // path is constructed from trusted inputs
-	if errors.Is(err, os.ErrNotExist) {
-		// Create from template.
-		if createErr := s.renderer.RenderToFile("agents/agents.md.tmpl", nil, dest, false); createErr != nil {
-			return fmt.Errorf("creating AGENTS.md: %w", createErr)
-		}
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("reading AGENTS.md: %w", err)
-	}
-
-	// File exists — check whether the reference is already present.
-	if strings.Contains(string(existing), "AGENTS-VIBEWARDEN.md") {
-		return nil
-	}
-
-	// Append reference.
-	f, err := os.OpenFile(dest, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // path is trusted
-	if err != nil {
-		return fmt.Errorf("opening AGENTS.md for append: %w", err)
-	}
-	defer f.Close() //nolint:errcheck // best-effort close on read path
-
-	const referenceBlock = "\n\nSee [AGENTS-VIBEWARDEN.md](./AGENTS-VIBEWARDEN.md) for VibeWarden sidecar instructions.\n"
-	if _, writeErr := f.WriteString(referenceBlock); writeErr != nil {
-		return fmt.Errorf("appending reference to AGENTS.md: %w", writeErr)
-	}
-	return nil
+	return ensureAgentsMD(s.renderer, dest)
 }
 
 // renderGoFiles renders all Go-specific template files into projectDir.

--- a/internal/cli/cmd/context.go
+++ b/internal/cli/cmd/context.go
@@ -19,10 +19,11 @@ import (
 // agentContextFiles returns the output paths for each agent type, relative to
 // the project root. These must stay in sync with the specs in
 // internal/app/scaffold/agent_context.go.
+// For AgentTypeGeneric the key file is AGENTS-VIBEWARDEN.md (vibew-owned);
+// AGENTS.md is also managed but its path is derived inside GenerateAgentContext.
 var agentContextFiles = map[domainscaffold.AgentType]string{
 	domainscaffold.AgentTypeClaude:  filepath.Join(".claude", "CLAUDE.md"),
-	domainscaffold.AgentTypeCursor:  filepath.Join(".cursor", "rules"),
-	domainscaffold.AgentTypeGeneric: "AGENTS.md",
+	domainscaffold.AgentTypeGeneric: "AGENTS-VIBEWARDEN.md",
 }
 
 // NewContextCmd creates the `vibew context` subcommand group.

--- a/internal/cli/cmd/context_test.go
+++ b/internal/cli/cmd/context_test.go
@@ -103,7 +103,7 @@ tls:
 	// Verify files were actually created.
 	expectedFiles := []string{
 		filepath.Join(".claude", "CLAUDE.md"),
-		filepath.Join(".cursor", "rules"),
+		"AGENTS-VIBEWARDEN.md",
 		"AGENTS.md",
 	}
 	for _, f := range expectedFiles {

--- a/internal/cli/cmd/wrap.go
+++ b/internal/cli/cmd/wrap.go
@@ -116,7 +116,7 @@ Examples:
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite existing files")
 	cmd.Flags().BoolVar(&skipWrapper, "skip-wrapper", false, "skip vibew wrapper script generation")
 	cmd.Flags().StringVar(&version, "version", "", "VibeWarden version to pin in .vibewarden-version (default: latest)")
-	cmd.Flags().StringVar(&agent, "agent", "all", `generate AI agent context files: "claude", "cursor", "generic", "all", or "none"`)
+	cmd.Flags().StringVar(&agent, "agent", "all", `generate AI agent context files: "claude", "generic", "all", or "none"`)
 
 	return cmd
 }
@@ -126,7 +126,6 @@ Examples:
 func parseAgentType(value string) (domainscaffold.AgentType, error) {
 	switch domainscaffold.AgentType(value) {
 	case domainscaffold.AgentTypeClaude,
-		domainscaffold.AgentTypeCursor,
 		domainscaffold.AgentTypeGeneric,
 		domainscaffold.AgentTypeAll:
 		return domainscaffold.AgentType(value), nil
@@ -134,7 +133,7 @@ func parseAgentType(value string) (domainscaffold.AgentType, error) {
 		return "", nil
 	default:
 		return "", fmt.Errorf(
-			"unknown --agent value %q: must be one of claude, cursor, generic, all, none",
+			"unknown --agent value %q: must be one of claude, generic, all, none",
 			value,
 		)
 	}

--- a/internal/cli/cmd/wrap_test.go
+++ b/internal/cli/cmd/wrap_test.go
@@ -148,11 +148,11 @@ func TestNewWrapCmd_AgentFlag(t *testing.T) {
 		checkFiles []string
 	}{
 		{
-			name: "agent all generates three context files",
+			name: "agent all generates claude and generic files",
 			args: []string{"--agent", "all"},
 			checkFiles: []string{
 				filepath.Join(".claude", "CLAUDE.md"),
-				filepath.Join(".cursor", "rules"),
+				"AGENTS-VIBEWARDEN.md",
 				"AGENTS.md",
 			},
 		},
@@ -162,14 +162,9 @@ func TestNewWrapCmd_AgentFlag(t *testing.T) {
 			checkFiles: []string{filepath.Join(".claude", "CLAUDE.md")},
 		},
 		{
-			name:       "agent cursor generates .cursor/rules only",
-			args:       []string{"--agent", "cursor"},
-			checkFiles: []string{filepath.Join(".cursor", "rules")},
-		},
-		{
-			name:       "agent generic generates AGENTS.md only",
+			name:       "agent generic generates AGENTS-VIBEWARDEN.md and AGENTS.md",
 			args:       []string{"--agent", "generic"},
-			checkFiles: []string{"AGENTS.md"},
+			checkFiles: []string{"AGENTS-VIBEWARDEN.md", "AGENTS.md"},
 		},
 		{
 			name:       "agent none generates no context files",
@@ -182,11 +177,16 @@ func TestNewWrapCmd_AgentFlag(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "cursor agent value returns error (removed)",
+			args:    []string{"--agent", "cursor"},
+			wantErr: true,
+		},
+		{
 			name: "default agent all is used when flag omitted",
 			args: []string{},
 			checkFiles: []string{
 				filepath.Join(".claude", "CLAUDE.md"),
-				filepath.Join(".cursor", "rules"),
+				"AGENTS-VIBEWARDEN.md",
 				"AGENTS.md",
 			},
 		},


### PR DESCRIPTION
Closes #695

## Summary

- `AgentTypeGeneric` in `agent_context.go` now generates `AGENTS-VIBEWARDEN.md` (always overwritten, vibew-owned) instead of writing directly to `AGENTS.md`
- After generating `AGENTS-VIBEWARDEN.md`, the shared `ensureAgentsMD` helper creates `AGENTS.md` from template when absent, or appends the reference line when the file exists but lacks it — exactly matching the `init_project.go` pattern from #632
- Extracted `ensureAgentsMD` from `InitProjectService` to a package-level function so both `AgentContextService` and `InitProjectService` share the same logic without duplication
- Removed `AgentTypeCursor` (`.cursor/rules`) from `agentSpecs` and `allAgentTypes` — tool-agnostic coverage is now handled by `AGENTS-VIBEWARDEN.md`
- Updated `parseAgentType` in `wrap.go` and `agentContextFiles` in `context.go` to reflect the removed cursor type
- Updated all affected tests

## Test plan

- `TestAgentContextService_GenerateAgentContext_GenericAlwaysOverwrites` — verifies AGENTS-VIBEWARDEN.md is overwritten even when Force=false
- `TestAgentContextService_GenerateAgentContext_ExistingAGENTSMDGetsReference` — verifies an existing AGENTS.md without a reference gets the line appended
- `TestAgentContextService_GenerateAgentContext_ExistingAGENTSMDWithReferenceUnchanged` — verifies idempotency: no duplicate reference is appended
- `TestNewWrapCmd_AgentFlag` — updated to check for `AGENTS-VIBEWARDEN.md` and `AGENTS.md`, and to assert cursor returns an error
- `TestContextRefresh_WithForce_CreatesFiles` — updated to check for `AGENTS-VIBEWARDEN.md` instead of `.cursor/rules`
- `make check` passes (format + golangci-lint + build + tests)