### PR TITLE
feat(#704): enrich event schema with actor model, causal chain, and risk signals

### DIFF
--- a/internal/adapters/log/slog_adapter.go
+++ b/internal/adapters/log/slog_adapter.go
@@ -107,14 +107,65 @@ func (l *SlogEventLogger) Log(ctx context.Context, event events.Event) error {
 		slog.Any("payload", json.RawMessage(payloadBytes)),
 	}
 
-	// Extract trace context if the request context carries a valid OTel span.
+	// Append optional enrichment fields. Each field is only included when it
+	// carries a meaningful value so that consumers are not burdened with empty
+	// strings or zero structs that add noise to every log line.
+
+	// Actor — omit when the zero value (unknown actor).
+	if event.Actor.Type != "" {
+		actorBytes, err := json.Marshal(event.Actor)
+		if err == nil {
+			attrs = append(attrs, slog.Any("actor", json.RawMessage(actorBytes)))
+		}
+	}
+
+	// Resource — omit when the zero value (informational events with no target).
+	if event.Resource.Type != "" {
+		resourceBytes, err := json.Marshal(event.Resource)
+		if err == nil {
+			attrs = append(attrs, slog.Any("resource", json.RawMessage(resourceBytes)))
+		}
+	}
+
+	// Outcome — omit for informational events that carry no enforcement decision.
+	if event.Outcome != "" {
+		attrs = append(attrs, slog.String("outcome", string(event.Outcome)))
+	}
+
+	// RiskSignals — omit when nil or empty.
+	if len(event.RiskSignals) > 0 {
+		rsBytes, err := json.Marshal(event.RiskSignals)
+		if err == nil {
+			attrs = append(attrs, slog.Any("risk_signals", json.RawMessage(rsBytes)))
+		}
+	}
+
+	// RequestID — omit when absent (most internal events do not carry one).
+	if event.RequestID != "" {
+		attrs = append(attrs, slog.String("request_id", event.RequestID))
+	}
+
+	// TriggeredBy — omit when implicit from the event type.
+	if event.TriggeredBy != "" {
+		attrs = append(attrs, slog.String("triggered_by", event.TriggeredBy))
+	}
+
+	// TraceID resolution: prefer the domain-level TraceID stored on the event
+	// (set by constructors that receive it from the middleware context). Fall
+	// back to the live OTel span context on the ctx argument for events that
+	// do not carry a pre-resolved trace ID.
+	//
 	// SpanContextFromContext is a cheap map lookup and returns an invalid
 	// SpanContext when no span has been stored — no allocation occurs.
+	resolvedTraceID := event.TraceID
 	if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
-		attrs = append(attrs,
-			slog.String("trace_id", sc.TraceID().String()),
-			slog.String("span_id", sc.SpanID().String()),
-		)
+		attrs = append(attrs, slog.String("span_id", sc.SpanID().String()))
+		if resolvedTraceID == "" {
+			resolvedTraceID = sc.TraceID().String()
+		}
+	}
+	if resolvedTraceID != "" {
+		attrs = append(attrs, slog.String("trace_id", resolvedTraceID))
 	}
 
 	l.logger.LogAttrs(

--- a/internal/adapters/log/slog_adapter_test.go
+++ b/internal/adapters/log/slog_adapter_test.go
@@ -554,3 +554,220 @@ func TestSlogEventLogger_Log_WithInvalidSpanContext(t *testing.T) {
 		t.Error("span_id should be absent for invalid span context, but it was present")
 	}
 }
+
+// TestSlogEventLogger_EnrichmentFields verifies that the optional enrichment
+// fields (actor, resource, outcome, risk_signals, request_id, trace_id,
+// triggered_by) are serialized to the top-level JSON object when present, and
+// are absent when not set.
+func TestSlogEventLogger_EnrichmentFields(t *testing.T) {
+	tests := []struct {
+		name          string
+		event         events.Event
+		wantActor     bool
+		wantResource  bool
+		wantOutcome   string
+		wantRiskLen   int
+		wantRequestID string
+		wantTraceID   string
+		wantTriggered string
+	}{
+		{
+			name: "auth success — all enrichment fields present",
+			event: events.NewAuthSuccess(events.AuthSuccessParams{
+				Method:     "GET",
+				Path:       "/api/data",
+				SessionID:  "sess-1",
+				IdentityID: "user-1",
+				Email:      "a@example.com",
+				ClientIP:   "10.0.0.1",
+				RequestID:  "req-abc",
+				TraceID:    "4bf92f3577b34da6a3ce929d0e0e4736",
+			}),
+			wantActor:     true,
+			wantResource:  true,
+			wantOutcome:   "allowed",
+			wantRiskLen:   0,
+			wantRequestID: "req-abc",
+			wantTraceID:   "4bf92f3577b34da6a3ce929d0e0e4736",
+			wantTriggered: "auth_middleware",
+		},
+		{
+			name: "rate limit hit — risk signal present",
+			event: events.NewRateLimitHit(events.RateLimitHitParams{
+				LimitType:         "ip",
+				Identifier:        "192.168.1.1",
+				RequestsPerSecond: 5,
+				Burst:             10,
+				RetryAfterSeconds: 1,
+				Path:              "/api",
+				Method:            "POST",
+			}),
+			wantActor:     true,
+			wantResource:  true,
+			wantOutcome:   "rate_limited",
+			wantRiskLen:   1,
+			wantTriggered: "rate_limit_middleware",
+		},
+		{
+			name: "base event with no enrichment — fields absent",
+			event: fixedEvent(
+				events.EventTypeProxyStarted,
+				"Reverse proxy started",
+				map[string]any{"listen": ":8080", "upstream": "localhost:3000"},
+			),
+			wantActor:    false,
+			wantResource: false,
+		},
+		{
+			name: "config reloaded — system actor",
+			event: events.NewConfigReloaded(events.ConfigReloadedParams{
+				ConfigPath:    "vibewarden.yaml",
+				TriggerSource: "file_watcher",
+				DurationMS:    20,
+			}),
+			wantActor:     true,
+			wantResource:  true,
+			wantOutcome:   "allowed",
+			wantTriggered: "file_watcher",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := logAndDecode(t, tt.event)
+
+			// actor
+			_, hasActor := result["actor"]
+			if hasActor != tt.wantActor {
+				t.Errorf("actor present = %v, want %v", hasActor, tt.wantActor)
+			}
+
+			// resource
+			_, hasResource := result["resource"]
+			if hasResource != tt.wantResource {
+				t.Errorf("resource present = %v, want %v", hasResource, tt.wantResource)
+			}
+
+			// outcome
+			if tt.wantOutcome != "" {
+				got, ok := result["outcome"].(string)
+				if !ok {
+					t.Errorf("outcome is not a string: %T", result["outcome"])
+				} else if got != tt.wantOutcome {
+					t.Errorf("outcome = %q, want %q", got, tt.wantOutcome)
+				}
+			} else {
+				if _, ok := result["outcome"]; ok {
+					t.Error("outcome should be absent but was present")
+				}
+			}
+
+			// risk_signals
+			if tt.wantRiskLen > 0 {
+				rs, ok := result["risk_signals"].([]any)
+				if !ok {
+					t.Errorf("risk_signals is not an array: %T", result["risk_signals"])
+				} else if len(rs) != tt.wantRiskLen {
+					t.Errorf("risk_signals length = %d, want %d", len(rs), tt.wantRiskLen)
+				}
+			}
+
+			// request_id
+			if tt.wantRequestID != "" {
+				if got, ok := result["request_id"].(string); !ok || got != tt.wantRequestID {
+					t.Errorf("request_id = %v, want %q", result["request_id"], tt.wantRequestID)
+				}
+			}
+
+			// trace_id
+			if tt.wantTraceID != "" {
+				if got, ok := result["trace_id"].(string); !ok || got != tt.wantTraceID {
+					t.Errorf("trace_id = %v, want %q", result["trace_id"], tt.wantTraceID)
+				}
+			}
+
+			// triggered_by
+			if tt.wantTriggered != "" {
+				if got, ok := result["triggered_by"].(string); !ok || got != tt.wantTriggered {
+					t.Errorf("triggered_by = %v, want %q", result["triggered_by"], tt.wantTriggered)
+				}
+			}
+		})
+	}
+}
+
+// TestSlogEventLogger_ActorFields verifies that the actor object is correctly
+// serialized with its type, id, and optional ip fields.
+func TestSlogEventLogger_ActorFields(t *testing.T) {
+	event := events.NewAuthSuccess(events.AuthSuccessParams{
+		Method:     "GET",
+		Path:       "/",
+		IdentityID: "user-42",
+		ClientIP:   "10.1.2.3",
+	})
+
+	result := logAndDecode(t, event)
+
+	actor, ok := result["actor"].(map[string]any)
+	if !ok {
+		t.Fatalf("actor is not a JSON object: %T", result["actor"])
+	}
+
+	if got := actor["type"]; got != "user" {
+		t.Errorf("actor.type = %v, want %q", got, "user")
+	}
+	if got := actor["id"]; got != "user-42" {
+		t.Errorf("actor.id = %v, want %q", got, "user-42")
+	}
+	if got := actor["ip"]; got != "10.1.2.3" {
+		t.Errorf("actor.ip = %v, want %q", got, "10.1.2.3")
+	}
+}
+
+// TestSlogEventLogger_ResourceFields verifies that the resource object is
+// correctly serialized with its type, path, and optional method fields.
+func TestSlogEventLogger_ResourceFields(t *testing.T) {
+	event := events.NewAuthFailed(events.AuthFailedParams{
+		Method:   "POST",
+		Path:     "/api/submit",
+		Reason:   "missing session",
+		ClientIP: "1.2.3.4",
+	})
+
+	result := logAndDecode(t, event)
+
+	resource, ok := result["resource"].(map[string]any)
+	if !ok {
+		t.Fatalf("resource is not a JSON object: %T", result["resource"])
+	}
+
+	if got := resource["type"]; got != "http_endpoint" {
+		t.Errorf("resource.type = %v, want %q", got, "http_endpoint")
+	}
+	if got := resource["path"]; got != "/api/submit" {
+		t.Errorf("resource.path = %v, want %q", got, "/api/submit")
+	}
+	if got := resource["method"]; got != "POST" {
+		t.Errorf("resource.method = %v, want %q", got, "POST")
+	}
+}
+
+// TestSlogEventLogger_DomainTraceIDPreferredOverOTel verifies that when the
+// domain Event carries a TraceID set by the constructor, it is emitted as the
+// trace_id field even if no OTel span is active in the context.
+func TestSlogEventLogger_DomainTraceIDPreferredOverOTel(t *testing.T) {
+	const domainTraceID = "aabbccddeeff00112233445566778899"
+	event := events.NewAuthSuccess(events.AuthSuccessParams{
+		Method:     "GET",
+		Path:       "/",
+		IdentityID: "u1",
+		TraceID:    domainTraceID,
+	})
+
+	result := logAndDecodeWithCtx(t, context.Background(), event)
+
+	got, ok := result["trace_id"].(string)
+	if !ok || got != domainTraceID {
+		t.Errorf("trace_id = %v, want %q", result["trace_id"], domainTraceID)
+	}
+}

