### PR TITLE
feat(#788): add vibewarden_stream_logs MCP tool

### DIFF
--- a/internal/mcp/stream_logs.go
+++ b/internal/mcp/stream_logs.go
@@ -1,0 +1,250 @@
+package mcp
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// vibewarden_stream_logs
+// ---------------------------------------------------------------------------
+
+// severityRank maps severity level strings to their numeric rank for
+// ordered filtering. Info is not ranked here because the filter applies to
+// the explicit levels low/medium/high/critical only.
+var severityRank = map[string]int{
+	"low":      1,
+	"medium":   2,
+	"high":     3,
+	"critical": 4,
+}
+
+// streamLogsToolDef returns the ToolDefinition for vibewarden_stream_logs.
+func streamLogsToolDef() ToolDefinition {
+	return ToolDefinition{
+		Name: "vibewarden_stream_logs",
+		Description: "Fetch and filter structured log events from the VibeWarden admin events endpoint. " +
+			"Unlike vibewarden_watch_events, this tool performs client-side filtering by event_type prefix, " +
+			"minimum severity, and a time window. Events are returned with ai_summary prominently displayed " +
+			"for fast AI triage.",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"url": {
+					Type:        "string",
+					Description: "Base URL of the VibeWarden sidecar, e.g. 'https://localhost:8443'.",
+				},
+				"admin_token": {
+					Type:        "string",
+					Description: "Bearer token for the admin API (set via admin.token in vibewarden.yaml).",
+				},
+				"event_type": {
+					Type:        "string",
+					Description: "Optional event type prefix filter (e.g. 'auth' matches 'auth.success', 'auth.failed'). Omit to return all event types.",
+				},
+				"severity": {
+					Type:        "string",
+					Description: "Optional minimum severity level: 'low', 'medium', 'high', or 'critical'. Only events at or above this level are returned. Omit to return all severities.",
+				},
+				"since": {
+					Type:        "string",
+					Description: "Optional duration window (e.g. '5m', '1h', '30s'). Only events with a timestamp within this window are returned. Omit to return all events.",
+				},
+				"limit": {
+					Type:        "number",
+					Description: "Maximum number of events to fetch from the endpoint before filtering (default 50, max 500).",
+				},
+			},
+			Required: []string{"url", "admin_token"},
+		},
+	}
+}
+
+// streamLogsArgs holds the arguments for vibewarden_stream_logs.
+type streamLogsArgs struct {
+	URL        string `json:"url"`
+	AdminToken string `json:"admin_token"`
+	EventType  string `json:"event_type,omitempty"`
+	Severity   string `json:"severity,omitempty"`
+	Since      string `json:"since,omitempty"`
+	Limit      *int   `json:"limit,omitempty"`
+}
+
+// streamLogsEvent is the shape we use for parsing individual events from the
+// admin events response. Only the fields we need for filtering and display are
+// decoded; the full raw JSON is preserved as-is in the output.
+type streamLogsEvent struct {
+	EventType string    `json:"event_type"`
+	Timestamp time.Time `json:"timestamp"`
+	Severity  string    `json:"severity"`
+	AISummary string    `json:"ai_summary"`
+}
+
+// streamLogsResult is the JSON structure returned by vibewarden_stream_logs.
+type streamLogsResult struct {
+	Events []json.RawMessage `json:"events"`
+	Count  int               `json:"count"`
+	// Filters echoes back the active filters for the caller's reference.
+	Filters streamLogsFilters `json:"filters"`
+}
+
+// streamLogsFilters documents which filters were applied.
+type streamLogsFilters struct {
+	EventTypePrefix string `json:"event_type_prefix,omitempty"`
+	MinSeverity     string `json:"min_severity,omitempty"`
+	Since           string `json:"since,omitempty"`
+}
+
+// handleStreamLogs implements the vibewarden_stream_logs MCP tool.
+func handleStreamLogs(ctx context.Context, params json.RawMessage) ([]ContentItem, error) {
+	var args streamLogsArgs
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &args); err != nil {
+			return nil, fmt.Errorf("invalid arguments: %w", err)
+		}
+	}
+
+	if args.URL == "" {
+		return nil, fmt.Errorf("url is required")
+	}
+	if args.AdminToken == "" {
+		return nil, fmt.Errorf("admin_token is required")
+	}
+
+	// Validate severity if provided.
+	if args.Severity != "" {
+		if _, ok := severityRank[strings.ToLower(args.Severity)]; !ok {
+			return nil, fmt.Errorf("severity must be one of low, medium, high, critical; got %q", args.Severity)
+		}
+		args.Severity = strings.ToLower(args.Severity)
+	}
+
+	// Parse the since duration if provided.
+	var sinceWindow time.Duration
+	if args.Since != "" {
+		d, err := time.ParseDuration(args.Since)
+		if err != nil {
+			return nil, fmt.Errorf("since must be a valid Go duration (e.g. '5m', '1h'): %w", err)
+		}
+		sinceWindow = d
+	}
+
+	// Determine the limit to pass to the endpoint.
+	limit := 50
+	if args.Limit != nil {
+		limit = *args.Limit
+	}
+
+	// Build the request URL.
+	endpoint := strings.TrimRight(args.URL, "/") + "/_vibewarden/admin/events"
+	endpoint += "?limit=" + strconv.Itoa(limit)
+
+	// Use InsecureSkipVerify so the tool works with self-signed TLS certificates,
+	// which is the default for local VibeWarden sidecars.
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // intentional for local sidecar
+	}
+	client := &http.Client{
+		Timeout:   15 * time.Second,
+		Transport: transport,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return text("Failed to build request to admin events endpoint."), nil
+	}
+
+	// Set the bearer token — it must never appear in any response or error text.
+	req.Header.Set("Authorization", "Bearer "+args.AdminToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		// Do NOT include the raw error as it can contain the URL with token context.
+		return text("Cannot reach the sidecar admin API. Ensure the sidecar is running and the url is correct."), nil
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return text("Authentication failed — check admin token."), nil
+	case http.StatusServiceUnavailable:
+		return text("Sidecar event ring buffer is not available. The sidecar may still be starting up."), nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return text(fmt.Sprintf("Admin events endpoint returned HTTP %d. Check that the sidecar is healthy.", resp.StatusCode)), nil
+	}
+
+	var payload adminEventsPayload
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return text("Failed to decode events response from sidecar."), nil
+	}
+
+	// Apply client-side filters.
+	now := time.Now().UTC()
+	minRank := 0
+	if args.Severity != "" {
+		minRank = severityRank[args.Severity]
+	}
+
+	var filtered []json.RawMessage
+	for _, raw := range payload.Events {
+		var ev streamLogsEvent
+		if err := json.Unmarshal(raw, &ev); err != nil {
+			// Skip events that cannot be parsed — never fail the whole call.
+			continue
+		}
+
+		// Filter by event_type prefix.
+		if args.EventType != "" && !strings.HasPrefix(ev.EventType, args.EventType) {
+			continue
+		}
+
+		// Filter by minimum severity rank.
+		if minRank > 0 {
+			evRank, ok := severityRank[strings.ToLower(ev.Severity)]
+			if !ok || evRank < minRank {
+				continue
+			}
+		}
+
+		// Filter by time window.
+		if sinceWindow > 0 {
+			cutoff := now.Add(-sinceWindow)
+			if ev.Timestamp.IsZero() || ev.Timestamp.Before(cutoff) {
+				continue
+			}
+		}
+
+		filtered = append(filtered, raw)
+	}
+
+	// Ensure a nil slice is serialised as an empty array, not null.
+	if filtered == nil {
+		filtered = []json.RawMessage{}
+	}
+
+	result := streamLogsResult{
+		Events: filtered,
+		Count:  len(filtered),
+		Filters: streamLogsFilters{
+			EventTypePrefix: args.EventType,
+			MinSeverity:     args.Severity,
+			Since:           args.Since,
+		},
+	}
+
+	out, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshalling stream logs response: %w", err)
+	}
+
+	return text(string(out)), nil
+}

