### PR TITLE
fix(#783): generate .dockerignore in vibew init

### DIFF
--- a/internal/app/scaffold/init_project.go
+++ b/internal/app/scaffold/init_project.go
@@ -59,6 +59,7 @@ func NewInitProjectService(renderer ports.TemplateRenderer, _ any) *InitProjectS
 //	├── AGENTS-VIBEWARDEN.md       (vibew-owned, regenerated on updates)
 //	├── vibewarden.yaml
 //	├── Dockerfile                 (generic placeholder)
+//	├── .dockerignore
 //	├── .gitignore
 //	└── .vibewarden-version
 //
@@ -120,6 +121,14 @@ func (s *InitProjectService) InitProject(ctx context.Context, parentDir string, 
 			return fmt.Errorf("rendering Dockerfile: %w", err)
 		}
 		return fmt.Errorf("dockerfile already exists; use --force to overwrite: %w", err)
+	}
+
+	// Render .dockerignore.
+	if err := s.renderer.RenderToFile("init-dockerignore.tmpl", data, filepath.Join(projectDir, ".dockerignore"), opts.Force); err != nil {
+		if !errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("rendering .dockerignore: %w", err)
+		}
+		return fmt.Errorf(".dockerignore already exists; use --force to overwrite: %w", err)
 	}
 
 	// Render .gitignore.

--- a/internal/app/scaffold/init_project_shared_templates_test.go
+++ b/internal/app/scaffold/init_project_shared_templates_test.go
@@ -180,6 +180,51 @@ func TestInitProject_SharedTemplatesWithRealFS(t *testing.T) {
 	}
 }
 
+// TestInitProject_DockerIgnore_WithRealFS verifies that the real embedded template
+// renders a .dockerignore containing all required exclusion patterns.
+func TestInitProject_DockerIgnore_WithRealFS(t *testing.T) {
+	r := mustBuildRealRenderer(t)
+	svc := scaffoldapp.NewInitProjectService(r, nil)
+
+	parent := t.TempDir()
+	opts := scaffoldapp.InitProjectOptions{
+		ProjectName: "dockerignoreapp",
+		Port:        3000,
+	}
+
+	if err := svc.InitProject(context.Background(), parent, opts); err != nil {
+		t.Fatalf("InitProject() unexpected error: %v", err)
+	}
+
+	dockerignorePath := filepath.Join(parent, "dockerignoreapp", ".dockerignore")
+	data, err := os.ReadFile(dockerignorePath)
+	if err != nil {
+		t.Fatalf("reading .dockerignore: %v", err)
+	}
+	content := string(data)
+
+	mustContain := []string{
+		".git",
+		".vibewarden",
+		"node_modules",
+		"__pycache__",
+		"*.pyc",
+		".env",
+		".env.*",
+		"vendor",
+		"target",
+		"dist",
+		"build",
+		".idea",
+		".vscode",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(content, want) {
+			t.Errorf(".dockerignore missing %q\nContent:\n%s", want, content)
+		}
+	}
+}
+
 // TestInitProject_WithRealFS_Description verifies that the real templates render
 // the description into PROJECT.md and AGENTS-VIBEWARDEN.md.
 func TestInitProject_WithRealFS_Description(t *testing.T) {

--- a/internal/app/scaffold/init_project_test.go
+++ b/internal/app/scaffold/init_project_test.go
@@ -33,6 +33,7 @@ func TestInitProject_CreatesStructure(t *testing.T) {
 	// Verify core files.
 	mustExist(t, parent, "myapp", "vibewarden.yaml")
 	mustExist(t, parent, "myapp", "Dockerfile")
+	mustExist(t, parent, "myapp", ".dockerignore")
 	mustExist(t, parent, "myapp", ".gitignore")
 	mustExist(t, parent, "myapp", ".vibewarden-version")
 }
@@ -502,6 +503,45 @@ func TestInitProject_NoClaudeCommandsDir(t *testing.T) {
 	claudeCommandsDir := filepath.Join(parent, "nocommands", ".claude", "commands")
 	if _, err := os.Stat(claudeCommandsDir); err == nil {
 		t.Errorf(".claude/commands/ directory must not be created, but it exists at %s", claudeCommandsDir)
+	}
+}
+
+// TestInitProject_DockerIgnore_RenderError verifies that a render error for
+// .dockerignore propagates correctly.
+func TestInitProject_DockerIgnore_RenderError(t *testing.T) {
+	renderer := newSelectiveErrorRenderer("init-dockerignore.tmpl", errors.New("disk full"))
+	svc := scaffoldapp.NewInitProjectService(renderer, nil)
+
+	parent := t.TempDir()
+	opts := scaffoldapp.InitProjectOptions{
+		ProjectName: "dierr",
+		Port:        3000,
+	}
+
+	err := svc.InitProject(context.Background(), parent, opts)
+	if err == nil {
+		t.Fatal("expected error from .dockerignore render, got nil")
+	}
+}
+
+// TestInitProject_DockerIgnore_RenderExistError verifies that an os.ErrExist error
+// from .dockerignore render propagates wrapped.
+func TestInitProject_DockerIgnore_RenderExistError(t *testing.T) {
+	renderer := newSelectiveErrorRenderer("init-dockerignore.tmpl", fmt.Errorf("file exists: %w", os.ErrExist))
+	svc := scaffoldapp.NewInitProjectService(renderer, nil)
+
+	parent := t.TempDir()
+	opts := scaffoldapp.InitProjectOptions{
+		ProjectName: "diexist",
+		Port:        3000,
+	}
+
+	err := svc.InitProject(context.Background(), parent, opts)
+	if err == nil {
+		t.Fatal("expected error from .dockerignore ErrExist, got nil")
+	}
+	if !errors.Is(err, os.ErrExist) {
+		t.Errorf("expected errors.Is(err, os.ErrExist), got: %v", err)
 	}
 }
 

--- a/internal/cli/templates/init-dockerignore.tmpl
+++ b/internal/cli/templates/init-dockerignore.tmpl
@@ -1,0 +1,30 @@
+# Version control
+.git
+
+# VibeWarden runtime
+.vibewarden
+
+# Node.js
+node_modules
+
+# Python
+__pycache__
+*.pyc
+
+# Environment files
+.env
+.env.*
+
+# Go vendor directory
+vendor
+
+# Java / Kotlin build output
+target
+
+# Build artefacts
+dist
+build
+
+# IDE
+.idea
+.vscode


### PR DESCRIPTION
Closes #783

## Summary

- Add `internal/cli/templates/init-dockerignore.tmpl` with exclusions for `.git`, `.vibewarden`, `node_modules`, `__pycache__`, `*.pyc`, `.env`, `.env.*`, `vendor`, `target`, `dist`, `build`, `.idea`, and `.vscode`
- Render `.dockerignore` in `InitProject` immediately after `Dockerfile` generation, with the same `--force` / `os.ErrExist` handling used by all other rendered files
- Update docstring on `InitProject` to list `.dockerignore` in the generated structure

## Test plan

- `TestInitProject_CreatesStructure` — extended to assert `.dockerignore` exists
- `TestInitProject_DockerIgnore_RenderError` — non-ErrExist render error propagates
- `TestInitProject_DockerIgnore_RenderExistError` — `os.ErrExist` wraps correctly
- `TestInitProject_DockerIgnore_WithRealFS` — real embedded template renders all required patterns
- `make check` passes (lint + build + tests + demo-app)