--- a/internal/domain/events/auth.go
+++ b/internal/domain/events/auth.go
@@ -22,6 +22,16 @@ type AuthSuccessParams struct {
 
 	// Email is the email address associated with the authenticated identity.
 	Email string
+
+	// ClientIP is the IP address of the authenticated client. Used to populate
+	// the Actor.IP field. May be empty.
+	ClientIP string
+
+	// RequestID is the inbound request identifier (e.g. X-Request-ID header).
+	RequestID string
+
+	// TraceID is the W3C trace-id of the active OTel span. May be empty.
+	TraceID string
 }
 
 // NewAuthSuccess creates an auth.success event indicating that a request
@@ -42,6 +52,12 @@ func NewAuthSuccess(params AuthSuccessParams) Event {
 			"identity_id": params.IdentityID,
 			"email":       params.Email,
 		},
+		Actor:       Actor{Type: ActorTypeUser, ID: params.IdentityID, IP: params.ClientIP},
+		Resource:    Resource{Type: ResourceTypeHTTPEndpoint, Path: params.Path, Method: params.Method},
+		Outcome:     OutcomeAllowed,
+		RequestID:   params.RequestID,
+		TraceID:     params.TraceID,
+		TriggeredBy: "auth_middleware",
 	}
 }
 
@@ -61,6 +77,15 @@ type AuthFailedParams struct {
 	// Detail is an optional additional detail string (e.g. an error message).
 	// May be empty.
 	Detail string
+
+	// ClientIP is the IP address of the unauthenticated client. May be empty.
+	ClientIP string
+
+	// RequestID is the inbound request identifier (e.g. X-Request-ID header).
+	RequestID string
+
+	// TraceID is the W3C trace-id of the active OTel span. May be empty.
+	TraceID string
 }
 
 // NewAuthFailed creates an auth.failed event indicating that a request was
@@ -80,5 +105,11 @@ func NewAuthFailed(params AuthFailedParams) Event {
 			"reason": params.Reason,
 			"detail": params.Detail,
 		},
+		Actor:       Actor{Type: ActorTypeIP, ID: params.ClientIP, IP: params.ClientIP},
+		Resource:    Resource{Type: ResourceTypeHTTPEndpoint, Path: params.Path, Method: params.Method},
+		Outcome:     OutcomeBlocked,
+		RequestID:   params.RequestID,
+		TraceID:     params.TraceID,
+		TriggeredBy: "auth_middleware",
 	}
 }

--- a/internal/domain/events/config.go
+++ b/internal/domain/events/config.go
@@ -51,6 +51,10 @@ func NewConfigReloaded(params ConfigReloadedParams) Event {
 			"trigger_source": params.TriggerSource,
 			"duration_ms":    params.DurationMS,
 		},
+		Actor:       Actor{Type: ActorTypeSystem},
+		Resource:    Resource{Type: ResourceTypeConfig, Path: params.ConfigPath},
+		Outcome:     OutcomeAllowed,
+		TriggeredBy: params.TriggerSource,
 	}
 }
 
@@ -75,5 +79,9 @@ func NewConfigReloadFailed(params ConfigReloadFailedParams) Event {
 			"reason":            params.Reason,
 			"validation_errors": errs,
 		},
+		Actor:       Actor{Type: ActorTypeSystem},
+		Resource:    Resource{Type: ResourceTypeConfig, Path: params.ConfigPath},
+		Outcome:     OutcomeFailed,
+		TriggeredBy: params.TriggerSource,
 	}
 }

--- a/internal/domain/events/config_test.go
+++ b/internal/domain/events/config_test.go
@@ -54,6 +54,23 @@ func TestNewConfigReloaded(t *testing.T) {
 			if ev.Payload["duration_ms"] != tt.params.DurationMS {
 				t.Errorf("duration_ms = %v, want %d", ev.Payload["duration_ms"], tt.params.DurationMS)
 			}
+
+			// Verify enrichment fields.
+			if ev.Actor.Type != events.ActorTypeSystem {
+				t.Errorf("Actor.Type = %q, want %q", ev.Actor.Type, events.ActorTypeSystem)
+			}
+			if ev.Resource.Type != events.ResourceTypeConfig {
+				t.Errorf("Resource.Type = %q, want %q", ev.Resource.Type, events.ResourceTypeConfig)
+			}
+			if ev.Resource.Path != tt.params.ConfigPath {
+				t.Errorf("Resource.Path = %q, want %q", ev.Resource.Path, tt.params.ConfigPath)
+			}
+			if ev.Outcome != events.OutcomeAllowed {
+				t.Errorf("Outcome = %q, want %q", ev.Outcome, events.OutcomeAllowed)
+			}
+			if ev.TriggeredBy != tt.params.TriggerSource {
+				t.Errorf("TriggeredBy = %q, want %q", ev.TriggeredBy, tt.params.TriggerSource)
+			}
 		})
 	}
 }
@@ -116,6 +133,23 @@ func TestNewConfigReloadFailed(t *testing.T) {
 			wantLen := len(tt.params.ValidationErrors)
 			if len(errs) != wantLen {
 				t.Errorf("len(validation_errors) = %d, want %d", len(errs), wantLen)
+			}
+
+			// Verify enrichment fields.
+			if ev.Actor.Type != events.ActorTypeSystem {
+				t.Errorf("Actor.Type = %q, want %q", ev.Actor.Type, events.ActorTypeSystem)
+			}
+			if ev.Resource.Type != events.ResourceTypeConfig {
+				t.Errorf("Resource.Type = %q, want %q", ev.Resource.Type, events.ResourceTypeConfig)
+			}
+			if ev.Resource.Path != tt.params.ConfigPath {
+				t.Errorf("Resource.Path = %q, want %q", ev.Resource.Path, tt.params.ConfigPath)
+			}
+			if ev.Outcome != events.OutcomeFailed {
+				t.Errorf("Outcome = %q, want %q", ev.Outcome, events.OutcomeFailed)
+			}
+			if ev.TriggeredBy != tt.params.TriggerSource {
+				t.Errorf("TriggeredBy = %q, want %q", ev.TriggeredBy, tt.params.TriggerSource)
 			}
 		})
 	}

--- a/internal/domain/events/egress.go
+++ b/internal/domain/events/egress.go
@@ -63,6 +63,10 @@ func NewEgressRequest(params EgressRequestParams) Event {
 			"url":      params.URL,
 			"trace_id": params.TraceID,
 		},
+		Actor:       Actor{Type: ActorTypeSystem},
+		Resource:    Resource{Type: ResourceTypeEgressRoute, Path: params.Route, Method: params.Method},
+		TraceID:     params.TraceID,
+		TriggeredBy: "egress_proxy",
 	}
 }
 
@@ -113,6 +117,10 @@ func NewEgressResponse(params EgressResponseParams) Event {
 			"attempts":         params.Attempts,
 			"trace_id":         params.TraceID,
 		},
+		Actor:       Actor{Type: ActorTypeSystem},
+		Resource:    Resource{Type: ResourceTypeEgressRoute, Path: params.Route, Method: params.Method},
+		TraceID:     params.TraceID,
+		TriggeredBy: "egress_proxy",
 	}
 }
 
