### PR TITLE
feat(#818): consolidate internal/ports per ADR-064

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -13333,3 +13333,148 @@ vibew deploy logs --target ssh://user@host [--lines 50]
 - No rollback on failure — the operator must redeploy manually
 - Health check polls `/_vibewarden/health` via a direct HTTP call over an
   SSH tunnel; does not validate TLS certificate in v1
+
+## ADR-064: Ports-layer consolidation — remove config, adapter, and app-service leaks from internal/ports
+**Date**: 2026-04-15
+**Status**: Accepted
+**Issue**: #818
+
+### Context
+
+A 2026-04-16 architect audit found three independent violations of the
+hexagonal invariant locked in `CLAUDE.md` ("domain layer has zero external
+dependencies… interfaces defined in `ports/`, not next to their
+implementations"):
+
+1. `internal/ports/generate.go` imported `internal/config`, reaching from the
+   ports package back into the config package.
+2. `internal/adapters/apikey/openbao_validator.go` declared a local
+   `KeyStore` interface that was really a generic outbound secret-KV-read
+   port, co-located with its sole consumer instead of living in
+   `internal/ports/`.
+3. `internal/adapters/http/admin_proposals.go` depended on
+   `*proposalapp.Service` directly, so the HTTP inbound adapter was coupled
+   to a concrete application type rather than an interface.
+
+Each finding is small on its own; together they show the ports layer is
+leaking. This ADR captures the cleanup and states the ports-layer import
+policy end-to-end.
+
+### Decision
+
+The `internal/ports/` package imports stdlib and `internal/domain/*` only.
+No import of `internal/config`, `internal/adapters/*`, or `internal/app/*`
+is permitted.
+
+To restore the invariant, three surgical changes land together:
+
+1. **F1 — `ConfigGenerator` takes a port-owned DTO.** A new
+   `ports.GeneratorInput` struct carries typed decision fields plus an
+   opaque `TemplateData any` payload. `ports.ConfigGenerator.Generate` is
+   retyped to `Generate(ctx, GeneratorInput, outputDir) error`. A new
+   mapper `(*config.Config).ToGeneratorInput()` lives in `internal/config`
+   so the ports package does not import config.
+
+   The typed decision fields (`Profile`, `AuthEnabled`, `AuthMode`,
+   `KratosExternal`, `SecretsEnabled`, `ObservabilityEnabled`) are
+   declared for the ports contract but **intentionally unread by the v1
+   service body**. The generator recovers the concrete `*config.Config`
+   from `TemplateData` via a type assertion and continues to branch on it.
+   This keeps template output byte-identical to main and leaves a clean
+   future path: the Generate body can migrate off the assertion in a later
+   PR by consuming the typed fields and narrowing `TemplateData` to a
+   named template model.
+
+2. **F2 — Promote `apikey.KeyStore` to `ports.SecretKVReader`.**
+   `ports.SecretKVReader` is the minimal outbound port for reading a
+   slice of a KV secret store (`Get(ctx, path) (map[string]string, error)`).
+   `ports.SecretStore` embeds `SecretKVReader` so every existing
+   implementation (including `*openbao.Adapter`) still satisfies the full
+   store interface. The local `apikey.KeyStore` declaration is deleted;
+   `OpenBaoValidator` consumes `ports.SecretKVReader`.
+
+3. **F3 — Introduce `ports.ProposalService` aggregate inbound port.**
+   The port aggregates the full `Create`/`List`/`Get`/`Approve`/`Dismiss`
+   surface because the HTTP handler — the only consumer today — exercises
+   every operation; splitting into reader/writer buys no ISP benefit and
+   forces shim boilerplate. `*proposalapp.Service` satisfies the port,
+   enforced by a `var _ ports.ProposalService = (*Service)(nil)`
+   compile-time assertion in the application package. The alias
+   `proposalapp.CreateParams = ports.ProposalCreateParams` keeps every
+   existing caller (HTTP handler, integration tests, unit tests) compiling
+   unchanged.
+
+### Ruling on the three open questions from the PM
+
+1. **`ProposalService` — single aggregate interface.** One port, five
+   methods. Future narrow consumers can embed a sub-interface locally
+   via Go structural typing.
+2. **`SecretKVReader`, not `KeyStore`.** The original name leaked the
+   apikey domain into a generic port. `SecretKVReader` describes what
+   the port *is*: a read-only slice of a secret KV store. Contract stays
+   minimal at `Get(ctx, path)`; no `Health` method.
+3. **Narrow DTO + opaque `TemplateData any`.** Typed decision fields
+   for the service-side branching layer; opaque payload for the template
+   renderer (which already takes `any`). Minimal surface, byte-identical
+   template output, clear future migration path.
+
+### Migration order
+
+To keep the tree green at each commit:
+
+1. Add the three port types without removing anything
+   (`SecretKVReader`, `GeneratorInput`, `ProposalService`,
+   `ProposalCreateParams`).
+2. Migrate the generate path — signature change, config mapper, three
+   callers (`cli/cmd/generate`, `app/ops/dev` x2, `app/deploy`), and
+   their test fakes.
+3. Migrate the adapter + HTTP — delete `apikey.KeyStore`, retype the
+   admin-proposals handler to `ports.ProposalService`, add the
+   compile-time assertion.
+
+### Behavioural equivalence guards
+
+- HTTP admin-proposals endpoints exercise identical status codes, bodies,
+  and error mappings under both the real `*proposalapp.Service` and a
+  hand-rolled stub that only satisfies `ports.ProposalService`
+  (`internal/adapters/http/admin_proposals_port_test.go`).
+- Generator output is byte-identical whether the input is built by
+  `cfg.ToGeneratorInput()` or by constructing `ports.GeneratorInput`
+  directly with the same `*config.Config` as `TemplateData`
+  (`internal/app/generate/service_port_test.go`).
+- A rejected-payload test confirms the Generate body's type assertion
+  errors cleanly when `TemplateData` is not `*config.Config`.
+- An advisory `//go:build purity` test in `internal/ports/purity_test.go`
+  asserts `internal/ports` imports only stdlib and `internal/domain/*`.
+  It is not part of the default `make check` gate — operators or CI can
+  opt in with `go test -tags=purity ./internal/ports/...`.
+
+### Consequences
+
+**Positive:**
+- `internal/ports/` is now a pure interface package — stdlib plus
+  `internal/domain/*` only.
+- HTTP admin-proposals handler is testable against any implementation of
+  `ports.ProposalService`, not just `*proposalapp.Service`.
+- `apikey.OpenBaoValidator` composes with any implementation of
+  `ports.SecretKVReader`, not just the colocated interface.
+- A compile-time assertion enforces that the app service and the inbound
+  port stay in sync.
+
+**Negative:**
+- The generator service body still carries a `TemplateData.(*config.Config)`
+  cast — this is intentional for v1 but is technical debt that must be
+  retired when the body migrates to consume the typed decision fields.
+  Follow-up work tracked outside this ADR.
+- `proposalapp.CreateParams` is now a type alias; this is load-bearing
+  public API to keep existing callers compiling. Renaming or removing
+  the alias requires a full caller audit.
+
+### Limitations (v1)
+
+- The purity test is advisory (build-tagged). No linter rule enforces
+  the ports import policy in CI. If the policy is re-violated, reviewers
+  and the advisory test are the safety net.
+- The `GeneratorInput` typed fields are not yet consumed by the service
+  body. Adding a new decision field requires coordinating the DTO, the
+  mapper, and — in a later PR — the service body.

--- a/internal/adapters/apikey/openbao_validator.go
+++ b/internal/adapters/apikey/openbao_validator.go
@@ -14,17 +14,6 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
-// KeyStore is the outbound dependency used by OpenBaoValidator to fetch
-// key data from a secret store. The map returned by Get must contain entries
-// where each key is the API key name and each value is its SHA-256 hex hash.
-//
-// This interface is satisfied by *openbao.Adapter.Get but is defined locally
-// so the adapter package does not import the openbao package directly.
-type KeyStore interface {
-	// Get returns all fields stored at the given KV path.
-	Get(ctx context.Context, path string) (map[string]string, error)
-}
-
 // OpenBaoValidator is an implementation of ports.APIKeyValidator that reads
 // API key hashes from an OpenBao KV path. Results are cached in memory and
 // refreshed after the configured TTL expires.
@@ -40,7 +29,7 @@ type KeyStore interface {
 //	  "mobile-app": "9b1c..."
 //	}
 type OpenBaoValidator struct {
-	store    KeyStore
+	store    ports.SecretKVReader
 	path     string
 	cacheTTL time.Duration
 	logger   *slog.Logger
@@ -53,7 +42,11 @@ type OpenBaoValidator struct {
 // NewOpenBaoValidator creates an OpenBaoValidator that reads API key hashes
 // from the given OpenBao KV path and caches them for cacheTTL.
 // A zero cacheTTL defaults to 5 minutes.
-func NewOpenBaoValidator(store KeyStore, path string, cacheTTL time.Duration, logger *slog.Logger) (*OpenBaoValidator, error) {
+//
+// store is the narrow ports.SecretKVReader port; any ports.SecretStore
+// implementation (including *openbao.Adapter) satisfies it because
+// SecretStore embeds SecretKVReader.
+func NewOpenBaoValidator(store ports.SecretKVReader, path string, cacheTTL time.Duration, logger *slog.Logger) (*OpenBaoValidator, error) {
 	if store == nil {
 		return nil, fmt.Errorf("openbao api key validator: store cannot be nil")
 	}

--- a/internal/adapters/apikey/openbao_validator_test.go
+++ b/internal/adapters/apikey/openbao_validator_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
-// fakeKeyStore is a test double for KeyStore.
+// fakeKeyStore is a test double for ports.SecretKVReader.
 type fakeKeyStore struct {
 	data      map[string]string
 	err       error
@@ -35,7 +35,7 @@ func (f *fakeKeyStore) Get(_ context.Context, _ string) (map[string]string, erro
 func TestNewOpenBaoValidator_Errors(t *testing.T) {
 	tests := []struct {
 		name     string
-		store    KeyStore
+		store    ports.SecretKVReader
 		path     string
 		cacheTTL time.Duration
 		wantErr  bool

--- a/internal/adapters/http/admin_proposals.go
+++ b/internal/adapters/http/admin_proposals.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strings"
 
-	proposalapp "github.com/vibewarden/vibewarden/internal/app/proposal"
 	"github.com/vibewarden/vibewarden/internal/domain/proposal"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
@@ -15,13 +14,15 @@ import (
 // ProposalHandlers provides HTTP handler functions for the proposal lifecycle API.
 // All routes are registered under /_vibewarden/admin/proposals.
 type ProposalHandlers struct {
-	svc    *proposalapp.Service
+	svc    ports.ProposalService
 	logger *slog.Logger
 }
 
 // NewProposalHandlers creates a new ProposalHandlers backed by the supplied service.
+// svc is the inbound port — the handler does not depend on the concrete
+// application service type.
 // logger may be nil; slog.Default() is used when nil.
-func NewProposalHandlers(svc *proposalapp.Service, logger *slog.Logger) *ProposalHandlers {
+func NewProposalHandlers(svc ports.ProposalService, logger *slog.Logger) *ProposalHandlers {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -94,7 +95,7 @@ func (h *ProposalHandlers) create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p, err := h.svc.Create(r.Context(), proposalapp.CreateParams{
+	p, err := h.svc.Create(r.Context(), ports.ProposalCreateParams{
 		Type:   actionType,
 		Params: req.Params,
 		Reason: req.Reason,

--- a/internal/adapters/http/admin_proposals_port_test.go
+++ b/internal/adapters/http/admin_proposals_port_test.go
@@ -1,0 +1,189 @@
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	httpadapter "github.com/vibewarden/vibewarden/internal/adapters/http"
+	"github.com/vibewarden/vibewarden/internal/domain/proposal"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// stubProposalService is a hand-rolled fake implementation of
+// ports.ProposalService used to prove that the HTTP handler depends on the
+// inbound port rather than the concrete *proposalapp.Service. It records the
+// most recent call arguments and returns caller-configured responses.
+type stubProposalService struct {
+	// createFn, listFn, getFn, approveFn, dismissFn override behaviour.
+	createFn  func(ctx context.Context, params ports.ProposalCreateParams) (proposal.Proposal, error)
+	listFn    func(ctx context.Context, status proposal.Status) ([]proposal.Proposal, error)
+	getFn     func(ctx context.Context, id string) (proposal.Proposal, error)
+	approveFn func(ctx context.Context, id string) (proposal.Proposal, error)
+	dismissFn func(ctx context.Context, id string) (proposal.Proposal, error)
+
+	lastCreateParams ports.ProposalCreateParams
+	lastListStatus   proposal.Status
+	lastID           string
+}
+
+func (s *stubProposalService) Create(ctx context.Context, params ports.ProposalCreateParams) (proposal.Proposal, error) {
+	s.lastCreateParams = params
+	if s.createFn != nil {
+		return s.createFn(ctx, params)
+	}
+	return proposal.Proposal{}, nil
+}
+
+func (s *stubProposalService) List(ctx context.Context, status proposal.Status) ([]proposal.Proposal, error) {
+	s.lastListStatus = status
+	if s.listFn != nil {
+		return s.listFn(ctx, status)
+	}
+	return nil, nil
+}
+
+func (s *stubProposalService) Get(ctx context.Context, id string) (proposal.Proposal, error) {
+	s.lastID = id
+	if s.getFn != nil {
+		return s.getFn(ctx, id)
+	}
+	return proposal.Proposal{}, ports.ErrProposalNotFound
+}
+
+func (s *stubProposalService) Approve(ctx context.Context, id string) (proposal.Proposal, error) {
+	s.lastID = id
+	if s.approveFn != nil {
+		return s.approveFn(ctx, id)
+	}
+	return proposal.Proposal{}, ports.ErrProposalNotFound
+}
+
+func (s *stubProposalService) Dismiss(ctx context.Context, id string) (proposal.Proposal, error) {
+	s.lastID = id
+	if s.dismissFn != nil {
+		return s.dismissFn(ctx, id)
+	}
+	return proposal.Proposal{}, ports.ErrProposalNotFound
+}
+
+func newStubMux(t *testing.T, stub ports.ProposalService) *http.ServeMux {
+	t.Helper()
+	h := httpadapter.NewProposalHandlers(stub, nil)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	return mux
+}
+
+func TestProposalHandlers_UsesPortNotConcreteService_Create(t *testing.T) {
+	now := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+	stub := &stubProposalService{
+		createFn: func(_ context.Context, params ports.ProposalCreateParams) (proposal.Proposal, error) {
+			return proposal.Proposal{
+				ID:        "stub-id-1",
+				Type:      params.Type,
+				Params:    params.Params,
+				Reason:    params.Reason,
+				Status:    proposal.StatusPending,
+				CreatedAt: now,
+				ExpiresAt: now.Add(proposal.DefaultTTL),
+				Source:    proposal.SourceMCPAgent,
+			}, nil
+		},
+	}
+	mux := newStubMux(t, stub)
+
+	body := map[string]any{
+		"action_type": "block_ip",
+		"params":      map[string]any{"ip": "1.2.3.4"},
+		"reason":      "traffic spike",
+	}
+	raw, _ := json.Marshal(body)
+	r := httptest.NewRequest(http.MethodPost, "/_vibewarden/admin/proposals", bytes.NewReader(raw))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("POST status = %d, want 201; body: %s", w.Code, w.Body.String())
+	}
+
+	if stub.lastCreateParams.Type != proposal.ActionBlockIP {
+		t.Errorf("stub.lastCreateParams.Type = %q, want %q",
+			stub.lastCreateParams.Type, proposal.ActionBlockIP)
+	}
+	if stub.lastCreateParams.Reason != "traffic spike" {
+		t.Errorf("stub.lastCreateParams.Reason = %q, want %q",
+			stub.lastCreateParams.Reason, "traffic spike")
+	}
+	if stub.lastCreateParams.Source != proposal.SourceMCPAgent {
+		t.Errorf("stub.lastCreateParams.Source = %q, want %q",
+			stub.lastCreateParams.Source, proposal.SourceMCPAgent)
+	}
+}
+
+func TestProposalHandlers_UsesPortNotConcreteService_GetNotFound(t *testing.T) {
+	stub := &stubProposalService{
+		getFn: func(_ context.Context, _ string) (proposal.Proposal, error) {
+			return proposal.Proposal{}, ports.ErrProposalNotFound
+		},
+	}
+	mux := newStubMux(t, stub)
+
+	r := httptest.NewRequest(http.MethodGet, "/_vibewarden/admin/proposals/does-not-exist", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("GET status = %d, want 404", w.Code)
+	}
+	if stub.lastID != "does-not-exist" {
+		t.Errorf("stub.lastID = %q, want %q", stub.lastID, "does-not-exist")
+	}
+}
+
+func TestProposalHandlers_UsesPortNotConcreteService_ApproveNotPending(t *testing.T) {
+	stub := &stubProposalService{
+		approveFn: func(_ context.Context, _ string) (proposal.Proposal, error) {
+			return proposal.Proposal{}, ports.ErrProposalNotPending
+		},
+	}
+	mux := newStubMux(t, stub)
+
+	r := httptest.NewRequest(http.MethodPost, "/_vibewarden/admin/proposals/some-id/approve", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("POST approve status = %d, want 409", w.Code)
+	}
+}
+
+func TestProposalHandlers_UsesPortNotConcreteService_InternalError(t *testing.T) {
+	stub := &stubProposalService{
+		createFn: func(_ context.Context, _ ports.ProposalCreateParams) (proposal.Proposal, error) {
+			return proposal.Proposal{}, errors.New("backing store offline")
+		},
+	}
+	mux := newStubMux(t, stub)
+
+	body := map[string]any{
+		"action_type": "block_ip",
+		"params":      map[string]any{"ip": "1.2.3.4"},
+		"reason":      "traffic spike",
+	}
+	raw, _ := json.Marshal(body)
+	r := httptest.NewRequest(http.MethodPost, "/_vibewarden/admin/proposals", bytes.NewReader(raw))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("POST on service error status = %d, want 500", w.Code)
+	}
+}

--- a/internal/app/deploy/service.go
+++ b/internal/app/deploy/service.go
@@ -99,7 +99,7 @@ func (s *Service) Deploy(ctx context.Context, cfg *config.Config, opts RunOption
 	if generatedDir == "" {
 		generatedDir = ".vibewarden/generated"
 	}
-	if err := s.generator.Generate(ctx, cfg, generatedDir); err != nil {
+	if err := s.generator.Generate(ctx, cfg.ToGeneratorInput(), generatedDir); err != nil {
 		return fmt.Errorf("generating config files: %w", err)
 	}
 

--- a/internal/app/deploy/service_test.go
+++ b/internal/app/deploy/service_test.go
@@ -11,6 +11,7 @@ import (
 
 	deployapp "github.com/vibewarden/vibewarden/internal/app/deploy"
 	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
 // fakeExecutor is a test double for ports.RemoteExecutor.
@@ -80,7 +81,7 @@ type fakeGenerator struct {
 	err error
 }
 
-func (f *fakeGenerator) Generate(_ context.Context, _ *config.Config, _ string) error {
+func (f *fakeGenerator) Generate(_ context.Context, _ ports.GeneratorInput, _ string) error {
 	return f.err
 }
 

--- a/internal/app/generate/service.go
+++ b/internal/app/generate/service.go
@@ -78,7 +78,18 @@ func (s *Service) WithConfigSourcePath(path string) *Service {
 //	kratos/identity.schema.json
 //	kratos/mappers/<provider>.jsonnet  (one per configured social provider)
 //	docker-compose.yml
-func (s *Service) Generate(ctx context.Context, cfg *config.Config, outputDir string) error {
+//
+// The typed decision fields on input are intentionally not read in v1 — the
+// service body continues to operate on the concrete *config.Config recovered
+// from input.TemplateData so that template output stays byte-identical to the
+// pre-ADR-064 behaviour. Future work will migrate the body to branch on
+// input's typed fields and narrow TemplateData to a named template model.
+func (s *Service) Generate(ctx context.Context, input ports.GeneratorInput, outputDir string) error {
+	cfg, ok := input.TemplateData.(*config.Config)
+	if !ok || cfg == nil {
+		return fmt.Errorf("generate: TemplateData must be *config.Config (got %T)", input.TemplateData)
+	}
+
 	if outputDir == "" {
 		outputDir = defaultOutputDir
 	}

--- a/internal/app/generate/service_integration_test.go
+++ b/internal/app/generate/service_integration_test.go
@@ -69,7 +69,7 @@ func TestGenerate_Integration_ExternalPostgres(t *testing.T) {
 			cfg := minimalConfig()
 			cfg.Database.ExternalURL = tt.externalURL
 
-			if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+			if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 				t.Fatalf("Generate() unexpected error: %v", err)
 			}
 
@@ -145,7 +145,7 @@ func TestGenerate_Integration_ExternalRedis(t *testing.T) {
 			cfg.RateLimit.Redis.Address = "localhost:6379" // required when URL is empty
 			cfg.RateLimit.Redis.URL = tt.redisURL
 
-			if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+			if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 				t.Fatalf("Generate() unexpected error: %v", err)
 			}
 
@@ -266,7 +266,7 @@ func TestGenerate_Integration_KratosOIDCRendering(t *testing.T) {
 			cfg := minimalConfig()
 			cfg.Auth.SocialProviders = tt.providers
 
-			if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+			if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 				t.Fatalf("Generate() unexpected error: %v", err)
 			}
 

--- a/internal/app/generate/service_port_test.go
+++ b/internal/app/generate/service_port_test.go
@@ -1,0 +1,88 @@
+package generate_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/app/generate"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// TestGenerate_ByteIdentical_AfterDTOMigration locks in byte-identical output
+// between two equivalent Generate invocations after the ADR-064 migration:
+//
+//  1. the "canonical" path: cfg.ToGeneratorInput() built from a full config.
+//  2. a "hand-built" path: a GeneratorInput constructed directly that preserves
+//     TemplateData as the same *config.Config pointer.
+//
+// Both must produce byte-identical kratos.yml, identity.schema.json, and
+// docker-compose.yml. This guards against future changes to the DTO shape
+// accidentally diverging template output.
+func TestGenerate_ByteIdentical_AfterDTOMigration(t *testing.T) {
+	cfg := minimalConfig()
+
+	// Path 1: canonical via ToGeneratorInput.
+	dir1 := t.TempDir()
+	out1 := filepath.Join(dir1, "generated")
+	svc1 := generate.NewService(realRenderer())
+	if err := svc1.Generate(context.Background(), cfg.ToGeneratorInput(), out1); err != nil {
+		t.Fatalf("canonical Generate: %v", err)
+	}
+
+	// Path 2: hand-built input that still carries the same *config.Config as
+	// TemplateData (this is what adapters must continue to do until the
+	// Generate body is migrated off the type assertion).
+	dir2 := t.TempDir()
+	out2 := filepath.Join(dir2, "generated")
+	svc2 := generate.NewService(realRenderer())
+	handBuilt := ports.GeneratorInput{
+		Profile:              cfg.Profile,
+		AuthEnabled:          cfg.Auth.Enabled,
+		AuthMode:             string(cfg.Auth.Mode),
+		KratosExternal:       cfg.Kratos.External,
+		SecretsEnabled:       cfg.Secrets.Enabled,
+		ObservabilityEnabled: cfg.Observability.Enabled,
+		TemplateData:         cfg,
+	}
+	if err := svc2.Generate(context.Background(), handBuilt, out2); err != nil {
+		t.Fatalf("hand-built Generate: %v", err)
+	}
+
+	files := []string{
+		filepath.Join("kratos", "kratos.yml"),
+		filepath.Join("kratos", "identity.schema.json"),
+		"docker-compose.yml",
+	}
+	for _, rel := range files {
+		t.Run(rel, func(t *testing.T) {
+			got1, err := os.ReadFile(filepath.Join(out1, rel))
+			if err != nil {
+				t.Fatalf("reading %s from canonical path: %v", rel, err)
+			}
+			got2, err := os.ReadFile(filepath.Join(out2, rel))
+			if err != nil {
+				t.Fatalf("reading %s from hand-built path: %v", rel, err)
+			}
+			if string(got1) != string(got2) {
+				t.Errorf("%s diverged between DTO paths (len %d vs %d)", rel, len(got1), len(got2))
+			}
+		})
+	}
+}
+
+// TestGenerate_WrongTemplateDataType_ReturnsError verifies that the Generate
+// body's recovery cast rejects a non-*config.Config payload with a clear error,
+// rather than panicking at render time. This is the sentinel guarding the
+// "TemplateData is opaque to the port but the adapter knows what type it is"
+// contract in ADR-064.
+func TestGenerate_WrongTemplateDataType_ReturnsError(t *testing.T) {
+	svc := generate.NewService(&fakeRenderer{})
+	bad := ports.GeneratorInput{TemplateData: "not a config"}
+
+	err := svc.Generate(context.Background(), bad, t.TempDir())
+	if err == nil {
+		t.Fatal("expected Generate with wrong TemplateData type to error, got nil")
+	}
+}

--- a/internal/app/generate/service_test.go
+++ b/internal/app/generate/service_test.go
@@ -81,7 +81,7 @@ func TestGenerate_CreatesExpectedFiles(t *testing.T) {
 	svc := generate.NewService(&fakeRenderer{})
 	cfg := minimalConfig()
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -115,7 +115,7 @@ func TestGenerate_DefaultOutputDir(t *testing.T) {
 	svc := generate.NewService(&fakeRenderer{})
 	cfg := minimalConfig()
 
-	if err := svc.Generate(context.Background(), cfg, ""); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), ""); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -162,7 +162,7 @@ func TestGenerate_IdentitySchemaPresets(t *testing.T) {
 			cfg := minimalConfig()
 			cfg.Auth.IdentitySchema = tt.identitySchema
 
-			if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+			if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 				t.Fatalf("Generate() unexpected error: %v", err)
 			}
 
@@ -191,7 +191,7 @@ func TestGenerate_OverrideIdentitySchema(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.Overrides.IdentitySchema = customSchemaPath
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -217,7 +217,7 @@ func TestGenerate_OverrideKratosConfig(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.Overrides.KratosConfig = customKratosPath
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -243,7 +243,7 @@ func TestGenerate_OverrideComposeFile(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.Overrides.ComposeFile = customComposePath
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -265,7 +265,7 @@ func TestGenerate_RendererError_PropagatesError(t *testing.T) {
 	})
 	cfg := minimalConfig()
 
-	err := svc.Generate(context.Background(), cfg, outputDir)
+	err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir)
 	if err == nil {
 		t.Error("Generate() expected error when renderer fails, got nil")
 	}
@@ -277,7 +277,7 @@ func TestGenerate_UnknownPreset_ReturnsError(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.Auth.IdentitySchema = "no_such_preset_or_path_xyz"
 
-	err := svc.Generate(context.Background(), cfg, outputDir)
+	err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir)
 	if err == nil {
 		t.Error("Generate() expected error for unknown preset, got nil")
 	}
@@ -333,7 +333,7 @@ func TestGenerate_WithSocialProviders_GeneratesMapperFiles(t *testing.T) {
 			cfg := minimalConfig()
 			cfg.Auth.SocialProviders = tt.providers
 
-			if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+			if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 				t.Fatalf("Generate() unexpected error: %v", err)
 			}
 
@@ -368,7 +368,7 @@ func TestGenerate_MapperFilesContainValidJsonnet(t *testing.T) {
 		{Provider: "oidc", ID: "custom", ClientID: "oid", ClientSecret: "osecret", IssuerURL: "https://issuer.example"},
 	}
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -396,7 +396,7 @@ func TestGenerate_WithoutSocialProviders_NoMappersDir(t *testing.T) {
 	cfg := minimalConfig()
 	// No social providers configured.
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -467,7 +467,7 @@ func TestGenerate_SocialProviders_AutoSelectsSocialSchema(t *testing.T) {
 			cfg.Auth.IdentitySchema = tt.identitySchema
 			cfg.Auth.SocialProviders = tt.socialProviders
 
-			if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+			if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 				t.Fatalf("Generate() unexpected error: %v", err)
 			}
 
@@ -506,7 +506,7 @@ func TestGenerate_WithSocialProviders_KratosTemplatePassesConfig(t *testing.T) {
 		{Provider: "google", ClientID: "my-client-id", ClientSecret: "my-secret"},
 	}
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -544,7 +544,7 @@ func renderCompose(t *testing.T, cfg *config.Config) []byte {
 	t.Helper()
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(outputDir, "docker-compose.yml"))
@@ -858,7 +858,7 @@ func TestGenerate_SeedSecretsFile_GeneratedWhenNeeded(t *testing.T) {
 
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -887,7 +887,7 @@ func TestGenerate_SeedSecretsFile_NotGeneratedWhenNotNeeded(t *testing.T) {
 
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -905,7 +905,7 @@ func TestGenerate_SeedSecretsFile_NotGeneratedWhenSecretsDisabled(t *testing.T) 
 
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -926,7 +926,7 @@ func TestGenerate_SeedSecretsFile_ContainsBothHeadersAndEnv(t *testing.T) {
 
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -970,7 +970,7 @@ func TestGenerate_Observability_WhenEnabled(t *testing.T) {
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1002,7 +1002,7 @@ func TestGenerate_Observability_WhenDisabled(t *testing.T) {
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1017,7 +1017,7 @@ func TestGenerate_Observability_PrometheusConfig(t *testing.T) {
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1043,7 +1043,7 @@ func TestGenerate_Observability_LokiRetention(t *testing.T) {
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1063,7 +1063,7 @@ func TestGenerate_Observability_GrafanaDatasources(t *testing.T) {
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1088,7 +1088,7 @@ func TestGenerate_Observability_Dashboard(t *testing.T) {
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1195,7 +1195,7 @@ func TestGenerate_OtelCollector_ConfigFileCreated(t *testing.T) {
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1210,7 +1210,7 @@ func TestGenerate_OtelCollector_ConfigContainsReceivers(t *testing.T) {
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1306,7 +1306,7 @@ func TestGenerate_OtelCollector_NotPresent_WhenDisabled(t *testing.T) {
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1345,7 +1345,7 @@ func TestGenerate_Jaeger_OtelCollector_TracesPipeline(t *testing.T) {
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1436,7 +1436,7 @@ func TestGenerate_ProdProfile_SecretsDisabled_Succeeds(t *testing.T) {
 	cfg.Profile = "prod"
 	cfg.Secrets.Enabled = false
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Errorf("Generate() unexpected error for prod profile without secrets.enabled: %v", err)
 	}
 }
@@ -1469,7 +1469,7 @@ func TestGenerate_DevProfile_AllowsNoSecrets(t *testing.T) {
 	cfg.Profile = "dev"
 	cfg.Secrets.Enabled = false
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Errorf("Generate() unexpected error for dev profile without secrets: %v", err)
 	}
 }
@@ -1485,7 +1485,7 @@ func TestGenerate_TLSProfile_AllowsNoSecrets(t *testing.T) {
 	cfg.Profile = "tls"
 	cfg.Secrets.Enabled = false
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Errorf("Generate() unexpected error for tls profile without secrets: %v", err)
 	}
 }
@@ -1501,7 +1501,7 @@ func TestGenerate_ProdProfile_WithSecretsEnabled_Succeeds(t *testing.T) {
 	cfg.Profile = "prod"
 	cfg.Secrets.Enabled = true
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Errorf("Generate() unexpected error for prod profile with secrets.enabled: %v", err)
 	}
 }
@@ -1515,7 +1515,7 @@ func TestGenerate_CredentialsWritten(t *testing.T) {
 		store,
 	)
 
-	if err := svc.Generate(context.Background(), minimalConfig(), outputDir); err != nil {
+	if err := svc.Generate(context.Background(), minimalConfig().ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1535,7 +1535,7 @@ func TestGenerate_CredentialGeneratorError_ReturnsError(t *testing.T) {
 		&fakeCredentialStore{},
 	)
 
-	err := svc.Generate(context.Background(), minimalConfig(), outputDir)
+	err := svc.Generate(context.Background(), minimalConfig().ToGeneratorInput(), outputDir)
 	if err == nil {
 		t.Fatal("Generate() expected error when credential generator fails, got nil")
 	}
@@ -1552,7 +1552,7 @@ func TestGenerate_CredentialStoreError_ReturnsError(t *testing.T) {
 		&fakeCredentialStore{writeErr: fmt.Errorf("disk full")},
 	)
 
-	err := svc.Generate(context.Background(), minimalConfig(), outputDir)
+	err := svc.Generate(context.Background(), minimalConfig().ToGeneratorInput(), outputDir)
 	if err == nil {
 		t.Fatal("Generate() expected error when credential store fails, got nil")
 	}
@@ -1566,7 +1566,7 @@ func TestGenerate_EnvTemplateWritten(t *testing.T) {
 	svc := generate.NewService(realRenderer())
 	cfg := minimalConfig()
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1582,7 +1582,7 @@ func TestGenerate_EnvTemplateNoSecrets(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.Profile = "dev"
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1612,7 +1612,7 @@ func TestGenerate_EnvTemplateContainsProfile(t *testing.T) {
 	cfg := minimalConfig()
 	cfg.Profile = "tls"
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1634,7 +1634,7 @@ func TestGenerate_SeedSecretsSourcesCredentials(t *testing.T) {
 
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1659,7 +1659,7 @@ func TestGenerate_NoCredentialAdapters_SkipsCredentials(t *testing.T) {
 	svc := generate.NewService(&fakeRenderer{})
 	cfg := minimalConfig()
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -1699,7 +1699,7 @@ func TestGenerate_NonKratosMode_NoKratosFiles(t *testing.T) {
 				},
 			}
 
-			if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+			if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 				t.Fatalf("Generate() error = %v", err)
 			}
 
@@ -1745,7 +1745,7 @@ func TestGenerate_KratosMode_CreatesKratosFiles(t *testing.T) {
 		},
 	}
 
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
 
@@ -1881,7 +1881,7 @@ func TestGenerate_Compose_ExternalKratosSkipsKratosFiles(t *testing.T) {
 	}
 
 	svc := generate.NewService(realRenderer())
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 
@@ -2016,7 +2016,7 @@ func renderComposeAndDir(t *testing.T, cfg *config.Config) ([]byte, string) {
 	t.Helper()
 	outputDir := t.TempDir()
 	svc := generate.NewService(realRenderer())
-	if err := svc.Generate(context.Background(), cfg, outputDir); err != nil {
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
 		t.Fatalf("Generate() unexpected error: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(outputDir, "docker-compose.yml"))

--- a/internal/app/ops/dev.go
+++ b/internal/app/ops/dev.go
@@ -154,7 +154,7 @@ func (s *DevService) watchLoop(ctx context.Context, cfg *config.Config, opts Dev
 			fmt.Fprintln(out, "config changed, regenerating...")
 
 			if s.generator != nil {
-				if err := s.generator.Generate(ctx, cfg, generatedOutputDir); err != nil {
+				if err := s.generator.Generate(ctx, cfg.ToGeneratorInput(), generatedOutputDir); err != nil {
 					slog.Error("regeneration failed", "error", err)
 					fmt.Fprintf(out, "regeneration failed: %v\n", err)
 					continue
@@ -180,7 +180,7 @@ func (s *DevService) watchLoop(ctx context.Context, cfg *config.Config, opts Dev
 func (s *DevService) resolveComposeFile(ctx context.Context, cfg *config.Config, out io.Writer) (string, error) {
 	if s.generator != nil {
 		fmt.Fprintln(out, "Generating runtime configuration files...")
-		if err := s.generator.Generate(ctx, cfg, generatedOutputDir); err != nil {
+		if err := s.generator.Generate(ctx, cfg.ToGeneratorInput(), generatedOutputDir); err != nil {
 			return "", fmt.Errorf("generating config: %w", err)
 		}
 		composePath := filepath.Join(generatedOutputDir, "docker-compose.yml")

--- a/internal/app/ops/dev_test.go
+++ b/internal/app/ops/dev_test.go
@@ -58,7 +58,7 @@ type fakeGenerator struct {
 	generateCallCount int
 }
 
-func (f *fakeGenerator) Generate(_ context.Context, _ *config.Config, outputDir string) error {
+func (f *fakeGenerator) Generate(_ context.Context, _ ports.GeneratorInput, outputDir string) error {
 	f.generateCalled = true
 	f.generateCallCount++
 	f.capturedOutputDir = outputDir

--- a/internal/app/proposal/service.go
+++ b/internal/app/proposal/service.go
@@ -16,6 +16,12 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
+// Compile-time assertion that *Service satisfies ports.ProposalService.
+// Any change to ports.ProposalService that is not matched here will fail the
+// build — this is how we keep the inbound-port contract and its sole
+// implementation in sync.
+var _ ports.ProposalService = (*Service)(nil)
+
 // Service orchestrates the proposal lifecycle.
 type Service struct {
 	store    ports.ProposalStore
@@ -44,23 +50,11 @@ func NewService(
 	}
 }
 
-// CreateParams holds the inputs required to create a new proposal.
-type CreateParams struct {
-	// Type is the action type (block_ip, adjust_rate_limit, update_config).
-	Type proposal.ActionType
-
-	// Params holds action-specific parameters.
-	Params map[string]any
-
-	// Reason is the agent's justification for the proposal.
-	Reason string
-
-	// Source identifies the creating component (typically "mcp_agent").
-	Source string
-
-	// TTL overrides the default proposal TTL. Zero means DefaultTTL (1 hour).
-	TTL time.Duration
-}
+// CreateParams is an alias for ports.ProposalCreateParams so that existing
+// callers (HTTP handler, integration tests, service unit tests) that
+// reference proposalapp.CreateParams keep compiling unchanged. The port-owned
+// type is the source of truth; this alias is load-bearing public API.
+type CreateParams = ports.ProposalCreateParams
 
 // Create creates a new pending proposal, persists it, and emits an audit event.
 func (s *Service) Create(ctx context.Context, p CreateParams) (proposal.Proposal, error) {

--- a/internal/cli/cmd/generate.go
+++ b/internal/cli/cmd/generate.go
@@ -64,7 +64,7 @@ Examples:
 				credentialsadapter.NewStore(),
 			).WithConfigSourcePath(configPath)
 
-			if err := generator.Generate(cmd.Context(), cfg, outputDir); err != nil {
+			if err := generator.Generate(cmd.Context(), cfg.ToGeneratorInput(), outputDir); err != nil {
 				return fmt.Errorf("generating config files: %w", err)
 			}
 

--- a/internal/config/generator_input.go
+++ b/internal/config/generator_input.go
@@ -1,0 +1,29 @@
+// Package config holds configuration types and loading logic for VibeWarden.
+package config
+
+import "github.com/vibewarden/vibewarden/internal/ports"
+
+// ToGeneratorInput maps a *Config into a ports.GeneratorInput.
+//
+// The decision fields are populated from the config's typed values so that
+// ConfigGenerator implementations can branch on the port-owned DTO without
+// importing internal/config. TemplateData carries the same *Config through to
+// the template renderer — the generator casts it back at render time, so
+// template output is byte-identical to passing the Config directly.
+//
+// The mapper lives in internal/config (not internal/ports) so that
+// internal/ports continues to depend only on stdlib and internal/domain/*.
+func (c *Config) ToGeneratorInput() ports.GeneratorInput {
+	if c == nil {
+		return ports.GeneratorInput{}
+	}
+	return ports.GeneratorInput{
+		Profile:              c.Profile,
+		AuthEnabled:          c.Auth.Enabled,
+		AuthMode:             string(c.Auth.Mode),
+		KratosExternal:       c.Kratos.External,
+		SecretsEnabled:       c.Secrets.Enabled,
+		ObservabilityEnabled: c.Observability.Enabled,
+		TemplateData:         c,
+	}
+}

--- a/internal/ports/generate.go
+++ b/internal/ports/generate.go
@@ -2,21 +2,62 @@ package ports
 
 import (
 	"context"
-
-	"github.com/vibewarden/vibewarden/internal/config"
 )
 
+// GeneratorInput is the port-owned DTO passed to ConfigGenerator.Generate.
+//
+// It decouples the ports package from internal/config: decision fields that
+// drive service-side branching are expressed as primitive-typed values, while
+// the full template payload is carried as an opaque TemplateData that the
+// adapter (not the port) interprets.
+//
+// v1 note: the Generate service body continues to read directly from the
+// concrete payload via a type assertion on TemplateData; the typed decision
+// fields are declared here for the ports contract and are intentionally not
+// consumed by the v1 service body. Future iterations will migrate the Generate
+// body to branch on these fields and narrow TemplateData to a named template
+// model.
+type GeneratorInput struct {
+	// Profile is the deployment profile, e.g. "dev" or "prod". It is used by
+	// future service-side branching (e.g. to emit prod-only warnings or to
+	// write openbao/config.hcl only in prod).
+	Profile string
+
+	// AuthEnabled reports whether authentication is turned on.
+	AuthEnabled bool
+
+	// AuthMode is the configured authentication mode, e.g. "kratos", "jwt",
+	// "api-key", or "none".
+	AuthMode string
+
+	// KratosExternal reports whether Kratos is managed externally. When true
+	// the generator must skip kratos.yml and identity-schema output.
+	KratosExternal bool
+
+	// SecretsEnabled reports whether the secrets plugin is active.
+	SecretsEnabled bool
+
+	// ObservabilityEnabled reports whether the observability stack should be
+	// generated.
+	ObservabilityEnabled bool
+
+	// TemplateData is the opaque payload passed through to TemplateRenderer
+	// calls. In v1 this is *config.Config; adapters that call Render /
+	// RenderToFile pass TemplateData verbatim.
+	TemplateData any
+}
+
 // ConfigGenerator generates VibeWarden runtime configuration files from a
-// loaded Config. Implementations write files under the .vibewarden/generated/
+// GeneratorInput. Implementations write files under the .vibewarden/generated/
 // directory so that Docker Compose and Ory Kratos can pick them up.
 type ConfigGenerator interface {
 	// Generate creates or overwrites the generated configuration files for the
-	// supplied cfg under outputDir. When outputDir is empty it defaults to
+	// supplied input under outputDir. When outputDir is empty it defaults to
 	// ".vibewarden/generated" relative to the current working directory.
 	//
 	// Generated files:
 	//   <outputDir>/kratos/kratos.yml
 	//   <outputDir>/kratos/identity.schema.json
 	//   <outputDir>/docker-compose.yml
-	Generate(ctx context.Context, cfg *config.Config, outputDir string) error
+	Generate(ctx context.Context, input GeneratorInput, outputDir string) error
 }

--- a/internal/ports/proposal_service.go
+++ b/internal/ports/proposal_service.go
@@ -1,0 +1,57 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/proposal"
+)
+
+// ProposalCreateParams holds the inputs required to create a new proposal
+// through ProposalService.Create. It is the port-owned equivalent of the
+// application-layer CreateParams struct and is shaped identically so the app
+// service can alias it without conversion.
+type ProposalCreateParams struct {
+	// Type is the action type (block_ip, adjust_rate_limit, update_config).
+	Type proposal.ActionType
+
+	// Params holds action-specific parameters.
+	Params map[string]any
+
+	// Reason is the agent's justification for the proposal.
+	Reason string
+
+	// Source identifies the creating component (typically "mcp_agent").
+	Source string
+
+	// TTL overrides the default proposal TTL. Zero means DefaultTTL.
+	TTL time.Duration
+}
+
+// ProposalService is the inbound port exposed to HTTP/MCP adapters for the
+// propose-action workflow. It aggregates the full create/list/get/approve/
+// dismiss surface because the HTTP handler — today the only consumer —
+// exercises every operation; splitting would force shim boilerplate without
+// any ISP benefit.
+//
+// *proposal.Service in internal/app/proposal satisfies this port.
+type ProposalService interface {
+	// Create creates a new pending proposal, persists it, and emits an audit
+	// event.
+	Create(ctx context.Context, params ProposalCreateParams) (proposal.Proposal, error)
+
+	// List returns proposals filtered by status. An empty status returns all
+	// proposals.
+	List(ctx context.Context, status proposal.Status) ([]proposal.Proposal, error)
+
+	// Get returns the proposal with the given ID. Returns ErrProposalNotFound
+	// when no proposal with that ID exists.
+	Get(ctx context.Context, id string) (proposal.Proposal, error)
+
+	// Approve transitions the proposal to approved, applies the config change,
+	// and emits an audit event.
+	Approve(ctx context.Context, id string) (proposal.Proposal, error)
+
+	// Dismiss transitions the proposal to dismissed and emits an audit event.
+	Dismiss(ctx context.Context, id string) (proposal.Proposal, error)
+}

--- a/internal/ports/purity_test.go
+++ b/internal/ports/purity_test.go
@@ -1,0 +1,58 @@
+//go:build purity
+// +build purity
+
+// Package ports advisory test — runs only under `go test -tags=purity`.
+//
+// This file guards the hexagonal-architecture invariant locked in
+// ADR-064: internal/ports/ may import stdlib and internal/domain/* only.
+// Imports of internal/config, internal/adapters/*, or internal/app/* would
+// re-introduce the leak that ADR-064 removed.
+//
+// It is behind a build tag because the repository's default make check
+// gate (go build + golangci-lint + go test) does not run this assertion;
+// operators or CI can opt in with `go test -tags=purity ./internal/ports/...`
+// when an extra guardrail is desirable.
+
+package ports_test
+
+import (
+	"go/build"
+	"strings"
+	"testing"
+)
+
+func TestPortsPackage_OnlyImportsStdlibAndDomain(t *testing.T) {
+	pkg, err := build.Default.Import("github.com/vibewarden/vibewarden/internal/ports", "", 0)
+	if err != nil {
+		t.Fatalf("importing internal/ports: %v", err)
+	}
+
+	const (
+		moduleRoot      = "github.com/vibewarden/vibewarden/"
+		allowedInternal = moduleRoot + "internal/domain/"
+	)
+
+	banned := []string{
+		moduleRoot + "internal/config",
+		moduleRoot + "internal/adapters",
+		moduleRoot + "internal/app",
+	}
+
+	// The stdlib is always allowed (Go treats stdlib imports as import paths
+	// without a dot in the first element). Module-relative imports must be
+	// under internal/domain/.
+	for _, imp := range pkg.Imports {
+		if !strings.HasPrefix(imp, moduleRoot) {
+			continue // stdlib or external module — not checked here
+		}
+		for _, bad := range banned {
+			if strings.HasPrefix(imp, bad) {
+				t.Errorf("internal/ports imports %q — forbidden by ADR-064", imp)
+			}
+		}
+		if !strings.HasPrefix(imp, allowedInternal) && imp != moduleRoot+"internal/ports" {
+			t.Errorf("internal/ports imports %q — only stdlib and %s*** are allowed",
+				imp, allowedInternal)
+		}
+	}
+}

--- a/internal/ports/secrets.go
+++ b/internal/ports/secrets.go
@@ -14,15 +14,32 @@ import (
 // transport, auth, or other failures via errors.Is.
 var ErrSecretNotFound = errors.New("secret not found")
 
+// SecretKVReader is the minimal outbound port for reading a slice of a secret
+// KV store. It returns all key/value fields stored at path.
+//
+// Consumers that only need read access (e.g. an API-key validator that fetches
+// hashes from a single KV path) should depend on this narrow port rather than
+// the full SecretStore so they do not accidentally couple to the unused
+// write/delete/list/health surface.
+//
+// Implementations must be safe for concurrent use. All path arguments are
+// store-relative (e.g. "auth/api-keys") and must not start with a slash.
+type SecretKVReader interface {
+	// Get fetches all key/value pairs stored at path. Returns an error when
+	// the path does not exist or the store is unreachable.
+	Get(ctx context.Context, path string) (map[string]string, error)
+}
+
 // SecretStore is the outbound port for reading and writing secrets in an
 // external secret store (e.g. OpenBao / HashiCorp Vault KV v2).
+//
+// SecretStore embeds SecretKVReader so that any implementation of
+// SecretStore automatically satisfies the narrower reader port.
 //
 // Implementations must be safe for concurrent use. All path arguments are
 // store-relative (e.g. "app/database") and must not start with a slash.
 type SecretStore interface {
-	// Get fetches all key/value pairs stored at path. Returns an error when
-	// the path does not exist or the store is unreachable.
-	Get(ctx context.Context, path string) (map[string]string, error)
+	SecretKVReader
 
 	// Put writes data at path, creating or updating the secret version.
 	Put(ctx context.Context, path string, data map[string]string) error


### PR DESCRIPTION
Closes #818

Implements ADR-064 (appended to `DECISIONS.md` in this PR). Three hexagonal-architecture violations in `internal/ports/` are repaired in a single, behaviour-preserving refactor.

## Summary

- **F1** — `internal/ports/generate.go` no longer imports `internal/config`. `ConfigGenerator.Generate` now takes a new `ports.GeneratorInput` DTO (typed decision fields + opaque `TemplateData any`). A new `(*config.Config).ToGeneratorInput()` mapper lives in `internal/config`. Per architect note 1, the decision fields are declared but intentionally unread by the v1 service body — the Generate body recovers `*config.Config` from `TemplateData` via a type assertion so template output stays byte-identical to `main`.
- **F2** — `apikey.KeyStore` is deleted; its role is filled by the new `ports.SecretKVReader`. `ports.SecretStore` embeds `SecretKVReader`, so `*openbao.Adapter` satisfies both interfaces with zero adapter-side code change.
- **F3** — `ProposalHandlers` now depends on `ports.ProposalService` (aggregate inbound port) instead of `*proposalapp.Service`. A compile-time assertion `var _ ports.ProposalService = (*Service)(nil)` keeps the contract and its sole implementation in lock-step. `proposalapp.CreateParams` becomes a type alias for `ports.ProposalCreateParams` so every caller keeps compiling unchanged (architect note 2).

Advisory purity guard: `internal/ports/purity_test.go` is gated by `//go:build purity` (architect note 3) — `make check` already has no ports import-policy check, so this is an opt-in CI knob (`go test -tags=purity ./internal/ports/...`).

## Architectural references
- Issue: #818
- Architect design: **ADR-064** in `DECISIONS.md`
- Open-question rulings captured in the ADR:
  1. Single aggregate `ports.ProposalService` (not split reader/writer)
  2. Renamed `KeyStore` to `ports.SecretKVReader`, no Health method
  3. Narrow `GeneratorInput` DTO + opaque `TemplateData any`

## Migration order (each commit builds green)

1. `7d8412c` — add `SecretKVReader`, `GeneratorInput`, `ProposalService`/`ProposalCreateParams`; migrate Generate path + callers + test fakes.
2. `c9f9635` — retype apikey + HTTP adapters; add compile-time assertion; add behavioural-equivalence tests; append ADR-064.

## Test plan

- [x] `make check` — gofmt, goimports, golangci-lint, `go test -race` on main module + demo-app (all green locally).
- [x] `go list` confirms `internal/ports` directly imports only `internal/domain/*` — zero `internal/config`, `internal/adapters/*`, or `internal/app/*`.
- [x] `go test -tags=purity ./internal/ports/...` passes (advisory guard).
- [x] New `internal/adapters/http/admin_proposals_port_test.go` proves the handler works identically over a stub that satisfies only `ports.ProposalService` (happy path, not-found, not-pending, internal error).
- [x] New `internal/app/generate/service_port_test.go` diffs kratos.yml, identity.schema.json, and docker-compose.yml byte-for-byte between `ToGeneratorInput()` and hand-built `GeneratorInput` paths; also asserts the Generate body rejects a non-`*config.Config` `TemplateData` cleanly.
- [x] Every existing test for apikey, HTTP admin-proposals, proposal service, deploy, and ops still passes unchanged (only the test fakes' method signatures were updated).

## Out of scope (explicit, per PM spec)

- #717 (move port tests into adapter packages).
- #809 (composition-root cleanup in `serve` / `mcp`).
- Migrating the Generate body to consume `GeneratorInput`'s typed decision fields (architect note 1).

Generated with Claude Code.