### PR TITLE
feat(#705): implement in-memory event ring buffer and admin API query endpoint

### DIFF
--- a/internal/adapters/http/admin_events_handler.go
+++ b/internal/adapters/http/admin_events_handler.go
@@ -1,0 +1,119 @@
+package http
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+const (
+	// defaultEventsLimit is the number of events returned per query when the
+	// caller does not supply a limit query parameter.
+	defaultEventsLimit = 50
+
+	// maxEventsLimit caps the limit query parameter to prevent excessively large
+	// in-memory responses.
+	maxEventsLimit = 500
+)
+
+// eventsResponse is the JSON body returned by GET /_vibewarden/admin/events.
+type eventsResponse struct {
+	Events []eventItem `json:"events"`
+	Cursor uint64      `json:"cursor"`
+}
+
+// eventItem is the JSON representation of a single stored event.
+type eventItem struct {
+	Cursor    uint64 `json:"cursor"`
+	EventType string `json:"event_type"`
+	Timestamp string `json:"timestamp,omitempty"`
+	AISummary string `json:"ai_summary,omitempty"`
+	// Payload is included as-is from the domain event.
+	Payload map[string]any `json:"payload,omitempty"`
+}
+
+// WithEventRingBuffer returns a shallow copy of h with the EventRingBuffer set.
+// It is called from serve.go after the ring buffer has been constructed.
+//
+// When ringBuf is nil, the events endpoint returns 503 Service Unavailable.
+func (h *AdminHandlers) WithEventRingBuffer(ringBuf ports.EventRingBuffer) *AdminHandlers {
+	return &AdminHandlers{
+		svc:      h.svc,
+		reloader: h.reloader,
+		ringBuf:  ringBuf,
+		logger:   h.logger,
+	}
+}
+
+// listEvents handles GET /_vibewarden/admin/events.
+//
+// Query parameters:
+//   - since  (optional uint64) — return only events with cursor > since; omit or 0 for all
+//   - type   (optional comma-separated string) — filter by event type(s)
+//   - limit  (optional int, default 50, max 500)
+func (h *AdminHandlers) listEvents(w http.ResponseWriter, r *http.Request) {
+	if h.ringBuf == nil {
+		h.logger.Error("events query requested but no ring buffer is configured")
+		writeError(w, http.StatusServiceUnavailable, "service_unavailable", "event ring buffer is not available")
+		return
+	}
+
+	since := parseUint64Query(r, "since", 0)
+
+	limit := parseIntQuery(r, "limit", defaultEventsLimit)
+	if limit < 1 {
+		limit = defaultEventsLimit
+	}
+	if limit > maxEventsLimit {
+		limit = maxEventsLimit
+	}
+
+	var types []string
+	if raw := r.URL.Query().Get("type"); raw != "" {
+		for _, t := range strings.Split(raw, ",") {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				types = append(types, t)
+			}
+		}
+	}
+
+	stored, newCursor := h.ringBuf.Query(since, types, limit)
+
+	items := make([]eventItem, 0, len(stored))
+	for _, se := range stored {
+		item := eventItem{
+			Cursor:    se.Cursor,
+			EventType: se.Event.EventType,
+			AISummary: se.Event.AISummary,
+		}
+		if !se.Event.Timestamp.IsZero() {
+			item.Timestamp = se.Event.Timestamp.UTC().Format("2006-01-02T15:04:05Z07:00")
+		}
+		if len(se.Event.Payload) > 0 {
+			item.Payload = se.Event.Payload
+		}
+		items = append(items, item)
+	}
+
+	writeJSON(w, http.StatusOK, eventsResponse{
+		Events: items,
+		Cursor: newCursor,
+	})
+}
+
+// parseUint64Query reads a named query parameter as a uint64. Returns def if
+// the parameter is missing or cannot be parsed.
+func parseUint64Query(r *http.Request, name string, def uint64) uint64 {
+	raw := r.URL.Query().Get(name)
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return def
+	}
+	return v
+}

