### PR TITLE
fix(#813): generate vibew mcp --help tool list from the live registry

### DIFF
--- a/internal/cli/cmd/mcp.go
+++ b/internal/cli/cmd/mcp.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"fmt"
+	"io"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -15,11 +18,10 @@ import (
 // It reads JSON-RPC 2.0 requests from stdin and writes responses to stdout.
 // All diagnostic output goes to stderr so it does not pollute the MCP stream.
 //
-// The server exposes four tools:
-//   - vibewarden_status  — check whether the sidecar is running
-//   - vibewarden_doctor  — run health checks
-//   - vibewarden_validate — validate vibewarden.yaml
-//   - vibewarden_explain  — explain what a config does
+// The tool list in --help is generated at command-construction time from the
+// live registry (see buildLongHelp / mcpToolSummary). Adding a new tool in
+// internal/mcp/ automatically shows up in "vibew mcp --help" — the list
+// cannot drift out of sync with the registered handlers.
 //
 // Intended usage in an AI agent / IDE MCP configuration:
 //
@@ -35,28 +37,7 @@ func NewMCPCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mcp",
 		Short: "Start the VibeWarden MCP server (stdio JSON-RPC 2.0)",
-		Long: `Start a Model Context Protocol (MCP) server on stdio.
-
-The server reads JSON-RPC 2.0 messages from stdin and writes responses to
-stdout, following the MCP 2024-11-05 specification. All diagnostic output
-goes to stderr.
-
-Available tools:
-  vibewarden_status   — check whether the VibeWarden sidecar is running
-  vibewarden_doctor   — run the full diagnostics suite
-  vibewarden_validate — validate a vibewarden.yaml configuration file
-  vibewarden_explain  — describe what a configuration does in plain language
-
-Configure in your AI agent / IDE:
-
-  {
-    "mcpServers": {
-      "vibewarden": {
-        "command": "vibew",
-        "args": ["mcp"]
-      }
-    }
-  }`,
+		Long:  buildMCPLongHelp(),
 		// SilenceUsage prevents cobra from printing usage on errors produced
 		// inside the MCP loop — those go to stderr as slog messages.
 		SilenceUsage: true,
@@ -79,4 +60,49 @@ Configure in your AI agent / IDE:
 	}
 
 	return cmd
+}
+
+// buildMCPLongHelp constructs the "vibew mcp --help" text from the live
+// default-tools registry, so the list stays in sync with whatever
+// RegisterDefaultTools registers. The throwaway server is only used to
+// enumerate tool metadata; it is never served.
+func buildMCPLongHelp() string {
+	discardLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	tmp := mcp.NewServer("vibewarden", "help", discardLogger)
+	mcp.RegisterDefaultTools(tmp)
+
+	var tools strings.Builder
+	for _, t := range tmp.Tools() {
+		fmt.Fprintf(&tools, "  %-36s  %s\n", t.Name, mcpFirstSentence(t.Description))
+	}
+
+	return fmt.Sprintf(`Start a Model Context Protocol (MCP) server on stdio.
+
+The server reads JSON-RPC 2.0 messages from stdin and writes responses to
+stdout, following the MCP 2024-11-05 specification. All diagnostic output
+goes to stderr.
+
+Available tools:
+%s
+Configure in your AI agent / IDE:
+
+  {
+    "mcpServers": {
+      "vibewarden": {
+        "command": "vibew",
+        "args": ["mcp"]
+      }
+    }
+  }`, tools.String())
+}
+
+// mcpFirstSentence returns the first sentence of a tool description, for
+// the compact listing in --help. If no sentence delimiter is found the
+// description is returned unchanged.
+func mcpFirstSentence(desc string) string {
+	desc = strings.TrimSpace(desc)
+	if i := strings.Index(desc, ". "); i > 0 {
+		return desc[:i+1]
+	}
+	return desc
 }

