### PR TITLE
fix(#819): CLI correctness sweep — 4 doc fixes (5th item rejected as incorrect audit)

### DIFF
--- a/docs/deploy-to-vps.md
+++ b/docs/deploy-to-vps.md
@@ -109,7 +109,7 @@ curl -fsSL https://vibewarden.dev/vibew > vibew && chmod +x vibew
 
 ```bash
 mkdir myapp && cd myapp
-vibew init myapp
+vibew init .
 vibew add auth
 vibew add tls --domain myapp.example.com
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -138,7 +138,7 @@ Your app receives authenticated user info via headers:
 |---------|-------------|
 | `vibew wrap` | Add VibeWarden sidecar to an existing project |
 | `vibew add auth` | Enable authentication |
-| `vibew add rate-limit` | Enable rate limiting |
+| `vibew add rate-limiting` | Enable rate limiting |
 | `vibew add tls --domain example.com` | Enable TLS |
 | `vibew add metrics` | Enable Prometheus metrics |
 | `vibew generate` | Regenerate `docker-compose.yml` from config |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -264,7 +264,7 @@ colons, or misaligned indentation.
 **Symptom**
 
 ```
-[WARN]  Generated files  .vibewarden/generated/docker-compose.yml not found — run 'vibewarden generate' first
+[WARN]  Generated files  .vibewarden/generated/docker-compose.yml not found — run 'vibew generate' first
 ```
 
 **Cause**

--- a/vibewarden.reference.yaml
+++ b/vibewarden.reference.yaml
@@ -75,6 +75,7 @@ tls:
   # Provider selects how TLS certificates are obtained. Valid values:
   #
   #   letsencrypt  — Automatic ACME certificate via Let's Encrypt.
+  #                  (Alias: "acme". Both values select the same behaviour.)
   #                  Requires a public domain and open port 443.
   #                  Also requires the "domain" field to be set.
   #


### PR DESCRIPTION
## Summary

Four of the five items from the audit's CLI correctness sweep. The fifth is a rejected audit finding — code review showed the claim was wrong. Details below.

Closes #819.

## Applied

- **\`docs/index.md:141\`** — \`vibew add rate-limit\` → \`rate-limiting\` (matches \`internal/cli/cmd/add_ratelimit.go:14\` — \`Use: "rate-limiting [directory]"\`)
- **\`docs/deploy-to-vps.md:111-112\`** — \`mkdir myapp && cd myapp; vibew init myapp\` would scaffold into \`myapp/myapp/\`. Fixed to \`vibew init .\` inside the already-created dir.
- **\`vibewarden.reference.yaml:77\`** — document the \`acme\` alias for the \`letsencrypt\` provider (previously only mentioned in \`docs/configuration.md:103\`).
- **\`docs/troubleshooting.md:267\`** — sample warning text used the old \`vibewarden generate\` binary name. Corrected to \`vibew generate\`.

## Rejected (item #5 from the audit)

The writer audit said README:319 and getting-started.md:194 instruct users to run \`./vibew build\` before \`./vibew dev\`, and claimed \`dev\` already runs \`build\`. **That claim is wrong.**

\`internal/cli/cmd/dev.go:86-88\`:
\`\`\`go
// Wire the image checker so that \`vibew dev\` fails early with a
// helpful message when the app image has not been built yet.
svc = svc.WithImageChecker(opsadapter.NewImageCheckerAdapter())
\`\`\`

\`vibew dev\` **fails early with build instructions** when the app image is missing — it does not build automatically. Removing \`./vibew build\` from the docs would break the documented demo flow. Audit item rejected against code.

## Test plan

- [x] \`make check\` green
- [x] \`vibew dev\` code reviewed — does not invoke \`build\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)