@@ -155,6 +163,11 @@ func NewEgressBlocked(params EgressBlockedParams) Event {
 			"reason":   params.Reason,
 			"trace_id": params.TraceID,
 		},
+		Actor:       Actor{Type: ActorTypeSystem},
+		Resource:    Resource{Type: ResourceTypeEgressRoute, Path: params.Route, Method: params.Method},
+		Outcome:     OutcomeBlocked,
+		TraceID:     params.TraceID,
+		TriggeredBy: "egress_proxy",
 	}
 }
 
@@ -199,6 +212,11 @@ func NewEgressError(params EgressErrorParams) Event {
 			"attempts": params.Attempts,
 			"trace_id": params.TraceID,
 		},
+		Actor:       Actor{Type: ActorTypeSystem},
+		Resource:    Resource{Type: ResourceTypeEgressRoute, Path: params.Route, Method: params.Method},
+		Outcome:     OutcomeFailed,
+		TraceID:     params.TraceID,
+		TriggeredBy: "egress_proxy",
 	}
 }
 
@@ -246,6 +264,9 @@ func NewEgressCircuitBreakerOpened(params EgressCircuitBreakerOpenedParams) Even
 			"threshold":       params.Threshold,
 			"timeout_seconds": params.TimeoutSeconds,
 		},
+		Actor:       Actor{Type: ActorTypeSystem},
+		Resource:    Resource{Type: ResourceTypeEgressRoute, Path: params.Route},
+		TriggeredBy: "egress_circuit_breaker",
 	}
 }
 
@@ -271,6 +292,9 @@ func NewEgressCircuitBreakerClosed(params EgressCircuitBreakerClosedParams) Even
 		Payload: map[string]any{
 			"route": params.Route,
 		},
+		Actor:       Actor{Type: ActorTypeSystem},
+		Resource:    Resource{Type: ResourceTypeEgressRoute, Path: params.Route},
+		TriggeredBy: "egress_circuit_breaker",
 	}
 }
 
@@ -328,6 +352,11 @@ func NewEgressResponseInvalid(params EgressResponseInvalidParams) Event {
 			"reason":       params.Reason,
 			"trace_id":     params.TraceID,
 		},
+		Actor:       Actor{Type: ActorTypeSystem},
+		Resource:    Resource{Type: ResourceTypeEgressRoute, Path: params.Route, Method: params.Method},
+		Outcome:     OutcomeFailed,
+		TraceID:     params.TraceID,
+		TriggeredBy: "egress_proxy",
 	}
 }
 
@@ -364,5 +393,10 @@ func NewEgressRateLimitHit(params EgressRateLimitHitParams) Event {
 			"limit":               params.Limit,
 			"retry_after_seconds": params.RetryAfterSeconds,
 		},
+		Actor:       Actor{Type: ActorTypeSystem},
+		Resource:    Resource{Type: ResourceTypeEgressRoute, Path: params.Route},
+		Outcome:     OutcomeRateLimited,
+		RiskSignals: []RiskSignal{{Signal: "rate_limit_exceeded", Score: 0.5, Details: fmt.Sprintf("route %q exceeded %.2f req/s", params.Route, params.Limit)}},
+		TriggeredBy: "egress_rate_limit_middleware",
 	}
 }