--- a/internal/cli/cmd/mcp.go
+++ b/internal/cli/cmd/mcp.go
@@ -19,9 +19,9 @@ import (
 // All diagnostic output goes to stderr so it does not pollute the MCP stream.
 //
 // The tool list in --help is generated at command-construction time from the
-// live registry (see buildLongHelp / mcpToolSummary). Adding a new tool in
-// internal/mcp/ automatically shows up in "vibew mcp --help" — the list
-// cannot drift out of sync with the registered handlers.
+// live registry (see buildMCPLongHelp and mcpFirstSentence). Adding a new
+// tool in internal/mcp/ automatically shows up in "vibew mcp --help" — the
+// list cannot drift out of sync with the registered handlers.
 //
 // Intended usage in an AI agent / IDE MCP configuration:
 //

--- a/internal/cli/cmd/mcp_test.go
+++ b/internal/cli/cmd/mcp_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/mcp"
+)
+
+// TestMCPLongHelp_ListsEveryRegisteredTool is the drift guard. If a new tool
+// gets added to internal/mcp.RegisterDefaultTools but is missing from the
+// Long help output, this test fails. It is the reason the Long string is
+// generated at runtime instead of hard-coded — before #813 the hard-coded
+// list had drifted to show 4 tools while 13+ were actually registered.
+func TestMCPLongHelp_ListsEveryRegisteredTool(t *testing.T) {
+	long := buildMCPLongHelp()
+
+	// Build a reference server the same way the CLI does, then enumerate.
+	ref := mcp.NewServer("test", "test", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	mcp.RegisterDefaultTools(ref)
+
+	if got := len(ref.Tools()); got == 0 {
+		t.Fatal("RegisterDefaultTools registered zero tools — guard test would pass vacuously")
+	}
+
+	for _, td := range ref.Tools() {
+		if !strings.Contains(long, td.Name) {
+			t.Errorf("Long help is missing registered tool %q", td.Name)
+		}
+	}
+}
+
+// TestMCPFirstSentence exercises the description-trimming used in the
+// compact tool listing, covering the single-sentence, multi-sentence, and
+// no-delimiter cases.
+func TestMCPFirstSentence(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"single sentence with period", "Check the sidecar.", "Check the sidecar."},
+		{"two sentences splits at first", "Check the sidecar. Returns HTTP status.", "Check the sidecar."},
+		{"no sentence delimiter", "Check the sidecar", "Check the sidecar"},
+		{"leading whitespace trimmed", "  Check the sidecar.  ", "Check the sidecar."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mcpFirstSentence(tt.in); got != tt.want {
+				t.Errorf("mcpFirstSentence(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -106,6 +106,15 @@ func (s *Server) RegisterTool(def ToolDefinition, handler ToolHandler) {
 	s.handlers[def.Name] = handler
 }
 
+// Tools returns a copy of the registered tool definitions in registration order.
+// Callers can enumerate them for discovery (e.g. generating CLI help text or
+// documentation from the live registry instead of hard-coding a list).
+func (s *Server) Tools() []ToolDefinition {
+	out := make([]ToolDefinition, len(s.tools))
+	copy(out, s.tools)
+	return out
+}
+
 // Serve reads JSON-RPC messages from in and writes responses to out.
 // It blocks until in is closed or ctx is cancelled.
 func (s *Server) Serve(ctx context.Context, in io.Reader, out io.Writer) error {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -230,3 +230,31 @@ func TestServer_MultipleRequests(t *testing.T) {
 		t.Errorf("expected 2 response lines, got %d: %q", len(lines), out.String())
 	}
 }
+
+// TestServer_Tools_ReturnsRegisteredToolsInOrder covers the public getter
+// used by external callers (e.g. cmd/vibewarden's mcp help generator).
+// Registration order must be preserved and the returned slice must be a
+// copy so callers can't mutate the server's state.
+func TestServer_Tools_ReturnsRegisteredToolsInOrder(t *testing.T) {
+	srv := newTestServer()
+	srv.RegisterTool(ToolDefinition{Name: "alpha", Description: "first"}, nil)
+	srv.RegisterTool(ToolDefinition{Name: "beta", Description: "second"}, nil)
+	srv.RegisterTool(ToolDefinition{Name: "gamma", Description: "third"}, nil)
+
+	got := srv.Tools()
+	want := []string{"alpha", "beta", "gamma"}
+	if len(got) != len(want) {
+		t.Fatalf("Tools() returned %d items, want %d", len(got), len(want))
+	}
+	for i, td := range got {
+		if td.Name != want[i] {
+			t.Errorf("Tools()[%d].Name = %q, want %q", i, td.Name, want[i])
+		}
+	}
+
+	// Mutating the returned slice must not affect the server's internal state.
+	got[0].Name = "MUTATED"
+	if srv.Tools()[0].Name != "alpha" {
+		t.Error("Tools() returned a mutable reference to internal state; should be a copy")
+	}
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -66,6 +66,7 @@ to inspect and manage a local sidecar. Tools:
 | `vibewarden_verify_deploy` | Verify a deployed sidecar is reachable and healthy |
 | `vibewarden_get_deploy_logs` | Instructions for retrieving sidecar logs |
 | `vibewarden_watch_events` | Stream live structured log events from the sidecar |
+| `vibewarden_stream_logs` | Stream raw container logs with client-side filtering (level, since, search) |
 | `vibewarden_schema_describe` | Describe the AI-readable log schema (pure metadata, no sidecar needed) |
 | `vibewarden_propose_action` | Create a configuration-change proposal for human review |
 | `vibewarden_list_proposals` | List pending configuration-change proposals |


### PR DESCRIPTION
## Summary

\`vibew mcp --help\` hard-coded four tools in its Long help. The binary actually registers 13 (10 default + 3 proposal). Users reading \`--help\` couldn't discover \`vibewarden_stream_logs\` (hyped in README.md:186), the three deploy-helper tools, the schema descriptor, or the proposals family. Writer audit flagged it as a HIGH-severity drift.

Fix makes drift structurally impossible: the Long string is generated at command-construction time from the live registry.

Closes #813.

## Changes

- **\`internal/mcp/server.go\`** — new \`Server.Tools() []ToolDefinition\` getter returns a defensive copy of the registered definitions in registration order.
- **\`internal/cli/cmd/mcp.go\`** — \`NewMCPCmd\` replaces the hard-coded \`Long\` with \`buildMCPLongHelp()\`, which constructs a throwaway server, calls \`RegisterDefaultTools\`, enumerates \`Tools()\`, and prints one line per tool using the first sentence of each description.
- **\`internal/cli/cmd/mcp_test.go\`** (new) — \`TestMCPLongHelp_ListsEveryRegisteredTool\` is the drift guard: fails if any registered tool is missing from the Long output.
- **\`internal/mcp/server_test.go\`** — \`TestServer_Tools_ReturnsRegisteredToolsInOrder\` covers the new getter, including the copy-semantics invariant.
- **\`llms-full.txt\`** — add the missing \`vibewarden_stream_logs\` row.

## What the fix looks like in practice

\`vibew mcp --help\` now prints:

\`\`\`
Available tools:
  vibewarden_status                     Check whether the VibeWarden sidecar is running…
  vibewarden_doctor                     Run the full VibeWarden health-check suite…
  vibewarden_validate                   Validate a vibewarden.yaml configuration file.
  vibewarden_explain                    Explain what a VibeWarden configuration does…
  vibewarden_prepare_deploy             Generate a deployment spec for the VibeWarden sidecar…
  vibewarden_verify_deploy              Verify that a deployed VibeWarden sidecar is reachable…
  vibewarden_get_deploy_logs            Retrieve recent sidecar logs from a deployed instance.
  vibewarden_watch_events               Poll the VibeWarden admin events endpoint…
  vibewarden_stream_logs                Fetch and filter structured log events…
  vibewarden_schema_describe            Describe the VibeWarden AI-readable log schema.
  vibewarden_propose_action             Propose a configuration change to the VibeWarden sidecar.
  vibewarden_list_proposals             List configuration-change proposals…
  vibewarden_get_proposal               Retrieve a single configuration-change proposal by ID…
\`\`\`

## Test plan

- [x] \`make check\` green locally
- [x] \`vibew mcp --help\` on a local build prints all 13 tools (verified manually)
- [x] Drift-guard test would fail if a new registered tool is missing from Long
- [x] \`Tools()\` copy-semantics pinned by test
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)