### PR TITLE
fix(#832): stop masking transport errors in tryDynamicCredentials

### DIFF
--- a/internal/app/secret/service.go
+++ b/internal/app/secret/service.go
@@ -147,9 +147,16 @@ func (s *Service) List(ctx context.Context) ([]string, error) {
 }
 
 // tryOpenBao attempts to retrieve a secret from OpenBao.
-// Returns nil, nil when OpenBao is not configured, not available, or the path
-// is empty (e.g. the "openbao" alias has no OpenBao path).
-// Returns nil, nil on health-check failure (triggering the fallback).
+//
+// Returns (nil, nil) — triggering the .credentials fallback — when:
+//   - OpenBao is not configured (secretStore is nil)
+//   - the path is empty (e.g. the "openbao" alias has no OpenBao path)
+//   - the health check fails (store unreachable)
+//   - the underlying Get returns ErrSecretNotFound
+//
+// Any other error from dynamic-credentials retrieval or static Get
+// (transport, auth, permission denied) is propagated so an operator
+// sees a broken OpenBao configuration instead of a silent fallback.
 func (s *Service) tryOpenBao(ctx context.Context, alias *domainsecret.WellKnownAlias, path string) (map[string]string, error) {
 	if s.secretStore == nil {
 		return nil, nil
@@ -166,10 +173,16 @@ func (s *Service) tryOpenBao(ctx context.Context, alias *domainsecret.WellKnownA
 	// For aliases with a dynamic role, try dynamic credentials first.
 	if alias != nil && alias.DynamicRole != "" {
 		data, err := s.tryDynamicCredentials(ctx, alias.DynamicRole)
-		if err == nil && data != nil {
+		if err != nil {
+			// Transport, auth, or any other failure during dynamic retrieval
+			// is propagated so an operator sees a broken dynamic-role setup
+			// instead of silently using stale static credentials.
+			return nil, fmt.Errorf("dynamic credentials for role %q: %w", alias.DynamicRole, err)
+		}
+		if data != nil {
 			return data, nil
 		}
-		// Dynamic failed — fall through to static path.
+		// No dynamic creds at this path (NotFound) — fall through to static.
 	}
 
 	data, err := s.secretStore.Get(ctx, path)
@@ -187,12 +200,18 @@ func (s *Service) tryOpenBao(ctx context.Context, alias *domainsecret.WellKnownA
 }
 
 // tryDynamicCredentials requests dynamic database credentials from OpenBao.
-// Returns nil, nil when the request fails (allows fallback to static path).
+// Returns nil, nil when no dynamic credentials exist at the role path (NotFound) —
+// the caller falls through to the static path. Any other error (transport,
+// auth, permission denied) is propagated so a broken dynamic-role setup
+// surfaces instead of silently masquerading as "no dynamic creds available."
 func (s *Service) tryDynamicCredentials(ctx context.Context, role string) (map[string]string, error) {
 	dynPath := "database/creds/" + role
 	data, err := s.secretStore.Get(ctx, dynPath)
 	if err != nil {
-		return nil, nil
+		if errors.Is(err, ports.ErrSecretNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("secretstore get %q: %w", dynPath, err)
 	}
 	return data, nil
 }

--- a/internal/app/secret/service_test.go
+++ b/internal/app/secret/service_test.go
@@ -19,7 +19,7 @@ import (
 type fakeSecretStore struct {
 	healthErr error
 	getErr    error                        // when set, every Get returns this error
-	getErrAt  map[string]error             // when set, Get at a specific path returns that error (takes precedence over data)
+	getErrAt  map[string]error             // when set, Get at a specific path returns that error (takes precedence over data, but not over getErr)
 	data      map[string]map[string]string // path -> key/values
 }
 

--- a/internal/app/secret/service_test.go
+++ b/internal/app/secret/service_test.go
@@ -18,13 +18,17 @@ import (
 // fakeSecretStore is a fake ports.SecretStore for testing.
 type fakeSecretStore struct {
 	healthErr error
-	getErr    error                        // when set, Get returns this error regardless of path
+	getErr    error                        // when set, every Get returns this error
+	getErrAt  map[string]error             // when set, Get at a specific path returns that error (takes precedence over data)
 	data      map[string]map[string]string // path -> key/values
 }
 
 func (f *fakeSecretStore) Get(_ context.Context, path string) (map[string]string, error) {
 	if f.getErr != nil {
 		return nil, f.getErr
+	}
+	if err, ok := f.getErrAt[path]; ok {
+		return nil, err
 	}
 	if d, ok := f.data[path]; ok {
 		return d, nil
@@ -344,5 +348,69 @@ func TestService_Get_NotFoundFallsBackToCredentials(t *testing.T) {
 	}
 	if got.Source != domainsecret.SourceCredentialsFile {
 		t.Errorf("Source = %q, want %q", got.Source, domainsecret.SourceCredentialsFile)
+	}
+}
+
+// TestService_Get_DynamicTransportErrorPropagates is the regression test for
+// the silent-masking bug in tryDynamicCredentials (#832). The fix to #812
+// addressed tryOpenBao but left the sibling function's same anti-pattern in
+// place. Before the fix, a transport/auth error during dynamic-role retrieval
+// silently fell through to the static path and onward to credentials — an
+// operator with a revoked database role or a broken dynamic-creds backend
+// would see the sidecar quietly use stale credentials and never learn that
+// dynamic generation was failing.
+func TestService_Get_DynamicTransportErrorPropagates(t *testing.T) {
+	transportErr := errors.New("connection refused")
+	store := &fakeSecretStore{
+		// Dynamic path for postgres (database/creds/app-readwrite) fails hard.
+		getErrAt: map[string]error{
+			"database/creds/app-readwrite": transportErr,
+		},
+		// Static path would succeed if we fell through — the test asserts we do NOT.
+		data: map[string]map[string]string{
+			"infra/postgres": {"password": "static-should-not-be-used"},
+		},
+	}
+	credStore := &fakeCredentialStore{}
+	svc := appsecret.NewService(store, credStore, "/tmp")
+
+	_, err := svc.Get(context.Background(), "postgres")
+	if err == nil {
+		t.Fatal("Get() returned nil error; want the dynamic transport error propagated")
+	}
+	if !errors.Is(err, transportErr) {
+		t.Errorf("Get() error = %v; want errors.Is(err, transportErr) == true", err)
+	}
+	if errors.Is(err, appsecret.ErrSecretNotFound) {
+		t.Error("Get() returned ErrSecretNotFound for a dynamic transport failure — masking regression")
+	}
+}
+
+// TestService_Get_DynamicNotFoundFallsThroughToStatic pins the happy-path
+// fallback contract: a wrapped ErrSecretNotFound on the dynamic role path
+// should still fall through to the static path (which then succeeds).
+func TestService_Get_DynamicNotFoundFallsThroughToStatic(t *testing.T) {
+	store := &fakeSecretStore{
+		// Dynamic path is empty -> fake returns wrapped ErrSecretNotFound.
+		// Static path has data -> should be returned.
+		data: map[string]map[string]string{
+			"infra/postgres": {"password": "static-password"},
+		},
+	}
+	credStore := &fakeCredentialStore{}
+	svc := appsecret.NewService(store, credStore, "/tmp")
+
+	got, err := svc.Get(context.Background(), "postgres")
+	if err != nil {
+		t.Fatalf("Get() unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get() returned nil; want the static-path secret")
+	}
+	if got.Source != domainsecret.SourceOpenBao {
+		t.Errorf("Source = %q, want %q (static OpenBao path)", got.Source, domainsecret.SourceOpenBao)
+	}
+	if got.Data["password"] != "static-password" {
+		t.Errorf("Data[password] = %q, want %q", got.Data["password"], "static-password")
 	}
 }


### PR DESCRIPTION
## Summary

Completes the error-discipline thread started in #812 / #830. The sibling function of \`tryOpenBao\` — \`tryDynamicCredentials\` — had the same silent-masking anti-pattern, flagged by the reviewer during #830 review and tracked as #832.

Before:

\`\`\`go
func (s *Service) tryDynamicCredentials(ctx, role) (..., error) {
    data, err := s.secretStore.Get(ctx, dynPath)
    if err != nil {
        return nil, nil  // every error -> silent fallback
    }
    return data, nil
}
\`\`\`

A revoked database role, an expired OpenBao token, or a network blip during dynamic-creds retrieval would silently fall through to the static path, then to \`.credentials\`. Operator never learns dynamic generation is broken.

## Changes

- **\`tryDynamicCredentials\`** distinguishes \`ErrSecretNotFound\` (legitimate — fall through to static) from any other error (propagated with context).
- **Caller in \`tryOpenBao\`** updated to propagate the error instead of dropping it with \`if err == nil && data != nil\`. Now aligned with the static-Get pattern introduced by #830.
- **Stale doc comment on \`tryOpenBao\`** refreshed to describe the post-#830 propagation contract (addresses reviewer nit #3 from the #830 review).
- **Test fake extended** with \`getErrAt map[string]error\` so regression tests can make the dynamic path fail while the static path would succeed — that's the exact condition that pins the bug.

## Behaviour change

Before: broken dynamic creds → silent fallback to static → silent fallback to .credentials. Operator never notices.
After: broken dynamic creds → error propagated with context. Operator sees it.

May surface previously-hidden dynamic-role misconfigurations on first deploy after merge. That's the point.

## Test plan

- [x] \`make check\` green locally
- [x] \`TestService_Get_DynamicTransportErrorPropagates\` would have caught the original bug
- [x] \`TestService_Get_DynamicNotFoundFallsThroughToStatic\` pins the happy path
- [ ] CI green

Closes #832.

🤖 Generated with [Claude Code](https://claude.com/claude-code)