### PR TITLE
fix: re-apply three review fixes lost when PR #795 was reverted

### DIFF
--- a/internal/adapters/caddy/waf_engine_handler.go
+++ b/internal/adapters/caddy/waf_engine_handler.go
@@ -37,7 +37,7 @@ type WAFEngineHandlerRulesConfig struct {
 // WAFEngineHandler Caddy module. It is embedded in the Caddy JSON config under
 // the "config" key of the "vibewarden_waf_engine" handler entry.
 type WAFEngineHandlerConfig struct {
-	// Mode is "block" or "detect". Empty defaults to "block".
+	// Mode is "block" or "detect". Empty defaults to "detect".
 	Mode string `json:"mode"`
 
 	// Rules toggles individual attack categories.
@@ -91,7 +91,7 @@ func (h *WAFEngineHandler) Provision(_ gocaddy.Context) error {
 
 	mode := middleware.WAFMode(h.Config.Mode)
 	if mode == "" {
-		mode = middleware.WAFModeBlock
+		mode = middleware.WAFModeDetect
 	}
 
 	cfg := middleware.WAFConfig{

--- a/internal/adapters/caddy/waf_engine_handler_test.go
+++ b/internal/adapters/caddy/waf_engine_handler_test.go
@@ -230,10 +230,10 @@ func TestWAFEngineHandler_CleanRequest_Passes(t *testing.T) {
 	}
 }
 
-func TestWAFEngineHandler_EmptyMode_DefaultsToBlock(t *testing.T) {
+func TestWAFEngineHandler_EmptyMode_DefaultsToDetect(t *testing.T) {
 	h := &WAFEngineHandler{
 		Config: WAFEngineHandlerConfig{
-			Mode: "", // empty — should default to block
+			Mode: "", // empty — should default to detect (pass-through)
 			Rules: WAFEngineHandlerRulesConfig{
 				SQLInjection: true,
 			},
@@ -252,7 +252,7 @@ func TestWAFEngineHandler_EmptyMode_DefaultsToBlock(t *testing.T) {
 	})
 	_ = h.ServeHTTP(rr, req, next)
 
-	if rr.Code != http.StatusForbidden {
-		t.Errorf("empty mode defaults to block: status = %d, want 403", rr.Code)
+	if rr.Code != http.StatusOK {
+		t.Errorf("empty mode defaults to detect (pass-through): status = %d, want 200", rr.Code)
 	}
 }

--- a/internal/cli/templates/init-vibewarden.yaml.tmpl
+++ b/internal/cli/templates/init-vibewarden.yaml.tmpl
@@ -29,7 +29,7 @@ security_headers:
   hsts_preload: false
   content_type_nosniff: true
   frame_option: "SAMEORIGIN"
-  content_security_policy: "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'"
+  content_security_policy: "default-src 'self'; style-src 'self' 'unsafe-inline'"
   referrer_policy: "strict-origin-when-cross-origin"
   permissions_policy: "geolocation=(), microphone=(), camera=()"
 

--- a/internal/cli/templates/vibewarden.yaml.tmpl
+++ b/internal/cli/templates/vibewarden.yaml.tmpl
@@ -29,7 +29,7 @@ security_headers:
   hsts_preload: false
   content_type_nosniff: true
   frame_option: "SAMEORIGIN"
-  content_security_policy: "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'"
+  content_security_policy: "default-src 'self'; style-src 'self' 'unsafe-inline'"
   referrer_policy: "strict-origin-when-cross-origin"
   permissions_policy: "geolocation=(), microphone=(), camera=()"
 {{- if .TLSEnabled }}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -388,7 +388,7 @@ type TLSConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 	// Domain for TLS certificate (required if enabled with provider "letsencrypt")
 	Domain string `mapstructure:"domain"`
-	// Provider: "letsencrypt", "self-signed", or "external"
+	// Provider: "letsencrypt" (or alias "acme"), "self-signed", or "external"
 	Provider string `mapstructure:"provider"`
 	// CertPath is the path to a PEM-encoded certificate file.
 	// Required when Provider is "external".
@@ -1557,7 +1557,7 @@ func (c *Config) Validate() error {
 		// valid — empty string is accepted (defaults to "self-signed" via Load)
 	default:
 		errs = append(errs, fmt.Sprintf(
-			"tls.provider %q is invalid; accepted values: \"self-signed\", \"letsencrypt\", \"external\" — "+
+			"tls.provider %q is invalid; accepted values: \"self-signed\", \"letsencrypt\" (or alias \"acme\"), \"external\" — "+
 				"set tls.provider to one of those values",
 			c.TLS.Provider,
 		))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2514,7 +2514,7 @@ func TestValidate_TLSProvider(t *testing.T) {
 			name:        "unknown provider cloudflare is rejected with actionable message",
 			cfg:         config.Config{TLS: config.TLSConfig{Provider: "cloudflare"}},
 			wantErr:     true,
-			wantContain: "accepted values: \"self-signed\", \"letsencrypt\", \"external\"",
+			wantContain: "accepted values: \"self-signed\", \"letsencrypt\" (or alias \"acme\"), \"external\"",
 		},
 		{
 			name:        "error message suggests fix",

--- a/internal/middleware/waf.go
+++ b/internal/middleware/waf.go
@@ -24,7 +24,7 @@ const (
 
 // WAFConfig holds the complete configuration for WAFMiddleware.
 type WAFConfig struct {
-	// Mode controls whether detections block or only log. Default: WAFModeBlock.
+	// Mode controls whether detections block or only log. Default: WAFModeDetect.
 	Mode WAFMode
 
 	// EnabledCategories maps a waf.Category to a toggle. Categories absent from
@@ -63,7 +63,7 @@ func WAFMiddleware(
 ) func(http.Handler) http.Handler {
 	mode := cfg.Mode
 	if mode != WAFModeBlock && mode != WAFModeDetect {
-		mode = WAFModeBlock
+		mode = WAFModeDetect
 	}
 
 	matcher, err := NewExemptPathMatcher(cfg.ExemptPaths)

--- a/internal/middleware/waf_test.go
+++ b/internal/middleware/waf_test.go
@@ -402,10 +402,10 @@ func TestWAFMiddleware_NilCollectorAndAuditLogger_NoPanic(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Invalid mode falls back to block
+// Invalid mode falls back to detect (pass-through)
 // ---------------------------------------------------------------------------
 
-func TestWAFMiddleware_InvalidMode_FallsBackToBlock(t *testing.T) {
+func TestWAFMiddleware_InvalidMode_FallsBackToDetect(t *testing.T) {
 	mc := &fakeWAFCollector{}
 	al := &fakeWAFAuditLogger{}
 	cfg := WAFConfig{Mode: WAFMode("invalid")}
@@ -415,8 +415,8 @@ func TestWAFMiddleware_InvalidMode_FallsBackToBlock(t *testing.T) {
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusForbidden {
-		t.Errorf("invalid mode should fall back to block: status = %d, want 403", rr.Code)
+	if rr.Code != http.StatusOK {
+		t.Errorf("invalid mode should fall back to detect (pass-through): status = %d, want 200", rr.Code)
 	}
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -81,7 +81,7 @@ security_headers:
   hsts_max_age: 0
   content_type_nosniff: true
   frame_option: "DENY"
-  content_security_policy: "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'"
+  content_security_policy: "default-src 'self'; style-src 'self' 'unsafe-inline'"
   referrer_policy: "strict-origin-when-cross-origin"
 
 telemetry:
@@ -330,7 +330,7 @@ func testSecurityHeaders(t *testing.T, s *stack) {
 	}{
 		{"X-Content-Type-Options", "nosniff"},
 		{"X-Frame-Options", "DENY"},
-		{"Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'"},
+		{"Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'"},
 		{"Referrer-Policy", "strict-origin-when-cross-origin"},
 	}
 


### PR DESCRIPTION
## Summary

Re-applies three review fixes that were present in the reverted PR #795.

- **CSP — remove script-src unsafe-inline**: Both generated config templates (`vibewarden.yaml.tmpl`, `init-vibewarden.yaml.tmpl`) and the e2e test config/assertion no longer include `script-src 'self' 'unsafe-inline'`. The correct value is `"default-src 'self'; style-src 'self' 'unsafe-inline'"`.
- **WAF — safe default mode**: The empty-string fallback in `WAFMiddleware` and the Caddy `WAFEngineHandler` is now `WAFModeDetect` instead of `WAFModeBlock`. Godoc comment on `WAFConfig.Mode` and the JSON comment in `WAFEngineHandlerConfig.Mode` updated to match. Tests renamed from `FallsBackToBlock` -> `FallsBackToDetect` / `DefaultsToBlock` -> `DefaultsToDetect` with assertions adjusted.
- **TLS provider — acme alias in error messages**: `TLSConfig.Provider` godoc now mentions `"acme"` as an alias for `"letsencrypt"`. The `Validate()` error message for an invalid provider now says `"letsencrypt" (or alias "acme")`. The corresponding test assertion is updated to match.

## Test plan

- `make check` passes locally (lint, build, all unit tests, demo-app)
- `TestWAFMiddleware_InvalidMode_FallsBackToDetect` — asserts 200 on unknown mode
- `TestWAFEngineHandler_EmptyMode_DefaultsToDetect` — asserts 200 on empty mode
- `TestValidate_TLSProvider/unknown_provider_cloudflare_is_rejected_with_actionable_message` — asserts error contains updated string