### PR TITLE
fix(#811): remove .claude/CLAUDE.md and .cursor/rules from scaffold file lists (BLOCKER)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,7 @@ Both `vibew init` and `vibew wrap` produce the same project scaffolding:
 vibewarden.yaml          # Main config — commit this
 vibew                    # CLI binary (installed via install script)
 .vibewarden-version      # Pinned version
-.claude/CLAUDE.md        # AI agent context (Claude Code)
-.cursor/rules            # AI agent context (Cursor)
-AGENTS.md                # AI agent context (generic)
+AGENTS.md                # AI agent context (generic — Claude Code, Cursor, etc.)
 AGENTS-VIBEWARDEN.md     # Tool-agnostic AI agent context (all agents)
 ```
 
@@ -295,8 +293,9 @@ add VibeWarden. Use `vibew add` to enable individual features after the initial 
 `vibew wrap` generates context files for your AI coding assistant. When you say
 "add a login page," the AI knows to use Kratos flows instead of building auth from scratch.
 
-Supported agents: **Claude Code** (`.claude/CLAUDE.md`), **Cursor** (`.cursor/rules`),
-**generic** (`AGENTS.md`).
+VibeWarden writes two files that any modern AI coding agent (Claude Code, Cursor,
+Aider, Continue, etc.) will read: **`AGENTS.md`** (conventional, tool-agnostic)
+and **`AGENTS-VIBEWARDEN.md`** (VibeWarden-specific context).
 
 Regenerate after config changes:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -123,9 +123,7 @@ vibewarden.yaml          # Main config — commit this
 vibew                    # Wrapper script (macOS/Linux)
 .vibewarden-version      # Pinned version
 .dockerignore            # Prevents secrets and build artifacts from entering the image
-.claude/CLAUDE.md        # AI agent context (Claude Code)
-.cursor/rules            # AI agent context (Cursor)
-AGENTS.md                # AI agent context (generic)
+AGENTS.md                # AI agent context (generic — Claude Code, Cursor, etc.)
 AGENTS-VIBEWARDEN.md     # Tool-agnostic AI agent context (all agents)
 ```
 


### PR DESCRIPTION
## Summary

README and getting-started docs claimed \`vibew init\`/\`wrap\` generate \`.claude/CLAUDE.md\` and \`.cursor/rules\`. The scaffold never writes those files — it only writes \`AGENTS-VIBEWARDEN.md\` + \`AGENTS.md\`. Scaffold tests at \`init_project_test.go:487,548\` explicitly assert CLAUDE.md is NOT created. Agents following the README searched for files that don't exist.

Closes #811.

## Changes

- \`README.md:101-108\` — removed \`.claude/CLAUDE.md\` and \`.cursor/rules\` lines
- \`docs/getting-started.md:121-130\` — same
- \`README.md:296-297\` — "Supported agents" paragraph rewritten to match the AGENTS.md convention (tool-agnostic; works for any modern coding agent) instead of listing per-agent paths that don't exist

## Kept as-is

- \`DECISIONS.md\` references to these paths are historical ADRs — records of decisions at a point in time, not current-state docs.

## Test plan

- [x] \`make check\` green
- [x] Confirmed against scaffold tests (\`init_project_test.go:487,548\`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)