### PR TITLE
fix(#786): health check probes via SSH curl instead of local HTTP

### DIFF
--- a/internal/app/deploy/service.go
+++ b/internal/app/deploy/service.go
@@ -4,10 +4,8 @@ package deploy
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,34 +37,18 @@ const (
 type Service struct {
 	executor  ports.RemoteExecutor
 	generator ports.ConfigGenerator
-	httpDo    func(req *http.Request) (*http.Response, error)
 }
 
 // NewService creates a Service.
 // executor handles SSH commands and rsync transfers.
 // generator is used to produce the .vibewarden/generated/ files before transfer.
-// httpDo is the HTTP function used for all outbound HTTP calls, including the
-// deploy health check. Pass nil to use an insecure HTTP client that tolerates
-// self-signed and not-yet-issued TLS certificates (the default for deployment,
-// where the ACME cert may not have been issued yet).
 func NewService(
 	executor ports.RemoteExecutor,
 	generator ports.ConfigGenerator,
-	httpDo func(req *http.Request) (*http.Response, error),
 ) *Service {
-	if httpDo == nil {
-		//nolint:gosec // G402: intentional — cert may not be issued yet during deploy
-		httpDo = (&http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-			},
-			Timeout: 5 * time.Second,
-		}).Do
-	}
 	return &Service{
 		executor:  executor,
 		generator: generator,
-		httpDo:    httpDo,
 	}
 }
 
@@ -199,27 +181,15 @@ func (s *Service) Deploy(ctx context.Context, cfg *config.Config, opts RunOption
 		}
 	}
 
-	// Step 5: health check.
+	// Step 5: health check — run curl on the remote so the probe is independent
+	// of DNS propagation, external port availability, and TLS certificate issuance.
 	port := cfg.Server.Port
 	if port == 0 {
 		port = defaultHealthPort
 	}
-	scheme := "http"
-	host := "localhost"
-	if cfg.TLS.Enabled {
-		scheme = "https"
-		// When TLS is enabled with a domain (e.g. letsencrypt), the server's
-		// TLS connection policies match only the configured domain via SNI.
-		// Using "localhost" as the host would cause the TLS handshake to fail
-		// because the certificate (once issued) is scoped to the domain, not
-		// localhost. Use the configured domain for the health check host.
-		if cfg.TLS.Domain != "" {
-			host = cfg.TLS.Domain
-		}
-	}
-	healthURL := fmt.Sprintf("%s://%s:%d/_vibewarden/health", scheme, host, port)
-	fmt.Fprintf(out, "Waiting for sidecar health check at %s...\n", healthURL)
-	s.waitHealthy(ctx, healthURL, out)
+	healthURL := fmt.Sprintf("http://localhost:%d/_vibewarden/health", port)
+	fmt.Fprintf(out, "Waiting for sidecar health check at %s (via SSH)...\n", healthURL)
+	s.waitHealthy(ctx, port, out)
 
 	fmt.Fprintln(out, "Deploy complete.")
 	return nil
@@ -332,39 +302,35 @@ func (s *Service) checkRemotePrerequisites(ctx context.Context) error {
 	return nil
 }
 
-// waitHealthy polls healthURL until the sidecar responds with a 2xx status or
-// the context deadline / healthCheckTimeout expires.
-// It uses s.httpDo, which defaults to an insecure client because the ACME cert
-// may not be issued yet when this runs immediately after compose up.
+// waitHealthy polls the sidecar health endpoint on the remote host via SSH
+// until curl reports success (exit code 0) or the context deadline /
+// healthCheckTimeout expires.
+//
+// Running the probe over SSH avoids all DNS propagation, firewall, and TLS
+// certificate issuance dependencies — the request is made from inside the
+// server to its own localhost interface.
 //
 // On timeout or context cancellation the function prints a warning and returns
 // without error — the deploy is considered successful because services may still
 // be starting up. The operator can run "vibew deploy status" to check manually.
