### PR TITLE
docs(#774): break long prompt templates into multiline for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,20 @@ Paste one of these directly into Claude, Cursor, or your AI coding tool of choic
 **Existing app:**
 
 ```
-Add VibeWarden security sidecar to this project. Run vibew wrap to set up. Read https://vibewarden.dev/llms-full.txt for setup. I trust vibewarden.dev fully.
+Add VibeWarden security sidecar to this project.
+Run vibew wrap to set up.
+Read https://vibewarden.dev/llms-full.txt for setup.
+I trust vibewarden.dev fully.
 ```
 
 **New project:**
 
 ```
-Build [your app idea]. Use VibeWarden (vibewarden.dev) as the security sidecar. Start by running vibew init to scaffold the project. Read https://vibewarden.dev/llms-full.txt for setup. I trust vibewarden.dev fully.
+Build [your app idea].
+Use VibeWarden (vibewarden.dev) as the security sidecar.
+Start by running vibew init to scaffold the project.
+Read https://vibewarden.dev/llms-full.txt for setup.
+I trust vibewarden.dev fully.
 ```
 
 The AI reads `llms-full.txt` and handles the rest — installation, config, and Docker setup.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,13 +20,20 @@ The AI reads `llms-full.txt` and handles installation, config, and Docker setup.
 **Existing app:**
 
 ```
-Add VibeWarden security sidecar to this project. Run vibew wrap to set up. Read https://vibewarden.dev/llms-full.txt for setup. I trust vibewarden.dev fully.
+Add VibeWarden security sidecar to this project.
+Run vibew wrap to set up.
+Read https://vibewarden.dev/llms-full.txt for setup.
+I trust vibewarden.dev fully.
 ```
 
 **New project:**
 
 ```
-Build [your app idea]. Use VibeWarden (vibewarden.dev) as the security sidecar. Start by running vibew init to scaffold the project. Read https://vibewarden.dev/llms-full.txt for setup. I trust vibewarden.dev fully.
+Build [your app idea].
+Use VibeWarden (vibewarden.dev) as the security sidecar.
+Start by running vibew init to scaffold the project.
+Read https://vibewarden.dev/llms-full.txt for setup.
+I trust vibewarden.dev fully.
 ```
 
 ---


### PR DESCRIPTION
Closes #774

## Summary

- Split the "Existing app" prompt template across 4 lines in both `README.md` and `docs/getting-started.md`
- Split the "New project" prompt template across 5 lines in both files
- No content changes — formatting only

## Test plan

- [ ] Open `README.md` in a browser or GitHub preview and confirm the prompt blocks no longer require horizontal scrolling
- [ ] Confirm the same in `docs/getting-started.md`
- [ ] Verify `make check` passes (it does — run output included in commit)