### PR TITLE
fix(#779): remove stale flags from docs

### DIFF
--- a/docs/deploy-to-vps.md
+++ b/docs/deploy-to-vps.md
@@ -109,7 +109,9 @@ curl -fsSL https://vibewarden.dev/vibew > vibew && chmod +x vibew
 
 ```bash
 mkdir myapp && cd myapp
-./vibew init myapp --upstream 3000 --auth --rate-limit
+vibew init myapp
+vibew add auth
+vibew add tls --domain myapp.example.com
 ```
 
 **Existing app:**

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -115,8 +115,6 @@ Common flags:
 | `--rate-limit` | Enable rate limiting |
 | `--tls --domain example.com` | Enable TLS (requires `--domain`) |
 | `--force` | Overwrite existing files |
-| `--skip-wrapper` | Skip vibew wrapper script generation |
-| `--agent <type>` | Generate AI context files: `claude`, `cursor`, `generic`, `all`, or `none` |
 
 ### What `wrap` generates
 


### PR DESCRIPTION
Init doesn't have --auth/--tls/--agent/--skip-wrapper. Fixed in docs, getting-started, deploy-to-vps, and llms-full.txt.