### PR TITLE
fix(#787): deduplicate structured events — wire audit logger to io.Discard in Caddy handlers

### DIFF
--- a/internal/adapters/caddy/admin_auth_handler.go
+++ b/internal/adapters/caddy/admin_auth_handler.go
@@ -4,8 +4,8 @@ package caddy
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
-	"os"
 
 	gocaddy "github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
@@ -71,7 +71,7 @@ func (h *AdminAuthHandler) Provision(_ gocaddy.Context) error {
 		Token:      h.Config.Token,
 		ConfigPath: h.Config.ConfigPath,
 	}
-	auditLogger := auditadapter.NewJSONWriter(os.Stdout)
+	auditLogger := auditadapter.NewJSONWriter(io.Discard)
 	h.handler = middleware.AdminAuthMiddleware(cfg, auditLogger)
 	return nil
 }

--- a/internal/adapters/caddy/circuit_breaker_handler.go
+++ b/internal/adapters/caddy/circuit_breaker_handler.go
@@ -4,6 +4,7 @@ package caddy
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -84,7 +85,7 @@ func (CircuitBreakerHandler) CaddyModule() gocaddy.ModuleInfo {
 func (h *CircuitBreakerHandler) Provision(_ gocaddy.Context) error {
 	h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	h.eventLogger = logadapter.NewSlogEventLogger(os.Stdout)
-	h.auditLogger = auditadapter.NewJSONWriter(os.Stdout)
+	h.auditLogger = auditadapter.NewJSONWriter(io.Discard)
 
 	cfg := ports.CircuitBreakerConfig{
 		Enabled:   true,

--- a/internal/adapters/caddy/ipfilter_handler.go
+++ b/internal/adapters/caddy/ipfilter_handler.go
@@ -3,6 +3,7 @@ package caddy
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -82,7 +83,7 @@ func (IPFilterHandler) CaddyModule() gocaddy.ModuleInfo {
 func (h *IPFilterHandler) Provision(_ gocaddy.Context) error {
 	h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	h.eventLogger = logadapter.NewSlogEventLogger(os.Stdout)
-	h.auditLogger = auditadapter.NewJSONWriter(os.Stdout)
+	h.auditLogger = auditadapter.NewJSONWriter(io.Discard)
 
 	list, err := ipfilter.ParseList(h.Config.Addresses)
 	if err != nil {

--- a/internal/adapters/caddy/ratelimit_handler.go
+++ b/internal/adapters/caddy/ratelimit_handler.go
@@ -4,6 +4,7 @@ package caddy
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -118,7 +119,7 @@ func (h *RateLimitHandler) Provision(_ gocaddy.Context) error {
 	}
 
 	eventLogger := logadapter.NewSlogEventLogger(os.Stdout)
-	auditLogger := auditadapter.NewJSONWriter(os.Stdout)
+	auditLogger := auditadapter.NewJSONWriter(io.Discard)
 
 	h.handler = middleware.RateLimitMiddleware(h.ipLimiter, h.userLimiter, cfg, logger, eventLogger, auditLogger)
 


### PR DESCRIPTION
Closes #787

## Summary

- Each Caddy module handler (AdminAuth, CircuitBreaker, IPFilter, RateLimit) was provisioning auditadapter.NewJSONWriter(os.Stdout) alongside logadapter.NewSlogEventLogger(os.Stdout) in their Provision() methods, causing every security event to produce two log lines on stdout: one structured event (with schema_version, event_type, ai_summary) from the event logger, and one audit JSON record from the audit writer.
- Fix: replace os.Stdout with io.Discard as the audit writer destination in all four Provision() methods. The structured event logger on stdout remains the single authoritative output stream.
- The audit adapter is intentionally kept wired (not removed) so callers who inject a file or OTel audit sink retain full audit functionality. Only the default stdout duplication is eliminated.

## Test plan

- [x] make check passes (golangci-lint, gofmt, build, all tests including -race)
- [x] go test ./internal/adapters/caddy/... ./internal/middleware/... passes
- [ ] Observe that a blocked IP request or rate-limit hit now emits a single JSON line to stdout instead of two

🤖 Generated with [Claude Code](https://claude.com/claude-code)