### PR TITLE
fix(#812,#821): make openbao NotFound a sentinel + stop masking transport errors

### DIFF
--- a/internal/adapters/openbao/adapter.go
+++ b/internal/adapters/openbao/adapter.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
 // AuthMethod selects how the adapter authenticates to OpenBao.
@@ -240,7 +242,7 @@ func (a *Adapter) Get(ctx context.Context, path string) (map[string]string, erro
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("openbao: secret not found at %q", path)
+		return nil, fmt.Errorf("openbao: secret not found at %q: %w", path, ports.ErrSecretNotFound)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("openbao: get %q returned %d", path, resp.StatusCode)

--- a/internal/app/secret/service.go
+++ b/internal/app/secret/service.go
@@ -15,7 +15,9 @@ import (
 )
 
 // ErrSecretNotFound is returned when a secret cannot be found in any source.
-var ErrSecretNotFound = errors.New("secret not found")
+// Aliased to ports.ErrSecretNotFound — adapters wrap the port-level sentinel
+// so errors.Is works across the adapter-to-service boundary.
+var ErrSecretNotFound = ports.ErrSecretNotFound
 
 // ErrNoSourceAvailable is returned when neither OpenBao nor the credentials
 // file is available.
@@ -172,8 +174,14 @@ func (s *Service) tryOpenBao(ctx context.Context, alias *domainsecret.WellKnownA
 
 	data, err := s.secretStore.Get(ctx, path)
 	if err != nil {
-		// Path not found in OpenBao is not an error — return nil to trigger fallback.
-		return nil, nil
+		// Path not found is not an error — return nil to trigger the
+		// .credentials fallback. Transport, auth, or any other failure
+		// is propagated so an operator sees a misconfigured OpenBao
+		// instead of silently using local credentials.
+		if errors.Is(err, ports.ErrSecretNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("secretstore get %q: %w", path, err)
 	}
 	return data, nil
 }

--- a/internal/app/secret/service_test.go
+++ b/internal/app/secret/service_test.go
@@ -3,12 +3,14 @@ package secret_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 
 	appsecret "github.com/vibewarden/vibewarden/internal/app/secret"
 	"github.com/vibewarden/vibewarden/internal/domain/generate"
 	domainsecret "github.com/vibewarden/vibewarden/internal/domain/secret"
+	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
 // --- Fakes ---
@@ -16,14 +18,18 @@ import (
 // fakeSecretStore is a fake ports.SecretStore for testing.
 type fakeSecretStore struct {
 	healthErr error
+	getErr    error                        // when set, Get returns this error regardless of path
 	data      map[string]map[string]string // path -> key/values
 }
 
 func (f *fakeSecretStore) Get(_ context.Context, path string) (map[string]string, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
 	if d, ok := f.data[path]; ok {
 		return d, nil
 	}
-	return nil, errors.New("not found")
+	return nil, fmt.Errorf("fake: %q: %w", path, ports.ErrSecretNotFound)
 }
 
 func (f *fakeSecretStore) Put(_ context.Context, _ string, _ map[string]string) error {
@@ -275,5 +281,68 @@ func TestService_List_Sorted(t *testing.T) {
 		if paths[i] < paths[i-1] {
 			t.Errorf("List() not sorted at index %d: %q > %q", i, paths[i-1], paths[i])
 		}
+	}
+}
+
+// TestService_Get_OpenBaoTransportErrorPropagates is the regression test for
+// the silent-masking bug (#812). Before the fix, tryOpenBao converted every
+// SecretStore.Get error into nil,nil — an operator running against a
+// misconfigured OpenBao (wrong token, network blip, auth expired) would see
+// the Service silently fall back to .credentials and never learn the primary
+// store was broken. After the fix, only wrapped ErrSecretNotFound triggers
+// fallback; any other error propagates up.
+func TestService_Get_OpenBaoTransportErrorPropagates(t *testing.T) {
+	transportErr := errors.New("connection refused")
+	store := &fakeSecretStore{
+		getErr: transportErr, // Health() is still healthy (nil); Get() fails hard.
+	}
+	credStore := &fakeCredentialStore{
+		creds: &generate.GeneratedCredentials{
+			PostgresPassword: "fallback-should-not-be-used",
+		},
+	}
+	svc := appsecret.NewService(store, credStore, "/tmp")
+
+	_, err := svc.Get(context.Background(), "postgres")
+	if err == nil {
+		t.Fatal("Get() returned nil error; want the transport error propagated")
+	}
+	if !errors.Is(err, transportErr) {
+		t.Errorf("Get() error = %v; want errors.Is(err, transportErr) == true", err)
+	}
+	if errors.Is(err, appsecret.ErrSecretNotFound) {
+		t.Error("Get() returned ErrSecretNotFound for a transport failure — masking regression")
+	}
+}
+
+// TestService_Get_NotFoundFallsBackToCredentials confirms the happy path: a
+// wrapped ErrSecretNotFound still triggers the fallback chain.
+func TestService_Get_NotFoundFallsBackToCredentials(t *testing.T) {
+	store := &fakeSecretStore{
+		// no data for "infra/postgres" — fake returns wrapped ErrSecretNotFound.
+	}
+	credStore := &fakeCredentialStore{
+		creds: &generate.GeneratedCredentials{
+			PostgresPassword: "cred-file-password",
+		},
+	}
+
+	// Write a .credentials file so fallback has something to read.
+	tmp := t.TempDir()
+	credPath := tmp + "/.credentials"
+	if err := os.WriteFile(credPath, []byte(`{"postgres_password":"cred-file-password"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	svc := appsecret.NewService(store, credStore, tmp)
+
+	got, err := svc.Get(context.Background(), "postgres")
+	if err != nil {
+		t.Fatalf("Get() unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get() returned nil; want a RetrievedSecret from credentials fallback")
+	}
+	if got.Source != domainsecret.SourceCredentialsFile {
+		t.Errorf("Source = %q, want %q", got.Source, domainsecret.SourceCredentialsFile)
 	}
 }

--- a/internal/ports/secrets.go
+++ b/internal/ports/secrets.go
@@ -3,9 +3,16 @@ package ports
 
 import (
 	"context"
+	"errors"
 
 	domainsecret "github.com/vibewarden/vibewarden/internal/domain/secret"
 )
+
+// ErrSecretNotFound is the sentinel returned by SecretStore implementations
+// (and by SecretRetriever) when the requested path or alias does not exist.
+// Adapters must wrap this sentinel so callers can distinguish NotFound from
+// transport, auth, or other failures via errors.Is.
+var ErrSecretNotFound = errors.New("secret not found")
 
 // SecretStore is the outbound port for reading and writing secrets in an
 // external secret store (e.g. OpenBao / HashiCorp Vault KV v2).


### PR DESCRIPTION
## Summary

**The bug (#812):** \`app/secret/service.go:tryOpenBao\` converted **every** \`SecretStore.Get\` error into \`nil, nil\` and silently fell back to \`.credentials\`. Transport failures, auth expiry, wrong-token misconfigurations — all became invisible. The sidecar silently used local credentials while the operator assumed OpenBao was working.

**The root cause (#821):** \`openbao/adapter.go:243\` returned a plain \`fmt.Errorf\` on 404, so callers had no way to distinguish NotFound from transport errors via \`errors.Is\`. The silent fallback was the only "safe" behaviour available.

Closes #812 and #821 in one PR — they're coupled.

## Changes

- \`internal/ports/secrets.go\` — defines \`ports.ErrSecretNotFound\` as the port-layer sentinel. Documents the wrapping contract.
- \`internal/app/secret/service.go\` — \`ErrSecretNotFound\` aliased to the port sentinel (preserves existing \`cli/secret_get\` errors.Is); \`tryOpenBao\` uses \`errors.Is(err, ports.ErrSecretNotFound)\` to decide fallback vs. propagation.
- \`internal/adapters/openbao/adapter.go:243\` — wraps the sentinel with \`%w\` on HTTP 404.
- Fake store in \`service_test.go\` updated to wrap the sentinel (matches the new adapter contract).
- **New regression test** \`TestService_Get_OpenBaoTransportErrorPropagates\` — transport error must propagate, must not match \`ErrSecretNotFound\`, must not trigger fallback. Also added \`TestService_Get_NotFoundFallsBackToCredentials\` to pin the happy-path fallback contract.

## Behaviour change

Before: broken OpenBao → silent fallback, operator never notices.
After:  broken OpenBao → error propagated up with context; fallback only for genuine NotFound.

This may surface previously-hidden OpenBao misconfigurations on first deploy after merge. That's the point.

## Test plan

- [x] \`make check\` green locally (gofmt, golangci-lint, build, \`go test -race\`, demo-app)
- [x] Regression test covers the exact bug path
- [x] Happy-path fallback still works
- [ ] CI green
- [ ] Manual smoke: start sidecar with a bad OpenBao token, confirm error surfaces instead of silent fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)