--- a/internal/domain/events/egress_enrichment_test.go
+++ b/internal/domain/events/egress_enrichment_test.go
@@ -1,0 +1,325 @@
+package events_test
+
+import (
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+)
+
+// TestEgressRequestEnrichment verifies that NewEgressRequest populates the
+// Actor, Resource, TriggeredBy, and TraceID fields correctly.
+func TestEgressRequestEnrichment(t *testing.T) {
+	tests := []struct {
+		name        string
+		params      events.EgressRequestParams
+		wantRoute   string
+		wantMethod  string
+		wantTraceID string
+	}{
+		{
+			name: "named route with trace",
+			params: events.EgressRequestParams{
+				Route:   "payments",
+				Method:  "POST",
+				URL:     "https://api.stripe.com/v1/charges",
+				TraceID: "trace-abc",
+			},
+			wantRoute:   "payments",
+			wantMethod:  "POST",
+			wantTraceID: "trace-abc",
+		},
+		{
+			name: "no trace id",
+			params: events.EgressRequestParams{
+				Route:  "analytics",
+				Method: "GET",
+				URL:    "https://analytics.example.com/data",
+			},
+			wantRoute:  "analytics",
+			wantMethod: "GET",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := events.NewEgressRequest(tt.params)
+
+			if e.Actor.Type != events.ActorTypeSystem {
+				t.Errorf("Actor.Type = %q, want %q", e.Actor.Type, events.ActorTypeSystem)
+			}
+			if e.Resource.Type != events.ResourceTypeEgressRoute {
+				t.Errorf("Resource.Type = %q, want %q", e.Resource.Type, events.ResourceTypeEgressRoute)
+			}
+			if e.Resource.Path != tt.wantRoute {
+				t.Errorf("Resource.Path = %q, want %q", e.Resource.Path, tt.wantRoute)
+			}
+			if e.Resource.Method != tt.wantMethod {
+				t.Errorf("Resource.Method = %q, want %q", e.Resource.Method, tt.wantMethod)
+			}
+			if e.TraceID != tt.wantTraceID {
+				t.Errorf("TraceID = %q, want %q", e.TraceID, tt.wantTraceID)
+			}
+			if e.TriggeredBy != "egress_proxy" {
+				t.Errorf("TriggeredBy = %q, want %q", e.TriggeredBy, "egress_proxy")
+			}
+		})
+	}
+}
+
+// TestEgressResponseEnrichment verifies that NewEgressResponse populates the
+// Actor, Resource, TriggeredBy, and TraceID fields correctly.
+func TestEgressResponseEnrichment(t *testing.T) {
+	params := events.EgressResponseParams{
+		Route:           "payments",
+		Method:          "POST",
+		URL:             "https://api.stripe.com/v1/charges",
+		StatusCode:      200,
+		DurationSeconds: 0.123,
+		Attempts:        1,
+		TraceID:         "trace-def",
+	}
+
+	e := events.NewEgressResponse(params)
+
+	if e.Actor.Type != events.ActorTypeSystem {
+		t.Errorf("Actor.Type = %q, want %q", e.Actor.Type, events.ActorTypeSystem)
+	}
+	if e.Resource.Type != events.ResourceTypeEgressRoute {
+		t.Errorf("Resource.Type = %q, want %q", e.Resource.Type, events.ResourceTypeEgressRoute)
+	}
+	if e.Resource.Path != params.Route {
+		t.Errorf("Resource.Path = %q, want %q", e.Resource.Path, params.Route)
+	}
+	if e.Resource.Method != params.Method {
+		t.Errorf("Resource.Method = %q, want %q", e.Resource.Method, params.Method)
+	}
+	if e.TraceID != params.TraceID {
+		t.Errorf("TraceID = %q, want %q", e.TraceID, params.TraceID)
+	}
+	if e.TriggeredBy != "egress_proxy" {
+		t.Errorf("TriggeredBy = %q, want %q", e.TriggeredBy, "egress_proxy")
+	}
+}
+
+// TestEgressBlockedEnrichment verifies that NewEgressBlocked populates the
+// Actor, Resource, Outcome, TriggeredBy, and TraceID fields correctly.
+func TestEgressBlockedEnrichment(t *testing.T) {
+	params := events.EgressBlockedParams{
+		Route:   "internal",
+		Method:  "GET",
+		URL:     "http://internal.corp/secrets",
+		Reason:  "no route matched default deny policy",
+		TraceID: "trace-ghi",
+	}
+
+	e := events.NewEgressBlocked(params)
+
+	if e.Actor.Type != events.ActorTypeSystem {
+		t.Errorf("Actor.Type = %q, want %q", e.Actor.Type, events.ActorTypeSystem)
+	}
+	if e.Resource.Type != events.ResourceTypeEgressRoute {
+		t.Errorf("Resource.Type = %q, want %q", e.Resource.Type, events.ResourceTypeEgressRoute)
+	}
+	if e.Resource.Path != params.Route {
+		t.Errorf("Resource.Path = %q, want %q", e.Resource.Path, params.Route)
+	}
+	if e.Outcome != events.OutcomeBlocked {
+		t.Errorf("Outcome = %q, want %q", e.Outcome, events.OutcomeBlocked)
+	}
+	if e.TraceID != params.TraceID {
+		t.Errorf("TraceID = %q, want %q", e.TraceID, params.TraceID)
+	}
+	if e.TriggeredBy != "egress_proxy" {
+		t.Errorf("TriggeredBy = %q, want %q", e.TriggeredBy, "egress_proxy")
+	}
+}
+
+// TestEgressErrorEnrichment verifies that NewEgressError populates the
+// Actor, Resource, Outcome, TriggeredBy, and TraceID fields correctly.
+func TestEgressErrorEnrichment(t *testing.T) {
+	params := events.EgressErrorParams{
+		Route:    "payments",
+		Method:   "POST",
+		URL:      "https://api.stripe.com/v1/charges",
+		Error:    "connection refused",
+		Attempts: 3,
+		TraceID:  "trace-jkl",
+	}
+
+	e := events.NewEgressError(params)
+
+	if e.Actor.Type != events.ActorTypeSystem {
+		t.Errorf("Actor.Type = %q, want %q", e.Actor.Type, events.ActorTypeSystem)
+	}
+	if e.Resource.Type != events.ResourceTypeEgressRoute {
+		t.Errorf("Resource.Type = %q, want %q", e.Resource.Type, events.ResourceTypeEgressRoute)
+	}
+	if e.Resource.Path != params.Route {
+		t.Errorf("Resource.Path = %q, want %q", e.Resource.Path, params.Route)
+	}
+	if e.Outcome != events.OutcomeFailed {
+		t.Errorf("Outcome = %q, want %q", e.Outcome, events.OutcomeFailed)
+	}
+	if e.TraceID != params.TraceID {
+		t.Errorf("TraceID = %q, want %q", e.TraceID, params.TraceID)
+	}
+	if e.TriggeredBy != "egress_proxy" {
+		t.Errorf("TriggeredBy = %q, want %q", e.TriggeredBy, "egress_proxy")
+	}
+}
+
+// TestEgressResponseInvalidEnrichment verifies that NewEgressResponseInvalid
+// populates the Actor, Resource, Outcome, TriggeredBy, and TraceID fields.
+func TestEgressResponseInvalidEnrichment(t *testing.T) {
+	params := events.EgressResponseInvalidParams{
+		Route:       "api",
+		Method:      "GET",
+		URL:         "https://api.example.com/data",
+		StatusCode:  500,
+		ContentType: "text/html",
+		Reason:      "status code not allowed",
+		TraceID:     "trace-mno",
+	}
+
+	e := events.NewEgressResponseInvalid(params)
+
+	if e.Actor.Type != events.ActorTypeSystem {
+		t.Errorf("Actor.Type = %q, want %q", e.Actor.Type, events.ActorTypeSystem)
+	}
+	if e.Resource.Type != events.ResourceTypeEgressRoute {
+		t.Errorf("Resource.Type = %q, want %q", e.Resource.Type, events.ResourceTypeEgressRoute)
+	}
+	if e.Resource.Path != params.Route {
+		t.Errorf("Resource.Path = %q, want %q", e.Resource.Path, params.Route)
+	}
+	if e.Resource.Method != params.Method {
+		t.Errorf("Resource.Method = %q, want %q", e.Resource.Method, params.Method)
+	}
+	if e.Outcome != events.OutcomeFailed {
+		t.Errorf("Outcome = %q, want %q", e.Outcome, events.OutcomeFailed)
+	}
+	if e.TraceID != params.TraceID {
+		t.Errorf("TraceID = %q, want %q", e.TraceID, params.TraceID)
+	}
+	if e.TriggeredBy != "egress_proxy" {
+		t.Errorf("TriggeredBy = %q, want %q", e.TriggeredBy, "egress_proxy")
+	}
+}
+
+// TestEgressRateLimitHitEnrichment verifies that NewEgressRateLimitHit
+// populates the Actor, Resource, Outcome, RiskSignals, and TriggeredBy fields.
+func TestEgressRateLimitHitEnrichment(t *testing.T) {
+	params := events.EgressRateLimitHitParams{
+		Route:             "payments",
+		Limit:             10.0,
+		RetryAfterSeconds: 5.0,
+	}
+
+	e := events.NewEgressRateLimitHit(params)
+
+	if e.Actor.Type != events.ActorTypeSystem {
+		t.Errorf("Actor.Type = %q, want %q", e.Actor.Type, events.ActorTypeSystem)
+	}
+	if e.Resource.Type != events.ResourceTypeEgressRoute {
+		t.Errorf("Resource.Type = %q, want %q", e.Resource.Type, events.ResourceTypeEgressRoute)
+	}
+	if e.Resource.Path != params.Route {
+		t.Errorf("Resource.Path = %q, want %q", e.Resource.Path, params.Route)
+	}
+	if e.Outcome != events.OutcomeRateLimited {
+		t.Errorf("Outcome = %q, want %q", e.Outcome, events.OutcomeRateLimited)
+	}
+	if len(e.RiskSignals) == 0 {
+		t.Error("RiskSignals must not be empty for a rate limit hit event")
+	} else if e.RiskSignals[0].Signal != "rate_limit_exceeded" {
+		t.Errorf("RiskSignals[0].Signal = %q, want %q", e.RiskSignals[0].Signal, "rate_limit_exceeded")
+	}
+	if e.TriggeredBy != "egress_rate_limit_middleware" {
+		t.Errorf("TriggeredBy = %q, want %q", e.TriggeredBy, "egress_rate_limit_middleware")
+	}
+}
+
+// TestEgressCircuitBreakerOpenedEnrichment verifies that
+// NewEgressCircuitBreakerOpened populates the Actor, Resource, and TriggeredBy
+// fields correctly.
+func TestEgressCircuitBreakerOpenedEnrichment(t *testing.T) {
+	params := events.EgressCircuitBreakerOpenedParams{
+		Route:          "payments",
+		Threshold:      5,
+		TimeoutSeconds: 30.0,
+	}
+
+	e := events.NewEgressCircuitBreakerOpened(params)
+
+	if e.Actor.Type != events.ActorTypeSystem {
+		t.Errorf("Actor.Type = %q, want %q", e.Actor.Type, events.ActorTypeSystem)
+	}
+	if e.Resource.Type != events.ResourceTypeEgressRoute {
+		t.Errorf("Resource.Type = %q, want %q", e.Resource.Type, events.ResourceTypeEgressRoute)
+	}
+	if e.Resource.Path != params.Route {
+		t.Errorf("Resource.Path = %q, want %q", e.Resource.Path, params.Route)
+	}
+	if e.TriggeredBy != "egress_circuit_breaker" {
+		t.Errorf("TriggeredBy = %q, want %q", e.TriggeredBy, "egress_circuit_breaker")
+	}
+}
+
+// TestEgressCircuitBreakerClosedEnrichment verifies that
+// NewEgressCircuitBreakerClosed populates the Actor, Resource, and TriggeredBy
+// fields correctly.
+func TestEgressCircuitBreakerClosedEnrichment(t *testing.T) {
+	params := events.EgressCircuitBreakerClosedParams{
+		Route: "payments",
+	}
+
+	e := events.NewEgressCircuitBreakerClosed(params)
+
+	if e.Actor.Type != events.ActorTypeSystem {
+		t.Errorf("Actor.Type = %q, want %q", e.Actor.Type, events.ActorTypeSystem)
+	}
+	if e.Resource.Type != events.ResourceTypeEgressRoute {
+		t.Errorf("Resource.Type = %q, want %q", e.Resource.Type, events.ResourceTypeEgressRoute)
+	}
+	if e.Resource.Path != params.Route {
+		t.Errorf("Resource.Path = %q, want %q", e.Resource.Path, params.Route)
+	}
+	if e.TriggeredBy != "egress_circuit_breaker" {
+		t.Errorf("TriggeredBy = %q, want %q", e.TriggeredBy, "egress_circuit_breaker")
+	}
+}
+
+// TestEgressSanitizedEnrichment verifies that NewEgressSanitized populates the
+// Actor, Resource, TriggeredBy, and TraceID fields correctly.
+func TestEgressSanitizedEnrichment(t *testing.T) {
+	params := events.EgressSanitizedParams{
+		Route:               "analytics",
+		Method:              "POST",
+		URL:                 "https://analytics.example.com/track",
+		RedactedHeaders:     1,
+		StrippedQueryParams: 2,
+		RedactedBodyFields:  3,
+		TraceID:             "trace-pqr",
+	}
+
+	e := events.NewEgressSanitized(params)
+
+	if e.Actor.Type != events.ActorTypeSystem {
+		t.Errorf("Actor.Type = %q, want %q", e.Actor.Type, events.ActorTypeSystem)
+	}
+	if e.Resource.Type != events.ResourceTypeEgressRoute {
+		t.Errorf("Resource.Type = %q, want %q", e.Resource.Type, events.ResourceTypeEgressRoute)
+	}
+	if e.Resource.Path != params.Route {
+		t.Errorf("Resource.Path = %q, want %q", e.Resource.Path, params.Route)
+	}
+	if e.Resource.Method != params.Method {
+		t.Errorf("Resource.Method = %q, want %q", e.Resource.Method, params.Method)
+	}
+	if e.TraceID != params.TraceID {
+		t.Errorf("TraceID = %q, want %q", e.TraceID, params.TraceID)
+	}
+	if e.TriggeredBy != "egress_sanitizer" {
+		t.Errorf("TriggeredBy = %q, want %q", e.TriggeredBy, "egress_sanitizer")
+	}
+}

--- a/internal/domain/events/egress_sanitized.go
+++ b/internal/domain/events/egress_sanitized.go
@@ -65,5 +65,9 @@ func NewEgressSanitized(params EgressSanitizedParams) Event {
 			"total_redacted":        total,
 			"trace_id":              params.TraceID,
 		},
+		Actor:       Actor{Type: ActorTypeSystem},
+		Resource:    Resource{Type: ResourceTypeEgressRoute, Path: params.Route, Method: params.Method},
+		TraceID:     params.TraceID,
+		TriggeredBy: "egress_sanitizer",
 	}
 }

