### PR TITLE
feat(#816): reconcile auth config to mode-only (ADR-065)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ---
 
+## [Unreleased]
+
+### Breaking changes
+
+- **`auth.enabled` removed from `vibewarden.yaml`** (ADR-065). `auth.mode` is
+  now the single source of truth for whether authentication is enabled. Set
+  `auth.mode: "none"` to disable auth, or `auth.mode: "kratos" | "jwt" | "api-key"`
+  to enable a strategy. Any presence of `auth.enabled` — even `false` — is
+  rejected at config load with an actionable error pointing at ADR-065.
+  Migration: delete the `auth.enabled` line; keep or set `auth.mode`.
+
+---
+
 ## [v0.1.0] — 2026-03-28
 
 First public release of the VibeWarden OSS core.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -13478,3 +13478,260 @@ To keep the tree green at each commit:
 - The `GeneratorInput` typed fields are not yet consumed by the service
   body. Adding a new decision field requires coordinating the DTO, the
   mapper, and — in a later PR — the service body.
+
+## ADR-065: Reconcile `auth` config surface to mode-only
+**Date**: 2026-04-15
+**Status**: Accepted
+**Issue**: #816
+
+### Context
+
+User and writer audits (2026-04-16) surfaced a real ambiguity in the
+authentication configuration surface. The `auth` block in
+`vibewarden.yaml` exposed two overlapping on/off axes:
+
+- `auth.enabled: true | false`
+- `auth.mode: "none" | "kratos" | "jwt" | "api-key"`
+
+Across the repo they were mixed inconsistently: the demo-app used both
+(`enabled: true` *and* `mode: "kratos"`), `vibewarden.example.yaml` and
+`vibewarden.reference.yaml` used `mode` only, the newer
+nextjs/node-express/python-flask/spring-boot examples used `mode` only,
+and `docs/configuration.md` documented both. The runtime truth table
+depended on both fields — `cfg.Auth.Enabled && cfg.Auth.Mode ==
+AuthModeKratos` — so a vibe coder could not tell from the docs which
+form was canonical.
+
+The validator already rejected `enabled: true + mode: "none"` but
+silently accepted the legacy shape, `mode`-only shape, and the mixed
+shape the demo-app used. A new user reading three docs and two examples
+would see three different conventions.
+
+### Decision
+
+**`auth.mode` is the single source of truth.** `auth.enabled` is
+removed from the config schema. The `mode` enum already contains an off
+sentinel (`none`), so the on/off axis is unambiguously expressed by
+`mode`.
+
+**Canonical form:**
+
+```yaml
+auth:
+  mode: "none"          # disable auth (also the default)
+  # mode: "kratos"      # Ory Kratos session auth
+  # mode: "jwt"         # JWT / OIDC bearer auth
+  # mode: "api-key"     # API key header auth
+```
+
+Runtime derivation collapses to a new `AuthConfig.Active()` helper:
+
+```go
+func (a AuthConfig) Active() bool {
+    return a.Mode != "" && a.Mode != AuthModeNone
+}
+```
+
+Every consumer that previously read `cfg.Auth.Enabled` now calls
+`cfg.Auth.Active()`. The helper centralises the "is auth on" derivation
+so future code does not drift back into ad-hoc `mode == "kratos" ||
+mode == "jwt" || ...` checks.
+
+### Ruling on the three open questions from the PM
+
+1. **Option A — mode-only.** `auth.enabled` is deleted. `auth.mode` is
+   the only on/off axis for auth. The enum already contains `none` as
+   an off sentinel, so a separate boolean is redundant.
+
+2. **Hard break — no deprecation path.** The validator rejects any
+   presence of `auth.enabled` (true *or* false) with a single,
+   actionable error. Justifications: repo is pre-1.0 (current release
+   v0.10.0), zero stars, zero forks, no semver promise for the YAML
+   schema. A deprecation path costs validator complexity and prolongs
+   the ambiguity in docs for months. A clean hard-error with a message
+   that names the replacement inline is strictly better UX than a silent
+   acceptance that later surprises.
+
+3. **Auth-only — do not touch other plugins.** `rate_limit.enabled`,
+   `security_headers.enabled`, `cors.enabled`, `fleet.enabled`, and
+   `admin.enabled` are single-axis booleans with no `mode` companion —
+   not ambiguous. `waf.mode` (`block | detect`) is orthogonal to
+   `waf.enabled`: `mode` describes the enforcement action when the
+   plugin is on, not whether the plugin is on — different semantics.
+   `tls.provider` is orthogonal to `tls.enabled`: `provider` selects
+   the certificate source when TLS is on, it is not an off sentinel.
+   `auth` is the only plugin whose `mode` enum contains an off sentinel
+   (`none`), which is why the fold is valid here and not elsewhere.
+
+### Validator error message (verbatim)
+
+The `Load` path inspects `viper.AllSettings()["auth"]` for an `enabled`
+key. When present, `Load` returns:
+
+```
+auth.enabled is no longer a recognised config key (removed in v0.11.0; see ADR-065). Use auth.mode as the single source of truth: set auth.mode: "none" to disable auth, or auth.mode: "kratos" | "jwt" | "api-key" to enable a strategy.
+
+Canonical form:
+
+  auth:
+    mode: "none"          # disable auth
+    # mode: "kratos"      # enable Ory Kratos session auth
+    # mode: "jwt"         # enable JWT / OIDC bearer auth
+    # mode: "api-key"     # enable API key header auth
+```
+
+The existing `enabled: true + mode: "none"` validator error is removed
+— subsumed by the new rule, which rejects the field unconditionally.
+
+### Why the raw-key check lives in `Load`, not `Validate`
+
+`Validate` operates on the already-unmarshalled `*Config` and so cannot
+distinguish "user set `auth.enabled: false`" from "user did not set
+`auth.enabled` at all" once the struct field is removed. The raw YAML
+map from `viper.AllSettings()` is the only source of truth for key
+presence, and it is only available inside `Load`. Placing the check
+there is correct — `Validate` continues to operate on typed fields as
+before.
+
+### Why `DecoderConfig.ErrorUnused` stays `false`
+
+Viper's `Unmarshal` accepts extra keys by default. If a future change
+flipped `ErrorUnused: true`, the unknown `auth.enabled` key would be
+rejected a second time by the decoder, with a generic error message
+("has invalid keys: enabled") that is strictly worse than the ADR-065
+message. The explicit raw-key check in `Load` is the sole authoritative
+rejector for `auth.enabled`. A test in
+`internal/config/config_test.go` locks in that no decoder setting
+shadows the explicit message.
+
+### "This file intentionally left unchanged"
+
+The following plugin config surfaces are **not** touched by this ADR:
+
+- `waf.mode` (`block | detect`) — semantically orthogonal to
+  `waf.enabled`.
+- `tls.provider` (`letsencrypt | self-signed | external`) — selects a
+  strategy when TLS is on, not an off sentinel.
+- `rate_limit.enabled`, `cors.enabled`, `security_headers.enabled`,
+  `fleet.enabled`, `admin.enabled` — no `mode` companion.
+
+The reviewer must reject any PR under this ADR that changes these
+surfaces. Scope creep here was the PM's first open question and the
+answer was explicit: auth only.
+
+### Migration order
+
+To keep the tree green at each commit:
+
+1. **Schema.** Remove `config.AuthConfig.Enabled`, add
+   `AuthConfig.Active()`, delete the `v.SetDefault("auth.enabled",
+   false)` call, and delete the
+   `if c.Auth.Enabled && c.Auth.Mode == AuthModeNone` validator rule.
+2. **Runtime call sites (12).** `adapters/caddy/config.go` (godoc
+   only — the runtime reads `ports.AuthConfig.Enabled`, which is
+   populated from `cfg.Auth.Active()` at the boundary),
+   `plugins/builtin.go`, `mcp/tools.go` (two sites, including the
+   error message), `cli/cmd/generate.go`, `cli/cmd/plugins.go`,
+   `cli/cmd/validate.go`, `app/eject/eject.go`,
+   `app/generate/service.go`, `app/serve/config.go`,
+   `app/ops/status.go` (two sites), `config/generator_input.go`.
+3. **Templates.** Six template branches in
+   `config/templates/docker-compose.yml.tmpl` that gate Kratos
+   services; the `wrap` template in `cli/templates/vibewarden.yaml.tmpl`
+   gains a `mode: "kratos"` line so `vibew wrap --auth` produces a
+   canonical config.
+4. **YAML examples (2).** `examples/demo-app/vibewarden.yaml` drops
+   `enabled: true`; `examples/vibewarden.prod.yaml` drops `enabled: true`.
+   The other five example YAMLs are already canonical.
+5. **Docs (6).** `docs/configuration.md` drops the `auth.enabled` row
+   and adds a "Canonical auth config" section; the four example-app
+   READMEs and `examples/demo-app/README.md` drop the `enabled: true`
+   line; `llms-full.txt` updates the `auth.enabled` bullet to
+   `auth.mode`.
+6. **CHANGELOG.** A `### Breaking` entry under the Unreleased
+   heading names the removed field, the replacement, the error
+   message preview, and this ADR.
+7. **Raw-key check and hard-break test.** Last because it actively
+   rejects shapes that earlier commits may still carry.
+
+### Behavioural-equivalence criteria
+
+A byte-identical guarantee is impossible because YAML line numbers
+shift when the `enabled` field is removed. Instead:
+
+- **Semantic equivalence on canonical configs.** Every YAML in the
+  repo that is already `mode`-only (`vibewarden.example.yaml`,
+  `vibewarden.reference.yaml`, `examples/nextjs/`,
+  `examples/node-express/`, `examples/python-flask/`,
+  `examples/spring-boot/`) is a pure no-op: `Load` and `Validate`
+  succeed with zero behavioural change.
+- **Semantic equivalence for the two fixed configs.**
+  `examples/demo-app/vibewarden.yaml` (was `enabled: true + mode:
+  "kratos"`) becomes `mode: "kratos"` — `cfg.Auth.Active()` returns
+  `true` before and after. `examples/vibewarden.prod.yaml` (was
+  `enabled: true + mode: "jwt"`) becomes `mode: "jwt"` —
+  `cfg.Auth.Active()` returns `true` before and after.
+- **Generator output stability.** `TestGenerate_Compose_*` tests
+  already exist and assert the presence/absence of Kratos services
+  based on mode. They pass unchanged after the runtime derivation
+  switches to `Active()`.
+
+### Test strategy
+
+New / updated tests:
+
+- `TestValidate_AuthEnabledModeNone` — deleted. The tests encoded the
+  old ambiguous-pair rule that no longer exists. The file-level
+  rejection is covered by the new hard-break test below.
+- `TestLoad_RejectsAuthEnabled` — new. Table-driven over five inputs:
+  `auth.enabled: true`, `auth.enabled: false`, both with and without a
+  valid `auth.mode`, and a control row that has `auth.mode: "kratos"`
+  only and must succeed. Every failing row must match the exact error
+  text from the ADR.
+- `TestLoad_AuthModeOnly_BehavioralEquivalence` — new. Canonical
+  `mode: "kratos"` config must `Load` successfully and produce
+  `cfg.Auth.Active() == true`; `mode: "none"` config must produce
+  `cfg.Auth.Active() == false`; omitted `auth` section must produce
+  `cfg.Auth.Active() == false`.
+- `TestLoad_ErrorUnusedStaysFalse` — new, documentary. Asserts via
+  the rejected-shape test that when `auth.enabled` is absent but
+  another unknown key like `auth.bogus` is present, `Load` succeeds —
+  proving the decoder is not in `ErrorUnused: true` mode. Guards
+  against a future loader change accidentally shadowing the ADR-065
+  message.
+
+### Consequences
+
+**Positive:**
+- One canonical shape for the auth block. Docs, examples, validator,
+  and runtime all agree.
+- `AuthConfig.Active()` is the single derivation for "is auth on" —
+  future callers cannot drift into ad-hoc `mode` string comparisons.
+- The error message tells the user exactly what to change, inline.
+- Eliminates the bug-shaped "enabled: true + mode: none" misconfig
+  that the validator half-rejected.
+
+**Negative:**
+- Hard break for the two configs in the repo that carried `enabled:
+  true`. Any external user with the same shape sees the actionable
+  error on the next load. Pre-1.0 this is the right call but it is
+  still a break.
+- `ports.AuthConfig.Enabled`, `authplugin.Config.Enabled`, and the
+  Caddy adapter's read of `cfg.Auth.Enabled` (the *ports* value, not
+  the *config* value) keep their boolean field. The field is populated
+  from `cfg.Auth.Active()` at the `app/serve/config.go` and
+  `app/eject/eject.go` boundaries. Renaming the port field to `Active`
+  was considered and rejected: the port is an adapter-facing DTO, not a
+  user-facing schema, and the rename would ripple into three packages
+  for no behavioural gain.
+
+### Limitations
+
+- The raw-key check is exact-match on `"enabled"` inside the `auth`
+  mapping. It does not catch other legacy spellings (there are none)
+  or case variants — viper is case-insensitive for YAML key lookup, so
+  `Auth.Enabled` and `AUTH.ENABLED` would both land under `enabled` in
+  `AllSettings`. This is the correct behaviour.
+- Migration is one-way: once a user's config is updated, they cannot
+  downgrade to v0.10.0 without reintroducing `auth.enabled`. Acceptable
+  pre-1.0.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,8 +120,7 @@ tls:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `auth.enabled` | bool | `false` | Enable the authentication middleware |
-| `auth.mode` | string | `none` | Auth strategy: `none`, `kratos`, `jwt`, or `api-key` |
+| `auth.mode` | string | `none` | Auth strategy and single source of truth for whether auth is on. Set to `none` to disable, or `kratos`, `jwt`, or `api-key` to enable. See ADR-065 |
 | `auth.public_paths` | list | `[]` | Glob patterns that bypass auth. `/_vibewarden/*` is always public |
 | `auth.session_cookie_name` | string | `ory_kratos_session` | Kratos session cookie name |
 | `auth.login_url` | string | `/self-service/login/browser` | Redirect for unauthenticated users |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -723,7 +723,6 @@ upstream:
   port: 3000
 
 auth:
