### PR TITLE
fix(#784): default WAF to enabled=true, mode=detect (log-only)

### DIFF
--- a/internal/cli/templates/vibewarden.yaml.tmpl
+++ b/internal/cli/templates/vibewarden.yaml.tmpl
@@ -84,6 +84,16 @@ rate_limit:
     - "/ready"
 {{- end }}
 
+
+waf:
+  enabled: true
+  mode: detect  # "detect" logs attacks without blocking; change to "block" to enforce
+  rules:
+    sqli: true
+    xss: true
+    path_traversal: true
+    command_injection: true
+
 # Escape hatches — uncomment to supply hand-crafted config files instead of
 # relying on VibeWarden's runtime generation. Paths are relative to the
 # .vibewarden/generated/ directory.


### PR DESCRIPTION
Closes #784

## Summary

- `waf.enabled` default changed from `false` to `true`
- `waf.mode` default changed from `"block"` to `"detect"` (log-only, no blocking)
- Updated godoc comments on `WAFConfig.Enabled` and `WAFConfig.Mode` to reflect new defaults
- Added a `waf` section to the `vibewarden wrap` template so generated configs explicitly show the new defaults and the escape-hatch comment

## Test plan

- `TestLoad_WAFDefaults` — asserts all six WAF default fields against their expected values after loading with no config file
- `TestLoad_WAFModeOverride` — three table-driven cases: explicit `mode: block`, `enabled: false` opt-out, and no WAF section at all (uses defaults)
- `make check` passes: lint, build, and full test suite green