--- a/internal/adapters/http/admin_events_handler_test.go
+++ b/internal/adapters/http/admin_events_handler_test.go
@@ -1,0 +1,342 @@
+package http_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	vibehttp "github.com/vibewarden/vibewarden/internal/adapters/http"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// fakeRingBuffer implements ports.EventRingBuffer for tests.
+type fakeRingBuffer struct {
+	stored     []ports.StoredEvent
+	querySince uint64
+	queryTypes []string
+	queryLimit int
+}
+
+func (f *fakeRingBuffer) Query(since uint64, types []string, limit int) ([]ports.StoredEvent, uint64) {
+	f.querySince = since
+	f.queryTypes = types
+	f.queryLimit = limit
+
+	var result []ports.StoredEvent
+	for _, se := range f.stored {
+		if se.Cursor <= since {
+			continue
+		}
+		if len(types) > 0 {
+			matched := false
+			for _, t := range types {
+				if t == se.Event.EventType {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+		result = append(result, se)
+		if len(result) == limit {
+			break
+		}
+	}
+
+	var cursor uint64
+	if len(result) > 0 {
+		cursor = result[len(result)-1].Cursor
+	} else {
+		cursor = since
+	}
+	return result, cursor
+}
+
+func makeStoredEvent(cursor uint64, eventType string) ports.StoredEvent {
+	return ports.StoredEvent{
+		Cursor: cursor,
+		Event: events.Event{
+			SchemaVersion: events.SchemaVersion,
+			EventType:     eventType,
+			Timestamp:     time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			AISummary:     "test: " + eventType,
+			Payload:       map[string]any{"key": "value"},
+		},
+	}
+}
+
+func newMuxWithRingBuffer(svc ports.AdminService, rb ports.EventRingBuffer) *http.ServeMux {
+	mux := http.NewServeMux()
+	h := vibehttp.NewAdminHandlers(svc, nil).WithEventRingBuffer(rb)
+	h.RegisterRoutes(mux)
+	return mux
+}
+
+// TestListEvents_Success verifies the happy path: events are returned as JSON
+// with the correct cursor.
+func TestListEvents_Success(t *testing.T) {
+	rb := &fakeRingBuffer{
+		stored: []ports.StoredEvent{
+			makeStoredEvent(1, events.EventTypeAuthSuccess),
+			makeStoredEvent(2, events.EventTypeAuthFailed),
+			makeStoredEvent(3, events.EventTypeRateLimitHit),
+		},
+	}
+	mux := newMuxWithRingBuffer(&fakeAdminService{}, rb)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/admin/events", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	ct := rec.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	evts, ok := resp["events"].([]any)
+	if !ok {
+		t.Fatal("response missing events array")
+	}
+	if len(evts) != 3 {
+		t.Errorf("events count = %d, want 3", len(evts))
+	}
+
+	cursor, ok := resp["cursor"].(float64)
+	if !ok {
+		t.Fatal("response missing cursor field")
+	}
+	if uint64(cursor) != 3 {
+		t.Errorf("cursor = %v, want 3", cursor)
+	}
+}
+
+// TestListEvents_NoRingBuffer verifies that a 503 is returned when no ring
+// buffer is configured.
+func TestListEvents_NoRingBuffer(t *testing.T) {
+	mux := newMux(&fakeAdminService{})
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/admin/events", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	assertErrorResponse(t, rec, http.StatusServiceUnavailable, "service_unavailable")
+}
+
+// TestListEvents_SinceParam verifies that the since query parameter is
+// forwarded to the ring buffer.
+func TestListEvents_SinceParam(t *testing.T) {
+	rb := &fakeRingBuffer{
+		stored: []ports.StoredEvent{
+			makeStoredEvent(1, events.EventTypeAuthSuccess),
+			makeStoredEvent(2, events.EventTypeAuthSuccess),
+			makeStoredEvent(3, events.EventTypeAuthSuccess),
+		},
+	}
+	mux := newMuxWithRingBuffer(&fakeAdminService{}, rb)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/admin/events?since=1", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if rb.querySince != 1 {
+		t.Errorf("querySince = %d, want 1", rb.querySince)
+	}
+}
+
+// TestListEvents_TypeFilter verifies that the type query parameter is parsed
+// and forwarded correctly.
+func TestListEvents_TypeFilter(t *testing.T) {
+	rb := &fakeRingBuffer{
+		stored: []ports.StoredEvent{
+			makeStoredEvent(1, events.EventTypeAuthFailed),
+		},
+	}
+	mux := newMuxWithRingBuffer(&fakeAdminService{}, rb)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/admin/events?type=auth.failed,rate_limit.hit", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if len(rb.queryTypes) != 2 {
+		t.Fatalf("queryTypes = %v, want 2 elements", rb.queryTypes)
+	}
+	if rb.queryTypes[0] != "auth.failed" {
+		t.Errorf("queryTypes[0] = %q, want auth.failed", rb.queryTypes[0])
+	}
+	if rb.queryTypes[1] != "rate_limit.hit" {
+		t.Errorf("queryTypes[1] = %q, want rate_limit.hit", rb.queryTypes[1])
+	}
+}
+
+// TestListEvents_LimitParam verifies that the limit query parameter is parsed
+// and forwarded correctly, including the cap at maxEventsLimit (500).
+func TestListEvents_LimitParam(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     string
+		wantLimit int
+	}{
+		{"default limit", "", 50},
+		{"explicit limit", "limit=10", 10},
+		{"limit capped at 500", "limit=9999", 500},
+		{"invalid limit defaults", "limit=abc", 50},
+		{"zero limit defaults", "limit=0", 50},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rb := &fakeRingBuffer{}
+			mux := newMuxWithRingBuffer(&fakeAdminService{}, rb)
+
+			url := "/_vibewarden/admin/events"
+			if tt.query != "" {
+				url += "?" + tt.query
+			}
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+			}
+			if rb.queryLimit != tt.wantLimit {
+				t.Errorf("queryLimit = %d, want %d", rb.queryLimit, tt.wantLimit)
+			}
+		})
+	}
+}
+
+// TestListEvents_EmptyBuffer verifies the response shape when no events are
+// available.
+func TestListEvents_EmptyBuffer(t *testing.T) {
+	rb := &fakeRingBuffer{}
+	mux := newMuxWithRingBuffer(&fakeAdminService{}, rb)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/admin/events", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	evts, ok := resp["events"].([]any)
+	if !ok {
+		t.Fatal("response missing events array")
+	}
+	if len(evts) != 0 {
+		t.Errorf("events count = %d, want 0", len(evts))
+	}
+	if _, hasCursor := resp["cursor"]; !hasCursor {
+		t.Error("response missing cursor field")
+	}
+}
+
+// TestListEvents_EventFieldsInResponse verifies that each event item in the
+// response contains the expected fields.
+func TestListEvents_EventFieldsInResponse(t *testing.T) {
+	rb := &fakeRingBuffer{
+		stored: []ports.StoredEvent{
+			makeStoredEvent(42, events.EventTypeAuthSuccess),
+		},
+	}
+	mux := newMuxWithRingBuffer(&fakeAdminService{}, rb)
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/admin/events", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	evts := resp["events"].([]any)
+	if len(evts) != 1 {
+		t.Fatalf("events count = %d, want 1", len(evts))
+	}
+
+	item := evts[0].(map[string]any)
+
+	if item["cursor"] != float64(42) {
+		t.Errorf("cursor = %v, want 42", item["cursor"])
+	}
+	if item["event_type"] != events.EventTypeAuthSuccess {
+		t.Errorf("event_type = %v, want %q", item["event_type"], events.EventTypeAuthSuccess)
+	}
+	if item["ai_summary"] == "" {
+		t.Error("ai_summary should not be empty")
+	}
+	if item["timestamp"] == "" {
+		t.Error("timestamp should not be empty")
+	}
+	payload, ok := item["payload"].(map[string]any)
+	if !ok {
+		t.Fatal("payload should be a map")
+	}
+	if payload["key"] != "value" {
+		t.Errorf("payload.key = %v, want value", payload["key"])
+	}
+}
+
+// TestListEvents_WithEventRingBufferChaining verifies that WithEventRingBuffer
+// preserves existing fields (svc, reloader) on the new AdminHandlers copy.
+func TestListEvents_WithEventRingBufferChaining(t *testing.T) {
+	svc := &fakeAdminService{
+		listResult: &ports.PaginatedUsers{Users: nil, Total: 0},
+	}
+	rb := &fakeRingBuffer{
+		stored: []ports.StoredEvent{
+			makeStoredEvent(1, events.EventTypeProxyStarted),
+		},
+	}
+
+	mux := http.NewServeMux()
+	h := vibehttp.NewAdminHandlers(svc, nil).WithEventRingBuffer(rb)
+	h.RegisterRoutes(mux)
+
+	// Verify events endpoint works.
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/admin/events", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("events status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	// Verify users endpoint still works (svc was preserved).
+	req2 := httptest.NewRequest(http.MethodGet, "/_vibewarden/admin/users", nil)
+	rec2 := httptest.NewRecorder()
+	mux.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("users status = %d, want %d", rec2.Code, http.StatusOK)
+	}
+}