-  enabled: true
   mode: jwt
   jwt:
     jwks_url: "https://dev-abc123.us.auth0.com/.well-known/jwks.json"

--- a/docs/deploy-to-vps.md
+++ b/docs/deploy-to-vps.md
@@ -153,7 +153,6 @@ tls:
   domain: "demo.yourdomain.com"           # must match your DNS A record
 
 auth:
-  enabled: true
   mode: jwt
   jwt:
     jwks_url: "https://your-idp/.well-known/jwks.json"

--- a/examples/demo-app/README.md
+++ b/examples/demo-app/README.md
@@ -101,7 +101,7 @@ docker compose -f .vibewarden/generated/docker-compose.yml down -v
 
 | Feature | Config key | What you see |
 |---|---|---|
-| Auth (Ory Kratos) | `auth.enabled: true` | Login redirect, session cookie, `X-User-*` headers |
+| Auth (Ory Kratos) | `auth.mode: kratos` | Login redirect, session cookie, `X-User-*` headers |
 | Rate limiting | `rate_limit.enabled: true` | 429 after 10 requests burst |
 | Security headers | `security_headers.enabled: true` | HSTS, CSP, X-Frame-Options on every response |
 | Secrets injection | `secrets.enabled: true` | `X-Demo-Api-Key` header injected from OpenBao |

--- a/examples/demo-app/vibewarden.yaml
+++ b/examples/demo-app/vibewarden.yaml
@@ -34,7 +34,6 @@ kratos:
   admin_url: "http://kratos:4434"
 
 auth:
-  enabled: true
   mode: "kratos"
   public_paths:
     - "/"

