### PR TITLE
fix(#814): replace err != http.ErrServerClosed with errors.Is across 5 sites

### DIFF
--- a/internal/adapters/authui/handler.go
+++ b/internal/adapters/authui/handler.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"html/template"
 	"log/slog"
@@ -122,7 +123,7 @@ func (h *Handler) Start() error {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 	go func() {
-		if serveErr := h.server.Serve(ln); serveErr != nil && serveErr != http.ErrServerClosed {
+		if serveErr := h.server.Serve(ln); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
 			h.logger.Error("authui server stopped unexpectedly", "err", serveErr)
 		}
 	}()

--- a/internal/adapters/egress/proxy.go
+++ b/internal/adapters/egress/proxy.go
@@ -268,7 +268,7 @@ func (p *Proxy) Start() error {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 	go func() {
-		if err := p.server.Serve(ln); err != nil && err != http.ErrServerClosed {
+		if err := p.server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			p.logger.Error("egress proxy stopped unexpectedly", "err", err)
 		}
 	}()

--- a/internal/adapters/http/admin_server.go
+++ b/internal/adapters/http/admin_server.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -55,7 +56,7 @@ func (s *AdminServer) Start() error {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 	go func() {
-		if serveErr := s.server.Serve(ln); serveErr != nil && serveErr != http.ErrServerClosed {
+		if serveErr := s.server.Serve(ln); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
 			s.logger.Error("admin server stopped unexpectedly", "err", serveErr)
 		}
 	}()

--- a/internal/adapters/jwt/dev_server.go
+++ b/internal/adapters/jwt/dev_server.go
@@ -3,6 +3,7 @@ package jwt
 import (
 	"context"
 	"crypto/rsa"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -63,7 +64,7 @@ func (s *DevServer) Start() error {
 	}
 
 	go func() {
-		if serveErr := s.server.Serve(ln); serveErr != nil && serveErr != http.ErrServerClosed {
+		if serveErr := s.server.Serve(ln); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
 			s.logger.Error("dev jwks server stopped unexpectedly", slog.String("error", serveErr.Error()))
 		}
 	}()

--- a/internal/adapters/metrics/server.go
+++ b/internal/adapters/metrics/server.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -50,7 +51,7 @@ func (s *Server) Start() error {
 	}
 	go func() {
 		// Serve until stopped; ErrServerClosed is the expected shutdown signal.
-		if serveErr := s.server.Serve(ln); serveErr != nil && serveErr != http.ErrServerClosed {
+		if serveErr := s.server.Serve(ln); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
 			s.logger.Error("metrics server stopped unexpectedly", "err", serveErr)
 		}
 	}()


### PR DESCRIPTION
## Summary

Mechanical sweep per reviewer-audit finding. Direct equality against \`http.ErrServerClosed\` breaks the moment any middleware wraps the error. Using \`errors.Is\` tolerates arbitrary \`%w\` wrapping.

Closes #814.

## Sites swept

- \`internal/adapters/metrics/server.go:53\`
- \`internal/adapters/egress/proxy.go:271\`
- \`internal/adapters/jwt/dev_server.go:66\`
- \`internal/adapters/http/admin_server.go:58\`
- \`internal/adapters/authui/handler.go:125\`

## Test plan

- [x] \`make check\` green locally
- [ ] CI green

Zero behaviour difference unless Serve ever returns a wrapped \`ErrServerClosed\` — which is exactly the case this change makes safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)