--- a/internal/domain/events/enrichment.go
+++ b/internal/domain/events/enrichment.go
@@ -1,0 +1,109 @@
+package events
+
+// ActorType identifies the kind of entity that initiated an action.
+type ActorType string
+
+const (
+	// ActorTypeIP identifies an anonymous client identified only by IP address.
+	ActorTypeIP ActorType = "ip"
+
+	// ActorTypeUser identifies an authenticated user (Kratos identity or JWT subject).
+	ActorTypeUser ActorType = "user"
+
+	// ActorTypeAPIKey identifies a request authenticated via an API key.
+	ActorTypeAPIKey ActorType = "api_key"
+
+	// ActorTypeSystem identifies an internally-initiated action (e.g. health probe,
+	// certificate renewal, config reload triggered by the file watcher).
+	ActorTypeSystem ActorType = "system"
+)
+
+// String returns the string representation of the ActorType.
+func (a ActorType) String() string { return string(a) }
+
+// Actor describes the entity that initiated a security-relevant action.
+// All fields except Type are optional; use the zero value when unknown.
+type Actor struct {
+	// Type identifies the category of the actor.
+	Type ActorType `json:"type"`
+
+	// ID is the actor's unique identifier within its type namespace:
+	// a user ID for ActorTypeUser, an API key name for ActorTypeAPIKey,
+	// an IP address for ActorTypeIP, or an empty string for ActorTypeSystem.
+	ID string `json:"id"`
+
+	// IP is the client IP address. Present for ActorTypeIP (where it equals ID)
+	// and optionally for ActorTypeUser and ActorTypeAPIKey when the source IP is
+	// known. Omitted for ActorTypeSystem.
+	IP string `json:"ip,omitempty"`
+}
+
+// ResourceType identifies the category of the resource being accessed or affected.
+type ResourceType string
+
+const (
+	// ResourceTypeHTTPEndpoint identifies an inbound HTTP endpoint exposed by the
+	// sidecar (proxy path/method).
+	ResourceTypeHTTPEndpoint ResourceType = "http_endpoint"
+
+	// ResourceTypeEgressRoute identifies a named egress route to an external service.
+	ResourceTypeEgressRoute ResourceType = "egress_route"
+
+	// ResourceTypeConfig identifies the VibeWarden configuration file.
+	ResourceTypeConfig ResourceType = "config"
+)
+
+// String returns the string representation of the ResourceType.
+func (r ResourceType) String() string { return string(r) }
+
+// Resource describes the target of a security-relevant action.
+// All fields except Type are optional; use the zero value when unknown.
+type Resource struct {
+	// Type identifies the category of the resource.
+	Type ResourceType `json:"type"`
+
+	// Path is the URL path (for HTTP endpoints) or route name (for egress routes)
+	// or file path (for config). May be empty for system-level resources.
+	Path string `json:"path"`
+
+	// Method is the HTTP method (e.g. "GET", "POST"). Only meaningful when Type is
+	// ResourceTypeHTTPEndpoint. Omitted otherwise.
+	Method string `json:"method,omitempty"`
+}
+
+// Outcome describes the result of a security enforcement decision.
+type Outcome string
+
+const (
+	// OutcomeAllowed indicates the request or action was permitted.
+	OutcomeAllowed Outcome = "allowed"
+
+	// OutcomeBlocked indicates the request or action was rejected by a policy.
+	OutcomeBlocked Outcome = "blocked"
+
+	// OutcomeRateLimited indicates the request was rejected due to rate limiting.
+	OutcomeRateLimited Outcome = "rate_limited"
+
+	// OutcomeFailed indicates the action failed due to an internal or transport error.
+	OutcomeFailed Outcome = "failed"
+)
+
+// String returns the string representation of the Outcome.
+func (o Outcome) String() string { return string(o) }
+
+// RiskSignal captures a single machine-detectable risk indicator associated with
+// a security event.
+type RiskSignal struct {
+	// Signal is a stable identifier for the risk pattern (e.g. "brute_force",
+	// "sqli_attempt", "prompt_injection").
+	Signal string `json:"signal"`
+
+	// Score is a normalised risk score in the range [0.0, 1.0]. Higher values
+	// indicate higher confidence that the signal is a genuine threat.
+	Score float64 `json:"score"`
+
+	// Details is a free-form human-readable explanation of why this signal was
+	// raised (e.g. the matched pattern text, the request count that triggered the
+	// brute-force heuristic).
+	Details string `json:"details"`
+}

--- a/internal/domain/events/events.go
+++ b/internal/domain/events/events.go
@@ -177,4 +177,33 @@ type Event struct {
 	// Payload contains event-specific structured data.
 	// Keys and value types are defined per event type in the JSON schema.
 	Payload map[string]any
+
+	// Actor identifies the entity that initiated the action (e.g. a client IP,
+	// an authenticated user, or the internal system). Zero value means unknown.
+	Actor Actor
+
+	// Resource describes the target of the action (e.g. an HTTP endpoint, an
+	// egress route, the configuration file). Zero value means unknown.
+	Resource Resource
+
+	// Outcome is the enforcement result: allowed, blocked, rate_limited, or
+	// failed. Empty string means the event is informational (no decision taken).
+	Outcome Outcome
+
+	// RiskSignals is the list of machine-detectable risk indicators associated
+	// with this event. Nil or empty means no risk signals were detected.
+	RiskSignals []RiskSignal
+
+	// RequestID is the inbound request identifier propagated from the client
+	// (e.g. the X-Request-ID header value). Empty when not present.
+	RequestID string
+
+	// TraceID is the W3C trace-id of the active OpenTelemetry span at the time
+	// the event was emitted. Empty when no tracing context is available.
+	TraceID string
+
+	// TriggeredBy is the internal component or subsystem that raised this event
+	// (e.g. "auth_middleware", "rate_limit_middleware", "egress_proxy").
+	// Empty when the source is implicit from the EventType.
+	TriggeredBy string
 }

--- a/internal/domain/events/placeholders.go
+++ b/internal/domain/events/placeholders.go
@@ -24,6 +24,12 @@ type RequestBlockedParams struct {
 	// ClientIP is the client IP address. May be empty if it could not be
 	// determined.
 	ClientIP string
+
+	// RequestID is the inbound request identifier (e.g. X-Request-ID header).
+	RequestID string
+
+	// TraceID is the W3C trace-id of the active OTel span. May be empty.
+	TraceID string
 }
 
 // NewRequestBlocked creates a request.blocked event indicating that a request
@@ -45,6 +51,12 @@ func NewRequestBlocked(params RequestBlockedParams) Event {
 			"blocked_by": params.BlockedBy,
 			"client_ip":  params.ClientIP,
 		},
+		Actor:       Actor{Type: ActorTypeIP, ID: params.ClientIP, IP: params.ClientIP},
+		Resource:    Resource{Type: ResourceTypeHTTPEndpoint, Path: params.Path, Method: params.Method},
+		Outcome:     OutcomeBlocked,
+		RequestID:   params.RequestID,
+		TraceID:     params.TraceID,
+		TriggeredBy: params.BlockedBy,
 	}
 }
 

--- a/internal/domain/events/prompt_injection.go
+++ b/internal/domain/events/prompt_injection.go
@@ -66,8 +66,17 @@ func NewLLMPromptInjectionBlocked(params LLMPromptInjectionParams) Event {
 			"pattern":      params.Pattern,
 			"content_path": params.ContentPath,
 			"action":       params.Action,
-			"trace_id":     params.TraceID,
 		},
+		Actor:    Actor{Type: ActorTypeSystem},
+		Resource: Resource{Type: ResourceTypeEgressRoute, Path: params.Route, Method: params.Method},
+		Outcome:  OutcomeBlocked,
+		RiskSignals: []RiskSignal{{
+			Signal:  "prompt_injection",
+			Score:   1.0,
+			Details: fmt.Sprintf("pattern %q matched at %s", params.Pattern, params.ContentPath),
+		}},
+		TraceID:     params.TraceID,
+		TriggeredBy: "prompt_injection_middleware",
 	}
 }
 
@@ -90,7 +99,16 @@ func NewLLMPromptInjectionDetected(params LLMPromptInjectionParams) Event {
 			"pattern":      params.Pattern,
 			"content_path": params.ContentPath,
 			"action":       params.Action,
-			"trace_id":     params.TraceID,
 		},
+		Actor:    Actor{Type: ActorTypeSystem},
+		Resource: Resource{Type: ResourceTypeEgressRoute, Path: params.Route, Method: params.Method},
+		Outcome:  OutcomeAllowed,
+		RiskSignals: []RiskSignal{{
+			Signal:  "prompt_injection",
+			Score:   0.9,
+			Details: fmt.Sprintf("pattern %q matched at %s (log-only)", params.Pattern, params.ContentPath),
+		}},
+		TraceID:     params.TraceID,
+		TriggeredBy: "prompt_injection_middleware",
 	}
 }

