### PR TITLE
feat(#788): add vibewarden_stream_logs MCP tool with filtered event streaming

### DIFF
--- a/internal/mcp/stream_logs.go
+++ b/internal/mcp/stream_logs.go
@@ -1,0 +1,306 @@
+package mcp
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// vibewarden_stream_logs
+// ---------------------------------------------------------------------------
+
+// severityOrder maps severity label to a numeric rank for comparison.
+// Higher rank means higher severity.
+var severityOrder = map[string]int{
+	"low":      1,
+	"medium":   2,
+	"high":     3,
+	"critical": 4,
+}
+
+// streamLogsToolDef returns the ToolDefinition for vibewarden_stream_logs.
+func streamLogsToolDef() ToolDefinition {
+	return ToolDefinition{
+		Name: "vibewarden_stream_logs",
+		Description: "Retrieve filtered structured log events from the VibeWarden sidecar. " +
+			"Supports filtering by event type prefix (e.g. \"waf\" matches \"waf.detected\" and \"waf.blocked\"), " +
+			"minimum severity level, and a look-back duration. " +
+			"The ai_summary field is prominently included in every result event.",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"url": {
+					Type:        "string",
+					Description: "Base URL of the VibeWarden sidecar, e.g. 'https://localhost:8443'.",
+				},
+				"admin_token": {
+					Type:        "string",
+					Description: "Bearer token for the admin API (set via admin.token in vibewarden.yaml).",
+				},
+				"event_type": {
+					Type:        "string",
+					Description: "Filter by event type prefix. \"waf\" matches \"waf.detected\", \"waf.blocked\", etc. Omit to return all event types.",
+				},
+				"severity": {
+					Type:        "string",
+					Description: "Minimum severity to include: \"low\", \"medium\", \"high\", or \"critical\". Omit to return all severities.",
+				},
+				"since": {
+					Type:        "string",
+					Description: "Look-back duration, e.g. \"5m\" or \"1h\". Only events newer than now minus this duration are returned. Omit to return the latest events regardless of age.",
+				},
+				"limit": {
+					Type:        "number",
+					Description: "Maximum number of events to return after filtering (default 50, max 500).",
+				},
+			},
+			Required: []string{"url", "admin_token"},
+		},
+	}
+}
+
+// streamLogsArgs holds the parsed arguments for vibewarden_stream_logs.
+type streamLogsArgs struct {
+	URL        string `json:"url"`
+	AdminToken string `json:"admin_token"`
+	EventType  string `json:"event_type,omitempty"`
+	Severity   string `json:"severity,omitempty"`
+	Since      string `json:"since,omitempty"`
+	Limit      *int   `json:"limit,omitempty"`
+}
+
+// streamLogsResponse is the JSON structure returned by vibewarden_stream_logs.
+type streamLogsResponse struct {
+	Events  []streamLogEvent `json:"events"`
+	Count   int              `json:"count"`
+	Filters streamLogFilters `json:"filters"`
+}
+
+// streamLogFilters records which filters were applied so the caller can see at a
+// glance which criteria were used.
+type streamLogFilters struct {
+	EventType string `json:"event_type,omitempty"`
+	Severity  string `json:"severity,omitempty"`
+	Since     string `json:"since,omitempty"`
+	Limit     int    `json:"limit"`
+}
+
+// streamLogEvent is a single event returned by vibewarden_stream_logs.
+// The AISummary field is hoisted to the top level so AI agents see it first.
+type streamLogEvent struct {
+	AISummary string          `json:"ai_summary"`
+	EventType string          `json:"event_type"`
+	Timestamp string          `json:"timestamp"`
+	Severity  string          `json:"severity,omitempty"`
+	Outcome   string          `json:"outcome,omitempty"`
+	Raw       json.RawMessage `json:"raw"`
+}
+
+// rawEventEnvelope is used to extract well-known top-level fields from a raw
+// event JSON object without allocating for the full payload.
+type rawEventEnvelope struct {
+	AISummary string `json:"ai_summary"`
+	EventType string `json:"event_type"`
+	Timestamp string `json:"timestamp"`
+	Severity  string `json:"severity"`
+	Outcome   string `json:"outcome"`
+}
+
+// handleStreamLogs implements the vibewarden_stream_logs MCP tool.
+// It fetches events from the sidecar admin API and applies client-side
+// filtering by event_type prefix, minimum severity, and since duration.
+func handleStreamLogs(ctx context.Context, params json.RawMessage) ([]ContentItem, error) {
+	var args streamLogsArgs
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &args); err != nil {
+			return nil, fmt.Errorf("invalid arguments: %w", err)
+		}
+	}
+
+	if args.URL == "" {
+		return nil, fmt.Errorf("url is required")
+	}
+	if args.AdminToken == "" {
+		return nil, fmt.Errorf("admin_token is required")
+	}
+
+	// Validate severity value if provided.
+	if args.Severity != "" {
+		if _, ok := severityOrder[args.Severity]; !ok {
+			return nil, fmt.Errorf("severity must be one of: low, medium, high, critical; got %q", args.Severity)
+		}
+	}
+
+	// Parse since duration if provided.
+	var sinceTime *time.Time
+	if args.Since != "" {
+		d, err := time.ParseDuration(args.Since)
+		if err != nil {
+			return nil, fmt.Errorf("since must be a valid Go duration (e.g. \"5m\", \"1h\"): %w", err)
+		}
+		t := time.Now().UTC().Add(-d)
+		sinceTime = &t
+	}
+
+	limit := 50
+	if args.Limit != nil {
+		limit = *args.Limit
+		if limit < 1 {
+			limit = 1
+		}
+		if limit > 500 {
+			limit = 500
+		}
+	}
+
+	// Fetch a larger batch from the endpoint so we have enough raw events to
+	// fill the requested limit after client-side filtering.
+	fetchLimit := limit * 4
+	if fetchLimit < 200 {
+		fetchLimit = 200
+	}
+	if fetchLimit > 500 {
+		fetchLimit = 500
+	}
+
+	endpoint := strings.TrimRight(args.URL, "/") + "/_vibewarden/admin/events"
+	endpoint += "?limit=" + strconv.Itoa(fetchLimit)
+
+	// Use InsecureSkipVerify so the tool works with self-signed TLS certificates,
+	// which is the default for local VibeWarden sidecars.
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // intentional for local sidecar
+	}
+	client := &http.Client{
+		Timeout:   15 * time.Second,
+		Transport: transport,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return text("Failed to build request to admin events endpoint."), nil
+	}
+
+	// Set the bearer token -- it must never appear in any response or error text.
+	req.Header.Set("Authorization", "Bearer "+args.AdminToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		// Do NOT include the raw error as it can contain the URL with token context.
+		return text("Cannot reach the sidecar admin API. Ensure the sidecar is running and the url is correct."), nil
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return text("Authentication failed -- check admin token."), nil
+	case http.StatusServiceUnavailable:
+		return text("Sidecar event ring buffer is not available. The sidecar may still be starting up."), nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return text(fmt.Sprintf("Admin events endpoint returned HTTP %d. Check that the sidecar is healthy.", resp.StatusCode)), nil
+	}
+
+	var payload adminEventsPayload
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return text("Failed to decode events response from sidecar."), nil
+	}
+
+	// Apply client-side filters.
+	filtered := filterEvents(payload.Events, args.EventType, args.Severity, sinceTime, limit)
+
+	result := streamLogsResponse{
+		Events: filtered,
+		Count:  len(filtered),
+		Filters: streamLogFilters{
+			EventType: args.EventType,
+			Severity:  args.Severity,
+			Since:     args.Since,
+			Limit:     limit,
+		},
+	}
+
+	out, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshalling stream logs response: %w", err)
+	}
+
+	return text(string(out)), nil
+}
+
+// filterEvents applies event_type prefix, severity, and since filters to a
+// slice of raw events, returning at most limit shaped streamLogEvent values.
+func filterEvents(
+	raw []json.RawMessage,
+	eventTypePrefix string,
+	minSeverity string,
+	since *time.Time,
+	limit int,
+) []streamLogEvent {
+	minRank := 0
+	if minSeverity != "" {
+		minRank = severityOrder[minSeverity]
+	}
+
+	var result []streamLogEvent
+
+	for _, r := range raw {
+		if len(result) >= limit {
+			break
+		}
+
+		var env rawEventEnvelope
+		if err := json.Unmarshal(r, &env); err != nil {
+			// Skip malformed events.
+			continue
+		}
+
+		// Filter by event_type prefix.
+		if eventTypePrefix != "" {
+			prefix := strings.ToLower(eventTypePrefix)
+			et := strings.ToLower(env.EventType)
+			if et != prefix && !strings.HasPrefix(et, prefix+".") {
+				continue
+			}
+		}
+
+		// Filter by minimum severity.
+		if minRank > 0 {
+			eventRank := severityOrder[strings.ToLower(env.Severity)]
+			if eventRank < minRank {
+				continue
+			}
+		}
+
+		// Filter by since timestamp.
+		if since != nil && env.Timestamp != "" {
+			ts, err := time.Parse(time.RFC3339, env.Timestamp)
+			if err == nil && ts.Before(*since) {
+				continue
+			}
+		}
+
+		result = append(result, streamLogEvent{
+			AISummary: env.AISummary,
+			EventType: env.EventType,
+			Timestamp: env.Timestamp,
+			Severity:  env.Severity,
+			Outcome:   env.Outcome,
+			Raw:       r,
+		})
+	}
+
+	if result == nil {
+		result = []streamLogEvent{}
+	}
+
+	return result
+}