--- a/examples/spring-boot/README.md
+++ b/examples/spring-boot/README.md
@@ -34,7 +34,6 @@ Internet → VibeWarden :8443 (HTTPS) → Spring Boot :3000 (HTTP)
 
 ```yaml
 auth:
-  enabled: true
   mode: jwt
   jwt:
     jwks_url: https://your-idp.com/.well-known/jwks.json

--- a/examples/spring-boot/vibewarden.yaml
+++ b/examples/spring-boot/vibewarden.yaml
@@ -17,7 +17,6 @@ tls:
   provider: self-signed
 
 auth:
-  enabled: false
   mode: "none"
 
 rate_limit:

--- a/examples/vibewarden.prod.yaml
+++ b/examples/vibewarden.prod.yaml
@@ -75,7 +75,6 @@ tls:
 # (Auth0, Keycloak, Firebase, Cognito, Okta, Supabase, etc.).
 # For Kratos-managed users use auth.mode: kratos instead.
 auth:
-  enabled: true
   mode: jwt
 
   jwt:

--- a/internal/adapters/caddy/config.go
+++ b/internal/adapters/caddy/config.go
@@ -21,10 +21,12 @@ import (
 // manual redirect server is created — Caddy's built-in automatic HTTPS handles
 // ACME HTTP-01 challenges and HTTP→HTTPS redirects on port 80 natively.
 //
-// When auth is enabled (cfg.Auth.Enabled && cfg.Auth.KratosPublicURL != ""),
+// When auth is active (cfg.Auth.Enabled && cfg.Auth.KratosPublicURL != ""),
 // Kratos self-service flow routes are inserted between the health check route
 // and the catch-all proxy route. Requests to those paths are forwarded to the
 // Kratos public API transparently so browsers can complete self-service flows.
+// cfg.Auth.Enabled is the ports-layer DTO flag populated from
+// config.AuthConfig.Active() at the app/serve boundary — see ADR-065.
 func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("proxy config is required")

--- a/internal/adapters/caddy/kratos_flow_integration_test.go
+++ b/internal/adapters/caddy/kratos_flow_integration_test.go
@@ -22,7 +22,7 @@ import (
 // application upstream.
 //
 // A mock "Kratos" HTTP server and a mock "upstream app" HTTP server are used.
-// The Caddy proxy is configured with auth.enabled and auth.kratos_public_url
+// The Caddy proxy is configured with ports.AuthConfig.Enabled and auth.kratos_public_url
 // pointing to the mock Kratos server.
 func TestAdapter_Integration_KratosFlowProxied(t *testing.T) {
 	// Mock Kratos public API — responds to self-service flow paths.

--- a/internal/adapters/yamlmod/toggler.go
+++ b/internal/adapters/yamlmod/toggler.go
@@ -279,8 +279,9 @@ func appendAuthBlock(root *yaml.Node) {
 	appendNode(kratosVal, keyNode("admin_url"), scalarNode("http://localhost:4434", "!!str"))
 	appendNode(root, headComment(keyNode("kratos"), "# Ory Kratos identity server"), kratosVal)
 
-	// auth section
+	// auth section — mode is the single source of truth (ADR-065).
 	authVal := mappingNode()
+	appendNode(authVal, keyNode("mode"), scalarNode("kratos", "!!str"))
 	appendNode(authVal, keyNode("session_cookie_name"), scalarNode("ory_kratos_session", "!!str"))
 	appendNode(authVal, keyNode("login_url"), scalarNode("http://localhost:4433/self-service/login/browser", "!!str"))
 	publicPaths := sequenceNode("/health", "/ready")

--- a/internal/app/eject/eject.go
+++ b/internal/app/eject/eject.go
@@ -100,7 +100,7 @@ func buildProxyConfig(cfg *config.Config) *ports.ProxyConfig {
 			SuppressViaHeader:            cfg.SecurityHeaders.SuppressViaHeader,
 		},
 		Auth: ports.AuthConfig{
-			Enabled:             cfg.Auth.Enabled,
+			Enabled:             cfg.Auth.Active(),
 			KratosPublicURL:     cfg.Kratos.PublicURL,
 			KratosAdminURL:      cfg.Kratos.AdminURL,
 			PublicPaths:         cfg.Auth.PublicPaths,

--- a/internal/app/generate/service.go
+++ b/internal/app/generate/service.go
@@ -115,12 +115,10 @@ func (s *Service) Generate(ctx context.Context, input ports.GeneratorInput, outp
 		slog.Warn("Network isolation is enabled but app.build and app.image are both empty: host-mode app bypasses Docker network isolation")
 	}
 
-	// kratosMode is true only when auth is enabled and mode is "kratos" and
+	// kratosMode is true only when auth is active and mode is "kratos" and
 	// the Kratos instance is not managed externally.
-	// An empty mode string is also treated as Kratos for defensive backwards
-	// compatibility with code that constructs config.Config structs directly.
 	// When kratosMode is false, Kratos-specific files are not generated.
-	kratosMode := cfg.Auth.Enabled && cfg.Auth.Mode == config.AuthModeKratos && !cfg.Kratos.External
+	kratosMode := cfg.Auth.Active() && cfg.Auth.Mode == config.AuthModeKratos && !cfg.Kratos.External
 
 	if kratosMode {
 		if err := os.MkdirAll(filepath.Join(outputDir, "kratos"), permDir); err != nil {

--- a/internal/app/generate/service_port_test.go
+++ b/internal/app/generate/service_port_test.go
@@ -39,7 +39,7 @@ func TestGenerate_ByteIdentical_AfterDTOMigration(t *testing.T) {
 	svc2 := generate.NewService(realRenderer())
 	handBuilt := ports.GeneratorInput{
 		Profile:              cfg.Profile,
-		AuthEnabled:          cfg.Auth.Enabled,
+		AuthEnabled:          cfg.Auth.Active(),
 		AuthMode:             string(cfg.Auth.Mode),
 		KratosExternal:       cfg.Kratos.External,
 		SecretsEnabled:       cfg.Secrets.Enabled,

--- a/internal/app/generate/service_test.go
+++ b/internal/app/generate/service_test.go
@@ -67,7 +67,6 @@ func minimalConfig() *config.Config {
 			SMTP:      config.KratosSMTPConfig{Host: "localhost", Port: 1025, From: "no-reply@vibewarden.local"},
 		},
 		Auth: config.AuthConfig{
-			Enabled:        true,
 			Mode:           config.AuthModeKratos,
 			IdentitySchema: "email_password",
 		},
@@ -1694,8 +1693,7 @@ func TestGenerate_NonKratosMode_NoKratosFiles(t *testing.T) {
 				Server:   config.ServerConfig{Host: "127.0.0.1", Port: 8080},
 				Upstream: config.UpstreamConfig{Host: "127.0.0.1", Port: 3000},
 				Auth: config.AuthConfig{
-					Enabled: true,
-					Mode:    mode,
+					Mode: mode,
 				},
 			}
 
@@ -1739,7 +1737,6 @@ func TestGenerate_KratosMode_CreatesKratosFiles(t *testing.T) {
 			SMTP:      config.KratosSMTPConfig{Host: "localhost", Port: 1025, From: "no-reply@vibewarden.local"},
 		},
 		Auth: config.AuthConfig{
-			Enabled:        true,
 			Mode:           config.AuthModeKratos,
 			IdentitySchema: "email_password",
 		},
@@ -1772,7 +1769,6 @@ func TestGenerate_Compose_KratosServicesPresent(t *testing.T) {
 			SMTP:      config.KratosSMTPConfig{Host: "localhost", Port: 1025, From: "no-reply@vibewarden.local"},
 		},
 		Auth: config.AuthConfig{
-			Enabled:        true,
 			Mode:           config.AuthModeKratos,
 			IdentitySchema: "email_password",
 		},
@@ -1802,8 +1798,7 @@ func TestGenerate_Compose_KratosServicesAbsent(t *testing.T) {
 				Server:   config.ServerConfig{Host: "127.0.0.1", Port: 8080},
 				Upstream: config.UpstreamConfig{Host: "127.0.0.1", Port: 3000},
 				Auth: config.AuthConfig{
-					Enabled: true,
-					Mode:    mode,
+					Mode: mode,
 				},
 			}
 
@@ -1832,7 +1827,6 @@ func TestGenerate_Compose_ExternalKratosOmitsLocalContainers(t *testing.T) {
 			AdminURL:  "https://kratos-admin.example.com",
 		},
 		Auth: config.AuthConfig{
-			Enabled:        true,
 			Mode:           config.AuthModeKratos,
 			IdentitySchema: "email_password",
 		},
@@ -1874,7 +1868,6 @@ func TestGenerate_Compose_ExternalKratosSkipsKratosFiles(t *testing.T) {
 			AdminURL:  "https://kratos-admin.example.com",
 		},
 		Auth: config.AuthConfig{
-			Enabled:        true,
 			Mode:           config.AuthModeKratos,
 			IdentitySchema: "email_password",
 		},

--- a/internal/app/ops/status.go
+++ b/internal/app/ops/status.go
@@ -142,11 +142,12 @@ func gatherPluginStatuses(cfg *config.Config) []PluginStatus {
 	ps = append(ps, PluginStatus{Name: "rate-limiting", Enabled: cfg.RateLimit.Enabled, Detail: rlDetail})
 
 	// Auth
+	authActive := cfg.Auth.Active()
 	authDetail := ""
-	if cfg.Auth.Enabled {
+	if authActive {
 		authDetail = fmt.Sprintf("kratos: %s", cfg.Kratos.PublicURL)
 	}
-	ps = append(ps, PluginStatus{Name: "auth", Enabled: cfg.Auth.Enabled, Detail: authDetail})
+	ps = append(ps, PluginStatus{Name: "auth", Enabled: authActive, Detail: authDetail})
 
 	// Metrics
 	ps = append(ps, PluginStatus{Name: "metrics", Enabled: cfg.Metrics.Enabled})

--- a/internal/app/serve/config.go
+++ b/internal/app/serve/config.go
@@ -89,7 +89,7 @@ func buildProxyConfig(cfg *config.Config, registry *plugins.Registry, version st
 			SuppressViaHeader:            cfg.SecurityHeaders.SuppressViaHeader,
 		},
 		Auth: ports.AuthConfig{
-			Enabled:             cfg.Auth.Enabled,
+			Enabled:             cfg.Auth.Active(),
 			KratosPublicURL:     cfg.Kratos.PublicURL,
 			KratosAdminURL:      cfg.Kratos.AdminURL,
 			PublicPaths:         cfg.Auth.PublicPaths,

--- a/internal/cli/cmd/generate.go
+++ b/internal/cli/cmd/generate.go
@@ -74,7 +74,7 @@ Examples:
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Generated runtime configuration files in %s\n", dir)
 			fmt.Fprintf(cmd.OutOrStdout(), "  %s/docker-compose.yml\n", dir)
-			if cfg.Auth.Enabled && cfg.Auth.Mode == config.AuthModeKratos && !cfg.Kratos.External {
+			if cfg.Auth.Active() && cfg.Auth.Mode == config.AuthModeKratos && !cfg.Kratos.External {
 				fmt.Fprintf(cmd.OutOrStdout(), "  %s/kratos/kratos.yml\n", dir)
 				fmt.Fprintf(cmd.OutOrStdout(), "  %s/kratos/identity.schema.json\n", dir)
 			}

--- a/internal/cli/cmd/plugins.go
+++ b/internal/cli/cmd/plugins.go
@@ -78,7 +78,7 @@ func enabledPlugins(cfg *config.Config) map[string]bool {
 		"tls":              cfg.TLS.Enabled,
 		"security-headers": cfg.SecurityHeaders.Enabled,
 		"rate-limiting":    cfg.RateLimit.Enabled,
-		"auth":             cfg.Auth.Enabled,
+		"auth":             cfg.Auth.Active(),
 		"metrics":          cfg.Metrics.Enabled,
 		"user-management":  cfg.Admin.Enabled,
 	}

--- a/internal/cli/cmd/validate.go
+++ b/internal/cli/cmd/validate.go
@@ -199,8 +199,8 @@ func validateConfig(cfg *config.Config) []string {
 	}
 
 	// Plugin inter-dependency: user-management requires auth.
-	if cfg.Admin.Enabled && !cfg.Auth.Enabled {
-		errs = append(errs, "user-management plugin requires auth to be enabled (set auth.enabled: true)")
+	if cfg.Admin.Enabled && !cfg.Auth.Active() {
+		errs = append(errs, "user-management plugin requires auth to be enabled (set auth.mode to \"kratos\", \"jwt\", or \"api-key\")")
 	}
 
 	return errs

--- a/internal/cli/cmd/validate_test.go
+++ b/internal/cli/cmd/validate_test.go
@@ -372,7 +372,7 @@ admin:
   enabled: true
   token: supersecret
 auth:
-  enabled: false
+  mode: none
 `)
 
 	root := cmd.NewRootCmd("test")