--- a/internal/domain/events/prompt_injection_test.go
+++ b/internal/domain/events/prompt_injection_test.go
@@ -1,0 +1,164 @@
+package events_test
+
+import (
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+)
+
+func TestNewLLMPromptInjectionBlocked(t *testing.T) {
+	tests := []struct {
+		name   string
+		params events.LLMPromptInjectionParams
+	}{
+		{
+			name: "block on messages content path",
+			params: events.LLMPromptInjectionParams{
+				Route:       "openai-chat",
+				Method:      "POST",
+				URL:         "https://api.openai.com/v1/chat/completions",
+				Pattern:     "ignore_previous_instructions",
+				ContentPath: ".messages[0].content",
+				Action:      "block",
+				TraceID:     "trace-abc",
+			},
+		},
+		{
+			name: "block on prompt field",
+			params: events.LLMPromptInjectionParams{
+				Route:       "anthropic-complete",
+				Method:      "POST",
+				URL:         "https://api.anthropic.com/v1/complete",
+				Pattern:     "jailbreak_pattern",
+				ContentPath: ".prompt",
+				Action:      "block",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := events.NewLLMPromptInjectionBlocked(tt.params)
+
+			assertEvent(t, ev, events.EventTypeLLMPromptInjectionBlocked)
+			requireSummaryContains(t, ev.AISummary, tt.params.Route)
+			requireSummaryContains(t, ev.AISummary, tt.params.Pattern)
+			requireSummaryContains(t, ev.AISummary, tt.params.ContentPath)
+
+			// Verify payload fields.
+			requirePayloadString(t, ev.Payload, "route", tt.params.Route)
+			requirePayloadString(t, ev.Payload, "method", tt.params.Method)
+			requirePayloadString(t, ev.Payload, "url", tt.params.URL)
+			requirePayloadString(t, ev.Payload, "pattern", tt.params.Pattern)
+			requirePayloadString(t, ev.Payload, "content_path", tt.params.ContentPath)
+			requirePayloadString(t, ev.Payload, "action", tt.params.Action)
+
+			// trace_id must NOT be in payload (moved to top-level field).
+			if _, ok := ev.Payload["trace_id"]; ok {
+				t.Error("trace_id should not be in payload — it must be on the top-level Event field")
+			}
+
+			// Verify enrichment fields.
+			if ev.Actor.Type != events.ActorTypeSystem {
+				t.Errorf("Actor.Type = %q, want %q", ev.Actor.Type, events.ActorTypeSystem)
+			}
+			if ev.Resource.Type != events.ResourceTypeEgressRoute {
+				t.Errorf("Resource.Type = %q, want %q", ev.Resource.Type, events.ResourceTypeEgressRoute)
+			}
+			if ev.Resource.Path != tt.params.Route {
+				t.Errorf("Resource.Path = %q, want %q", ev.Resource.Path, tt.params.Route)
+			}
+			if ev.Resource.Method != tt.params.Method {
+				t.Errorf("Resource.Method = %q, want %q", ev.Resource.Method, tt.params.Method)
+			}
+			if ev.Outcome != events.OutcomeBlocked {
+				t.Errorf("Outcome = %q, want %q", ev.Outcome, events.OutcomeBlocked)
+			}
+			if len(ev.RiskSignals) == 0 {
+				t.Error("RiskSignals must not be empty for a blocked prompt injection event")
+			} else {
+				rs := ev.RiskSignals[0]
+				if rs.Signal != "prompt_injection" {
+					t.Errorf("RiskSignals[0].Signal = %q, want %q", rs.Signal, "prompt_injection")
+				}
+				if rs.Score != 1.0 {
+					t.Errorf("RiskSignals[0].Score = %v, want 1.0", rs.Score)
+				}
+			}
+			if ev.TraceID != tt.params.TraceID {
+				t.Errorf("TraceID = %q, want %q", ev.TraceID, tt.params.TraceID)
+			}
+			if ev.TriggeredBy != "prompt_injection_middleware" {
+				t.Errorf("TriggeredBy = %q, want %q", ev.TriggeredBy, "prompt_injection_middleware")
+			}
+		})
+	}
+}
+
+func TestNewLLMPromptInjectionDetected(t *testing.T) {
+	tests := []struct {
+		name   string
+		params events.LLMPromptInjectionParams
+	}{
+		{
+			name: "detect on messages content path (log-only)",
+			params: events.LLMPromptInjectionParams{
+				Route:       "openai-chat",
+				Method:      "POST",
+				URL:         "https://api.openai.com/v1/chat/completions",
+				Pattern:     "ignore_previous_instructions",
+				ContentPath: ".messages[0].content",
+				Action:      "detect",
+				TraceID:     "trace-xyz",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := events.NewLLMPromptInjectionDetected(tt.params)
+
+			assertEvent(t, ev, events.EventTypeLLMPromptInjectionDetected)
+			requireSummaryContains(t, ev.AISummary, tt.params.Route)
+			requireSummaryContains(t, ev.AISummary, tt.params.Pattern)
+
+			// Verify payload fields.
+			requirePayloadString(t, ev.Payload, "route", tt.params.Route)
+			requirePayloadString(t, ev.Payload, "action", tt.params.Action)
+
+			// trace_id must NOT be in payload.
+			if _, ok := ev.Payload["trace_id"]; ok {
+				t.Error("trace_id should not be in payload — it must be on the top-level Event field")
+			}
+
+			// Verify enrichment fields.
+			if ev.Actor.Type != events.ActorTypeSystem {
+				t.Errorf("Actor.Type = %q, want %q", ev.Actor.Type, events.ActorTypeSystem)
+			}
+			if ev.Resource.Type != events.ResourceTypeEgressRoute {
+				t.Errorf("Resource.Type = %q, want %q", ev.Resource.Type, events.ResourceTypeEgressRoute)
+			}
+			if ev.Outcome != events.OutcomeAllowed {
+				t.Errorf("Outcome = %q, want %q", ev.Outcome, events.OutcomeAllowed)
+			}
+			if len(ev.RiskSignals) == 0 {
+				t.Error("RiskSignals must not be empty for a detected prompt injection event")
+			} else {
+				rs := ev.RiskSignals[0]
+				if rs.Signal != "prompt_injection" {
+					t.Errorf("RiskSignals[0].Signal = %q, want %q", rs.Signal, "prompt_injection")
+				}
+				// Detected (log-only) has a lower score than blocked.
+				if rs.Score >= 1.0 {
+					t.Errorf("RiskSignals[0].Score = %v, want < 1.0 for log-only detection", rs.Score)
+				}
+			}
+			if ev.TraceID != tt.params.TraceID {
+				t.Errorf("TraceID = %q, want %q", ev.TraceID, tt.params.TraceID)
+			}
+			if ev.TriggeredBy != "prompt_injection_middleware" {
+				t.Errorf("TriggeredBy = %q, want %q", ev.TriggeredBy, "prompt_injection_middleware")
+			}
+		})
+	}
+}

--- a/internal/domain/events/ratelimit.go
+++ b/internal/domain/events/ratelimit.go
@@ -34,6 +34,12 @@ type RateLimitHitParams struct {
 	// "user" to record which IP the user was connecting from.
 	// May be empty when LimitType is "ip" (identifier already is the IP).
 	ClientIP string
+
+	// RequestID is the inbound request identifier (e.g. X-Request-ID header).
+	RequestID string
+
+	// TraceID is the W3C trace-id of the active OTel span. May be empty.
+	TraceID string
 }
 
 // NewRateLimitHit creates a rate_limit.hit event indicating that a request
@@ -52,6 +58,15 @@ func NewRateLimitHit(params RateLimitHitParams) Event {
 		payload["client_ip"] = params.ClientIP
 	}
 
+	// Build the actor from the limit type and identifier.
+	var actor Actor
+	switch params.LimitType {
+	case "user":
+		actor = Actor{Type: ActorTypeUser, ID: params.Identifier, IP: params.ClientIP}
+	default:
+		actor = Actor{Type: ActorTypeIP, ID: params.Identifier, IP: params.Identifier}
+	}
+
 	return Event{
 		SchemaVersion: SchemaVersion,
 		EventType:     EventTypeRateLimitHit,
@@ -60,7 +75,14 @@ func NewRateLimitHit(params RateLimitHitParams) Event {
 			"Rate limit exceeded for %s %s: %.0f requests/second limit reached",
 			params.LimitType, params.Identifier, params.RequestsPerSecond,
 		),
-		Payload: payload,
+		Payload:     payload,
+		Actor:       actor,
+		Resource:    Resource{Type: ResourceTypeHTTPEndpoint, Path: params.Path, Method: params.Method},
+		Outcome:     OutcomeRateLimited,
+		RiskSignals: []RiskSignal{{Signal: "rate_limit_exceeded", Score: 0.5, Details: fmt.Sprintf("%s %s exceeded %.0f req/s", params.LimitType, params.Identifier, params.RequestsPerSecond)}},
+		RequestID:   params.RequestID,
+		TraceID:     params.TraceID,
+		TriggeredBy: "rate_limit_middleware",
 	}
 }
 
@@ -72,6 +94,12 @@ type RateLimitUnidentifiedParams struct {
 
 	// Method is the HTTP method of the rejected request.
 	Method string
+
+	// RequestID is the inbound request identifier (e.g. X-Request-ID header).
+	RequestID string
+
+	// TraceID is the W3C trace-id of the active OTel span. May be empty.
+	TraceID string
 }
 
 // NewRateLimitUnidentified creates a rate_limit.unidentified_client event