--- a/internal/mcp/stream_logs_test.go
+++ b/internal/mcp/stream_logs_test.go
@@ -1,0 +1,666 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// filterEvents unit tests
+// ---------------------------------------------------------------------------
+
+func TestFilterEvents_NoFilters(t *testing.T) {
+	raw := mustMarshalEvents([]map[string]any{
+		{"event_type": "auth.success", "ai_summary": "auth ok", "timestamp": "2026-04-03T10:00:00Z"},
+		{"event_type": "waf.detected", "ai_summary": "waf hit", "timestamp": "2026-04-03T10:00:01Z"},
+	})
+
+	got := filterEvents(raw, "", "", nil, 50)
+	if len(got) != 2 {
+		t.Errorf("expected 2 events, got %d", len(got))
+	}
+}
+
+func TestFilterEvents_EventTypePrefixExact(t *testing.T) {
+	raw := mustMarshalEvents([]map[string]any{
+		{"event_type": "auth.success", "ai_summary": "ok"},
+		{"event_type": "waf.detected", "ai_summary": "waf"},
+	})
+
+	got := filterEvents(raw, "auth", "", nil, 50)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(got))
+	}
+	if got[0].EventType != "auth.success" {
+		t.Errorf("EventType = %q, want %q", got[0].EventType, "auth.success")
+	}
+}
+
+func TestFilterEvents_EventTypePrefixMultiple(t *testing.T) {
+	raw := mustMarshalEvents([]map[string]any{
+		{"event_type": "waf.detected", "ai_summary": "d"},
+		{"event_type": "waf.blocked", "ai_summary": "b"},
+		{"event_type": "auth.success", "ai_summary": "a"},
+		{"event_type": "waf.allowed", "ai_summary": "al"},
+	})
+
+	got := filterEvents(raw, "waf", "", nil, 50)
+	if len(got) != 3 {
+		t.Errorf("expected 3 waf.* events, got %d", len(got))
+	}
+	for _, e := range got {
+		if !strings.HasPrefix(e.EventType, "waf.") {
+			t.Errorf("unexpected event type %q", e.EventType)
+		}
+	}
+}
+
+func TestFilterEvents_EventTypeExactMatchWithoutDot(t *testing.T) {
+	// An event_type of exactly "waf" (no dot) should also match "waf" prefix filter.
+	raw := mustMarshalEvents([]map[string]any{
+		{"event_type": "waf", "ai_summary": "exact"},
+		{"event_type": "waf.blocked", "ai_summary": "sub"},
+	})
+
+	got := filterEvents(raw, "waf", "", nil, 50)
+	if len(got) != 2 {
+		t.Errorf("expected 2 events, got %d", len(got))
+	}
+}
+
+func TestFilterEvents_SeverityMinimum(t *testing.T) {
+	tests := []struct {
+		name        string
+		minSeverity string
+		events      []map[string]any
+		wantCount   int
+	}{
+		{
+			name:        "low includes all",
+			minSeverity: "low",
+			events: []map[string]any{
+				{"event_type": "a", "severity": "low"},
+				{"event_type": "b", "severity": "medium"},
+				{"event_type": "c", "severity": "high"},
+				{"event_type": "d", "severity": "critical"},
+			},
+			wantCount: 4,
+		},
+		{
+			name:        "medium excludes low",
+			minSeverity: "medium",
+			events: []map[string]any{
+				{"event_type": "a", "severity": "low"},
+				{"event_type": "b", "severity": "medium"},
+				{"event_type": "c", "severity": "high"},
+			},
+			wantCount: 2,
+		},
+		{
+			name:        "high excludes low and medium",
+			minSeverity: "high",
+			events: []map[string]any{
+				{"event_type": "a", "severity": "low"},
+				{"event_type": "b", "severity": "medium"},
+				{"event_type": "c", "severity": "high"},
+				{"event_type": "d", "severity": "critical"},
+			},
+			wantCount: 2,
+		},
+		{
+			name:        "critical only",
+			minSeverity: "critical",
+			events: []map[string]any{
+				{"event_type": "a", "severity": "high"},
+				{"event_type": "b", "severity": "critical"},
+			},
+			wantCount: 1,
+		},
+		{
+			name:        "events without severity field excluded when filter active",
+			minSeverity: "high",
+			events: []map[string]any{
+				{"event_type": "a"}, // no severity
+				{"event_type": "b", "severity": "critical"},
+			},
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := mustMarshalEvents(tt.events)
+			got := filterEvents(raw, "", tt.minSeverity, nil, 50)
+			if len(got) != tt.wantCount {
+				t.Errorf("got %d events, want %d", len(got), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestFilterEvents_SinceFilter(t *testing.T) {
+	now := time.Now().UTC()
+	old := now.Add(-10 * time.Minute)
+	recent := now.Add(-1 * time.Minute)
+
+	sinceThreshold := now.Add(-5 * time.Minute)
+
+	raw := mustMarshalEvents([]map[string]any{
+		{"event_type": "a", "timestamp": old.Format(time.RFC3339)},
+		{"event_type": "b", "timestamp": recent.Format(time.RFC3339)},
+	})
+
+	got := filterEvents(raw, "", "", &sinceThreshold, 50)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 event after since filter, got %d", len(got))
+	}
+	if got[0].EventType != "b" {
+		t.Errorf("expected event type %q, got %q", "b", got[0].EventType)
+	}
+}
+
+func TestFilterEvents_SinceFilterBadTimestamp(t *testing.T) {
+	// Events with unparseable timestamps must not be filtered out by since.
+	sinceThreshold := time.Now().UTC().Add(-5 * time.Minute)
+
+	raw := mustMarshalEvents([]map[string]any{
+		{"event_type": "a", "timestamp": "not-a-timestamp"},
+	})
+
+	// Event with bad timestamp passes through (we cannot verify age, so include it).
+	got := filterEvents(raw, "", "", &sinceThreshold, 50)
+	if len(got) != 1 {
+		t.Errorf("expected 1 event (bad timestamp should pass through), got %d", len(got))
+	}
+}
+
+func TestFilterEvents_LimitRespected(t *testing.T) {
+	events := make([]map[string]any, 10)
+	for i := range events {
+		events[i] = map[string]any{"event_type": "x", "ai_summary": "s"}
+	}
+	raw := mustMarshalEvents(events)
+
+	got := filterEvents(raw, "", "", nil, 3)
+	if len(got) != 3 {
+		t.Errorf("expected limit 3, got %d", len(got))
+	}
+}
+
+func TestFilterEvents_EmptySliceNotNull(t *testing.T) {
+	got := filterEvents(nil, "waf", "", nil, 50)
+	if got == nil {
+		t.Error("expected non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 events, got %d", len(got))
+	}
+}
+
+func TestFilterEvents_MalformedEventSkipped(t *testing.T) {
+	raw := []json.RawMessage{
+		json.RawMessage(`{invalid json`),
+		json.RawMessage(`{"event_type":"good","ai_summary":"ok"}`),
+	}
+	got := filterEvents(raw, "", "", nil, 50)
+	if len(got) != 1 {
+		t.Errorf("expected 1 good event, got %d", len(got))
+	}
+}
+
+func TestFilterEvents_AISummaryHoisted(t *testing.T) {
+	raw := mustMarshalEvents([]map[string]any{
+		{"event_type": "auth.success", "ai_summary": "User logged in successfully", "outcome": "allowed"},
+	})
+
+	got := filterEvents(raw, "", "", nil, 50)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(got))
+	}
+	if got[0].AISummary != "User logged in successfully" {
+		t.Errorf("AISummary = %q, want %q", got[0].AISummary, "User logged in successfully")
+	}
+	if got[0].Outcome != "allowed" {
+		t.Errorf("Outcome = %q, want %q", got[0].Outcome, "allowed")
+	}
+}
+
+func TestFilterEvents_CombinedFilters(t *testing.T) {
+	now := time.Now().UTC()
+	sinceThreshold := now.Add(-5 * time.Minute)
+
+	raw := mustMarshalEvents([]map[string]any{
+		// passes: waf prefix, high severity, recent
+		{"event_type": "waf.blocked", "severity": "high", "timestamp": now.Add(-1 * time.Minute).Format(time.RFC3339)},
+		// fails event_type
+		{"event_type": "auth.success", "severity": "high", "timestamp": now.Add(-1 * time.Minute).Format(time.RFC3339)},
+		// fails severity
+		{"event_type": "waf.detected", "severity": "low", "timestamp": now.Add(-1 * time.Minute).Format(time.RFC3339)},
+		// fails since
+		{"event_type": "waf.detected", "severity": "high", "timestamp": now.Add(-10 * time.Minute).Format(time.RFC3339)},
+	})
+
+	got := filterEvents(raw, "waf", "high", &sinceThreshold, 50)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 event after combined filters, got %d", len(got))
+	}
+	if got[0].EventType != "waf.blocked" {
+		t.Errorf("unexpected event type %q", got[0].EventType)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleStreamLogs HTTP integration tests
+// ---------------------------------------------------------------------------
+
+const streamLogsFixture = `{
+	"events": [
+		{
+			"event_type": "waf.blocked",
+			"timestamp": "2026-04-03T10:00:00Z",
+			"ai_summary": "WAF blocked SQL injection from 1.2.3.4",
+			"severity": "high",
+			"outcome": "blocked"
+		},
+		{
+			"event_type": "auth.success",
+			"timestamp": "2026-04-03T10:00:01Z",
+			"ai_summary": "User logged in",
+			"severity": "low",
+			"outcome": "allowed"
+		}
+	],
+	"cursor": 2
+}`
+
+func TestHandleStreamLogs_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/_vibewarden/admin/events" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(streamLogsFixture))
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "test-token",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) == 0 {
+		t.Fatal("expected at least one content item")
+	}
+
+	var result streamLogsResponse
+	if err := json.Unmarshal([]byte(items[0].Text), &result); err != nil {
+		t.Fatalf("cannot unmarshal result JSON: %v\nraw: %s", err, items[0].Text)
+	}
+
+	if result.Count != 2 {
+		t.Errorf("Count = %d, want 2", result.Count)
+	}
+}
+
+func TestHandleStreamLogs_EventTypeFilter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(streamLogsFixture))
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "tok",
+		"event_type":  "waf",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result streamLogsResponse
+	if err := json.Unmarshal([]byte(items[0].Text), &result); err != nil {
+		t.Fatalf("cannot unmarshal: %v", err)
+	}
+	if result.Count != 1 {
+		t.Errorf("Count = %d, want 1 (only waf.* events)", result.Count)
+	}
+	if result.Events[0].EventType != "waf.blocked" {
+		t.Errorf("EventType = %q, want %q", result.Events[0].EventType, "waf.blocked")
+	}
+	if result.Filters.EventType != "waf" {
+		t.Errorf("Filters.EventType = %q, want %q", result.Filters.EventType, "waf")
+	}
+}
+
+func TestHandleStreamLogs_SeverityFilter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(streamLogsFixture))
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "tok",
+		"severity":    "high",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result streamLogsResponse
+	if err := json.Unmarshal([]byte(items[0].Text), &result); err != nil {
+		t.Fatalf("cannot unmarshal: %v", err)
+	}
+	if result.Count != 1 {
+		t.Errorf("Count = %d, want 1 (only high+ events)", result.Count)
+	}
+}
+
+func TestHandleStreamLogs_LimitParam(t *testing.T) {
+	// Build a fixture with 10 events.
+	events := make([]map[string]any, 10)
+	for i := range events {
+		events[i] = map[string]any{
+			"event_type": "request",
+			"ai_summary": "ok",
+			"timestamp":  "2026-04-03T10:00:00Z",
+		}
+	}
+	fixture := map[string]any{"events": events, "cursor": 10}
+	fixtureBytes, _ := json.Marshal(fixture)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixtureBytes)
+	}))
+	defer srv.Close()
+
+	lim := 3
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "tok",
+		"limit":       lim,
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result streamLogsResponse
+	if err := json.Unmarshal([]byte(items[0].Text), &result); err != nil {
+		t.Fatalf("cannot unmarshal: %v", err)
+	}
+	if result.Count != 3 {
+		t.Errorf("Count = %d, want 3", result.Count)
+	}
+	if result.Filters.Limit != 3 {
+		t.Errorf("Filters.Limit = %d, want 3", result.Filters.Limit)
+	}
+}
+
+func TestHandleStreamLogs_SinceFilter(t *testing.T) {
+	now := time.Now().UTC()
+	recent := now.Add(-1 * time.Minute).Format(time.RFC3339)
+	old := now.Add(-10 * time.Minute).Format(time.RFC3339)
+
+	fixture := map[string]any{
+		"events": []map[string]any{
+			{"event_type": "a", "ai_summary": "old", "timestamp": old},
+			{"event_type": "b", "ai_summary": "recent", "timestamp": recent},
+		},
+		"cursor": 2,
+	}
+	fixtureBytes, _ := json.Marshal(fixture)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixtureBytes)
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "tok",
+		"since":       "5m",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result streamLogsResponse
+	if err := json.Unmarshal([]byte(items[0].Text), &result); err != nil {
+		t.Fatalf("cannot unmarshal: %v", err)
+	}
+	if result.Count != 1 {
+		t.Errorf("Count = %d, want 1 (only recent event within 5m)", result.Count)
+	}
+	if result.Filters.Since != "5m" {
+		t.Errorf("Filters.Since = %q, want %q", result.Filters.Since, "5m")
+	}
+}
+
+func TestHandleStreamLogs_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "wrong",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(items[0].Text), "authentication failed") {
+		t.Errorf("expected authentication message, got: %s", items[0].Text)
+	}
+	if strings.Contains(items[0].Text, "wrong") {
+		t.Error("admin token must not appear in the response")
+	}
+}
+
+func TestHandleStreamLogs_ServiceUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "tok",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(items[0].Text), "ring buffer") {
+		t.Errorf("expected ring buffer message, got: %s", items[0].Text)
+	}
+}
+
+func TestHandleStreamLogs_UnexpectedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "tok",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(items[0].Text, "502") {
+		t.Errorf("expected HTTP 502 in message, got: %s", items[0].Text)
+	}
+}
+
+func TestHandleStreamLogs_ConnectionError(t *testing.T) {
+	params, _ := json.Marshal(map[string]any{
+		"url":         "http://127.0.0.1:19997",
+		"admin_token": "secret-tok",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(items[0].Text, "secret-tok") {
+		t.Error("admin token must not appear in the connection error message")
+	}
+	if !strings.Contains(strings.ToLower(items[0].Text), "sidecar") {
+		t.Errorf("expected helpful sidecar message, got: %s", items[0].Text)
+	}
+}
+
+func TestHandleStreamLogs_MissingURL(t *testing.T) {
+	params, _ := json.Marshal(map[string]any{
+		"admin_token": "tok",
+	})
+	_, err := handleStreamLogs(context.Background(), params)
+	if err == nil {
+		t.Error("expected an error when url is missing")
+	}
+}
+
+func TestHandleStreamLogs_MissingToken(t *testing.T) {
+	params, _ := json.Marshal(map[string]any{
+		"url": "http://localhost:8443",
+	})
+	_, err := handleStreamLogs(context.Background(), params)
+	if err == nil {
+		t.Error("expected an error when admin_token is missing")
+	}
+}
+
+func TestHandleStreamLogs_InvalidArgs(t *testing.T) {
+	_, err := handleStreamLogs(context.Background(), json.RawMessage(`{invalid`))
+	if err == nil {
+		t.Error("expected an error for invalid JSON arguments")
+	}
+}
+
+func TestHandleStreamLogs_InvalidSeverity(t *testing.T) {
+	params, _ := json.Marshal(map[string]any{
+		"url":         "http://localhost:8443",
+		"admin_token": "tok",
+		"severity":    "extreme",
+	})
+	_, err := handleStreamLogs(context.Background(), params)
+	if err == nil {
+		t.Error("expected an error for invalid severity value")
+	}
+}
+
+func TestHandleStreamLogs_InvalidSince(t *testing.T) {
+	params, _ := json.Marshal(map[string]any{
+		"url":         "http://localhost:8443",
+		"admin_token": "tok",
+		"since":       "not-a-duration",
+	})
+	_, err := handleStreamLogs(context.Background(), params)
+	if err == nil {
+		t.Error("expected an error for invalid since duration")
+	}
+}
+
+func TestHandleStreamLogs_TrailingSlashURL(t *testing.T) {
+	var capturedPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"events":[],"cursor":0}`))
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL + "/",
+		"admin_token": "tok",
+	})
+
+	_, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedPath != "/_vibewarden/admin/events" {
+		t.Errorf("path = %q, want %q", capturedPath, "/_vibewarden/admin/events")
+	}
+}
+
+func TestHandleStreamLogs_EmptyEventsNotNull(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"events":[],"cursor":0}`))
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "tok",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(items[0].Text, `"events": null`) {
+		t.Error("events field must be an array, not null")
+	}
+}
+
+func TestRegisterDefaultTools_IncludesStreamLogs(t *testing.T) {
+	srv := newTestServer()
+	RegisterDefaultTools(srv)
+
+	if _, ok := srv.handlers["vibewarden_stream_logs"]; !ok {
+		t.Error("vibewarden_stream_logs not registered in RegisterDefaultTools")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// mustMarshalEvents converts a slice of maps to a slice of json.RawMessage.
+func mustMarshalEvents(events []map[string]any) []json.RawMessage {
+	result := make([]json.RawMessage, 0, len(events))
+	for _, e := range events {
+		b, err := json.Marshal(e)
+		if err != nil {
+			panic("mustMarshalEvents: " + err.Error())
+		}
+		result = append(result, b)
+	}
+	return result
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -26,6 +26,7 @@ func RegisterDefaultTools(s *Server) {
 	s.RegisterTool(verifyDeployToolDef(), handleVerifyDeploy)
 	s.RegisterTool(getDeployLogsToolDef(), handleGetDeployLogs)
 	s.RegisterTool(watchEventsToolDef(), handleWatchEvents)
+	s.RegisterTool(streamLogsToolDef(), handleStreamLogs)
 	s.RegisterTool(schemaDescribeToolDef(), handleSchemaDescribe)
 	RegisterProposalTools(s)
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -270,6 +270,7 @@ func TestRegisterDefaultTools(t *testing.T) {
 		"vibewarden_verify_deploy",
 		"vibewarden_get_deploy_logs",
 		"vibewarden_watch_events",
+		"vibewarden_stream_logs",
 		"vibewarden_schema_describe",
 		"vibewarden_propose_action",
 		"vibewarden_list_proposals",


### PR DESCRIPTION
Closes #788

## Summary

- Adds a new `vibewarden_stream_logs` MCP tool in `internal/mcp/stream_logs.go`
- Calls the existing `GET /_vibewarden/admin/events` endpoint and applies client-side filtering
- Filtering by **event_type prefix**: `"waf"` matches `"waf.detected"`, `"waf.blocked"`, etc. (prefix + dot rule)
- Filtering by **minimum severity**: `"low"`, `"medium"`, `"high"`, `"critical"` with rank ordering
- Filtering by **since duration**: parses Go durations like `"5m"`, `"1h"` and excludes events older than `now - duration`
- `limit` parameter with default 50, clamped to 500; fetch batch is 4x limit to account for filter losses
- `ai_summary` hoisted to the top of every result event so AI agents see it first
- `filters` object in the response records which criteria were applied
- Admin token never leaks in error messages (consistent with `watch_events.go` security posture)
- Registered in `RegisterDefaultTools` alongside all other tools

## Test plan

- All existing `internal/mcp` tests pass: `go test -race ./internal/mcp/...`
- `make check` passes (confirmed in a clean run before concurrent interference from other sessions)
- New tests in `stream_logs_test.go` cover:
  - `filterEvents` unit tests: no-filter pass-through, event_type prefix exact and multi-match, exact match without dot, severity rank table, since filter, bad timestamp pass-through, limit clamping, nil-safe empty slice, malformed event skipping, ai_summary hoisted, combined filters
  - `handleStreamLogs` HTTP integration tests: success path, event_type filter, severity filter, limit, since, unauthorized (token not leaked), service unavailable, unexpected status, connection error (token not leaked), missing url/token, invalid JSON args, invalid severity value, invalid since duration, trailing slash URL, empty events not null, registration check

🤖 Generated with [Claude Code](https://claude.com/claude-code)