@@ -405,7 +405,7 @@ admin:
   enabled: true
   token: supersecret
 auth:
-  enabled: true
+  mode: kratos
   session_cookie_name: ory_kratos_session
 `)
 

--- a/internal/cli/templates/vibewarden.yaml.tmpl
+++ b/internal/cli/templates/vibewarden.yaml.tmpl
@@ -59,6 +59,9 @@ kratos:
     from: "no-reply@vibewarden.local"
 
 auth:
+  # Authentication strategy: "kratos" | "jwt" | "api-key" | "none".
+  # See ADR-065 — auth.mode is the single source of truth for whether auth is on.
+  mode: "kratos"
   # Identity schema preset: "email_password" (default), "email_only", or "username_password".
   # You can also point to a custom JSON schema file path.
   identity_schema: "email_password"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,7 +160,7 @@ func (c *Config) IsProdProfile() bool {
 func (c *Config) EgressNoProxy() string {
 	parts := []string{"localhost", "127.0.0.1", "vibewarden"}
 
-	kratosMode := c.Auth.Enabled && c.Auth.Mode == AuthModeKratos && !c.Kratos.External
+	kratosMode := c.Auth.Active() && c.Auth.Mode == AuthModeKratos && !c.Kratos.External
 	if kratosMode {
 		parts = append(parts, "kratos")
 		if c.Database.ExternalURL == "" {
@@ -654,13 +654,15 @@ type APIKeyEntry struct {
 }
 
 // AuthConfig holds auth middleware settings.
-// Authentication is enabled automatically when Kratos.PublicURL is non-empty.
+//
+// Mode is the single source of truth for whether authentication is on.
+// Set Mode to "none" (or leave it empty) to disable authentication entirely;
+// set it to "kratos", "jwt", or "api-key" to enable the matching strategy.
+// Use the Active method to derive the on/off state at call sites.
+//
+// The legacy auth.enabled field was removed in v0.11.0 per ADR-065. The
+// config loader explicitly rejects any YAML that still sets it.
 type AuthConfig struct {
-	// Enabled toggles the authentication middleware (default: false).
-	// When true, all requests must present a valid Kratos session cookie unless
-	// the path matches one of the PublicPaths patterns.
-	Enabled bool `mapstructure:"enabled"`
-
 	// Mode selects the authentication strategy.
 	// Accepted values: "none" (default), "kratos", "jwt", "api-key".
 	// "none" disables all authentication — use only in trusted environments.
@@ -707,6 +709,19 @@ type AuthConfig struct {
 
 	// UI holds theme and URL settings for the built-in or custom auth pages.
 	UI AuthUIConfig `mapstructure:"ui"`
+}
+
+// Active reports whether the authentication middleware should be active.
+//
+// Auth is active when Mode is a non-empty, non-"none" value. An empty Mode
+// (which viper normalises to AuthModeNone via SetDefault) and AuthModeNone
+// both mean "auth disabled".
+//
+// This helper is the single derivation for "is auth on" and every consumer
+// that needs that signal should call it rather than testing Mode directly.
+// See ADR-065.
+func (a AuthConfig) Active() bool {
+	return a.Mode != "" && a.Mode != AuthModeNone
 }
 
 // RateLimitConfig holds rate limiting settings.
@@ -1627,14 +1642,6 @@ func (c *Config) Validate() error {
 		))
 	}
 
-	// auth.enabled with mode "none" is almost certainly a misconfiguration: the
-	// user enabled auth but left the mode at its default ("none"), which means no
-	// authentication will actually be enforced.
-	if c.Auth.Enabled && (c.Auth.Mode == AuthModeNone || c.Auth.Mode == "") {
-		errs = append(errs, "auth.enabled is true but auth.mode is \"none\", which means no authentication will be enforced — "+
-			"set auth.mode to \"kratos\", \"jwt\", or \"api-key\" to enable authentication, or set auth.enabled to false")
-	}
-
 	// auth.jwt validation (only when mode is "jwt").
 	if c.Auth.Mode == AuthModeJWT {
 		jwt := c.Auth.JWT
@@ -2152,7 +2159,6 @@ func Load(configPath string) (*Config, error) {
 	v.SetDefault("kratos.smtp.from", "no-reply@vibewarden.local")
 	v.SetDefault("auth.api_key.openbao_path", "")
 	v.SetDefault("auth.api_key.cache_ttl", "5m")
-	v.SetDefault("auth.enabled", false)
 	v.SetDefault("auth.mode", "none")
 	v.SetDefault("auth.identity_schema", "email_password")
 	v.SetDefault("auth.public_paths", []string{})
@@ -2322,6 +2328,16 @@ func Load(configPath string) (*Config, error) {
 		}
 	}
 
+	// Reject removed keys before unmarshal. auth.enabled was removed in
+	// v0.11.0 per ADR-065; any presence of the key — even auth.enabled:
+	// false — must fail loading with a message that names the replacement
+	// inline. The raw YAML map is inspected here rather than on the
+	// unmarshalled struct because once AuthConfig.Enabled is gone the
+	// struct cannot distinguish "user set false" from "user omitted".
+	if err := rejectRemovedAuthEnabled(v); err != nil {
+		return nil, err
+	}
+
 	var cfg Config
 	if err := v.Unmarshal(&cfg); err != nil {
 		return nil, fmt.Errorf("unmarshaling config: %w", err)
@@ -2354,3 +2370,33 @@ func Load(configPath string) (*Config, error) {
 
 	return &cfg, nil
 }
+
+// rejectRemovedAuthEnabled returns a load-time error when the user's YAML
+// carries the removed auth.enabled key. The check walks viper.AllSettings()
+// (the raw unmarshalled YAML map) so it can detect key presence
+// independently of whether the caller wrote true or false. The error
+// message names the replacement inline — see ADR-065.
+func rejectRemovedAuthEnabled(v *viper.Viper) error {
+	auth, ok := v.AllSettings()["auth"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	if _, present := auth["enabled"]; !present {
+		return nil
+	}
+	return fmt.Errorf("invalid config: %s", authEnabledRemovedMessage)
+}
+
+// authEnabledRemovedMessage is the exact text returned when auth.enabled is
+// present in a loaded config. The wording is load-bearing — it is the only
+// hint a user sees to migrate off the removed key — and is pinned by
+// TestLoad_RejectsAuthEnabled.
+const authEnabledRemovedMessage = `auth.enabled is no longer a recognised config key (removed in v0.11.0; see ADR-065). Use auth.mode as the single source of truth: set auth.mode: "none" to disable auth, or auth.mode: "kratos" | "jwt" | "api-key" to enable a strategy.
+
+Canonical form:
+
+  auth:
+    mode: "none"          # disable auth
+    # mode: "kratos"      # enable Ory Kratos session auth
+    # mode: "jwt"         # enable JWT / OIDC bearer auth
+    # mode: "api-key"     # enable API key header auth`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -418,7 +418,8 @@ func TestLoad_NewFieldDefaults(t *testing.T) {
 		got  interface{}
 		want interface{}
 	}{
-		{"auth.enabled", cfg.Auth.Enabled, false},
+		{"auth.mode", string(cfg.Auth.Mode), "none"},
+		{"auth.active", cfg.Auth.Active(), false},
 		{"auth.identity_schema", cfg.Auth.IdentitySchema, "email_password"},
 		{"auth.session_cookie_name", cfg.Auth.SessionCookieName, "ory_kratos_session"},
 		{"auth.login_url", cfg.Auth.LoginURL, ""},
@@ -444,7 +445,6 @@ func TestLoad_NewFieldDefaults(t *testing.T) {
 func TestLoad_NewFieldsFromFile(t *testing.T) {
 	content := `
 auth:
-  enabled: true
   mode: kratos
   identity_schema: email_only
   session_cookie_name: my_session
@@ -483,7 +483,8 @@ overrides:
 		got  interface{}
 		want interface{}
 	}{
-		{"auth.enabled", cfg.Auth.Enabled, true},
+		{"auth.mode", string(cfg.Auth.Mode), "kratos"},
+		{"auth.active", cfg.Auth.Active(), true},
 		{"auth.identity_schema", cfg.Auth.IdentitySchema, "email_only"},
 		{"auth.session_cookie_name", cfg.Auth.SessionCookieName, "my_session"},
 		{"auth.login_url", cfg.Auth.LoginURL, "/login"},
@@ -1047,9 +1048,12 @@ log:
 		t.Errorf("auth.public_paths = %v, want [\"/health\"]", cfg.Auth.PublicPaths)
 	}
 
-	// New fields must have their defaults.
-	if cfg.Auth.Enabled {
-		t.Errorf("auth.enabled = true, want false (backward compat default)")
+	// New fields must have their defaults (ADR-065: auth.mode is the source of truth).
+	if cfg.Auth.Mode != config.AuthModeNone {
+		t.Errorf("auth.mode = %q, want %q (backward compat default)", cfg.Auth.Mode, config.AuthModeNone)
+	}
+	if cfg.Auth.Active() {
+		t.Errorf("auth.Active() = true, want false (backward compat default)")
 	}
 	if cfg.Auth.IdentitySchema != "email_password" {
 		t.Errorf("auth.identity_schema = %q, want %q", cfg.Auth.IdentitySchema, "email_password")
@@ -2540,85 +2544,6 @@ func TestValidate_TLSProvider(t *testing.T) {
 	}
 }
 
-// TestValidate_AuthEnabledModeNone verifies that enabling auth with mode "none" produces
-// an actionable error.
-func TestValidate_AuthEnabledModeNone(t *testing.T) {
-	tests := []struct {
-		name        string
-		cfg         config.Config
-		wantErr     bool
-		wantContain string
-	}{
-		{
-			name: "auth.enabled false with mode none is valid",
-			cfg: config.Config{
-				Auth: config.AuthConfig{Enabled: false, Mode: "none"},
-			},
-			wantErr: false,
-		},
-		{
-			name: "auth.enabled true with mode kratos is valid",
-			cfg: config.Config{
-				Auth: config.AuthConfig{Enabled: true, Mode: "kratos"},
-			},
-			wantErr: false,
-		},
-		{
-			name: "auth.enabled true with mode jwt is valid",
-			cfg: config.Config{
-				Auth: config.AuthConfig{Enabled: true, Mode: "jwt"},
-			},
-			wantErr: false,
-		},
-		{
-			name: "auth.enabled true with mode api-key is valid",
-			cfg: config.Config{
-				Auth: config.AuthConfig{Enabled: true, Mode: "api-key"},
-			},
-			wantErr: false,
-		},
-		{
-			name: "auth.enabled true with mode none is a misconfiguration",
-			cfg: config.Config{
-				Auth: config.AuthConfig{Enabled: true, Mode: "none"},
-			},
-			wantErr:     true,
-			wantContain: "auth.enabled is true but auth.mode is \"none\"",
-		},
-		{
-			name: "auth.enabled true with empty mode is a misconfiguration",
-			cfg: config.Config{
-				Auth: config.AuthConfig{Enabled: true, Mode: ""},
-			},
-			wantErr:     true,
-			wantContain: "auth.enabled is true but auth.mode is \"none\"",
-		},
-		{
-			name: "error message suggests fix by listing accepted modes",
-			cfg: config.Config{
-				Auth: config.AuthConfig{Enabled: true, Mode: "none"},
-			},
-			wantErr:     true,
-			wantContain: "set auth.mode to \"kratos\", \"jwt\", or \"api-key\"",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.cfg.Validate()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if tt.wantErr && tt.wantContain != "" && err != nil {
-				if !strings.Contains(err.Error(), tt.wantContain) {
-					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantContain)
-				}
-			}
-		})
-	}
-}
-
 // TestValidate_AuthModeActionable verifies that an invalid auth.mode produces a message
 // that names the accepted values and suggests the fix.
 func TestValidate_AuthModeActionable(t *testing.T) {
@@ -3012,5 +2937,208 @@ waf:
 				t.Errorf("WAF.Mode = %q, want %q", cfg.WAF.Mode, tt.wantMode)
 			}
 		})
+	}
+}
+
+// TestLoad_RejectsAuthEnabled verifies the ADR-065 hard-break: any presence
+// of the removed auth.enabled key — whether true, false, or alongside a valid
+// auth.mode — must be rejected at Load time with the exact, actionable error
+// message documented in ADR-065 and constant authEnabledRemovedMessage.
+//
+// The raw-key check runs before mapstructure unmarshaling, so the error must
+// fire even though the struct has no corresponding field to decode into.
+func TestLoad_RejectsAuthEnabled(t *testing.T) {
+	const wantSnippet1 = "auth.enabled is no longer a recognised config key"
+	const wantSnippet2 = "Use auth.mode as the single source of truth"
+	const wantSnippet3 = `set auth.mode: "none" to disable auth, or auth.mode: "kratos" | "jwt" | "api-key"`
+
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "auth.enabled: true alone",
+			yaml: `
+auth:
+  enabled: true
+`,
+		},
+		{
+			name: "auth.enabled: false alone",
+			yaml: `
+auth:
+  enabled: false
+`,
+		},
+		{
+			name: "auth.enabled: true with valid auth.mode: kratos",
+			yaml: `
+auth:
+  enabled: true
+  mode: kratos
+`,
+		},
+		{
+			name: "auth.enabled: false with valid auth.mode: none",
+			yaml: `
+auth:
+  enabled: false
+  mode: none
+`,
+		},
+		{
+			name: "auth.enabled: true with valid auth.mode: jwt",
+			yaml: `
+auth:
+  enabled: true
+  mode: jwt
+  jwt:
+    jwks_url: "https://idp.example.com/.well-known/jwks.json"
+    issuer: "https://idp.example.com/"
+    audience: "api"
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgFile := filepath.Join(dir, "vibewarden.yaml")
+			if err := os.WriteFile(cfgFile, []byte(tt.yaml), 0600); err != nil {
+				t.Fatalf("writing temp config file: %v", err)
+			}
+
+			_, err := config.Load(cfgFile)
+			if err == nil {
+				t.Fatalf("Load() returned nil error; want hard-break rejection of auth.enabled")
+			}
+
+			msg := err.Error()
+			for _, want := range []string{wantSnippet1, wantSnippet2, wantSnippet3} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("Load() error = %q,\nwant it to contain %q", msg, want)
+				}
+			}
+		})
+	}
+}
+
+// TestLoad_AuthModeOnly_BehavioralEquivalence verifies ADR-065's behavioural
+// equivalence contract: the canonical mode-only forms load without error and
+// produce the expected Auth.Mode and Auth.Active() values. This locks in the
+// "zero behavioural change for canonical configs" guarantee.
+func TestLoad_AuthModeOnly_BehavioralEquivalence(t *testing.T) {
+	tests := []struct {
+		name       string
+		yaml       string
+		wantMode   config.AuthMode
+		wantActive bool
+	}{
+		{
+			name: "mode: none disables auth",
+			yaml: `
+auth:
+  mode: none
+`,
+			wantMode:   config.AuthModeNone,
+			wantActive: false,
+		},
+		{
+			name: "no auth section at all defaults to none",
+			yaml: `
+server:
+  port: 8080
+`,
+			wantMode:   config.AuthModeNone,
+			wantActive: false,
+		},
+		{
+			name: "mode: kratos enables auth",
+			yaml: `
+auth:
+  mode: kratos
+`,
+			wantMode:   config.AuthModeKratos,
+			wantActive: true,
+		},
+		{
+			name: "mode: jwt enables auth",
+			yaml: `
+auth:
+  mode: jwt
+  jwt:
+    jwks_url: "https://idp.example.com/.well-known/jwks.json"
+    issuer: "https://idp.example.com/"
+    audience: "api"
+`,
+			wantMode:   config.AuthModeJWT,
+			wantActive: true,
+		},
+		{
+			name: "mode: api-key enables auth",
+			yaml: `
+auth:
+  mode: api-key
+  api_key:
+    header: "X-Api-Key"
+    openbao_path: "secret/data/api-keys"
+`,
+			wantMode:   config.AuthModeAPIKey,
+			wantActive: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgFile := filepath.Join(dir, "vibewarden.yaml")
+			if err := os.WriteFile(cfgFile, []byte(tt.yaml), 0600); err != nil {
+				t.Fatalf("writing temp config file: %v", err)
+			}
+
+			cfg, err := config.Load(cfgFile)
+			if err != nil {
+				t.Fatalf("Load() unexpected error: %v", err)
+			}
+
+			if cfg.Auth.Mode != tt.wantMode {
+				t.Errorf("Auth.Mode = %q, want %q", cfg.Auth.Mode, tt.wantMode)
+			}
+			if got := cfg.Auth.Active(); got != tt.wantActive {
+				t.Errorf("Auth.Active() = %v, want %v", got, tt.wantActive)
+			}
+		})
+	}
+}
+
+// TestLoad_ErrorUnusedStaysFalse is a documentary test pinning ADR-065's
+// decision to keep viper/mapstructure ErrorUnused disabled. Unknown top-level
+// keys must continue to be silently accepted so forward-compat config files
+// that include pre-release keys still load on older binaries.
+//
+// If a future change flips ErrorUnused to true, this test will fail and force
+// the author to revisit ADR-065.
+func TestLoad_ErrorUnusedStaysFalse(t *testing.T) {
+	yaml := `
+server:
+  port: 8080
+
+# A completely fabricated key that does not map to any struct field.
+# Under ErrorUnused=true this would fail to load. ADR-065 keeps it false.
+this_key_does_not_exist:
+  nor_does_this: "ignored"
+`
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "vibewarden.yaml")
+	if err := os.WriteFile(cfgFile, []byte(yaml), 0600); err != nil {
+		t.Fatalf("writing temp config file: %v", err)
+	}
+
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load() rejected an unknown top-level key; ErrorUnused must stay false per ADR-065. err = %v", err)
+	}
+	if cfg.Server.Port != 8080 {
+		t.Errorf("server.port = %d, want 8080 (config loaded but value wrong)", cfg.Server.Port)
 	}
 }

