### PR TITLE
fix(#781): broaden default CSP to allow unsafe-inline for styles and scripts

### DIFF
--- a/internal/cli/templates/init-vibewarden.yaml.tmpl
+++ b/internal/cli/templates/init-vibewarden.yaml.tmpl
@@ -29,7 +29,7 @@ security_headers:
   hsts_preload: false
   content_type_nosniff: true
   frame_option: "SAMEORIGIN"
-  content_security_policy: "default-src 'self'"
+  content_security_policy: "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'"
   referrer_policy: "strict-origin-when-cross-origin"
   permissions_policy: "geolocation=(), microphone=(), camera=()"
 

--- a/internal/cli/templates/vibewarden.yaml.tmpl
+++ b/internal/cli/templates/vibewarden.yaml.tmpl
@@ -29,7 +29,7 @@ security_headers:
   hsts_preload: false
   content_type_nosniff: true
   frame_option: "SAMEORIGIN"
-  content_security_policy: "default-src 'self'"
+  content_security_policy: "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'"
   referrer_policy: "strict-origin-when-cross-origin"
   permissions_policy: "geolocation=(), microphone=(), camera=()"
 {{- if .TLSEnabled }}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -81,7 +81,7 @@ security_headers:
   hsts_max_age: 0
   content_type_nosniff: true
   frame_option: "DENY"
-  content_security_policy: "default-src 'self'"
+  content_security_policy: "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'"
   referrer_policy: "strict-origin-when-cross-origin"
 
 telemetry:
@@ -330,7 +330,7 @@ func testSecurityHeaders(t *testing.T, s *stack) {
 	}{
 		{"X-Content-Type-Options", "nosniff"},
 		{"X-Frame-Options", "DENY"},
-		{"Content-Security-Policy", "default-src 'self'"},
+		{"Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'"},
 		{"Referrer-Policy", "strict-origin-when-cross-origin"},
 	}
 


### PR DESCRIPTION
Closes #781

## Summary

- Updated `internal/cli/templates/vibewarden.yaml.tmpl` (generated by `vibew wrap`) to use the new default CSP: `default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'`
- Updated `internal/cli/templates/init-vibewarden.yaml.tmpl` (generated by `vibew init`) with the same new default CSP
- Updated `test/e2e/e2e_test.go` to match the new CSP value in both the inline config fixture and the header assertion

The runtime default in `internal/config/config.go` is already empty (CSP opt-in), so no change was needed there. The templates are the source of the broken default that users see immediately after `vibew init` or `vibew wrap`.

## Test plan

- [ ] `go build ./...` — passes
- [ ] `go vet ./...` — passes
- [ ] `golangci-lint run ./...` — 0 issues
- [ ] `go test -race ./...` — all green (confirmed via pre-push hook)
- [ ] Run `vibew init` on a fresh project and verify the generated `vibewarden.yaml` contains the new CSP string
- [ ] Run `vibew wrap` on an existing project and verify the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)