--- a/internal/mcp/stream_logs_test.go
+++ b/internal/mcp/stream_logs_test.go
@@ -1,0 +1,526 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// streamLogsFixture returns a JSON payload with events at various severity
+// levels and event types for use in filter tests.
+func streamLogsFixture(now time.Time) string {
+	// Two minutes ago — should be within a 5m window but outside a 1m window.
+	twoMinsAgo := now.Add(-2 * time.Minute).UTC().Format(time.RFC3339)
+	// Thirty seconds ago — should be inside a 1m window.
+	thirtySecsAgo := now.Add(-30 * time.Second).UTC().Format(time.RFC3339)
+
+	return fmt.Sprintf(`{
+  "events": [
+    {
+      "event_type": "auth.failed",
+      "timestamp": %q,
+      "severity": "high",
+      "ai_summary": "Authentication failed for 192.0.2.1"
+    },
+    {
+      "event_type": "auth.success",
+      "timestamp": %q,
+      "severity": "info",
+      "ai_summary": "User alice authenticated successfully"
+    },
+    {
+      "event_type": "rate_limit.hit",
+      "timestamp": %q,
+      "severity": "medium",
+      "ai_summary": "Rate limit exceeded for 198.51.100.2"
+    },
+    {
+      "event_type": "request.blocked",
+      "timestamp": %q,
+      "severity": "critical",
+      "ai_summary": "Request blocked by WAF: SQL injection pattern"
+    }
+  ],
+  "cursor": 4
+}`, twoMinsAgo, thirtySecsAgo, twoMinsAgo, thirtySecsAgo)
+}
+
+func newStreamLogsServer(t *testing.T, body func() string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/_vibewarden/admin/events" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body()))
+	}))
+}
+
+func TestHandleStreamLogs_NoFilter(t *testing.T) {
+	now := time.Now()
+	srv := newStreamLogsServer(t, func() string { return streamLogsFixture(now) })
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "test-token",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) == 0 {
+		t.Fatal("expected at least one content item")
+	}
+
+	var result streamLogsResult
+	if err := json.Unmarshal([]byte(items[0].Text), &result); err != nil {
+		t.Fatalf("cannot unmarshal result: %v\nraw: %s", err, items[0].Text)
+	}
+	// All 4 events should be returned when no filter is applied.
+	if result.Count != 4 {
+		t.Errorf("Count = %d, want 4", result.Count)
+	}
+}
+
+func TestHandleStreamLogs_EventTypePrefix(t *testing.T) {
+	tests := []struct {
+		name      string
+		prefix    string
+		wantCount int
+	}{
+		{"auth prefix matches two events", "auth", 2},
+		{"rate_limit prefix matches one event", "rate_limit", 1},
+		{"auth.failed exact match", "auth.failed", 1},
+		{"no match", "tls", 0},
+	}
+
+	now := time.Now()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newStreamLogsServer(t, func() string { return streamLogsFixture(now) })
+			defer srv.Close()
+
+			params, _ := json.Marshal(map[string]any{
+				"url":         srv.URL,
+				"admin_token": "test-token",
+				"event_type":  tt.prefix,
+			})
+
+			items, err := handleStreamLogs(context.Background(), params)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var result streamLogsResult
+			if err := json.Unmarshal([]byte(items[0].Text), &result); err != nil {
+				t.Fatalf("cannot unmarshal result: %v", err)
+			}
+			if result.Count != tt.wantCount {
+				t.Errorf("Count = %d, want %d", result.Count, tt.wantCount)
+			}
+			if result.Filters.EventTypePrefix != tt.prefix {
+				t.Errorf("Filters.EventTypePrefix = %q, want %q", result.Filters.EventTypePrefix, tt.prefix)
+			}
+		})
+	}
+}
+
+func TestHandleStreamLogs_Severity(t *testing.T) {
+	tests := []struct {
+		name      string
+		severity  string
+		wantCount int
+	}{
+		// info is not in the rank map, so min_severity=low should return low/medium/high/critical events
+		{"low returns low+medium+high+critical (excludes info)", "low", 3},
+		{"medium returns medium+high+critical events", "medium", 3},
+		{"high returns high+critical", "high", 2},
+		{"critical returns only critical", "critical", 1},
+	}
+
+	now := time.Now()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newStreamLogsServer(t, func() string { return streamLogsFixture(now) })
+			defer srv.Close()
+
+			params, _ := json.Marshal(map[string]any{
+				"url":         srv.URL,
+				"admin_token": "test-token",
+				"severity":    tt.severity,
+			})
+
+			items, err := handleStreamLogs(context.Background(), params)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var result streamLogsResult
+			if err := json.Unmarshal([]byte(items[0].Text), &result); err != nil {
+				t.Fatalf("cannot unmarshal result: %v", err)
+			}
+			if result.Count != tt.wantCount {
+				t.Errorf("severity=%q: Count = %d, want %d", tt.severity, result.Count, tt.wantCount)
+			}
+			if result.Filters.MinSeverity != tt.severity {
+				t.Errorf("Filters.MinSeverity = %q, want %q", result.Filters.MinSeverity, tt.severity)
+			}
+		})
+	}
+}
+
+func TestHandleStreamLogs_Since(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name      string
+		since     string
+		wantCount int
+	}{
+		// 2 events are 30s ago (inside 1m), 2 events are 2m ago (outside 1m).
+		{"1m window returns 2 recent events", "1m", 2},
+		// All 4 events are within 5m.
+		{"5m window returns all events", "5m", 4},
+		// All events are older than 10s.
+		{"10s window returns 0 events", "10s", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newStreamLogsServer(t, func() string { return streamLogsFixture(now) })
+			defer srv.Close()
+
+			params, _ := json.Marshal(map[string]any{
+				"url":         srv.URL,
+				"admin_token": "test-token",
+				"since":       tt.since,
+			})
+
+			items, err := handleStreamLogs(context.Background(), params)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var result streamLogsResult
+			if err := json.Unmarshal([]byte(items[0].Text), &result); err != nil {
+				t.Fatalf("cannot unmarshal result: %v", err)
+			}
+			if result.Count != tt.wantCount {
+				t.Errorf("since=%q: Count = %d, want %d", tt.since, result.Count, tt.wantCount)
+			}
+			if result.Filters.Since != tt.since {
+				t.Errorf("Filters.Since = %q, want %q", result.Filters.Since, tt.since)
+			}
+		})
+	}
+}
+
+func TestHandleStreamLogs_CombinedFilters(t *testing.T) {
+	now := time.Now()
+	srv := newStreamLogsServer(t, func() string { return streamLogsFixture(now) })
+	defer srv.Close()
+
+	// event_type=auth, severity=high, since=5m
+	// auth.failed: high, 2m ago -> passes all three
+	// auth.success: info (not in rank map, fails severity filter)
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "test-token",
+		"event_type":  "auth",
+		"severity":    "high",
+		"since":       "5m",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var result streamLogsResult
+	if err := json.Unmarshal([]byte(items[0].Text), &result); err != nil {
+		t.Fatalf("cannot unmarshal result: %v", err)
+	}
+	if result.Count != 1 {
+		t.Errorf("Count = %d, want 1", result.Count)
+	}
+}
+
+func TestHandleStreamLogs_DefaultLimit(t *testing.T) {
+	var capturedLimit string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedLimit = r.URL.Query().Get("limit")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"events":[],"cursor":0}`))
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "tok",
+	})
+
+	_, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedLimit != "50" {
+		t.Errorf("limit query param = %q, want %q", capturedLimit, "50")
+	}
+}
+
+func TestHandleStreamLogs_CustomLimit(t *testing.T) {
+	var capturedLimit string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedLimit = r.URL.Query().Get("limit")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"events":[],"cursor":0}`))
+	}))
+	defer srv.Close()
+
+	lim := 100
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "tok",
+		"limit":       lim,
+	})
+
+	_, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedLimit != "100" {
+		t.Errorf("limit query param = %q, want %q", capturedLimit, "100")
+	}
+}
+
+func TestHandleStreamLogs_EmptyEventsNotNull(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"events":[],"cursor":0}`))
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "tok",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(items[0].Text, `"events": null`) {
+		t.Error("events field must be an array, not null")
+	}
+	if !strings.Contains(items[0].Text, `"events": []`) {
+		t.Errorf("expected empty array for events, got: %s", items[0].Text)
+	}
+}
+
+func TestHandleStreamLogs_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "bad-token",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(items[0].Text), "authentication failed") {
+		t.Errorf("expected authentication failure message, got: %s", items[0].Text)
+	}
+	if strings.Contains(items[0].Text, "bad-token") {
+		t.Error("admin token must not appear in the response")
+	}
+}
+
+func TestHandleStreamLogs_ServiceUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "tok",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(items[0].Text), "ring buffer") {
+		t.Errorf("expected ring buffer message, got: %s", items[0].Text)
+	}
+}
+
+func TestHandleStreamLogs_UnexpectedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "tok",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(items[0].Text, "500") {
+		t.Errorf("expected HTTP 500 in message, got: %s", items[0].Text)
+	}
+}
+
+func TestHandleStreamLogs_ConnectionError(t *testing.T) {
+	params, _ := json.Marshal(map[string]any{
+		"url":         "http://127.0.0.1:19997",
+		"admin_token": "secret-token",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(items[0].Text, "secret-token") {
+		t.Error("admin token must not appear in the connection error message")
+	}
+	if !strings.Contains(strings.ToLower(items[0].Text), "sidecar") {
+		t.Errorf("expected helpful sidecar message, got: %s", items[0].Text)
+	}
+}
+
+func TestHandleStreamLogs_MissingURL(t *testing.T) {
+	params, _ := json.Marshal(map[string]any{
+		"admin_token": "tok",
+	})
+	_, err := handleStreamLogs(context.Background(), params)
+	if err == nil {
+		t.Error("expected an error when url is missing")
+	}
+}
+
+func TestHandleStreamLogs_MissingToken(t *testing.T) {
+	params, _ := json.Marshal(map[string]any{
+		"url": "http://localhost:8443",
+	})
+	_, err := handleStreamLogs(context.Background(), params)
+	if err == nil {
+		t.Error("expected an error when admin_token is missing")
+	}
+}
+
+func TestHandleStreamLogs_InvalidArgs(t *testing.T) {
+	_, err := handleStreamLogs(context.Background(), json.RawMessage(`{invalid`))
+	if err == nil {
+		t.Error("expected an error for invalid JSON arguments")
+	}
+}
+
+func TestHandleStreamLogs_InvalidSeverity(t *testing.T) {
+	params, _ := json.Marshal(map[string]any{
+		"url":         "http://localhost:8443",
+		"admin_token": "tok",
+		"severity":    "ultra",
+	})
+	_, err := handleStreamLogs(context.Background(), params)
+	if err == nil {
+		t.Error("expected an error for invalid severity")
+	}
+}
+
+func TestHandleStreamLogs_InvalidSince(t *testing.T) {
+	params, _ := json.Marshal(map[string]any{
+		"url":         "http://localhost:8443",
+		"admin_token": "tok",
+		"since":       "not-a-duration",
+	})
+	_, err := handleStreamLogs(context.Background(), params)
+	if err == nil {
+		t.Error("expected an error for invalid since duration")
+	}
+}
+
+func TestHandleStreamLogs_TrailingSlashURL(t *testing.T) {
+	var capturedPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"events":[],"cursor":0}`))
+	}))
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL + "/",
+		"admin_token": "tok",
+	})
+
+	_, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedPath != "/_vibewarden/admin/events" {
+		t.Errorf("path = %q, want %q", capturedPath, "/_vibewarden/admin/events")
+	}
+}
+
+func TestHandleStreamLogs_SeverityCaseInsensitive(t *testing.T) {
+	now := time.Now()
+	srv := newStreamLogsServer(t, func() string { return streamLogsFixture(now) })
+	defer srv.Close()
+
+	params, _ := json.Marshal(map[string]any{
+		"url":         srv.URL,
+		"admin_token": "test-token",
+		"severity":    "HIGH",
+	})
+
+	items, err := handleStreamLogs(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var result streamLogsResult
+	if err := json.Unmarshal([]byte(items[0].Text), &result); err != nil {
+		t.Fatalf("cannot unmarshal result: %v", err)
+	}
+	// high and critical events: auth.failed (high, 2m ago) + request.blocked (critical, 30s ago) = 2
+	if result.Count != 2 {
+		t.Errorf("Count = %d, want 2", result.Count)
+	}
+}
+
+// TestRegisterDefaultTools_IncludesStreamLogs ensures the tool is registered.
+func TestRegisterDefaultTools_IncludesStreamLogs(t *testing.T) {
+	srv := newTestServer()
+	RegisterDefaultTools(srv)
+
+	if _, ok := srv.handlers["vibewarden_stream_logs"]; !ok {
+		t.Error("vibewarden_stream_logs not registered in RegisterDefaultTools")
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -26,6 +26,7 @@ func RegisterDefaultTools(s *Server) {
 	s.RegisterTool(verifyDeployToolDef(), handleVerifyDeploy)
 	s.RegisterTool(getDeployLogsToolDef(), handleGetDeployLogs)
 	s.RegisterTool(watchEventsToolDef(), handleWatchEvents)
+	s.RegisterTool(streamLogsToolDef(), handleStreamLogs)
 	s.RegisterTool(schemaDescribeToolDef(), handleSchemaDescribe)
 	RegisterProposalTools(s)
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -270,6 +270,7 @@ func TestRegisterDefaultTools(t *testing.T) {
 		"vibewarden_verify_deploy",
 		"vibewarden_get_deploy_logs",
 		"vibewarden_watch_events",
+		"vibewarden_stream_logs",
 		"vibewarden_schema_describe",
 		"vibewarden_propose_action",
 		"vibewarden_list_proposals",


### PR DESCRIPTION
Closes #788

## Summary

- Adds `internal/mcp/stream_logs.go` with the `vibewarden_stream_logs` MCP tool
- Calls `GET /_vibewarden/admin/events` with Bearer token and `InsecureSkipVerify` for self-signed TLS
- Client-side filtering by **event_type prefix** (e.g. `"auth"` matches `"auth.success"`, `"auth.failed"`)
- Client-side filtering by **minimum severity rank**: `low=1`, `medium=2`, `high=3`, `critical=4`; events without a ranked severity (e.g. `"info"`) are excluded when a severity filter is active
- Client-side filtering by **since duration**: parses Go durations like `"5m"`, `"1h"`, `"30s"` and excludes events older than `now - duration`
- `limit` parameter defaults to 50; passed as a query param to the endpoint
- Response includes a `filters` object echoing which criteria were applied
- Admin token never appears in any response or error message
- Registered in `RegisterDefaultTools` alongside all other tools; `tools_test.go` updated to expect 13 tools

## Test plan

- `make check` passes (lint, build, race-detected tests across all packages)
- `stream_logs_test.go` covers: no-filter pass-through, event_type prefix matching, severity rank filtering, since duration window, combined filters, default/custom limit query param, empty events serialised as `[]` not `null`, unauthorized (token not leaked), service unavailable, unexpected HTTP status, connection error (token not leaked), missing url, missing admin_token, invalid JSON args, invalid severity value, invalid since duration, trailing slash URL normalisation, severity case-insensitivity, registration check

🤖 Generated with [Claude Code](https://claude.com/claude-code)