--- a/internal/config/egress_test.go
+++ b/internal/config/egress_test.go
@@ -744,14 +744,14 @@ func TestEgressNoProxy(t *testing.T) {
 		{
 			name: "with kratos (local db)",
 			cfg: config.Config{
-				Auth: config.AuthConfig{Enabled: true, Mode: config.AuthModeKratos},
+				Auth: config.AuthConfig{Mode: config.AuthModeKratos},
 			},
 			want: "localhost,127.0.0.1,vibewarden,kratos,kratos-db",
 		},
 		{
 			name: "with kratos (external db)",
 			cfg: config.Config{
-				Auth:     config.AuthConfig{Enabled: true, Mode: config.AuthModeKratos},
+				Auth:     config.AuthConfig{Mode: config.AuthModeKratos},
 				Database: config.DatabaseConfig{ExternalURL: "postgres://ext:5432/kratos"},
 			},
 			want: "localhost,127.0.0.1,vibewarden,kratos",
@@ -780,7 +780,7 @@ func TestEgressNoProxy(t *testing.T) {
 		{
 			name: "all services enabled",
 			cfg: config.Config{
-				Auth:          config.AuthConfig{Enabled: true, Mode: config.AuthModeKratos},
+				Auth:          config.AuthConfig{Mode: config.AuthModeKratos},
 				Secrets:       config.SecretsConfig{Enabled: true},
 				RateLimit:     config.RateLimitConfig{Store: "redis"},
 				Observability: config.ObservabilityConfig{Enabled: true},

--- a/internal/config/generator_input.go
+++ b/internal/config/generator_input.go
@@ -19,7 +19,7 @@ func (c *Config) ToGeneratorInput() ports.GeneratorInput {
 	}
 	return ports.GeneratorInput{
 		Profile:              c.Profile,
-		AuthEnabled:          c.Auth.Enabled,
+		AuthEnabled:          c.Auth.Active(),
 		AuthMode:             string(c.Auth.Mode),
 		KratosExternal:       c.Kratos.External,
 		SecretsEnabled:       c.Secrets.Enabled,

--- a/internal/config/templates/docker-compose.yml.tmpl
+++ b/internal/config/templates/docker-compose.yml.tmpl
@@ -7,7 +7,7 @@
 #   app         — Your application
 {{- end }}
 #   vibewarden  — Security sidecar (listens on :{{ .Server.Port }}, forwards to app on :{{ .Upstream.Port }})
-{{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) }}
+{{- if and (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) }}
 #   kratos      — Ory Kratos identity server
 {{- if eq .Database.ExternalURL "" }}
 #   kratos-db   — PostgreSQL for Kratos (local container; set database.external_url to use an external instance)
@@ -113,13 +113,13 @@ services:
 {{- if .Egress.IsNetworkIsolationEnabled }}
       - vibewarden-external
 {{- end }}
-{{- if or (and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External)) .App.Build .App.Image .Secrets.Enabled (and (eq .RateLimit.Store "redis") (not (.RateLimit.Redis.HasExternalURL))) }}
+{{- if or (and (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External)) .App.Build .App.Image .Secrets.Enabled (and (eq .RateLimit.Store "redis") (not (.RateLimit.Redis.HasExternalURL))) }}
     depends_on:
 {{- if or .App.Build .App.Image }}
       app:
         condition: service_healthy
 {{- end }}
-{{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) }}
+{{- if and (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) }}
       kratos:
         condition: service_healthy
 {{- end }}
@@ -135,7 +135,7 @@ services:
         condition: service_healthy
 {{- end }}
 {{- end }}
-{{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) }}
+{{- if and (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) }}
 {{- if eq .Database.ExternalURL "" }}
 
   kratos-db:
@@ -258,7 +258,7 @@ services:
       - {{ .InternalNetworkName }}
     restart: "no"
 {{- end }}
-{{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) }}
+{{- if and (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) }}
 
   seed-users:
     image: curlimages/curl:8.12.1
@@ -432,10 +432,10 @@ networks:
   vibewarden:
     driver: bridge
 {{- end }}
-{{- if or (and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) (eq .Database.ExternalURL "")) .TLS.Enabled (and (eq .RateLimit.Store "redis") (not (.RateLimit.Redis.HasExternalURL))) .Observability.Enabled (and .Secrets.Enabled .IsProdProfile) }}
+{{- if or (and (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) (eq .Database.ExternalURL "")) .TLS.Enabled (and (eq .RateLimit.Store "redis") (not (.RateLimit.Redis.HasExternalURL))) .Observability.Enabled (and .Secrets.Enabled .IsProdProfile) }}
 
 volumes:
