### PR TITLE
feat(#785): add --follow/-f flag to vibew deploy logs

### DIFF
--- a/internal/adapters/ssh/executor.go
+++ b/internal/adapters/ssh/executor.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"os/exec"
 	"strconv"
@@ -105,6 +106,31 @@ func (e *Executor) Run(ctx context.Context, cmd string) (string, error) {
 		return buf.String(), fmt.Errorf("ssh %s: %w\noutput: %s", cmd, err, strings.TrimSpace(buf.String()))
 	}
 	return strings.TrimSpace(buf.String()), nil
+}
+
+// RunStream executes cmd on the remote host via ssh, writing stdout and stderr
+// directly to the provided writers without buffering. It is intended for
+// long-running commands (e.g. "docker compose logs -f") where output must be
+// streamed to the caller in real-time. Cancel ctx to terminate the remote
+// process.
+func (e *Executor) RunStream(ctx context.Context, cmd string, stdout, stderr io.Writer) error {
+	args := e.sshArgs(cmd)
+	//nolint:gosec // cmd is caller-supplied; see the Run method for the same
+	// rationale.
+	c := exec.CommandContext(ctx, "ssh", args...)
+	c.Stdout = stdout
+	c.Stderr = stderr
+
+	if err := c.Run(); err != nil {
+		// When the context is cancelled (user pressed Ctrl-C) the ssh process is
+		// killed and Run returns a non-nil error. Treat context cancellation as a
+		// clean exit so the caller does not print a spurious error message.
+		if ctx.Err() != nil {
+			return nil
+		}
+		return fmt.Errorf("ssh %s: %w", cmd, err)
+	}
+	return nil
 }
 
 // Transfer syncs localDir to remoteDir on the remote host using rsync over SSH.

--- a/internal/app/deploy/openbao_test.go
+++ b/internal/app/deploy/openbao_test.go
@@ -3,6 +3,7 @@ package deploy_test
 import (
 	"context"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -352,6 +353,10 @@ func (w *wildcardExecutor) Run(_ context.Context, cmd string) (string, error) {
 		}
 	}
 	return "", nil
