### PR TITLE
fix(#787): wire audit loggers to io.Discard to stop duplicate stdout lines

### DIFF
--- a/internal/adapters/caddy/admin_auth_handler.go
+++ b/internal/adapters/caddy/admin_auth_handler.go
@@ -4,8 +4,8 @@ package caddy
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
-	"os"
 
 	gocaddy "github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
@@ -71,7 +71,7 @@ func (h *AdminAuthHandler) Provision(_ gocaddy.Context) error {
 		Token:      h.Config.Token,
 		ConfigPath: h.Config.ConfigPath,
 	}
-	auditLogger := auditadapter.NewJSONWriter(os.Stdout)
+	auditLogger := auditadapter.NewJSONWriter(io.Discard)
 	h.handler = middleware.AdminAuthMiddleware(cfg, auditLogger)
 	return nil
 }

--- a/internal/adapters/caddy/circuit_breaker_handler.go
+++ b/internal/adapters/caddy/circuit_breaker_handler.go
@@ -4,6 +4,7 @@ package caddy
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -84,7 +85,7 @@ func (CircuitBreakerHandler) CaddyModule() gocaddy.ModuleInfo {
 func (h *CircuitBreakerHandler) Provision(_ gocaddy.Context) error {
 	h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	h.eventLogger = logadapter.NewSlogEventLogger(os.Stdout)
-	h.auditLogger = auditadapter.NewJSONWriter(os.Stdout)
+	h.auditLogger = auditadapter.NewJSONWriter(io.Discard)
 
 	cfg := ports.CircuitBreakerConfig{
 		Enabled:   true,

--- a/internal/adapters/caddy/ipfilter_handler.go
+++ b/internal/adapters/caddy/ipfilter_handler.go
@@ -3,6 +3,7 @@ package caddy
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -82,7 +83,7 @@ func (IPFilterHandler) CaddyModule() gocaddy.ModuleInfo {
 func (h *IPFilterHandler) Provision(_ gocaddy.Context) error {
 	h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	h.eventLogger = logadapter.NewSlogEventLogger(os.Stdout)
-	h.auditLogger = auditadapter.NewJSONWriter(os.Stdout)
+	h.auditLogger = auditadapter.NewJSONWriter(io.Discard)
 
 	list, err := ipfilter.ParseList(h.Config.Addresses)
 	if err != nil {

--- a/internal/adapters/caddy/ratelimit_handler.go
+++ b/internal/adapters/caddy/ratelimit_handler.go
@@ -4,6 +4,7 @@ package caddy
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -118,7 +119,7 @@ func (h *RateLimitHandler) Provision(_ gocaddy.Context) error {
 	}
 
 	eventLogger := logadapter.NewSlogEventLogger(os.Stdout)
-	auditLogger := auditadapter.NewJSONWriter(os.Stdout)
+	auditLogger := auditadapter.NewJSONWriter(io.Discard)
 
 	h.handler = middleware.RateLimitMiddleware(h.ipLimiter, h.userLimiter, cfg, logger, eventLogger, auditLogger)
 


### PR DESCRIPTION
Closes #787

## Summary

- In `AdminAuthHandler.Provision()`, `CircuitBreakerHandler.Provision()`, `IPFilterHandler.Provision()`, and `RateLimitHandler.Provision()` the audit logger was created with `auditadapter.NewJSONWriter(os.Stdout)`.
- This caused every security event to produce two log lines on stdout: one structured event from the event logger and one audit record from the audit logger.
- Fix: pass `io.Discard` instead of `os.Stdout` so audit records are silently discarded. The structured event emitted by the event logger is the single source of truth for stdout.

## Test plan

- `make check` passes (lint, build, race tests) — verified locally before push.
- The pre-push hook also ran `make check` and reported "All checks passed!".
- Manual verification: run `vibewarden serve` against a test app, trigger a blocked IP or rate-limited request, and confirm only one JSON line appears in stdout per event.