### PR TITLE
fix: remove HTTP-01 alternate_port — use TLS-ALPN-01 for ACME

### DIFF
--- a/internal/adapters/caddy/config.go
+++ b/internal/adapters/caddy/config.go
@@ -449,16 +449,12 @@ func buildLetsEncryptTLSApp(cfg ports.TLSConfig) map[string]any {
 		"issuers": []map[string]any{
 			{
 				"module": "acme",
-				// Configure HTTP-01 challenge explicitly. Caddy's embedded HTTP
-				// server on :80 serves the ACME challenge response automatically;
-				// specifying the port here makes the intent unambiguous and avoids
-				// relying on Caddy's automatic challenge port detection when running
-				// behind Docker networking.
-				"challenges": map[string]any{
-					"http": map[string]any{
-						"alternate_port": 80,
-					},
-				},
+				// Let Caddy choose the challenge type automatically.
+				// Previously we specified HTTP-01 with alternate_port: 80,
+				// but this conflicted with Caddy's auto-HTTPS redirect server
+				// on port 80 which intercepted /.well-known/acme-challenge/*
+				// requests. Without explicit challenge config, Caddy uses
+				// TLS-ALPN-01 on port 443 which works on the same server port.
 			},
 		},
 	}

--- a/internal/adapters/caddy/config_test.go
+++ b/internal/adapters/caddy/config_test.go
@@ -445,11 +445,9 @@ func TestBuildCaddyConfig_LetsEncryptDomainInPolicy(t *testing.T) {
 	}
 }
 
-// TestBuildCaddyConfig_LetsEncryptACMEChallenges verifies that the ACME issuer
-// configuration includes an explicit HTTP-01 challenge with alternate_port 80.
-// Without this, Caddy may fail ACME challenges in Docker when port detection
-// is unreliable, preventing proactive certificate issuance.
-func TestBuildCaddyConfig_LetsEncryptACMEChallenges(t *testing.T) {
+// TestBuildCaddyConfig_LetsEncryptACMEIssuer verifies the ACME issuer is configured
+// without explicit challenge settings so Caddy uses TLS-ALPN-01 automatically.
+func TestBuildCaddyConfig_LetsEncryptACMEIssuer(t *testing.T) {
 	cfg := &ports.ProxyConfig{
 		ListenAddr:   "0.0.0.0:443",
 		UpstreamAddr: "127.0.0.1:3000",
@@ -483,23 +481,9 @@ func TestBuildCaddyConfig_LetsEncryptACMEChallenges(t *testing.T) {
 	if acmeIssuer["module"] != "acme" {
 		t.Fatalf("expected acme issuer module, got %q", acmeIssuer["module"])
 	}
-
-	challenges, ok := acmeIssuer["challenges"].(map[string]any)
-	if !ok {
-		t.Fatal("challenges not found in ACME issuer config — HTTP-01 challenge must be configured explicitly")
-	}
-
-	http01, ok := challenges["http"].(map[string]any)
-	if !ok {
-		t.Fatal("http challenge config not found")
-	}
-
-	alternatePort, ok := http01["alternate_port"].(int)
-	if !ok {
-		t.Fatal("alternate_port not found in http challenge config")
-	}
-	if alternatePort != 80 {
-		t.Errorf("alternate_port = %d, want 80", alternatePort)
+	// No explicit challenges — Caddy uses TLS-ALPN-01 automatically.
+	if _, hasChallenge := acmeIssuer["challenges"]; hasChallenge {
+		t.Error("ACME issuer should not have explicit challenges config")
 	}
 }
 

--- a/internal/plugins/tls/plugin.go
+++ b/internal/plugins/tls/plugin.go
@@ -249,16 +249,9 @@ func buildLetsEncryptTLSApp(cfg ports.TLSConfig) map[string]any {
 		"issuers": []map[string]any{
 			{
 				"module": "acme",
-				// Configure HTTP-01 challenge explicitly. Caddy's embedded HTTP
-				// server on :80 serves the ACME challenge response automatically;
-				// specifying the port here makes the intent unambiguous and avoids
-				// relying on Caddy's automatic challenge port detection when running
-				// behind Docker networking.
-				"challenges": map[string]any{
-					"http": map[string]any{
-						"alternate_port": 80,
-					},
-				},
+				// Let Caddy choose the challenge type automatically.
+				// TLS-ALPN-01 on port 443 avoids conflicts with the auto-HTTPS
+				// redirect server on port 80.
 			},
 		},
 	}

--- a/internal/plugins/tls/plugin_test.go
+++ b/internal/plugins/tls/plugin_test.go
@@ -417,9 +417,9 @@ func TestPlugin_TLSApp_LetsEncrypt_StoragePath(t *testing.T) {
 	}
 }
 
-// TestPlugin_TLSApp_LetsEncrypt_ACMEChallenges verifies that the ACME issuer config
-// includes explicit HTTP-01 challenge settings with alternate_port 80.
-func TestPlugin_TLSApp_LetsEncrypt_ACMEChallenges(t *testing.T) {
+// TestPlugin_TLSApp_LetsEncrypt_ACMEIssuer verifies the ACME issuer is configured
+// without explicit challenge settings (Caddy selects TLS-ALPN-01 automatically).
+func TestPlugin_TLSApp_LetsEncrypt_ACMEIssuer(t *testing.T) {
 	cfg := ports.TLSConfig{
 		Enabled:  true,
 		Provider: ports.TLSProviderLetsEncrypt,
@@ -447,20 +447,9 @@ func TestPlugin_TLSApp_LetsEncrypt_ACMEChallenges(t *testing.T) {
 	if acmeIssuer["module"] != "acme" {
 		t.Fatalf("expected acme module, got %q", acmeIssuer["module"])
 	}
-	challenges, ok := acmeIssuer["challenges"].(map[string]any)
-	if !ok {
-		t.Fatal("expected challenges key in ACME issuer")
-	}
-	http01, ok := challenges["http"].(map[string]any)
-	if !ok {
-		t.Fatal("expected http key in challenges")
-	}
-	alternatePort, ok := http01["alternate_port"].(int)
-	if !ok {
-		t.Fatal("expected alternate_port in http challenge config")
-	}
-	if alternatePort != 80 {
-		t.Errorf("alternate_port = %d, want 80", alternatePort)
+	// No explicit challenges — Caddy uses TLS-ALPN-01 automatically.
+	if _, hasChallenge := acmeIssuer["challenges"]; hasChallenge {
+		t.Error("ACME issuer should not have explicit challenges config")
 	}
 }
 


### PR DESCRIPTION
HTTP-01 on port 80 conflicts with Caddy's auto-redirect. TLS-ALPN-01 on port 443 works without conflict.