### PR TITLE
fix(#757): remove --lang flag references from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ all in a single binary that sits next to your app.
 curl -sS https://vibewarden.dev/install.sh | sh
 
 # Create a new project — multi-stage Dockerfile builds everything automatically
-vibew init --lang go myapp
+vibew init myapp
 cd myapp
 vibew dev
 ```
@@ -214,7 +214,7 @@ If you need a general-purpose load balancer or a CDN edge, use the right tool fo
 
 | Scenario | Command |
 |----------|---------|
-| Starting a new project | `vibew init --lang go myapp` |
+| Starting a new project | `vibew init myapp` |
 | Adding the sidecar to an existing app | `vibew wrap` |
 | Adding a feature to an existing config | `vibew add <feature>` |
 
@@ -228,7 +228,7 @@ add VibeWarden. Use `vibew add` to enable individual features after the initial 
 
 | Command | Description |
 |---------|-------------|
-| `vibew init --lang <lang> <name>` | Scaffold a new project with VibeWarden |
+| `vibew init <name>` | Scaffold a new project with VibeWarden |
 | `vibew wrap` | Add VibeWarden sidecar to an existing project |
 | `vibew add auth` | Enable authentication |
 | `vibew add rate-limiting` | Enable rate limiting |

--- a/docs/claude-md-snippet.md
+++ b/docs/claude-md-snippet.md
@@ -27,11 +27,11 @@ the network layer. Do not implement any of the following in application code:
 If the feature maps to a VibeWarden plugin, enable it there instead of
 writing application code. Plugin docs: https://vibewarden.dev/docs
 
-**When scaffolding a new project with `vibewarden init`**, always pass
-`--lang` explicitly. The flag is required — omitting it returns an error.
-Supported values: `go`. Example:
+**When scaffolding a new project**, use `vibew init <name>` to create a new
+project directory, or `vibew init .` to scaffold in the current directory.
+Example:
 
 ```sh
-vibewarden init --lang go myproject
+vibew init myproject
 ```
 ```

--- a/docs/deploy-to-vps.md
+++ b/docs/deploy-to-vps.md
@@ -109,7 +109,7 @@ curl -fsSL https://vibewarden.dev/vibew > vibew && chmod +x vibew
 
 ```bash
 mkdir myapp && cd myapp
-./vibew init --name myapp --lang go --upstream 3000 --auth --rate-limit
+./vibew init myapp --upstream 3000 --auth --rate-limit
 ```
 
 **Existing app:**

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ and explains what happens under the hood.
 
 | Scenario | Command |
 |----------|---------|
-| Starting a new project | `vibew init --lang go myapp` |
+| Starting a new project | `vibew init myapp` |
 | Adding the sidecar to an existing app | `vibew wrap` |
 | Adding a feature to an existing config | `vibew add <feature>` |
 

--- a/internal/cli/cmd/main_test.go
+++ b/internal/cli/cmd/main_test.go
@@ -12,7 +12,7 @@ import (
 // and restore it via t.Cleanup.
 func TestMain(m *testing.M) {
 	// In test runs stdin is never a real TTY; force non-interactive mode so that
-	// tests which omit --lang receive a proper error rather than a prompt read.
+	// tests run non-interactively without prompting for user input.
 	cmd.IsTTY = func(*os.File) bool { return false }
 	os.Exit(m.Run())
 }

--- a/internal/cli/cmd/require_config.go
+++ b/internal/cli/cmd/require_config.go
@@ -27,7 +27,7 @@ func requireConfig(configPath string) error {
 	}
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return fmt.Errorf("vibewarden.yaml not found\n\nRun one of:\n  vibew init --name myapp --lang go    # new project\n  vibew wrap --upstream 3000           # existing project\n\nThese commands generate the required config, Dockerfile, and agent context files")
+		return fmt.Errorf("vibewarden.yaml not found\n\nRun one of:\n  vibew init myapp                     # new project\n  vibew wrap --upstream 3000           # existing project\n\nThese commands generate the required config, Dockerfile, and agent context files")
 	}
 
 	return nil
@@ -46,7 +46,7 @@ func requireConfig(configPath string) error {
 func RequireScaffolding(dir string) error {
 	path := filepath.Join(dir, scaffoldingMarker)
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return fmt.Errorf("vibewarden not initialized in this directory\n\nRun one of:\n  vibew init --name myapp --lang go    # new project\n  vibew wrap --upstream 3000           # existing project\n\nThese commands generate the required config, Dockerfile, and agent context files")
+		return fmt.Errorf("vibewarden not initialized in this directory\n\nRun one of:\n  vibew init myapp                     # new project\n  vibew wrap --upstream 3000           # existing project\n\nThese commands generate the required config, Dockerfile, and agent context files")
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #757

## Summary

- Removed all `--lang` flag references from `README.md`, `docs/getting-started.md`, `docs/deploy-to-vps.md`, and `docs/claude-md-snippet.md`
- Replaced `vibew init --lang go myapp` / `vibew init --name myapp --lang go` with `vibew init myapp`
- Removed the CLI reference table entry `vibew init --lang <lang> <name>` — updated to `vibew init <name>`
- Replaced the `claude-md-snippet.md` paragraph that stated `--lang` was required with accurate usage of `vibew init <name>` or `vibew init .`

## Test plan

- `make check` passes (build, lint, tests all green)
- Grep for `--lang` in the four changed files returns no matches