### PR TITLE
chore(agents): upgrade all agents to Opus 4.7

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: Software architect agent. Invoke after PM sets status READY_FOR_ARCH. Reads the PM spec, validates against locked decisions, produces a concrete technical design (interfaces, types, file layout, sequence diagrams in text), writes a full ADR to decisions.md, posts a short status comment to the GitHub issue, and sets issue status to READY_FOR_DEV.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-opus-4-6
+model: claude-opus-4-7[1m]
 ---
 
 You are the VibeWarden Software Architect. You own technical correctness, architectural

--- a/.claude/agents/auditor.md
+++ b/.claude/agents/auditor.md
@@ -2,7 +2,7 @@
 name: auditor
 description: Dependency auditor agent. Invoke periodically to scan go.mod for license compliance, CVEs (govulncheck), outdated versions, and Docker base image vulnerabilities. Creates issues for anything that needs updating.
 tools: Read, Bash, Glob, Grep
-model: claude-sonnet-4-6
+model: claude-opus-4-7
 ---
 
 You are the VibeWarden Dependency Auditor. You scan all dependencies for license

--- a/.claude/agents/benchmarker.md
+++ b/.claude/agents/benchmarker.md
@@ -2,7 +2,7 @@
 name: benchmarker
 description: Performance benchmarker agent. Invoke to run load tests against the running VibeWarden sidecar, measure latency overhead per middleware, memory usage, and connection limits. Reports numbers, not opinions. Catches performance regressions.
 tools: Read, Bash, Glob, Grep
-model: claude-sonnet-4-6
+model: claude-opus-4-7
 ---
 
 You are the VibeWarden Performance Benchmarker. You measure the sidecar's performance

--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -2,7 +2,7 @@
 name: dev
 description: Senior Go developer agent. Invoke after architect sets status READY_FOR_DEV. Reads the architectural design from the issue comments, implements it precisely following hexagonal architecture and DDD, writes tests, commits, and opens a PR. Sets issue status to READY_FOR_REVIEW.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-opus-4-6
+model: claude-opus-4-7[1m]
 ---
 
 You are the VibeWarden Senior Go Developer. You implement exactly what the architect

--- a/.claude/agents/pentester.md
+++ b/.claude/agents/pentester.md
@@ -2,7 +2,7 @@
 name: pentester
 description: Security pentester agent. Invoke to run automated security tests against the running VibeWarden sidecar. Tests for header spoofing, auth bypasses, rate limit evasion, SSRF, open redirects, and other OWASP Top 10 attacks. Reports CVE-style findings.
 tools: Read, Bash, Glob, Grep
-model: claude-opus-4-6
+model: claude-opus-4-7
 ---
 
 You are a security penetration tester evaluating VibeWarden. You attack the running

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -2,7 +2,7 @@
 name: pm
 description: Product manager agent. Invoke when you need to turn a feature idea or GitHub issue into a detailed spec ready for the architect. Use for: writing acceptance criteria, breaking epics into stories, creating GitHub issues via gh CLI, setting issue status to READY_FOR_ARCH.
 tools: Read, Write, Edit, Bash
-model: claude-opus-4-6
+model: claude-opus-4-7
 ---
 
 You are the VibeWarden Product Manager. You translate product ideas and rough GitHub issues

--- a/.claude/agents/release.md
+++ b/.claude/agents/release.md
@@ -2,7 +2,7 @@
 name: release
 description: Release manager agent. Invoke to prepare a release — generates changelog from git log, bumps version, creates GitHub release with notes, tags Docker images. Verifies all linked issues are closed before release.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-sonnet-4-6
+model: claude-opus-4-7
 ---
 
 You are the VibeWarden Release Manager. You handle the mechanics of cutting a release:

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,7 +2,7 @@
 name: reviewer
 description: Code reviewer agent. Invoke after dev sets status READY_FOR_REVIEW. Reads the PR diff, checks against architectural design and code quality rules, writes inline review comments via gh CLI, and either approves or requests changes. Sets issue status to CHANGES_REQUESTED or APPROVED.
 tools: Read, Bash, Glob, Grep
-model: claude-opus-4-6
+model: claude-opus-4-7[1m]
 ---
 
 You are the VibeWarden Code Reviewer. You are the last automated gate before the human

--- a/.claude/agents/user.md
+++ b/.claude/agents/user.md
@@ -2,7 +2,7 @@
 name: user
 description: Simulated end-user agent. Invoke to test VibeWarden from a vibe coder's perspective — setting up, configuring, running the demo, and reporting friction, confusion, or bugs. Focused on ease of use, especially for AI agents consuming the docs and config.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-opus-4-6
+model: claude-opus-4-7
 ---
 
 You are a vibe coder evaluating VibeWarden. You are NOT a VibeWarden developer — you are

--- a/.claude/agents/writer.md
+++ b/.claude/agents/writer.md
@@ -2,7 +2,7 @@
 name: writer
 description: Technical writer agent. Invoke to audit and improve user-facing documentation — README, docs/, example configs, CLI help text. Ensures docs match actual behavior, are AI-agent-parseable, and get a new user from zero to working in under 5 minutes.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-opus-4-6
+model: claude-opus-4-7[1m]
 ---
 
 You are the VibeWarden Technical Writer. You own all user-facing documentation. Your


### PR DESCRIPTION
## Summary

- Upgrade every agent definition to Opus 4.7
- **1M context** for context-heavy roles: `architect`, `reviewer`, `dev`, `writer`
- **Standard context** for task-focused roles: `pm`, `pentester`, `user`
- Move `auditor`, `benchmarker`, `release` from Sonnet 4.6 → plain Opus 4.7 (all Opus per project direction; these were the only non-Opus agents)

Companion PR on vibewarden.dev upgrades the 4 website agents (\`writer\`, \`docs-integrator\`, \`seo\`, \`web-designer\`) using the same two model IDs.

## Validation

- All 10 agents smoke-tested via Task tool with \`claude-opus-4-7\` and \`claude-opus-4-7[1m]\` — both IDs resolve, responses returned.
- \`make check\` (gofmt, golangci-lint, \`go test -race ./...\`, demo-app build/test) passes locally as pre-push hook.

## Test plan

- [x] \`make check\` green
- [x] Every agent returns from a trivial invocation (no model-not-found)
- [ ] CI green on this PR
- [ ] Next real agent invocation in this repo (PM / architect / dev on an actual issue) confirms production viability

## Notes

- Diff is 10 files × 1 line — pure frontmatter \`model:\` bump.
- No code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)