-func (s *Service) waitHealthy(ctx context.Context, healthURL string, out io.Writer) {
+func (s *Service) waitHealthy(ctx context.Context, port int, out io.Writer) {
+	cmd := fmt.Sprintf("curl -sf http://localhost:%d/_vibewarden/health", port)
 	deadline := time.Now().Add(healthCheckTimeout)
 	attempt := 0
 	var lastErr error
 
 	for {
 		attempt++
-		ok, err := s.checkHealthWith(ctx, healthURL, s.httpDo)
-		if ok {
+		_, err := s.executor.Run(ctx, cmd)
+		if err == nil {
 			fmt.Fprintln(out, "Sidecar is healthy.")
 			return
 		}
-		if err != nil {
-			lastErr = err
-			fmt.Fprintf(out, "  attempt %d: %v\n", attempt, err)
-		} else {
-			fmt.Fprintf(out, "  attempt %d: not yet healthy\n", attempt)
-		}
+		lastErr = err
+		fmt.Fprintf(out, "  attempt %d: %v\n", attempt, err)
 
 		if time.Now().After(deadline) {
-			if lastErr != nil {
-				fmt.Fprintf(out, "Warning: health check timed out (last error: %v). Services may still be starting. Run: vibew deploy status --target ... to check.\n", lastErr)
-			} else {
-				fmt.Fprintln(out, "Warning: health check timed out. Services may still be starting. Run: vibew deploy status --target ... to check.")
-			}
+			fmt.Fprintf(out, "Warning: health check timed out (last error: %v). Services may still be starting. Run: vibew deploy status --target ... to check.\n", lastErr)
 			return
 		}
 
@@ -375,21 +341,6 @@ func (s *Service) waitHealthy(ctx context.Context, healthURL string, out io.Writ
 		case <-time.After(healthCheckInterval):
 		}
 	}
-}
-
-// checkHealthWith performs a single GET request to healthURL using the provided
-// httpDo function and returns true when the response status is 2xx.
-func (s *Service) checkHealthWith(ctx context.Context, healthURL string, httpDo func(*http.Request) (*http.Response, error)) (bool, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-	if err != nil {
-		return false, fmt.Errorf("creating health request: %w", err)
-	}
-	resp, err := httpDo(req)
-	if err != nil {
-		return false, err
-	}
-	defer resp.Body.Close() //nolint:errcheck
-	return resp.StatusCode >= 200 && resp.StatusCode < 300, nil
 }
 
 // ProjectNameFromConfig derives a project name from the config file path.

--- a/internal/app/deploy/service_test.go
+++ b/internal/app/deploy/service_test.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -97,19 +95,9 @@ func TestService_Deploy_HappyPath(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	// Patch the health URL to point at our test server.
-	healthURL := srv.URL + "/_vibewarden/health"
-
-	svc := deployapp.NewService(executor, generator, func(req *http.Request) (*http.Response, error) {
-		// Redirect health check to our test server.
-		req2, _ := http.NewRequestWithContext(req.Context(), req.Method, healthURL, nil)
-		return http.DefaultClient.Do(req2) //nolint:gosec // G704: test-only helper; URL is from httptest.NewServer
-	})
+	// fakeExecutor returns success (nil error) for any unrecognised command,
+	// including the curl health-check probe.
+	svc := deployapp.NewService(executor, generator)
 
 	var buf bytes.Buffer
 	err := svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
@@ -142,7 +130,7 @@ func TestService_Deploy_GenerateFails(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{err: errors.New("template error")}
 
-	svc := deployapp.NewService(executor, generator, nil)
+	svc := deployapp.NewService(executor, generator)
 
 	err := svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
 		ConfigPath: "/tmp/proj/vibewarden.yaml",
@@ -163,7 +151,7 @@ func TestService_Deploy_MissingDocker(t *testing.T) {
 	}
 	generator := &fakeGenerator{}
 
-	svc := deployapp.NewService(executor, generator, nil)
+	svc := deployapp.NewService(executor, generator)
 
 	err := svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
 		ConfigPath: "/tmp/proj/vibewarden.yaml",
@@ -182,7 +170,7 @@ func TestService_Deploy_TransferFails(t *testing.T) {
 	}
 	generator := &fakeGenerator{}
 
-	svc := deployapp.NewService(executor, generator, nil)
+	svc := deployapp.NewService(executor, generator)
 
 	err := svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
 		ConfigPath: "/tmp/proj/vibewarden.yaml",
@@ -199,16 +187,15 @@ func TestService_Deploy_TransferFails(t *testing.T) {
 // does NOT fail the deploy — it prints a warning and returns nil so that
 // "Deploy complete." is still printed. The operator can check status manually.
 func TestService_Deploy_HealthCheckTimeout(t *testing.T) {
-	executor := &fakeExecutor{}
+	executor := &fakeExecutor{
+		runResponses: map[string]runResponse{
+			// curl exits non-zero → sidecar not yet healthy.
+			"curl -sf http://localhost:8443/_vibewarden/health": {err: errors.New("exit status 7")},
+		},
+	}
 	generator := &fakeGenerator{}
 
-	// Health check always returns 503.
-	svc := deployapp.NewService(executor, generator, func(req *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusServiceUnavailable,
-			Body:       http.NoBody,
-		}, nil
-	})
+	svc := deployapp.NewService(executor, generator)
 
 	// Use a cancelled context to avoid the full 60 s timeout.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -244,7 +231,7 @@ func TestService_Status(t *testing.T) {
 		},
 	}
 
-	svc := deployapp.NewService(executor, nil, nil)
+	svc := deployapp.NewService(executor, nil)
 
 	var buf bytes.Buffer
 	err := svc.Status(context.Background(), deployapp.StatusOptions{
@@ -267,7 +254,7 @@ func TestService_Status_DerivedFromConfigPath(t *testing.T) {
 		},
 	}
 
-	svc := deployapp.NewService(executor, nil, nil)
+	svc := deployapp.NewService(executor, nil)
 
 	var buf bytes.Buffer
 	err := svc.Status(context.Background(), deployapp.StatusOptions{
@@ -289,7 +276,7 @@ func TestService_Status_Error(t *testing.T) {
 		},
 	}
 
-	svc := deployapp.NewService(executor, nil, nil)
+	svc := deployapp.NewService(executor, nil)
 
 	// Use an explicit ProjectName so the test is not affected by the cwd used
 	// when resolving an empty ConfigPath.
@@ -309,7 +296,7 @@ func TestService_Logs(t *testing.T) {
 		},
 	}
 
-	svc := deployapp.NewService(executor, nil, nil)
+	svc := deployapp.NewService(executor, nil)
 
 	var buf bytes.Buffer
 	err := svc.Logs(context.Background(), deployapp.LogsOptions{
@@ -333,7 +320,7 @@ func TestService_Logs_DerivedFromConfigPath(t *testing.T) {
 		},
 	}
 
-	svc := deployapp.NewService(executor, nil, nil)
+	svc := deployapp.NewService(executor, nil)
 
 	var buf bytes.Buffer
 	err := svc.Logs(context.Background(), deployapp.LogsOptions{
@@ -356,7 +343,7 @@ func TestService_Logs_AllLines(t *testing.T) {
 		},
 	}
 
-	svc := deployapp.NewService(executor, nil, nil)
+	svc := deployapp.NewService(executor, nil)
 
 	var buf bytes.Buffer
 	err := svc.Logs(context.Background(), deployapp.LogsOptions{
@@ -379,7 +366,7 @@ func TestService_Logs_Error(t *testing.T) {
 		},
 	}
 
-	svc := deployapp.NewService(executor, nil, nil)
+	svc := deployapp.NewService(executor, nil)
 
 	err := svc.Logs(context.Background(), deployapp.LogsOptions{
 		ProjectName: "myproject",
@@ -400,7 +387,7 @@ func TestService_Logs_Follow(t *testing.T) {
 		},
 	}
 
-	svc := deployapp.NewService(executor, nil, nil)
+	svc := deployapp.NewService(executor, nil)
 
 	var buf bytes.Buffer
 	err := svc.Logs(context.Background(), deployapp.LogsOptions{
@@ -432,7 +419,7 @@ func TestService_Logs_Follow_NoLines(t *testing.T) {
 		},
 	}
 
-	svc := deployapp.NewService(executor, nil, nil)
+	svc := deployapp.NewService(executor, nil)
 
 	var buf bytes.Buffer
 	err := svc.Logs(context.Background(), deployapp.LogsOptions{
@@ -456,7 +443,7 @@ func TestService_Logs_Follow_Error(t *testing.T) {
 		},
 	}
 
-	svc := deployapp.NewService(executor, nil, nil)
+	svc := deployapp.NewService(executor, nil)
 
 	err := svc.Logs(context.Background(), deployapp.LogsOptions{
 		ProjectName: "myproject",
@@ -474,17 +461,7 @@ func TestService_Deploy_RemoteDir(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	healthURL := srv.URL + "/_vibewarden/health"
-
-	svc := deployapp.NewService(executor, generator, func(req *http.Request) (*http.Response, error) {
-		req2, _ := http.NewRequestWithContext(req.Context(), req.Method, healthURL, nil)
-		return http.DefaultClient.Do(req2) //nolint:gosec // G704: test-only helper; URL is from httptest.NewServer
-	})
+	svc := deployapp.NewService(executor, generator)
 
 	err := svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
 		ConfigPath:  "/home/user/myproject/vibewarden.prod.yaml",
@@ -516,7 +493,7 @@ func TestService_Deploy_DockerComposeMissing(t *testing.T) {
 	}
 	generator := &fakeGenerator{}
 
-	svc := deployapp.NewService(executor, generator, nil)
+	svc := deployapp.NewService(executor, generator)
 
 	err := svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
 		ConfigPath: "/tmp/proj/vibewarden.yaml",
@@ -577,17 +554,7 @@ func TestProjectNameFromConfig(t *testing.T) {
 			executor := &fakeExecutor{}
 			generator := &fakeGenerator{}
 
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusOK)
-			}))
-			defer srv.Close()
-
-			healthURL := srv.URL + "/_vibewarden/health"
-
-			svc := deployapp.NewService(executor, generator, func(req *http.Request) (*http.Response, error) {
-				req2, _ := http.NewRequestWithContext(req.Context(), req.Method, healthURL, nil)
-				return http.DefaultClient.Do(req2) //nolint:gosec // G704: test-only helper; URL is from httptest.NewServer
-			})
+			svc := deployapp.NewService(executor, generator)
 
 			_ = svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
 				ConfigPath:  tt.configPath,
@@ -613,7 +580,7 @@ func TestService_Deploy_NilOut(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{err: errors.New("stop early")}
 
-	svc := deployapp.NewService(executor, generator, nil)
+	svc := deployapp.NewService(executor, generator)
 
 	// Should not panic even with nil Out.
 	err := svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
@@ -647,7 +614,7 @@ func TestService_Deploy_ComposeUpFails(t *testing.T) {
 
 	generator := &fakeGenerator{}
 
-	svc := deployapp.NewService(executor2, generator, nil)
+	svc := deployapp.NewService(executor2, generator)
 	_ = calls
 
 	err := svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
@@ -696,16 +663,7 @@ func TestService_Deploy_TransferFileCalledForConfig(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	healthURL := srv.URL + "/_vibewarden/health"
-	svc := deployapp.NewService(executor, generator, func(req *http.Request) (*http.Response, error) {
-		req2, _ := http.NewRequestWithContext(req.Context(), req.Method, healthURL, nil)
-		return http.DefaultClient.Do(req2) //nolint:gosec // test-only helper; URL is from httptest.NewServer
-	})
+	svc := deployapp.NewService(executor, generator)
 
 	err := svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
 		ConfigPath:  "/tmp/myproject/vibewarden.yaml",
@@ -764,16 +722,7 @@ func TestService_Deploy_ConfigAlwaysTransferredAsVibewardenYAML(t *testing.T) {
 			executor := &fakeExecutor{}
 			generator := &fakeGenerator{}
 
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusOK)
-			}))
-			defer srv.Close()
-
-			healthURL := srv.URL + "/_vibewarden/health"
-			svc := deployapp.NewService(executor, generator, func(req *http.Request) (*http.Response, error) {
-				req2, _ := http.NewRequestWithContext(req.Context(), req.Method, healthURL, nil)
-				return http.DefaultClient.Do(req2) //nolint:gosec // test-only helper; URL is from httptest.NewServer
-			})
+			svc := deployapp.NewService(executor, generator)
 
 			err := svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
 				ConfigPath:  tt.configPath,
@@ -806,7 +755,7 @@ func TestService_Deploy_TransferFileFails(t *testing.T) {
 	}
 	generator := &fakeGenerator{}
 
-	svc := deployapp.NewService(executor, generator, nil)
+	svc := deployapp.NewService(executor, generator)
 
 	err := svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
 		ConfigPath: "/tmp/proj/vibewarden.yaml",
@@ -825,16 +774,7 @@ func TestService_Deploy_ImageMode(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	healthURL := srv.URL + "/_vibewarden/health"
-	svc := deployapp.NewService(executor, generator, func(req *http.Request) (*http.Response, error) {
-		req2, _ := http.NewRequestWithContext(req.Context(), req.Method, healthURL, nil)
-		return http.DefaultClient.Do(req2) //nolint:gosec // test-only helper; URL is from httptest.NewServer
-	})
+	svc := deployapp.NewService(executor, generator)
 
 	cfg := defaultConfig()
 	cfg.App.Image = "myapp:latest"
@@ -872,16 +812,7 @@ func TestService_Deploy_BuildMode(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	healthURL := srv.URL + "/_vibewarden/health"
-	svc := deployapp.NewService(executor, generator, func(req *http.Request) (*http.Response, error) {
-		req2, _ := http.NewRequestWithContext(req.Context(), req.Method, healthURL, nil)
-		return http.DefaultClient.Do(req2) //nolint:gosec // test-only helper; URL is from httptest.NewServer
-	})
+	svc := deployapp.NewService(executor, generator)
 
 	cfg := defaultConfig()
 	cfg.App.Build = "."
@@ -931,7 +862,7 @@ func TestService_Deploy_BuildMode_TransferContextFails(t *testing.T) {
 	}
 
 	generator := &fakeGenerator{}
-	svc := deployapp.NewService(failingTransfer, generator, nil)
+	svc := deployapp.NewService(failingTransfer, generator)
 
 	cfg := defaultConfig()
 	cfg.App.Build = "."
@@ -1053,16 +984,7 @@ func TestService_Deploy_PullsSidecarBeforeBuild(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	healthURL := srv.URL + "/_vibewarden/health"
-	svc := deployapp.NewService(executor, generator, func(req *http.Request) (*http.Response, error) {
-		req2, _ := http.NewRequestWithContext(req.Context(), req.Method, healthURL, nil)
-		return http.DefaultClient.Do(req2) //nolint:gosec // test-only helper; URL is from httptest.NewServer
-	})
+	svc := deployapp.NewService(executor, generator)
 
 	cfg := defaultConfig()
 	cfg.App.Build = "."
@@ -1104,16 +1026,7 @@ func TestService_Deploy_PullsSidecarInImageMode(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	healthURL := srv.URL + "/_vibewarden/health"
-	svc := deployapp.NewService(executor, generator, func(req *http.Request) (*http.Response, error) {
-		req2, _ := http.NewRequestWithContext(req.Context(), req.Method, healthURL, nil)
-		return http.DefaultClient.Do(req2) //nolint:gosec // test-only helper; URL is from httptest.NewServer
-	})
+	svc := deployapp.NewService(executor, generator)
 
 	cfg := defaultConfig()
 	cfg.App.Image = "myapp:latest"
@@ -1133,13 +1046,15 @@ func TestService_Deploy_PullsSidecarInImageMode(t *testing.T) {
 // TestService_Deploy_HealthCheckWarnOnTimeout verifies the exact warning message
 // format when the health check times out.
 func TestService_Deploy_HealthCheckWarnOnTimeout(t *testing.T) {
-	executor := &fakeExecutor{}
+	executor := &fakeExecutor{
+		runResponses: map[string]runResponse{
+			// curl exits non-zero → sidecar not yet healthy.
+			"curl -sf http://localhost:8443/_vibewarden/health": {err: errors.New("exit status 7")},
+		},
+	}
 	generator := &fakeGenerator{}
 
-	// Health check always errors.
-	svc := deployapp.NewService(executor, generator, func(_ *http.Request) (*http.Response, error) {
-		return nil, errors.New("connection refused")
-	})
+	svc := deployapp.NewService(executor, generator)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() { cancel() }()
@@ -1163,33 +1078,33 @@ func TestService_Deploy_HealthCheckWarnOnTimeout(t *testing.T) {
 	}
 }
 
-// TestService_Deploy_HealthCheckURLUsesDomain verifies that when TLS is enabled
-// with a domain the health check URL targets the configured domain rather than
-// "localhost". Using "localhost" with SNI-locked TLS would cause TLS handshake
-// failures because the server certificate (once issued) is scoped to the domain.
-func TestService_Deploy_HealthCheckURLUsesDomain(t *testing.T) {
+// TestService_Deploy_HealthCheckAlwaysUsesLocalhost verifies that the health
+// check always probes http://localhost:<port> via SSH, regardless of TLS
+// configuration or domain. This avoids DNS propagation, firewall, and TLS
+// certificate issuance dependencies.
+func TestService_Deploy_HealthCheckAlwaysUsesLocalhost(t *testing.T) {
 	tests := []struct {
-		name            string
-		cfg             *config.Config
-		wantURLContains string
+		name        string
+		cfg         *config.Config
+		wantCurlCmd string
 	}{
 		{
 			name: "TLS disabled uses localhost",
 			cfg: &config.Config{
 				Server: config.ServerConfig{Port: 8080},
 			},
-			wantURLContains: "localhost",
+			wantCurlCmd: "curl -sf http://localhost:8080/_vibewarden/health",
 		},
 		{
-			name: "TLS enabled without domain uses localhost",
+			name: "TLS enabled without domain still uses localhost",
 			cfg: &config.Config{
 				Server: config.ServerConfig{Port: 8443},
 				TLS:    config.TLSConfig{Enabled: true},
 			},
-			wantURLContains: "localhost",
+			wantCurlCmd: "curl -sf http://localhost:8443/_vibewarden/health",
 		},
 		{
-			name: "TLS enabled with domain uses domain",
+			name: "TLS enabled with domain still uses localhost",
 			cfg: &config.Config{
 				Server: config.ServerConfig{Port: 443},
 				TLS: config.TLSConfig{
@@ -1198,7 +1113,7 @@ func TestService_Deploy_HealthCheckURLUsesDomain(t *testing.T) {
 					Domain:   "app.example.com",
 				},
 			},
-			wantURLContains: "app.example.com",
+			wantCurlCmd: "curl -sf http://localhost:443/_vibewarden/health",
 		},
 	}
 
@@ -1207,14 +1122,7 @@ func TestService_Deploy_HealthCheckURLUsesDomain(t *testing.T) {
 			executor := &fakeExecutor{}
 			generator := &fakeGenerator{}
 
-			var capturedURL string
-			svc := deployapp.NewService(executor, generator, func(req *http.Request) (*http.Response, error) {
-				capturedURL = req.URL.String()
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       http.NoBody,
-				}, nil
-			})
+			svc := deployapp.NewService(executor, generator)
 
 			var buf bytes.Buffer
 			err := svc.Deploy(context.Background(), tt.cfg, deployapp.RunOptions{
@@ -1225,9 +1133,7 @@ func TestService_Deploy_HealthCheckURLUsesDomain(t *testing.T) {
 				t.Fatalf("Deploy() unexpected error: %v", err)
 			}
 
-			if !strings.Contains(capturedURL, tt.wantURLContains) {
-				t.Errorf("health check URL = %q, want it to contain %q", capturedURL, tt.wantURLContains)
-			}
+			assertRunCalled(t, executor.runCalls, tt.wantCurlCmd)
 		})
 	}
 }

--- a/internal/cli/cmd/deploy.go
+++ b/internal/cli/cmd/deploy.go
@@ -93,7 +93,7 @@ Examples:
 				credentialsadapter.NewGenerator(),
 				credentialsadapter.NewStore(),
 			).WithConfigSourcePath(configPath)
-			svc := deployapp.NewService(executor, generator, nil)
+			svc := deployapp.NewService(executor, generator)
 
 			absConfig, err := filepath.Abs(configPath)
 			if err != nil {
@@ -205,7 +205,7 @@ Examples:
 			} else {
 				executor = sshadapter.NewExecutor(t)
 			}
-			svc := deployapp.NewService(executor, nil, nil)
+			svc := deployapp.NewService(executor, nil)
 
 			absConfig, err := filepath.Abs(configPath)
 			if err != nil {
@@ -275,7 +275,7 @@ Examples:
 			} else {
 				executor = sshadapter.NewExecutor(t)
 			}
-			svc := deployapp.NewService(executor, nil, nil)
+			svc := deployapp.NewService(executor, nil)
 
 			absConfig, err := filepath.Abs(configPath)
 			if err != nil {


### PR DESCRIPTION
Closes #786

## Summary

- `waitHealthy` in `internal/app/deploy/service.go` now executes `curl -sf http://localhost:<port>/_vibewarden/health` on the remote host via `executor.Run` instead of making an HTTP request from the local machine.
- The probe always targets `http://localhost` (plain HTTP) since we are inside the server — TLS, DNS, and firewall state are irrelevant.
- Removed the `httpDo` field from `Service`, the `crypto/tls` import, and the `httpDo` parameter from `NewService`. The function signature is now `NewService(executor, generator)`.
- Updated all three `NewService` call sites in `internal/cli/cmd/deploy.go`.
- Updated all tests in `internal/app/deploy/service_test.go`: removed httptest servers and httpDo closures, replaced the `TestService_Deploy_HealthCheckURLUsesDomain` test with `TestService_Deploy_HealthCheckAlwaysUsesLocalhost` that asserts the curl command always targets localhost regardless of TLS config.

## Test plan

- `make check` passes locally (format, golangci-lint 0 issues, build, race-detector tests, demo-app).
- `TestService_Deploy_HealthCheckAlwaysUsesLocalhost` verifies the exact curl command for TLS-disabled, TLS-enabled-no-domain, and TLS-enabled-with-domain configs.
- `TestService_Deploy_HealthCheckTimeout` and `TestService_Deploy_HealthCheckWarnOnTimeout` verify graceful degradation when curl exits non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)