### PR TITLE
chore: add Dependabot version-update config for all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,68 @@
+version: 2
+
+updates:
+  # Go module — main binary + all internal packages.
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "deps"
+    labels:
+      - tech-debt
+    groups:
+      # Bundle minor/patch bumps for the OpenTelemetry family — they move
+      # in lockstep and reviewing them individually is churn.
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"
+      # Bundle testcontainers modules — same lockstep pattern.
+      testcontainers:
+        patterns:
+          - "github.com/testcontainers/*"
+
+  # Go module — demo app (separate go.mod).
+  - package-ecosystem: gomod
+    directory: /examples/demo-app
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "deps(demo)"
+    labels:
+      - tech-debt
+      - demo-app
+
+  # Python — Flask example app (requirements.txt).
+  - package-ecosystem: pip
+    directory: /examples/python-flask
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "deps(flask-example)"
+    labels:
+      - tech-debt
+
+  # Docker — base images in Dockerfile + docker-compose.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "deps(docker)"
+    labels:
+      - tech-debt
+
+  # GitHub Actions — keep CI actions pinned to latest.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "ci"
+    labels:
+      - tech-debt


### PR DESCRIPTION
## Summary

Dependabot security alerts were already active (GitHub default). **Version-update PRs were not** — dependencies drifted silently until the auditor agent caught them (issues #804, #806, #807, #808). Adding weekly automated PRs so staleness surfaces as a PR instead of accumulating into audit findings.

## Ecosystems configured

| Ecosystem | Directory | Grouping | Why |
|---|---|---|---|
| \`gomod\` | \`/\` | otel (lockstep), testcontainers (lockstep) | Main module — where most deps live |
| \`gomod\` | \`/examples/demo-app\` | — | Separate go.mod |
| \`pip\` | \`/examples/python-flask\` | — | Flask CVEs bit us (#806) |
| \`docker\` | \`/\` | — | Base image staleness caused Trivy failure (#833) |
| \`github-actions\` | \`/\` | — | Keep CI actions current |

All updates: weekly on Monday, conventional-commit prefix, \`tech-debt\` label.

## Test plan

- [x] YAML validates (\`version: 2\` schema)
- [ ] CI green
- [ ] After merge: Dependabot tab shows scheduled updates for all 5 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)