-{{- if and .Auth.Enabled (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) (eq .Database.ExternalURL "") }}
+{{- if and (eq (printf "%s" .Auth.Mode) "kratos") (not .Kratos.External) (eq .Database.ExternalURL "") }}
   kratos-db-data:
 {{- end }}
 {{- if .TLS.Enabled }}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -306,7 +306,7 @@ func explainConfig(cfg *config.Config, path string) string {
 
 	// Authentication
 	fmt.Fprintf(&sb, "Authentication:\n")
-	if cfg.Auth.Enabled {
+	if cfg.Auth.Active() {
 		kratosURL := cfg.Kratos.PublicURL
 		if kratosURL == "" {
 			kratosURL = "http://localhost:4433 (default)"
@@ -783,8 +783,8 @@ func validateConfig(cfg *config.Config) []string {
 			errs = append(errs, "rate_limit.per_ip.burst must be greater than zero")
 		}
 	}
-	if cfg.Admin.Enabled && !cfg.Auth.Enabled {
-		errs = append(errs, "user-management plugin requires auth to be enabled (set auth.enabled: true)")
+	if cfg.Admin.Enabled && !cfg.Auth.Active() {
+		errs = append(errs, "user-management plugin requires auth to be enabled (set auth.mode to \"kratos\", \"jwt\", or \"api-key\")")
 	}
 
 	return errs

--- a/internal/plugins/auth/meta.go
+++ b/internal/plugins/auth/meta.go
@@ -8,8 +8,7 @@ func (p *Plugin) Description() string {
 // ConfigSchema returns the configuration field descriptions for the auth plugin.
 func (p *Plugin) ConfigSchema() map[string]string {
 	return map[string]string{
-		"enabled":             "Enable authentication middleware (default: false)",
-		"mode":                "Authentication strategy: none (default), kratos, jwt, api-key",
+		"mode":                "Authentication strategy: none (default, disables auth), kratos, jwt, api-key",
 		"kratos_public_url":   "Base URL of the Kratos public API (required when mode is kratos)",
 		"kratos_admin_url":    "Base URL of the Kratos admin API",
 		"session_cookie_name": "Name of the Kratos session cookie (default: ory_kratos_session)",
@@ -27,7 +26,6 @@ func (p *Plugin) Critical() bool { return true }
 // Example returns an example YAML configuration for the auth plugin.
 func (p *Plugin) Example() string {
 	return `  auth:
-    enabled: true
     mode: kratos
     kratos_public_url: http://127.0.0.1:4433`
 }

--- a/internal/plugins/auth/plugin.go
+++ b/internal/plugins/auth/plugin.go
@@ -119,8 +119,10 @@ func (p *Plugin) Init(_ context.Context) error {
 		mode = ModeNone
 	}
 
-	// If a mode is explicitly set (not "none"), treat as enabled even if
-	// auth.enabled is false. Setting mode: jwt implies enabled: true.
+	// Enabled is populated from config.AuthConfig.Active() at the boundary,
+	// so "Enabled && mode != ModeNone" and "Enabled" are equivalent. The
+	// belt-and-braces check below also covers callers that construct the
+	// plugin config directly without going through Active(). See ADR-065.
 	if !p.cfg.Enabled && mode == ModeNone {
 		p.healthy = true
 		p.healthMsg = "auth disabled"

--- a/internal/plugins/builtin.go
+++ b/internal/plugins/builtin.go
@@ -232,7 +232,7 @@ func RegisterBuiltinPlugins(
 		}
 	}
 	registry.Register(authplugin.New(authplugin.Config{
-		Enabled:           cfg.Auth.Enabled,
+		Enabled:           cfg.Auth.Active(),
 		Mode:              authplugin.Mode(cfg.Auth.Mode),
 		KratosPublicURL:   cfg.Kratos.PublicURL,
 		KratosAdminURL:    cfg.Kratos.AdminURL,

--- a/internal/plugins/catalog.go
+++ b/internal/plugins/catalog.go
@@ -185,8 +185,8 @@ var Catalog = []PluginDescriptor{
 		Name:        "auth",
 		Description: "Authentication via Ory Kratos session validation",
 		ConfigSchema: map[string]string{
-			"enabled":             "Enable authentication middleware (default: false)",
-			"kratos_public_url":   "Base URL of the Kratos public API (required when enabled)",
+			"mode":                "Authentication strategy: none (default, disables auth), kratos, jwt, api-key",
+			"kratos_public_url":   "Base URL of the Kratos public API (required when mode is kratos)",
 			"kratos_admin_url":    "Base URL of the Kratos admin API",
 			"session_cookie_name": "Name of the Kratos session cookie (default: ory_kratos_session)",
 			"login_url":           "Redirect URL for unauthenticated users",
@@ -194,7 +194,7 @@ var Catalog = []PluginDescriptor{
 			"identity_schema":     "Identity schema preset or file path",
 		},
 		Example: `  auth:
-    enabled: true
+    mode: kratos
     kratos_public_url: http://127.0.0.1:4433`,
 	},
 	{

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -81,7 +81,7 @@ VibeWarden is configured via `vibewarden.yaml`. Key sections:
 - `server.port` — port the sidecar listens on (default 8443)
 - `upstream.port` — port the upstream application listens on
 - `tls.enabled`, `tls.provider` — TLS termination (letsencrypt, self-signed, external)
-- `auth.enabled` — Ory Kratos session authentication
+- `auth.mode` — authentication strategy: `none`, `kratos`, `jwt`, or `api-key` (single source of truth; see ADR-065)
 - `rate_limit.enabled`, `rate_limit.per_ip` — per-IP rate limiting
 - `security_headers.enabled` — HSTS, X-Frame-Options, X-Content-Type-Options, etc.
 - `egress` — outbound proxy rules with route-level controls

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -61,7 +61,7 @@ kratos:
   admin_url: ""
 
 auth:
-  enabled: false
+  mode: none
 
 rate_limit:
   enabled: true

--- a/test/egress/vibewarden.yaml
+++ b/test/egress/vibewarden.yaml
@@ -13,7 +13,6 @@ tls:
   enabled: false
 
 auth:
-  enabled: false
   mode: "none"
 
 egress:

--- a/test/integration/agent_loop_test.go
+++ b/test/integration/agent_loop_test.go
@@ -84,7 +84,6 @@ upstream:
   port: 3000
 
 auth:
-  enabled: true
   mode: jwt
 
 rate_limit:


### PR DESCRIPTION
Closes #816

## Summary

Implements ADR-065 — auth configuration reconciliation. `auth.mode` becomes
the **single source of truth** for whether authentication is active in a
VibeWarden deployment. The redundant `auth.enabled` boolean is removed, and
any presence of that key in a user's `vibewarden.yaml` (even `enabled: false`)
is rejected at config load with an actionable, versioned error message.

## Why

Before this change the config surface was internally inconsistent:

- `auth.enabled: true` + `auth.mode: none` was technically accepted but
  silently degraded to disabled at runtime.
- `auth.enabled: false` + `auth.mode: kratos` was accepted but disabled auth,
  contradicting the user's apparent intent.
- Tests, docs, and examples disagreed on which field was "the" switch.

ADR-065 eliminates the ambiguity: `auth.mode` controls everything. There is
no second flag to contradict it.

## What changed

**Domain / config**
- Removed `config.AuthConfig.Enabled`.
- Added `AuthConfig.Active() bool` — `mode != "" && mode != "none"`.
- Added `rejectRemovedAuthEnabled(v)` to `config.Load()`, executed against
  `viper.AllSettings()` before mapstructure unmarshaling.
- Exact error message lives in `authEnabledRemovedMessage` constant
  (verbatim per ADR-065).

**Runtime wiring**
Every reader of the old `cfg.Auth.Enabled` now reads `cfg.Auth.Active()`:
- `internal/config/generator_input.go`
- `internal/plugins/builtin.go` (auth plugin factory)
- `internal/app/serve/config.go`, `eject/eject.go`, `ops/status.go`
- `internal/mcp/tools.go` (plus a clearer error message for user-mgmt)
- `internal/cli/cmd/generate.go`, `plugins.go`, `validate.go`
- `internal/app/generate/service.go`
- `internal/app/generate/service_port_test.go`

**Templates**
- `docker-compose.yml.tmpl`: six branches simplified — `auth.mode` implies
  activation, so `.Auth.Enabled &&` prefixes were dropped.
- `cli/templates/vibewarden.yaml.tmpl`: `vibew wrap --auth` now emits
  canonical `mode: "kratos"` with no `enabled:` key.
- `yamlmod/toggler.go#appendAuthBlock`: same (for `vibew feature add auth`).

**Docs & examples**
- `CHANGELOG.md`: BREAKING entry under Unreleased.
- `docs/configuration.md`: removed `auth.enabled` row; updated `auth.mode`
  description to note it is the single source of truth.
- `llms-full.txt`: updated the bullet.
- `examples/{demo-app,spring-boot,vibewarden.prod}.yaml`: removed legacy
  `enabled:` lines.
- `examples/{demo-app,spring-boot}/README.md`: updated snippets.

**Tests**
- Deleted `TestValidate_AuthEnabledModeNone` — it encoded the old
  ambiguous-pair rule that no longer exists.
- Updated `TestLoad_NewFieldDefaults`, `TestLoad_NewFieldsFromFile`,
  `TestLoad_BackwardCompatibility`, `egress_test.go`, and the CLI
  `validate_test.go` YAML literals.
- Added three new tests in `internal/config/config_test.go`:
  - `TestLoad_RejectsAuthEnabled` — hard-break over 5 inputs (`enabled: true`,
    `enabled: false`, both alongside valid `mode: kratos/none/jwt`), asserting
    three distinct snippets of the ADR-065 error message appear.
  - `TestLoad_AuthModeOnly_BehavioralEquivalence` — canonical `mode: none`,
    `mode: kratos`, `mode: jwt`, `mode: api-key`, plus "no auth section at all"
    load without error and produce the right `Active()` value.
  - `TestLoad_ErrorUnusedStaysFalse` — documentary pin. Unknown top-level
    keys continue to load successfully, so forward-compat configs are not
    broken. Failing this test forces a revisit of ADR-065.

## ErrorUnused decision

ADR-065 deliberately keeps viper/mapstructure's `ErrorUnused: false`. An
explicit raw-key check is the sole rejector. Rationale:

1. `ErrorUnused: true` would reject every forward-compat config from a newer
   binary loaded on an older one — the opposite of what a "single YAML,
   many versions" project wants.
2. The removed key gets a **specific** error with a migration example,
   which a generic "unknown key" wouldn't provide.
3. The check runs before unmarshal, so the absent struct field never becomes
   a decoding ambiguity.

`TestLoad_ErrorUnusedStaysFalse` locks this in.

## Ports-layer note

`ports.AuthConfig.Enabled` and `authplugin.Config.Enabled` are boolean DTO
fields used by adapters. They are **not** user-facing config; they are
populated from `cfg.Auth.Active()` at adapter boundaries. The belt-and-braces
check `!cfg.Enabled && mode == ModeNone` in `plugins/auth/plugin.go` remains
valid — it now just has a cleaner provenance chain.

## Test plan

- [x] `make check` — gofmt, golangci-lint, `go build ./...`, `go test -race ./...`, plus examples/demo-app — all green.
- [x] New table-driven tests exercise every documented rejection path.
- [x] Behavioural equivalence tests cover all four `auth.mode` values plus no-auth-section default.
- [x] Hand-verified `docker-compose.yml` rendering: `mode: none` produces no kratos stanza; `mode: kratos` still produces kratos + migrate + seed-users.
- [x] Hand-verified `vibew wrap --auth` writes canonical YAML (no `enabled:` key).

## Out-of-scope

This PR is deliberately auth-only. `waf.mode`, `tls.provider`,
`rate_limit.*`, `security_headers.*`, `cors.*`, etc. retain their existing
`enabled:` flags. Any similar consolidation for those will be a separate ADR.