### PR TITLE
docs(#781-788): update docs for WAF default, CSP default, acme alias, --follow, SSH health check, dedup events, MCP stream, .dockerignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ It never holds external secrets or connects directly to third-party APIs.
 | TLS | Let's Encrypt (prod), self-signed (dev), or external (Cloudflare, ACM, …) |
 | Authentication | `none`, `jwt` (any OIDC provider), `kratos` (self-hosted), `api-key` |
 | Rate limiting | Token-bucket, per-IP and per-user; in-memory or Redis-backed |
-| WAF | Pattern detection for SQLi, XSS, path traversal; `block` or `detect` mode |
+| WAF | Pattern detection for SQLi, XSS, path traversal; `block` or `detect` mode — enabled by default in `detect` mode |
 | Security headers | HSTS, CSP, X-Frame-Options, Referrer-Policy, Permissions-Policy, CORS |
 | Secrets management | OpenBao (Apache 2.0 Vault fork) — inject secrets as headers or env vars |
 | Egress proxy | Outbound HTTP with mTLS, circuit breaker, retry, SSRF protection, PII redaction |
@@ -183,7 +183,7 @@ It never holds external secrets or connects directly to third-party APIs.
 | Response headers | Modify upstream response headers before forwarding |
 | Webhook verification | Signature verification for Stripe, GitHub, Slack, Twilio |
 | Hot reload | File watcher + admin API — no restart required |
-| MCP server | `vibew mcp` — AI agent integration via Model Context Protocol |
+| MCP server | `vibew mcp` — AI agent integration via Model Context Protocol; `vibewarden_stream_logs` tool for filtered real-time event streaming |
 | Config schema | JSON schema for `vibewarden.yaml` — editor autocomplete |
 | Agent context | `AGENTS-VIBEWARDEN.md` generated for AI coding tools |
 | Eject | `vibew eject` — export raw proxy config to graduate past VibeWarden |
@@ -278,6 +278,7 @@ add VibeWarden. Use `vibew add` to enable individual features after the initial 
 | `vibew status` | Show health of all components |
 | `vibew doctor` | Diagnose common issues |
 | `vibew logs` | Pretty-print structured logs |
+| `vibew deploy logs --follow` | Stream remote logs in real-time |
 | `vibew secret get <alias-or-path>` | Read a secret from OpenBao |
 | `vibew secret list` | List all managed secret paths |
 | `vibew token` | Generate a signed dev JWT for local testing |

--- a/docs/ai-log-schema.md
+++ b/docs/ai-log-schema.md
@@ -9,6 +9,10 @@ Changes to the schema are treated with the same care as a public API:
 backwards-incompatible changes increment the schema version and are documented
 in [Schema Evolution](schema-evolution.md).
 
+Each action produces exactly one structured event — there are no duplicate audit
+lines for the same request. Every middleware decision (auth, rate limiting, WAF,
+etc.) is captured in a single event per action with the relevant fields in `payload`.
+
 ---
 
 ## Why "AI-readable"?
@@ -175,6 +179,10 @@ These envelope fields let agents and observability tools link related events:
 This section lists every event type. Use the MCP tool
 `vibewarden_schema_describe` with `event_type=<type>` for full field listings,
 or with no arguments to see a condensed version of this table.
+
+To stream events in real-time from a running sidecar, use the MCP tool
+`vibewarden_stream_logs`. Supports filtering by `severity`, `event_type`, and
+`since` (ISO 8601 timestamp).
 
 ### Proxy
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,7 +100,7 @@ app:
 |-------|------|---------|-------------|
 | `tls.enabled` | bool | `true` | Enable TLS |
 | `tls.domain` | string | `""` | Domain for the TLS certificate. Required when `provider` is `letsencrypt` |
-| `tls.provider` | string | `""` | Certificate provider: `letsencrypt`, `self-signed`, or `external` |
+| `tls.provider` | string | `""` | Certificate provider: `letsencrypt` (or `acme`), `self-signed`, or `external` |
 | `tls.cert_path` | string | `""` | Path to PEM certificate. Required when `provider` is `external` |
 | `tls.key_path` | string | `""` | Path to PEM private key. Required when `provider` is `external` |
 | `tls.storage_path` | string | `""` | Directory for ACME certificate storage. Applies to `letsencrypt` only |
@@ -269,7 +269,7 @@ Only read when `store` is `redis`.
 | `security_headers.hsts_preload` | bool | `false` | Add `preload` to HSTS |
 | `security_headers.content_type_nosniff` | bool | `true` | Set `X-Content-Type-Options: nosniff` |
 | `security_headers.frame_option` | string | `DENY` | `X-Frame-Options`: `DENY`, `SAMEORIGIN`, or `""` to disable |
-| `security_headers.content_security_policy` | string | `""` (disabled) | `Content-Security-Policy` value — empty by default; set explicitly to opt in |
+| `security_headers.content_security_policy` | string | `default-src 'self'; style-src 'self' 'unsafe-inline'` | `Content-Security-Policy` value |
 | `security_headers.referrer_policy` | string | `strict-origin-when-cross-origin` | `Referrer-Policy` value |
 | `security_headers.permissions_policy` | string | `""` | `Permissions-Policy` value |
 | `security_headers.cross_origin_opener_policy` | string | `same-origin` | `Cross-Origin-Opener-Policy` value |
@@ -302,8 +302,8 @@ for common attack patterns in-process, with no external dependencies.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `waf.enabled` | bool | `false` | Enable the WAF middleware |
-| `waf.mode` | string | `block` | Detection mode: `block` (reject with 400) or `detect` (pass through and log) |
+| `waf.enabled` | bool | `true` | Enable the WAF middleware |
+| `waf.mode` | string | `detect` | Detection mode: `block` (reject with 400) or `detect` (pass through and log) |
 
 ### `waf.rules`
 

--- a/docs/deploy-to-vps.md
+++ b/docs/deploy-to-vps.md
@@ -257,17 +257,23 @@ myapp-vibewarden        Up (healthy)
 myapp-app               Up (healthy)
 ```
 
-Hit the health endpoint:
+Hit the health endpoint via SSH (the deploy command probes `localhost` on the remote, not the external domain):
 
 ```bash
-curl -I https://demo.yourdomain.com/_vibewarden/healthz
-# HTTP/2 200
+ssh root@<server-ip> 'curl -sf http://localhost/_vibewarden/healthz && echo OK'
+# OK
 ```
 
 Open your browser and navigate to `https://demo.yourdomain.com`. You should see
 your app served over HTTPS with a valid Let's Encrypt certificate.
 
-Check logs if anything looks wrong:
+Stream logs in real-time with `--follow`:
+
+```bash
+vibew deploy logs --target ssh://root@<server-ip> --follow
+```
+
+Or check logs directly on the server:
 
 ```bash
 ssh root@<server-ip> 'cd /opt/myapp && docker compose logs -f --tail 50'

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,6 +122,7 @@ Common flags:
 vibewarden.yaml          # Main config — commit this
 vibew                    # Wrapper script (macOS/Linux)
 .vibewarden-version      # Pinned version
+.dockerignore            # Prevents secrets and build artifacts from entering the image
 .claude/CLAUDE.md        # AI agent context (Claude Code)
 .cursor/rules            # AI agent context (Cursor)
 AGENTS.md                # AI agent context (generic)
@@ -273,7 +274,7 @@ Request
  Body size limit
    │
    ▼
- WAF — SQLi / XSS / path traversal detection
+ WAF — SQLi / XSS / path traversal detection (enabled by default in `detect` mode)
    │
    ▼
  Authentication — JWT / Kratos / API key

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -17,7 +17,7 @@ The sidecar handles:
 - Authentication (Ory Kratos) — identity injected via headers
 - Rate limiting — configured in vibewarden.yaml
 - Security headers (HSTS, CSP, X-Frame-Options, etc.)
-- WAF and egress security
+- WAF and egress security (enabled by default in `detect` mode; set `waf.mode: block` for production)
 
 App code focuses on **business logic only**.
 


### PR DESCRIPTION
Closes #781, #782, #783, #784, #785, #786, #787, #788

## Summary

- **WAF default** (`waf.enabled: true`, `waf.mode: detect`) — updated in `docs/configuration.md`, `docs/getting-started.md`, `README.md`, agent template, and `llms-full.txt`
- **CSP default** (`default-src 'self'; style-src 'self' 'unsafe-inline'`) — updated in `docs/configuration.md` and `llms-full.txt`
- **`acme` TLS alias** — noted alongside `letsencrypt` in `docs/configuration.md` and `llms-full.txt`
- **`.dockerignore` from `vibew init`** — added to generated-files lists in `docs/getting-started.md` and `llms-full.txt`
- **`vibew deploy logs --follow`** — added to CLI table in `README.md`, deploy guide in `docs/deploy-to-vps.md`, and `llms-full.txt`
- **SSH health check** — deploy step 7 in `docs/deploy-to-vps.md` and `llms-full.txt` updated to probe `localhost` on remote via SSH
- **Deduplicated events** — single-event-per-action note added to `docs/ai-log-schema.md`
- **MCP `vibewarden_stream_logs`** — added to MCP tools list in `README.md`, `docs/ai-log-schema.md`, `llms-full.txt`, and `llms.txt`

## Test plan

- [ ] `make check` passes (confirmed locally — all green)
- [ ] Review each changed section against the change list above