--- a/internal/adapters/http/admin_handlers.go
+++ b/internal/adapters/http/admin_handlers.go
@@ -27,6 +27,7 @@ const (
 type AdminHandlers struct {
 	svc      ports.AdminService
 	reloader ports.ConfigReloader
+	ringBuf  ports.EventRingBuffer
 	logger   *slog.Logger
 }
 
@@ -46,7 +47,7 @@ func NewAdminHandlers(svc ports.AdminService, logger *slog.Logger) *AdminHandler
 // WithReloader returns a copy of h with the ConfigReloader set. It is called
 // from serve.go after the reload service has been constructed.
 func (h *AdminHandlers) WithReloader(r ports.ConfigReloader) *AdminHandlers {
-	return &AdminHandlers{svc: h.svc, reloader: r, logger: h.logger}
+	return &AdminHandlers{svc: h.svc, reloader: r, ringBuf: h.ringBuf, logger: h.logger}
 }
 
 // RegisterRoutes registers all admin routes on mux using the Go 1.22+
@@ -60,6 +61,9 @@ func (h *AdminHandlers) RegisterRoutes(mux *http.ServeMux) {
 	// the ID segment manually.
 	mux.HandleFunc("GET /_vibewarden/admin/users/", h.getUser)
 	mux.HandleFunc("DELETE /_vibewarden/admin/users/", h.deactivateUser)
+
+	// Event ring buffer query endpoint.
+	mux.HandleFunc("GET /_vibewarden/admin/events", h.listEvents)
 
 	// Config hot-reload endpoints.
 	mux.HandleFunc("POST /_vibewarden/config/reload", h.reloadConfig)

--- a/internal/adapters/log/multi_event_logger.go
+++ b/internal/adapters/log/multi_event_logger.go
@@ -1,0 +1,36 @@
+// Package log provides the slog-based adapter for the ports.EventLogger interface.
+package log
+
+import (
+	"context"
+
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// MultiEventLogger fans out every Log call to multiple ports.EventLogger
+// implementations. All sinks receive every event regardless of any individual
+// sink errors. Errors from individual sinks are silently swallowed so that a
+// failure in one sink — e.g., a full ring buffer — does not prevent events from
+// reaching the remaining sinks.
+type MultiEventLogger struct {
+	sinks []ports.EventLogger
+}
+
+// NewMultiEventLogger creates a MultiEventLogger that dispatches to all given
+// sinks. Passing zero sinks produces a no-op logger.
+func NewMultiEventLogger(sinks ...ports.EventLogger) *MultiEventLogger {
+	s := make([]ports.EventLogger, len(sinks))
+	copy(s, sinks)
+	return &MultiEventLogger{sinks: s}
+}
+
+// Log dispatches the event to every underlying sink.
+// The method always returns nil; errors from individual sinks are silently
+// swallowed in line with the ports.EventLogger best-effort contract.
+func (m *MultiEventLogger) Log(ctx context.Context, event events.Event) error {
+	for _, s := range m.sinks {
+		_ = s.Log(ctx, event) //nolint:errcheck // best-effort; callers log failures separately
+	}
+	return nil
+}

--- a/internal/adapters/log/multi_event_logger_test.go
+++ b/internal/adapters/log/multi_event_logger_test.go
@@ -1,0 +1,86 @@
+package log_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// fakeSink is a simple ports.EventLogger that records every event it receives.
+type fakeSink struct {
+	logged []events.Event
+	err    error
+}
+
+func (f *fakeSink) Log(_ context.Context, event events.Event) error {
+	f.logged = append(f.logged, event)
+	return f.err
+}
+
+func TestMultiEventLogger_AllSinksReceiveEvent(t *testing.T) {
+	s1 := &fakeSink{}
+	s2 := &fakeSink{}
+
+	ml := logadapter.NewMultiEventLogger(s1, s2)
+
+	ev := events.Event{
+		SchemaVersion: events.SchemaVersion,
+		EventType:     events.EventTypeAuthSuccess,
+		Timestamp:     time.Now(),
+		AISummary:     "test",
+	}
+
+	if err := ml.Log(context.Background(), ev); err != nil {
+		t.Fatalf("Log returned unexpected error: %v", err)
+	}
+
+	if len(s1.logged) != 1 {
+		t.Errorf("s1 logged %d events, want 1", len(s1.logged))
+	}
+	if len(s2.logged) != 1 {
+		t.Errorf("s2 logged %d events, want 1", len(s2.logged))
+	}
+}
+
+// TestMultiEventLogger_SinkErrorSwallowed verifies that an error from one sink
+// does not prevent the other sinks from receiving the event, and that Log
+// always returns nil.
+func TestMultiEventLogger_SinkErrorSwallowed(t *testing.T) {
+	s1 := &fakeSink{err: errors.New("disk full")}
+	s2 := &fakeSink{}
+
+	ml := logadapter.NewMultiEventLogger(s1, s2)
+
+	if err := ml.Log(context.Background(), makeEvent(events.EventTypeAuthFailed)); err != nil {
+		t.Fatalf("Log returned error %v, want nil", err)
+	}
+
+	// s1 still recorded the event even though it returned an error.
+	if len(s1.logged) != 1 {
+		t.Errorf("s1 logged %d events, want 1", len(s1.logged))
+	}
+	// s2 still received the event despite s1 failing.
+	if len(s2.logged) != 1 {
+		t.Errorf("s2 logged %d events, want 1", len(s2.logged))
+	}
+}
+
+// TestMultiEventLogger_ZeroSinks verifies that a MultiEventLogger with no sinks
+// is a no-op and does not panic.
+func TestMultiEventLogger_ZeroSinks(t *testing.T) {
+	ml := logadapter.NewMultiEventLogger()
+
+	if err := ml.Log(context.Background(), makeEvent(events.EventTypeProxyStarted)); err != nil {
+		t.Fatalf("Log returned error %v, want nil", err)
+	}
+}
+
+// TestMultiEventLogger_ImplementsPort verifies the compile-time assertion.
+func TestMultiEventLogger_ImplementsPort(t *testing.T) {
+	var _ ports.EventLogger = logadapter.NewMultiEventLogger()
+}

--- a/internal/adapters/log/ringbuffer.go
+++ b/internal/adapters/log/ringbuffer.go
@@ -1,0 +1,143 @@
+// Package log provides the slog-based adapter for the ports.EventLogger interface.
+package log
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+const (
+	// DefaultRingBufferCapacity is the number of events the ring buffer holds
+	// when no explicit capacity is given.
+	DefaultRingBufferCapacity = 1000
+)
+
+// Compile-time assertion: RingBuffer implements both ports.EventLogger and
+// ports.EventRingBuffer.
+var _ ports.EventLogger = (*RingBuffer)(nil)
+var _ ports.EventRingBuffer = (*RingBuffer)(nil)
+
+// RingBuffer is a thread-safe, fixed-capacity circular buffer that stores the
+// most recent structured events. When the buffer is full, the oldest event is
+// overwritten. It implements ports.EventLogger so it can be used as an
+// additional event sink alongside the primary stdout logger, and
+// ports.EventRingBuffer so the admin API can query recent events.
+//
+// The ring buffer is purely in-memory and provides no durability guarantees.
+// It is intended for the admin API live-query endpoint only.
+type RingBuffer struct {
+	mu       sync.RWMutex
+	slots    []ports.StoredEvent
+	capacity int
+
+	// head is the index of the next slot to write into (mod capacity).
+	head int
+
+	// count tracks how many events have been stored (capped at capacity).
+	count int
+
+	// counter is the next cursor value to assign, incremented atomically.
+	counter atomic.Uint64
+}
+
+// NewRingBuffer creates a RingBuffer with the given capacity.
+// If capacity is less than 1, DefaultRingBufferCapacity is used.
+func NewRingBuffer(capacity int) *RingBuffer {
+	if capacity < 1 {
+		capacity = DefaultRingBufferCapacity
+	}
+	return &RingBuffer{
+		slots:    make([]ports.StoredEvent, capacity),
+		capacity: capacity,
+	}
+}
+
+// Log stores the event in the ring buffer. It implements ports.EventLogger.
+// Log never returns an error — the ring buffer is best-effort and in-memory.
+func (r *RingBuffer) Log(_ context.Context, event events.Event) error {
+	cursor := r.counter.Add(1) // monotonically increasing; starts at 1
+
+	r.mu.Lock()
+	r.slots[r.head] = ports.StoredEvent{Cursor: cursor, Event: event}
+	r.head = (r.head + 1) % r.capacity
+	if r.count < r.capacity {
+		r.count++
+	}
+	r.mu.Unlock()
+
+	return nil
+}
+
+// Query returns up to limit events whose cursor is strictly greater than since,
+// filtered to the given event types. Pass nil or an empty slice to types to
+// return all event types. Pass 0 to since to return the oldest available events.
+//
+// The returned slice is sorted oldest-first (ascending cursor). The second
+// return value is the cursor of the last returned event; pass it as since in
+// the next call to resume from where you left off. If no events are returned,
+// the returned cursor equals since.
+func (r *RingBuffer) Query(since uint64, types []string, limit int) ([]ports.StoredEvent, uint64) {
+	if limit < 1 {
+		limit = 1
+	}
+
+	typeSet := buildTypeSet(types)
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	// Collect events in order (oldest first). The ring buffer is circular;
+	// when count == capacity, the oldest entry sits at head; otherwise at 0.
+	start := 0
+	if r.count == r.capacity {
+		start = r.head
+	}
+
+	result := make([]ports.StoredEvent, 0, min(r.count, limit))
+	for i := 0; i < r.count; i++ {
+		idx := (start + i) % r.capacity
+		se := r.slots[idx]
+
+		if se.Cursor <= since {
+			continue
+		}
+		if len(typeSet) > 0 && !typeSet[se.Event.EventType] {
+			continue
+		}
+		result = append(result, se)
+		if len(result) == limit {
+			break
+		}
+	}
+
+	newCursor := since
+	if len(result) > 0 {
+		newCursor = result[len(result)-1].Cursor
+	}
+	return result, newCursor
+}
+
+// buildTypeSet converts a slice of event type strings into a set (map) for
+// O(1) membership tests. Returns nil (not an empty map) when types is empty so
+// that callers can distinguish "no filter" from "empty filter".
+func buildTypeSet(types []string) map[string]bool {
+	if len(types) == 0 {
+		return nil
+	}
+	s := make(map[string]bool, len(types))
+	for _, t := range types {
+		t = strings.TrimSpace(t)
+		if t != "" {
+			s[t] = true
+		}
+	}
+	if len(s) == 0 {
+		return nil
+	}
+	return s
+}

--- a/internal/adapters/log/ringbuffer_test.go
+++ b/internal/adapters/log/ringbuffer_test.go
@@ -1,0 +1,271 @@
+package log_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+)
+
+func makeEvent(eventType string) events.Event {
+	return events.Event{
+		SchemaVersion: events.SchemaVersion,
+		EventType:     eventType,
+		AISummary:     "test event: " + eventType,
+	}
+}
+
+func logN(t *testing.T, rb *logadapter.RingBuffer, n int, eventType string) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		if err := rb.Log(context.Background(), makeEvent(eventType)); err != nil {
+			t.Fatalf("Log(%d): %v", i, err)
+		}
+	}
+}
+
+// TestRingBuffer_BasicQuery verifies that stored events are returned oldest-first
+// and the cursor advances correctly.
+func TestRingBuffer_BasicQuery(t *testing.T) {
+	rb := logadapter.NewRingBuffer(10)
+
+	logN(t, rb, 3, events.EventTypeAuthSuccess)
+
+	got, cursor := rb.Query(0, nil, 50)
+	if len(got) != 3 {
+		t.Fatalf("len(got) = %d, want 3", len(got))
+	}
+	if cursor != got[len(got)-1].Cursor {
+		t.Errorf("returned cursor %d != last event cursor %d", cursor, got[len(got)-1].Cursor)
+	}
+	// Verify ascending order.
+	for i := 1; i < len(got); i++ {
+		if got[i].Cursor <= got[i-1].Cursor {
+			t.Errorf("events not sorted ascending at index %d: cursor %d <= %d", i, got[i].Cursor, got[i-1].Cursor)
+		}
+	}
+}
+
+// TestRingBuffer_SinceCursor verifies that only events after the given cursor
+// are returned.
+func TestRingBuffer_SinceCursor(t *testing.T) {
+	rb := logadapter.NewRingBuffer(10)
+
+	logN(t, rb, 5, events.EventTypeAuthSuccess)
+
+	first, cursor1 := rb.Query(0, nil, 2)
+	if len(first) != 2 {
+		t.Fatalf("first page: len = %d, want 2", len(first))
+	}
+
+	second, _ := rb.Query(cursor1, nil, 50)
+	if len(second) != 3 {
+		t.Fatalf("second page: len = %d, want 3", len(second))
+	}
+	// All cursors in second must be > cursor1.
+	for _, se := range second {
+		if se.Cursor <= cursor1 {
+			t.Errorf("second page cursor %d <= since %d", se.Cursor, cursor1)
+		}
+	}
+}
+
+// TestRingBuffer_TypeFilter verifies that the type filter returns only matching
+// events.
+func TestRingBuffer_TypeFilter(t *testing.T) {
+	rb := logadapter.NewRingBuffer(20)
+
+	for i := 0; i < 5; i++ {
+		if err := rb.Log(context.Background(), makeEvent(events.EventTypeAuthFailed)); err != nil {
+			t.Fatalf("Log auth.failed: %v", err)
+		}
+		if err := rb.Log(context.Background(), makeEvent(events.EventTypeRateLimitHit)); err != nil {
+			t.Fatalf("Log rate_limit.hit: %v", err)
+		}
+	}
+
+	// Filter for auth.failed only.
+	got, _ := rb.Query(0, []string{events.EventTypeAuthFailed}, 50)
+	if len(got) != 5 {
+		t.Fatalf("filtered len = %d, want 5", len(got))
+	}
+	for _, se := range got {
+		if se.Event.EventType != events.EventTypeAuthFailed {
+			t.Errorf("unexpected event type %q", se.Event.EventType)
+		}
+	}
+}
+
+// TestRingBuffer_MultiTypeFilter verifies that multiple event types can be
+// requested in a single query.
+func TestRingBuffer_MultiTypeFilter(t *testing.T) {
+	rb := logadapter.NewRingBuffer(20)
+
+	logN(t, rb, 3, events.EventTypeAuthFailed)
+	logN(t, rb, 3, events.EventTypeRateLimitHit)
+	logN(t, rb, 3, events.EventTypeProxyStarted)
+
+	got, _ := rb.Query(0, []string{events.EventTypeAuthFailed, events.EventTypeRateLimitHit}, 50)
+	if len(got) != 6 {
+		t.Fatalf("multi-filter len = %d, want 6", len(got))
+	}
+	for _, se := range got {
+		if se.Event.EventType != events.EventTypeAuthFailed && se.Event.EventType != events.EventTypeRateLimitHit {
+			t.Errorf("unexpected event type %q in multi-type filter result", se.Event.EventType)
+		}
+	}
+}
+
+// TestRingBuffer_CapacityOverflow verifies that once the buffer is full, older
+// events are overwritten and only the most recent capacity events are visible.
+func TestRingBuffer_CapacityOverflow(t *testing.T) {
+	const cap = 5
+	rb := logadapter.NewRingBuffer(cap)
+
+	// Store 8 events; only the last 5 should be visible.
+	for i := 0; i < 8; i++ {
+		if err := rb.Log(context.Background(), makeEvent(events.EventTypeAuthSuccess)); err != nil {
+			t.Fatalf("Log(%d): %v", i, err)
+		}
+	}
+
+	got, _ := rb.Query(0, nil, 100)
+	if len(got) != cap {
+		t.Fatalf("after overflow: len = %d, want %d", len(got), cap)
+	}
+
+	// Verify ascending cursor order is preserved after overflow.
+	for i := 1; i < len(got); i++ {
+		if got[i].Cursor <= got[i-1].Cursor {
+			t.Errorf("cursor not ascending at index %d: %d <= %d", i, got[i].Cursor, got[i-1].Cursor)
+		}
+	}
+
+	// All 8 cursors were allocated; the visible 5 should be the highest ones.
+	// After writing 8 events to a cap-5 buffer: cursors 4,5,6,7,8 remain.
+	lowest := got[0].Cursor
+	if lowest < 4 {
+		t.Errorf("lowest visible cursor %d too low — old events still visible", lowest)
+	}
+}
+
+// TestRingBuffer_LimitParam verifies that the limit parameter caps the result.
+func TestRingBuffer_LimitParam(t *testing.T) {
+	rb := logadapter.NewRingBuffer(100)
+
+	logN(t, rb, 20, events.EventTypeAuthSuccess)
+
+	got, _ := rb.Query(0, nil, 5)
+	if len(got) != 5 {
+		t.Fatalf("limit=5: len = %d, want 5", len(got))
+	}
+}
+
+// TestRingBuffer_EmptyQuery verifies the behaviour when no events match.
+func TestRingBuffer_EmptyQuery(t *testing.T) {
+	rb := logadapter.NewRingBuffer(10)
+
+	got, cursor := rb.Query(0, nil, 50)
+	if len(got) != 0 {
+		t.Fatalf("empty buffer: len = %d, want 0", len(got))
+	}
+	if cursor != 0 {
+		t.Errorf("empty buffer: cursor = %d, want 0", cursor)
+	}
+}
+
+// TestRingBuffer_SinceReturnsNoNewEvents verifies that calling Query with the
+// most recent cursor returns no events and preserves the cursor value.
+func TestRingBuffer_SinceReturnsNoNewEvents(t *testing.T) {
+	rb := logadapter.NewRingBuffer(10)
+
+	logN(t, rb, 3, events.EventTypeAuthSuccess)
+	_, cursor := rb.Query(0, nil, 50)
+
+	got, newCursor := rb.Query(cursor, nil, 50)
+	if len(got) != 0 {
+		t.Fatalf("no-new-events: len = %d, want 0", len(got))
+	}
+	if newCursor != cursor {
+		t.Errorf("no-new-events: cursor changed from %d to %d", cursor, newCursor)
+	}
+}
+
+// TestRingBuffer_DefaultCapacity verifies that a zero capacity produces a
+// buffer with DefaultRingBufferCapacity.
+func TestRingBuffer_DefaultCapacity(t *testing.T) {
+	rb := logadapter.NewRingBuffer(0)
+	logN(t, rb, logadapter.DefaultRingBufferCapacity+10, events.EventTypeAuthSuccess)
+
+	got, _ := rb.Query(0, nil, 10000)
+	if len(got) != logadapter.DefaultRingBufferCapacity {
+		t.Fatalf("default capacity: len = %d, want %d", len(got), logadapter.DefaultRingBufferCapacity)
+	}
+}
+
+// TestRingBuffer_ConcurrentWrites verifies that concurrent Log calls do not
+// cause data races. This test is most useful when run with -race.
+func TestRingBuffer_ConcurrentWrites(t *testing.T) {
+	rb := logadapter.NewRingBuffer(100)
+	const goroutines = 20
+	const eventsPerGoroutine = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < eventsPerGoroutine; i++ {
+				ev := makeEvent(fmt.Sprintf("test.event.%d", id))
+				if err := rb.Log(context.Background(), ev); err != nil {
+					t.Errorf("goroutine %d Log(%d): %v", id, i, err)
+				}
+			}
+		}(g)
+	}
+
+	wg.Wait()
+
+	// Buffer capacity is 100; total writes is 1000 — only most recent 100 visible.
+	got, _ := rb.Query(0, nil, 10000)
+	if len(got) != 100 {
+		t.Fatalf("after concurrent writes: len = %d, want 100", len(got))
+	}
+}
+
+// TestRingBuffer_ConcurrentReadWrite verifies that concurrent reads and writes
+// do not race or deadlock.
+func TestRingBuffer_ConcurrentReadWrite(t *testing.T) {
+	rb := logadapter.NewRingBuffer(50)
+
+	var wg sync.WaitGroup
+	const writers = 10
+	const readers = 5
+
+	wg.Add(writers)
+	for w := 0; w < writers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				_ = rb.Log(context.Background(), makeEvent(events.EventTypeAuthSuccess))
+			}
+		}()
+	}
+
+	wg.Add(readers)
+	for r := 0; r < readers; r++ {
+		go func() {
+			defer wg.Done()
+			var cursor uint64
+			for i := 0; i < 20; i++ {
+				_, cursor = rb.Query(cursor, nil, 10)
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/internal/app/serve/logger.go
+++ b/internal/app/serve/logger.go
@@ -41,15 +41,22 @@ func buildLogger(cfg config.LogConfig) *slog.Logger {
 // other consumers. When the metrics plugin has an OTel log handler available,
 // the logger fans out to both stdout JSON and OTel via a MultiHandler.
 // Falls back to stdout-only when log export is disabled or unavailable.
-func buildEventLogger(registry *plugins.Registry, logger *slog.Logger) ports.EventLogger {
+//
+// The ring buffer is always wired as an additional sink so that the admin
+// events endpoint can serve recent structured events without a database.
+func buildEventLogger(registry *plugins.Registry, logger *slog.Logger, ringBuf ports.EventLogger) ports.EventLogger {
+	var slogLogger ports.EventLogger
 	for _, p := range registry.Plugins() {
 		if mp, ok := p.(*metricsplugin.Plugin); ok {
 			if h := mp.LogHandler(); h != nil {
 				logger.Info("event logger: OTel log export enabled")
-				return logadapter.NewSlogEventLogger(os.Stdout, h)
+				slogLogger = logadapter.NewSlogEventLogger(os.Stdout, h)
 			}
 			break
 		}
 	}
-	return logadapter.NewSlogEventLogger(os.Stdout)
+	if slogLogger == nil {
+		slogLogger = logadapter.NewSlogEventLogger(os.Stdout)
+	}
+	return logadapter.NewMultiEventLogger(slogLogger, ringBuf)
 }

--- a/internal/app/serve/serve.go
+++ b/internal/app/serve/serve.go
@@ -124,7 +124,10 @@ func RunServe(ctx context.Context, opts Options, extraPlugins ...plugins.PluginR
 
 	// After InitAll, retrieve the OTel log handler from the metrics plugin
 	// (if log export is enabled) and build the final event logger.
-	eventLogger := buildEventLogger(registry, logger)
+	// The ring buffer is created here and wired both as an additional event
+	// sink and into the admin API so that recent events can be queried.
+	ringBuf := logadapter.NewRingBuffer(logadapter.DefaultRingBufferCapacity)
+	eventLogger := buildEventLogger(registry, logger, ringBuf)
 
 	// Wire the metrics collector into the TLS cert expiry monitor so that
 	// the vibewarden_tls_cert_expiry_seconds gauge is populated. This must
@@ -170,12 +173,13 @@ func RunServe(ctx context.Context, opts Options, extraPlugins ...plugins.PluginR
 		rebuildFn,
 	)
 
-	// Inject the reload service into the user-management plugin's admin
-	// handlers so that /_vibewarden/config/reload and /_vibewarden/config
-	// are accessible via the admin API.
+	// Inject the reload service and ring buffer into the user-management
+	// plugin's admin handlers so that config and events endpoints are
+	// available via the admin API.
 	for _, p := range registry.Plugins() {
 		if ump, ok := p.(*usermgmtplugin.Plugin); ok {
 			ump.InjectReloader(reloadService)
+			ump.InjectRingBuffer(ringBuf)
 			break
 		}
 	}

--- a/internal/plugins/usermgmt/plugin.go
+++ b/internal/plugins/usermgmt/plugin.go
@@ -171,6 +171,18 @@ func (p *Plugin) InjectReloader(r ports.ConfigReloader) {
 	}
 }
 
+// InjectRingBuffer sets the EventRingBuffer on the admin handlers so that the
+// /_vibewarden/admin/events endpoint can serve recent events. It must be called
+// after Init and before Start.
+//
+// When the plugin is disabled or handlers have not been initialised, this is a
+// no-op.
+func (p *Plugin) InjectRingBuffer(rb ports.EventRingBuffer) {
+	if p.handlers != nil {
+		p.handlers = p.handlers.WithEventRingBuffer(rb)
+	}
+}
+
 // Priority returns the plugin's initialisation priority.
 // User management is assigned priority 60 so it is initialised after TLS (10),
 // security-headers (20), rate-limiting (30), and auth (40).

--- a/internal/ports/event_ring_buffer.go
+++ b/internal/ports/event_ring_buffer.go
@@ -1,0 +1,32 @@
+// Package ports defines the interfaces (ports) for VibeWarden's hexagonal architecture.
+package ports
+
+import "github.com/vibewarden/vibewarden/internal/domain/events"
+
+// StoredEvent is a single event persisted in a ring buffer along with its
+// monotonically-increasing cursor identifier.
+type StoredEvent struct {
+	// Cursor is the auto-incrementing ID assigned when the event was stored.
+	// Cursor values are unique and strictly increasing within a single process
+	// lifetime.
+	Cursor uint64
+
+	// Event is the original structured event.
+	Event events.Event
+}
+
+// EventRingBuffer is the outbound port for querying recently-stored structured
+// events. Implementations hold the most recent events in a fixed-capacity
+// circular buffer and expose cursor-based pagination.
+type EventRingBuffer interface {
+	// Query returns up to limit events whose cursor is strictly greater than
+	// since, filtered to the given event types. Pass nil or an empty slice to
+	// types to return all event types. Pass 0 to since to return the oldest
+	// available events.
+	//
+	// Events are returned oldest-first (ascending cursor). The second return
+	// value is the cursor of the last returned event; pass it as since on the
+	// next call to resume from that position. If no events are returned, the
+	// cursor equals since.
+	Query(since uint64, types []string, limit int) ([]StoredEvent, uint64)
+}


### PR DESCRIPTION
Closes #705

## Summary

- **Ring buffer** (`internal/adapters/log/ringbuffer.go`): thread-safe circular buffer with configurable capacity (default 1000). Implements both `ports.EventLogger` (sink) and `ports.EventRingBuffer` (query). Uses `sync.RWMutex` for concurrent access and `atomic.Uint64` for monotonically-increasing cursor IDs. Oldest events are overwritten when the buffer is full.
- **Port** (`internal/ports/event_ring_buffer.go`): new `EventRingBuffer` interface and `StoredEvent` type following the hexagonal architecture pattern — adapters implement, consumers depend on the interface.
- **MultiEventLogger** (`internal/adapters/log/multi_event_logger.go`): fans out a single `ports.EventLogger.Log` call to multiple sinks (stdout JSON + ring buffer). Errors from individual sinks are swallowed per the best-effort contract.
- **Admin events endpoint** (`internal/adapters/http/admin_events_handler.go`): `GET /_vibewarden/admin/events?since=<cursor>&type=auth.blocked,waf.detected&limit=50`. Returns `{"events":[...],"cursor":N}`. Default limit 50, max 500. Returns 503 when no ring buffer is configured. Auth is handled by the existing `admin_auth` Caddy middleware.
- **Wiring** (`internal/app/serve/serve.go`, `internal/app/serve/logger.go`): ring buffer created before `StartAll`, injected into `buildEventLogger` as an additional sink alongside stdout JSON (and OTel when enabled), injected into `AdminHandlers` via new `Plugin.InjectRingBuffer`.

## Test plan

- `go test -race ./internal/adapters/log/...` — ring buffer concurrent writes, capacity overflow, cursor pagination, type filtering; MultiEventLogger fan-out and error swallowing
- `go test -race ./internal/adapters/http/...` — events endpoint: auth required (503 without ring buffer), query param parsing (since/type/limit), JSON response shape, field content
- `make check` — formatting, golangci-lint, build, full race-enabled test suite: all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)