@@ -87,5 +115,11 @@ func NewRateLimitUnidentified(params RateLimitUnidentifiedParams) Event {
 			"path":   params.Path,
 			"method": params.Method,
 		},
+		Actor:       Actor{Type: ActorTypeIP, ID: ""},
+		Resource:    Resource{Type: ResourceTypeHTTPEndpoint, Path: params.Path, Method: params.Method},
+		Outcome:     OutcomeBlocked,
+		RequestID:   params.RequestID,
+		TraceID:     params.TraceID,
+		TriggeredBy: "rate_limit_middleware",
 	}
 }

--- a/internal/domain/events/webhook.go
+++ b/internal/domain/events/webhook.go
@@ -39,6 +39,10 @@ func NewWebhookSignatureValid(params WebhookSignatureValidParams) Event {
 			"provider":  params.Provider,
 			"client_ip": params.ClientIP,
 		},
+		Actor:       Actor{Type: ActorTypeIP, ID: params.ClientIP, IP: params.ClientIP},
+		Resource:    Resource{Type: ResourceTypeHTTPEndpoint, Path: params.Path, Method: params.Method},
+		Outcome:     OutcomeAllowed,
+		TriggeredBy: "webhook_middleware",
 	}
 }
 
@@ -81,5 +85,9 @@ func NewWebhookSignatureInvalid(params WebhookSignatureInvalidParams) Event {
 			"reason":    params.Reason,
 			"client_ip": params.ClientIP,
 		},
+		Actor:       Actor{Type: ActorTypeIP, ID: params.ClientIP, IP: params.ClientIP},
+		Resource:    Resource{Type: ResourceTypeHTTPEndpoint, Path: params.Path, Method: params.Method},
+		Outcome:     OutcomeBlocked,
+		TriggeredBy: "webhook_middleware",
 	}
 }

--- a/internal/domain/events/webhook_test.go
+++ b/internal/domain/events/webhook_test.go
@@ -53,6 +53,29 @@ func TestNewWebhookSignatureValid(t *testing.T) {
 			requirePayloadString(t, e.Payload, "method", tt.params.Method)
 			requirePayloadString(t, e.Payload, "provider", tt.params.Provider)
 			requirePayloadString(t, e.Payload, "client_ip", tt.params.ClientIP)
+
+			// Verify enrichment fields.
+			if e.Actor.Type != events.ActorTypeIP {
+				t.Errorf("Actor.Type = %q, want %q", e.Actor.Type, events.ActorTypeIP)
+			}
+			if e.Actor.IP != tt.params.ClientIP {
+				t.Errorf("Actor.IP = %q, want %q", e.Actor.IP, tt.params.ClientIP)
+			}
+			if e.Resource.Type != events.ResourceTypeHTTPEndpoint {
+				t.Errorf("Resource.Type = %q, want %q", e.Resource.Type, events.ResourceTypeHTTPEndpoint)
+			}
+			if e.Resource.Path != tt.params.Path {
+				t.Errorf("Resource.Path = %q, want %q", e.Resource.Path, tt.params.Path)
+			}
+			if e.Resource.Method != tt.params.Method {
+				t.Errorf("Resource.Method = %q, want %q", e.Resource.Method, tt.params.Method)
+			}
+			if e.Outcome != events.OutcomeAllowed {
+				t.Errorf("Outcome = %q, want %q", e.Outcome, events.OutcomeAllowed)
+			}
+			if e.TriggeredBy != "webhook_middleware" {
+				t.Errorf("TriggeredBy = %q, want %q", e.TriggeredBy, "webhook_middleware")
+			}
 		})
 	}
 }
@@ -98,6 +121,29 @@ func TestNewWebhookSignatureInvalid(t *testing.T) {
 			requirePayloadString(t, e.Payload, "provider", tt.params.Provider)
 			requirePayloadString(t, e.Payload, "reason", tt.params.Reason)
 			requirePayloadString(t, e.Payload, "client_ip", tt.params.ClientIP)
+
+			// Verify enrichment fields.
+			if e.Actor.Type != events.ActorTypeIP {
+				t.Errorf("Actor.Type = %q, want %q", e.Actor.Type, events.ActorTypeIP)
+			}
+			if e.Actor.IP != tt.params.ClientIP {
+				t.Errorf("Actor.IP = %q, want %q", e.Actor.IP, tt.params.ClientIP)
+			}
+			if e.Resource.Type != events.ResourceTypeHTTPEndpoint {
+				t.Errorf("Resource.Type = %q, want %q", e.Resource.Type, events.ResourceTypeHTTPEndpoint)
+			}
+			if e.Resource.Path != tt.params.Path {
+				t.Errorf("Resource.Path = %q, want %q", e.Resource.Path, tt.params.Path)
+			}
+			if e.Resource.Method != tt.params.Method {
+				t.Errorf("Resource.Method = %q, want %q", e.Resource.Method, tt.params.Method)
+			}
+			if e.Outcome != events.OutcomeBlocked {
+				t.Errorf("Outcome = %q, want %q", e.Outcome, events.OutcomeBlocked)
+			}
+			if e.TriggeredBy != "webhook_middleware" {
+				t.Errorf("TriggeredBy = %q, want %q", e.TriggeredBy, "webhook_middleware")
+			}
 		})
 	}
 }

