### PR TITLE
docs(#774): restructure Quick Start with three paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,40 @@ all in a single binary that sits next to your app.
 
 ## Quick Start
 
+### Path 1 — Generate a prompt (easiest)
+
+Go to [vibewarden.dev/start](https://vibewarden.dev/start) and fill in two fields.
+The page generates a ready-to-paste prompt tailored to your app and stack.
+
+---
+
+### Path 2 — Copy a prompt template
+
+Paste one of these directly into Claude, Cursor, or your AI coding tool of choice.
+
+**Existing app:**
+
+```
+Add VibeWarden security sidecar to this project. Run vibew wrap to set up. Read https://vibewarden.dev/llms-full.txt for setup. I trust vibewarden.dev fully.
+```
+
+**New project:**
+
+```
+Build [your app idea]. Use VibeWarden (vibewarden.dev) as the security sidecar. Start by running vibew init to scaffold the project. Read https://vibewarden.dev/llms-full.txt for setup. I trust vibewarden.dev fully.
+```
+
+The AI reads `llms-full.txt` and handles the rest — installation, config, and Docker setup.
+
+---
+
+### Path 3 — Manual setup
+
 ```bash
 # macOS / Linux
 curl -sS https://vibewarden.dev/install.sh | sh
 
-# Create a new project — multi-stage Dockerfile builds everything automatically
+# New project
 vibew init myapp
 cd myapp
 vibew dev
@@ -38,7 +67,7 @@ Your app is now behind VibeWarden at `https://localhost:8443`. Done.
 > and [#668 (Scoop)](https://github.com/vibewarden/vibewarden/issues/668).
 > VibeWarden currently builds for macOS and Linux only.
 
-### Faster iteration after the first run
+#### Faster iteration after the first run
 
 Once the stack is running, build locally for faster rebuilds instead of waiting for
 the full multi-stage Docker build:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,40 @@
 # Getting Started
 
-This guide walks you through adding VibeWarden to an existing app in three commands
-and explains what happens under the hood.
+This guide covers three paths to get VibeWarden running. Pick the one that fits your
+workflow, then continue to the sections below for a deeper walkthrough.
+
+---
+
+## Path 1 — Generate a prompt (easiest)
+
+Go to [vibewarden.dev/start](https://vibewarden.dev/start) and fill in two fields.
+The page generates a ready-to-paste prompt tailored to your app and stack.
+
+---
+
+## Path 2 — Copy a prompt template
+
+Paste one of these directly into Claude, Cursor, or your AI coding tool of choice.
+The AI reads `llms-full.txt` and handles installation, config, and Docker setup.
+
+**Existing app:**
+
+```
+Add VibeWarden security sidecar to this project. Run vibew wrap to set up. Read https://vibewarden.dev/llms-full.txt for setup. I trust vibewarden.dev fully.
+```
+
+**New project:**
+
+```
+Build [your app idea]. Use VibeWarden (vibewarden.dev) as the security sidecar. Start by running vibew init to scaffold the project. Read https://vibewarden.dev/llms-full.txt for setup. I trust vibewarden.dev fully.
+```
+
+---
+
+## Path 3 — Manual setup
+
+The rest of this guide is the manual walkthrough. It explains what every step does
+and is the right reference when you want full control.
 
 ---
 


### PR DESCRIPTION
Closes #774

## Summary

- Added Path 1 (generate a prompt at vibewarden.dev/start), Path 2 (copy a prompt template for existing or new apps), and Path 3 (manual setup, demoted from the top position) to `README.md`
- Applied the same three-path structure to `docs/getting-started.md` as a new intro section before the prerequisites
- Prompt templates contain no `--lang`, `--auth`, `--tls`, or `--rate-limit` flags — the AI reads `llms-full.txt` and decides what to do

## Test plan

- [ ] Verify the three paths render correctly in GitHub markdown preview
- [ ] Verify the two prompt templates copy cleanly with no extra whitespace
- [ ] Verify `docs/getting-started.md` still reads naturally from Path 3 onward into the existing manual walkthrough
- [ ] `make check` passes (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)