+}
+
+func (w *wildcardExecutor) RunStream(_ context.Context, _ string, _ io.Writer, _ io.Writer) error {
+	return nil
 }
 
 func (w *wildcardExecutor) Transfer(_ context.Context, _, _ string, _ bool) error {

--- a/internal/app/deploy/service.go
+++ b/internal/app/deploy/service.go
@@ -274,11 +274,20 @@ type LogsOptions struct {
 
 	// Lines is the number of log lines to retrieve (0 = all).
 	Lines int
+
+	// Follow streams new log lines continuously, like "docker compose logs -f".
+	// When true the command runs until the context is cancelled (e.g. Ctrl-C).
+	// Output is written directly to Out in real-time without buffering.
+	Follow bool
+
 	// Out is the writer used for log output. May be nil.
 	Out io.Writer
 }
 
 // Logs retrieves Docker Compose logs from the remote.
+// When opts.Follow is true the command streams log output in real-time by
+// using RunStream; the call blocks until the context is cancelled. When false
+// the output is fetched in a single buffered Run call and written to opts.Out.
 func (s *Service) Logs(ctx context.Context, opts LogsOptions) error {
 	out := opts.Out
 	if out == nil {
@@ -294,6 +303,13 @@ func (s *Service) Logs(ctx context.Context, opts LogsOptions) error {
 	cmd := "docker compose --project-directory " + remoteDir + " logs"
 	if opts.Lines > 0 {
 		cmd += fmt.Sprintf(" --tail=%d", opts.Lines)
+	}
+	if opts.Follow {
+		cmd += " -f"
+		if err := s.executor.RunStream(ctx, cmd, out, out); err != nil {
+			return fmt.Errorf("streaming remote logs: %w", err)
+		}
+		return nil
 	}
 
 	output, err := s.executor.Run(ctx, cmd)

--- a/internal/app/deploy/service_test.go
+++ b/internal/app/deploy/service_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -53,6 +54,17 @@ func (f *fakeExecutor) Run(_ context.Context, cmd string) (string, error) {
 	}
 	// Default: success with empty output.
 	return "", nil
+}
+
+func (f *fakeExecutor) RunStream(_ context.Context, cmd string, stdout, _ io.Writer) error {
+	f.runCalls = append(f.runCalls, cmd)
+	if r, ok := f.runResponses[cmd]; ok {
+		if r.output != "" {
+			fmt.Fprint(stdout, r.output)
+		}
+		return r.err
+	}
+	return nil
 }
 
 func (f *fakeExecutor) Transfer(_ context.Context, localDir, remoteDir string, deleteExtra bool) error {
@@ -381,6 +393,83 @@ func TestService_Logs_Error(t *testing.T) {
 	}
 }
 
+func TestService_Logs_Follow(t *testing.T) {
+	executor := &fakeExecutor{
+		runResponses: map[string]runResponse{
+			"docker compose --project-directory ~/vibewarden/myproject/ logs --tail=20 -f": {output: "streamed line 1\nstreamed line 2"},
+		},
+	}
+
+	svc := deployapp.NewService(executor, nil, nil)
+
+	var buf bytes.Buffer
+	err := svc.Logs(context.Background(), deployapp.LogsOptions{
+		ProjectName: "myproject",
+		Lines:       20,
+		Follow:      true,
+		Out:         &buf,
+	})
+	if err != nil {
+		t.Fatalf("Logs(Follow=true) unexpected error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "streamed line 1") {
+		t.Errorf("expected streamed output in buf, got:\n%s", buf.String())
+	}
+	// Verify RunStream was called (not Run) by checking the recorded command.
+	if len(executor.runCalls) != 1 {
+		t.Fatalf("expected exactly 1 run call, got: %v", executor.runCalls)
+	}
+	if !strings.Contains(executor.runCalls[0], "-f") {
+		t.Errorf("expected '-f' in the run call command, got: %q", executor.runCalls[0])
+	}
+}
+
+func TestService_Logs_Follow_NoLines(t *testing.T) {
+	executor := &fakeExecutor{
+		runResponses: map[string]runResponse{
+			"docker compose --project-directory ~/vibewarden/myproject/ logs -f": {output: "all streamed"},
+		},
+	}
+
+	svc := deployapp.NewService(executor, nil, nil)
+
+	var buf bytes.Buffer
+	err := svc.Logs(context.Background(), deployapp.LogsOptions{
+		ProjectName: "myproject",
+		Lines:       0,
+		Follow:      true,
+		Out:         &buf,
+	})
+	if err != nil {
+		t.Fatalf("Logs(Follow=true, Lines=0) unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "all streamed") {
+		t.Errorf("expected 'all streamed' in output, got:\n%s", buf.String())
+	}
+}
+
+func TestService_Logs_Follow_Error(t *testing.T) {
+	executor := &fakeExecutor{
+		runResponses: map[string]runResponse{
+			"docker compose --project-directory ~/vibewarden/myproject/ logs -f": {err: errors.New("stream broken")},
+		},
+	}
+
+	svc := deployapp.NewService(executor, nil, nil)
+
+	err := svc.Logs(context.Background(), deployapp.LogsOptions{
+		ProjectName: "myproject",
+		Follow:      true,
+	})
+	if err == nil {
+		t.Fatal("expected error when RunStream fails")
+	}
+	if !strings.Contains(err.Error(), "streaming remote logs") {
+		t.Errorf("error should mention 'streaming remote logs', got: %v", err)
+	}
+}
+
 func TestService_Deploy_RemoteDir(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{}
@@ -584,6 +673,10 @@ func (m *mockRunExecutor) Run(_ context.Context, cmd string) (string, error) {
 		return m.runFn(cmd)
 	}
 	return "", nil
+}
+
+func (m *mockRunExecutor) RunStream(_ context.Context, _ string, _ io.Writer, _ io.Writer) error {
+	return nil
 }
 
 func (m *mockRunExecutor) Transfer(_ context.Context, localDir, remoteDir string, deleteExtra bool) error {

--- a/internal/cli/cmd/deploy.go
+++ b/internal/cli/cmd/deploy.go
@@ -242,6 +242,7 @@ func newDeployLogsCmd() *cobra.Command {
 		target     string
 		sshKey     string
 		lines      int
+		follow     bool
 	)
 
 	cmd := &cobra.Command{
@@ -256,7 +257,8 @@ when the project was deployed. When omitted the current directory name is used.
 Examples:
   vibew deploy logs --target ssh://ubuntu@203.0.113.10
   vibew deploy logs --config vibewarden.prod.yaml --target ssh://ubuntu@203.0.113.10
-  vibew deploy logs --target ssh://ubuntu@203.0.113.10 --lines 100`,
+  vibew deploy logs --target ssh://ubuntu@203.0.113.10 --lines 100
+  vibew deploy logs --target ssh://ubuntu@203.0.113.10 --follow`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if target == "" {
 				return fmt.Errorf("--target is required (e.g. ssh://user@host)")
@@ -283,6 +285,7 @@ Examples:
 			return svc.Logs(cmd.Context(), deployapp.LogsOptions{
 				ConfigPath: absConfig,
 				Lines:      lines,
+				Follow:     follow,
 				Out:        cmd.OutOrStdout(),
 			})
 		},
@@ -292,6 +295,7 @@ Examples:
 	cmd.Flags().StringVar(&target, "target", "", "remote target in ssh://user@host[:port] format (required)")
 	cmd.Flags().StringVar(&sshKey, "ssh-key", "", "path to the SSH private key file (default: use SSH agent / ~/.ssh/config)")
 	cmd.Flags().IntVar(&lines, "lines", 50, "number of log lines to fetch (0 = all)")
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "stream log output continuously until cancelled (Ctrl-C)")
 
 	if err := cmd.MarkFlagRequired("target"); err != nil {
 		fmt.Fprintln(os.Stderr, "warning: flag required registration failed:", err)

--- a/internal/ports/remote.go
+++ b/internal/ports/remote.go
@@ -1,6 +1,9 @@
 package ports
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 // RemoteExecutor runs commands and transfers files on a remote server reachable
 // via SSH. Implementations shell out to the system ssh and rsync binaries so
@@ -9,6 +12,13 @@ type RemoteExecutor interface {
 	// Run executes cmd on the remote host and returns the combined stdout+stderr
 	// output. A non-zero exit code is returned as an error.
 	Run(ctx context.Context, cmd string) (output string, err error)
+
+	// RunStream executes cmd on the remote host, writing stdout and stderr
+	// directly to the provided writers in real-time. Unlike Run, output is not
+	// buffered — it is streamed as the remote process produces it. This is used
+	// for long-running commands such as "docker compose logs -f" where the caller
+	// needs to receive output continuously until the context is cancelled.
+	RunStream(ctx context.Context, cmd string, stdout, stderr io.Writer) error
 
 	// Transfer syncs localDir to remoteDir on the remote host using rsync.
 	// localDir must be a path on the local filesystem. remoteDir is a path on


### PR DESCRIPTION
Closes #785

## Summary

- Added `RunStream(ctx, cmd, stdout, stderr io.Writer) error` to the `RemoteExecutor` port in `internal/ports/remote.go`. Unlike `Run`, it pipes the ssh process stdout/stderr directly to the provided writers without buffering, enabling real-time output.
- Implemented `RunStream` on `*ssh.Executor` in `internal/adapters/ssh/executor.go`. Context cancellation (Ctrl-C) is treated as a clean exit so no spurious error is printed.
- Added `Follow bool` to `LogsOptions` in `internal/app/deploy/service.go`. When true, appends `-f` to the docker compose logs command and calls `RunStream`; otherwise behaviour is unchanged.
- Added `--follow` / `-f` flag to `newDeployLogsCmd` in `internal/cli/cmd/deploy.go`.
- Updated `fakeExecutor`, `mockRunExecutor`, and `wildcardExecutor` test doubles to implement the new interface method.
- Added `TestService_Logs_Follow`, `TestService_Logs_Follow_NoLines`, and `TestService_Logs_Follow_Error` table-driven tests.

## Test plan

- `make check` passes (lint, build, all tests including race detector).
- Unit tests cover: follow with `--tail`, follow without `--tail`, and RunStream error propagation.
- To verify manually: `vibew deploy logs --target ssh://user@host --follow` should stream logs until Ctrl-C.