### PR TITLE
fix(#699): docs audit findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ vibew                    # CLI binary (installed via install script)
 .claude/CLAUDE.md        # AI agent context (Claude Code)
 .cursor/rules            # AI agent context (Cursor)
 AGENTS.md                # AI agent context (generic)
+AGENTS-VIBEWARDEN.md     # Tool-agnostic AI agent context (all agents)
 ```
 
 Running `vibew dev` or `vibew generate` creates runtime files under
@@ -221,6 +222,7 @@ If you need a general-purpose load balancer or a CDN edge, use the right tool fo
 | `vibew add rate-limiting` | Enable rate limiting |
 | `vibew add tls --domain example.com` | Enable TLS |
 | `vibew add metrics` | Enable Prometheus metrics |
+| `vibew add admin` | Enable admin API |
 | `vibew generate` | Regenerate `docker-compose.yml` from config |
 | `vibew build` | Build the Docker image for the app |
 | `vibew dev` | Start local dev environment |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,6 +74,7 @@ vibew / vibew.ps1        # Wrapper scripts (macOS/Linux/Windows)
 .claude/CLAUDE.md        # AI agent context (Claude Code)
 .cursor/rules            # AI agent context (Cursor)
 AGENTS.md                # AI agent context (generic)
+AGENTS-VIBEWARDEN.md     # Tool-agnostic AI agent context (all agents)
 ```
 
 !!! tip "AI agent context"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,13 +81,13 @@ nav:
   - Framework Examples:
       - Express (Node.js): examples/express.md
       - Next.js: examples/nextjs.md
-      - Django: examples/django.md
-      - Rails: examples/rails.md
   - Upgrading: upgrading.md
   - Troubleshooting: troubleshooting.md
   - FAQ: faq.md
   - Reference:
       - Architectural Decisions: decisions.md
+      - Claude Code Snippet: claude-md-snippet.md
+      - Schema Evolution: schema-evolution.md
 
 extra:
   social:


### PR DESCRIPTION
Closes #699

## Summary

- Add `AGENTS-VIBEWARDEN.md` to the generated files list in `README.md` and `docs/getting-started.md` (both `vibew wrap` sections)
- Add `vibew add admin` row to the CLI reference table in `README.md`
- Remove Django and Rails entries from the Framework Examples section in `mkdocs.yml` (no example apps exist for those stacks)
- Add `claude-md-snippet.md` and `schema-evolution.md` to the Reference section in `mkdocs.yml` (previously orphaned)

The `vibewarden.dev` repo change (deploy commands added to `llms-full.txt` CLI reference) was committed and pushed directly to main in that repo per the issue instructions.

## Test plan

- [ ] `make check` passes (all linting, build, and tests green — verified locally)
- [ ] Verify `README.md` "What wrap generates" block includes `AGENTS-VIBEWARDEN.md`
- [ ] Verify CLI reference table in `README.md` contains `vibew add admin`
- [ ] Verify `docs/getting-started.md` "What wrap generates" block includes `AGENTS-VIBEWARDEN.md`
- [ ] Verify `mkdocs.yml` Framework Examples no longer lists Django or Rails
- [ ] Verify `mkdocs.yml` Reference section lists `claude-md-snippet.md` and `schema-evolution.md`