--- a/internal/schema/v1/event.json
+++ b/internal/schema/v1/event.json
@@ -31,6 +31,42 @@
     "payload": {
       "type": "object",
       "description": "Event-specific structured data. The shape depends on event_type; see the conditional schemas below."
+    },
+    "actor": {
+      "$ref": "#/$defs/Actor",
+      "description": "The entity that initiated the action. Omitted for events where the actor is implicit (e.g. system-internal events with no inbound request)."
+    },
+    "resource": {
+      "$ref": "#/$defs/Resource",
+      "description": "The target of the action. Omitted for informational events with no specific target resource."
+    },
+    "outcome": {
+      "type": "string",
+      "description": "The enforcement result of this event.",
+      "enum": ["allowed", "blocked", "rate_limited", "failed"]
+    },
+    "risk_signals": {
+      "type": "array",
+      "description": "Machine-detectable risk indicators associated with this event. Omitted or empty when no risk signals were detected.",
+      "items": {
+        "$ref": "#/$defs/RiskSignal"
+      }
+    },
+    "request_id": {
+      "type": "string",
+      "description": "The inbound request identifier propagated from the client (e.g. the X-Request-ID header value). Omitted when not present."
+    },
+    "trace_id": {
+      "type": "string",
+      "description": "The W3C trace-id of the active OpenTelemetry span at the time the event was emitted. Omitted when no tracing context is available."
+    },
+    "span_id": {
+      "type": "string",
+      "description": "The W3C span-id of the active OpenTelemetry span at the time the event was emitted. Omitted when no tracing context is available."
+    },
+    "triggered_by": {
+      "type": "string",
+      "description": "The internal component or subsystem that raised this event (e.g. 'auth_middleware', 'rate_limit_middleware'). Omitted when the source is implicit from the event_type."
     }
   },
   "allOf": [
@@ -166,6 +202,70 @@
     }
   ],
   "$defs": {
+    "Actor": {
+      "type": "object",
+      "description": "The entity that initiated a security-relevant action.",
+      "required": ["type", "id"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The category of the actor.",
+          "enum": ["ip", "user", "api_key", "system"]
+        },
+        "id": {
+          "type": "string",
+          "description": "The actor's unique identifier within its type namespace."
+        },
+        "ip": {
+          "type": "string",
+          "description": "The client IP address. Present for 'ip' type actors and optionally for 'user' and 'api_key' actors when the source IP is known."
+        }
+      }
+    },
+    "Resource": {
+      "type": "object",
+      "description": "The target of a security-relevant action.",
+      "required": ["type", "path"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The category of the resource.",
+          "enum": ["http_endpoint", "egress_route", "config"]
+        },
+        "path": {
+          "type": "string",
+          "description": "The URL path, route name, or file path of the resource."
+        },
+        "method": {
+          "type": "string",
+          "description": "The HTTP method. Only meaningful when type is 'http_endpoint'."
+        }
+      }
+    },
+    "RiskSignal": {
+      "type": "object",
+      "description": "A single machine-detectable risk indicator.",
+      "required": ["signal", "score", "details"],
+      "additionalProperties": false,
+      "properties": {
+        "signal": {
+          "type": "string",
+          "description": "Stable identifier for the risk pattern (e.g. 'brute_force', 'sqli_attempt', 'prompt_injection')."
+        },
+        "score": {
+          "type": "number",
+          "description": "Normalised risk score in [0.0, 1.0]. Higher values indicate higher confidence.",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "details": {
+          "type": "string",
+          "description": "Human-readable explanation of why this signal was raised."
+        }
+      }
+    },
     "ProxyStartedPayload": {
       "type": "object",
       "description": "Payload for proxy.started events. Emitted once at startup when the reverse proxy is ready to accept connections.",

--- a/schema/v1/event.json
+++ b/schema/v1/event.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://vibewarden.dev/schema/v1/event.json",
   "title": "VibeWarden Event Schema v1",
-  "description": "Schema for all structured log events emitted by the VibeWarden security sidecar. Every event carries five top-level fields: schema_version, event_type, timestamp, ai_summary, and payload. Optional tracing fields (trace_id, span_id) are present when an active OTel span is associated with the event.",
+  "description": "Schema for all structured log events emitted by the VibeWarden security sidecar. Every event carries five required top-level fields: schema_version, event_type, timestamp, ai_summary, and payload. Optional enrichment fields (actor, resource, outcome, risk_signals, request_id, triggered_by, trace_id, span_id) are present when relevant context is available.",
   "type": "object",
   "required": ["schema_version", "event_type", "timestamp", "ai_summary", "payload"],
   "additionalProperties": false,
@@ -31,10 +31,37 @@
       "type": "object",
       "description": "Event-specific structured data. The set of keys is defined per event_type by the if/then constraints in this schema."
     },
+    "actor": {
+      "$ref": "#/$defs/Actor",
+      "description": "The entity that initiated the action. Omitted for events where the actor is implicit or unknown."
+    },
+    "resource": {
+      "$ref": "#/$defs/Resource",
+      "description": "The target of the action. Omitted for informational events with no specific target resource."
+    },
+    "outcome": {
+      "type": "string",
+      "description": "The enforcement result of this event. Omitted for purely informational events where no enforcement decision was taken.",
+      "enum": ["allowed", "blocked", "rate_limited", "failed"]
+    },
+    "risk_signals": {
+      "type": "array",
+      "description": "Machine-detectable risk indicators associated with this event. Omitted or empty when no risk signals were detected.",
+      "items": {
+        "$ref": "#/$defs/RiskSignal"
+      }
+    },
+    "request_id": {
+      "type": "string",
+      "description": "The inbound request identifier propagated from the client (e.g. the X-Request-ID header value). Omitted when not present."
+    },
+    "triggered_by": {
+      "type": "string",
+      "description": "The internal component or subsystem that raised this event (e.g. 'auth_middleware', 'rate_limit_middleware'). Omitted when the source is implicit from the event_type."
+    },
     "trace_id": {
       "type": "string",
-      "description": "OTel W3C trace ID (32 lowercase hex characters). Present only when the event is associated with an active tracing span.",
-      "pattern": "^[0-9a-f]{32}$"
+      "description": "W3C trace ID associated with the active OpenTelemetry span or the inbound request. Present only when tracing context is available."
     },
     "span_id": {
       "type": "string",
@@ -389,6 +416,70 @@
     }
   ],
   "$defs": {
+    "Actor": {
+      "description": "Describes the entity that initiated a security-relevant action.",
+      "type": "object",
+      "required": ["type", "id"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The category of the actor.",
+          "enum": ["ip", "user", "api_key", "system"]
+        },
+        "id": {
+          "type": "string",
+          "description": "The actor's unique identifier within its type namespace: a user ID for 'user', an API key name for 'api_key', an IP address for 'ip', or an empty string for 'system'."
+        },
+        "ip": {
+          "type": "string",
+          "description": "The client IP address. Present for 'ip' actors (where it equals id) and optionally for 'user' and 'api_key' actors when the source IP is known. Omitted for 'system' actors."
+        }
+      }
+    },
+    "Resource": {
+      "description": "Describes the target of a security-relevant action.",
+      "type": "object",
+      "required": ["type", "path"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The category of the resource.",
+          "enum": ["http_endpoint", "egress_route", "config"]
+        },
+        "path": {
+          "type": "string",
+          "description": "The URL path (for HTTP endpoints), route name (for egress routes), or file path (for config)."
+        },
+        "method": {
+          "type": "string",
+          "description": "The HTTP method (e.g. 'GET', 'POST'). Only meaningful when type is 'http_endpoint'. Omitted otherwise."
+        }
+      }
+    },
+    "RiskSignal": {
+      "description": "A single machine-detectable risk indicator associated with a security event.",
+      "type": "object",
+      "required": ["signal", "score", "details"],
+      "additionalProperties": false,
+      "properties": {
+        "signal": {
+          "type": "string",
+          "description": "A stable identifier for the risk pattern (e.g. 'brute_force', 'sqli_attempt', 'prompt_injection')."
+        },
+        "score": {
+          "type": "number",
+          "description": "A normalised risk score in the range [0.0, 1.0]. Higher values indicate higher confidence that the signal is a genuine threat.",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "details": {
+          "type": "string",
+          "description": "A free-form human-readable explanation of why this signal was raised."
+        }
+      }
+    },
     "payload_proxy_started": {
       "description": "Payload for proxy.started — emitted once when the reverse proxy is ready.",
       "type": "object",

--- a/schema/v1/schema_validate_test.go
+++ b/schema/v1/schema_validate_test.go
@@ -461,6 +461,67 @@ func TestSchemaValidation(t *testing.T) {
 				Route: "payments",
 			}),
 		},
+		// --- webhook ---
+		{
+			name: "webhook.signature_valid",
+			event: events.NewWebhookSignatureValid(events.WebhookSignatureValidParams{
+				Path:     "/webhooks/stripe",
+				Method:   "POST",
+				Provider: "stripe",
+				ClientIP: "1.2.3.4",
+			}),
+		},
+		{
+			name: "webhook.signature_invalid",
+			event: events.NewWebhookSignatureInvalid(events.WebhookSignatureInvalidParams{
+				Path:     "/webhooks/github",
+				Method:   "POST",
+				Provider: "github",
+				Reason:   "signature mismatch",
+				ClientIP: "140.82.112.1",
+			}),
+		},
+		// --- config ---
+		{
+			name: "config.reloaded",
+			event: events.NewConfigReloaded(events.ConfigReloadedParams{
+				ConfigPath:    "/etc/vibewarden/vibewarden.yaml",
+				TriggerSource: "file_watcher",
+				DurationMS:    12,
+			}),
+		},
+		{
+			name: "config.reload_failed",
+			event: events.NewConfigReloadFailed(events.ConfigReloadFailedParams{
+				ConfigPath:       "/etc/vibewarden/vibewarden.yaml",
+				TriggerSource:    "file_watcher",
+				Reason:           "validation error",
+				ValidationErrors: []string{"plugins.tls: unknown provider"},
+			}),
+		},
+		// --- llm ---
+		{
+			name: "llm.prompt_injection_blocked",
+			event: events.NewLLMPromptInjectionBlocked(events.LLMPromptInjectionParams{
+				Route:       "openai-chat",
+				Method:      "POST",
+				URL:         "https://api.openai.com/v1/chat/completions",
+				Pattern:     "ignore_previous_instructions",
+				ContentPath: ".messages[0].content",
+				Action:      "block",
+			}),
+		},
+		{
+			name: "llm.prompt_injection_detected",
+			event: events.NewLLMPromptInjectionDetected(events.LLMPromptInjectionParams{
+				Route:       "anthropic",
+				Method:      "POST",
+				URL:         "https://api.anthropic.com/v1/complete",
+				Pattern:     "jailbreak_pattern",
+				ContentPath: ".prompt",
+				Action:      "detect",
+			}),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #704

## Summary

- Add `Actor`, `Resource`, `Outcome`, `RiskSignals`, `RequestID`, `TraceID`, and `TriggeredBy` typed fields to the base `Event` struct in `internal/domain/events/events.go`
- Create `internal/domain/events/enrichment.go` with `Actor`, `Resource`, `ResourceType`, `ActorType`, `Outcome`, and `RiskSignal` types and their constants
- Update all key event constructors to populate enrichment fields:
  - `auth.go` — Actor (user/IP), Resource (http_endpoint), Outcome, RequestID, TraceID, TriggeredBy
  - `ratelimit.go` — Actor (IP/user), Resource, Outcome (rate_limited), RiskSignals, TraceID, TriggeredBy
  - `config.go` — Actor (system), Resource (config), Outcome, TriggeredBy
  - `prompt_injection.go` — Actor (system), Resource (egress_route), Outcome, RiskSignals, TraceID, TriggeredBy
  - `egress.go` — Actor (system), Resource (egress_route), Outcome, TraceID, TriggeredBy for all 6 constructors
  - `egress_sanitized.go` — Actor (system), Resource (egress_route), TraceID, TriggeredBy
  - `webhook.go` — Actor (IP), Resource (http_endpoint), Outcome, TriggeredBy
- Update `internal/adapters/log/slog_adapter.go` to emit all enrichment fields as top-level JSON keys (omitting zero values)
- Update `schema/v1/event.json` (the published schema) to add `actor`, `resource`, `outcome`, `risk_signals`, `request_id`, and `triggered_by` as allowed top-level optional properties, with `Actor`, `Resource`, and `RiskSignal` type definitions in `$defs`; relax the `trace_id` pattern constraint to allow non-hex trace IDs
- Add `internal/domain/events/egress_enrichment_test.go` with tests for all egress constructor enrichment fields
- Expand `internal/domain/events/webhook_test.go` with enrichment field assertions
- Expand `schema/v1/schema_validate_test.go` to validate webhook, config, and LLM events against the schema
- All new fields use `omitempty` — fully backward compatible

## Test plan

- `go test ./...` passes with no failures
- `make check` passes (formatting, golangci-lint, build, race tests, demo-app)
- `schema/v1` validation tests cover all previously-failing event types (auth.success, auth.failed, rate_limit.hit, etc.)
- New enrichment tests verify Actor/Resource/Outcome/TriggeredBy on all updated constructors