### PR TITLE
fix(#823): error discipline + concurrency tightening (3 reviewer-audit items)

### DIFF
--- a/internal/adapters/fsnotify/watcher.go
+++ b/internal/adapters/fsnotify/watcher.go
@@ -93,6 +93,13 @@ func (w *Watcher) Watch(ctx context.Context, path string) (<-chan struct{}, erro
 					if timer != nil {
 						timer.Stop()
 					}
+					// AfterFunc fires in a separate goroutine after the debounce
+					// window. The select races with the outer loop closing `done`:
+					//   - <-done wins if the watcher shuts down before the timer fires.
+					//   - ch <- wins if the watcher is still alive and ch has capacity.
+					//   - default wins if ch is already full (duplicate signal dropped).
+					// All three outcomes are safe; the only risk is a late send on ch
+					// after done is closed, which the <-done case handles.
 					timer = time.AfterFunc(w.debounce, func() {
 						select {
 						case <-done:

--- a/internal/app/scaffold/agent_context.go
+++ b/internal/app/scaffold/agent_context.go
@@ -97,11 +97,14 @@ func ensureAgentsMD(renderer ports.TemplateRenderer, dest string) error {
 	if err != nil {
 		return fmt.Errorf("opening AGENTS.md for append: %w", err)
 	}
-	defer f.Close() //nolint:errcheck // best-effort close on read path
 
 	const referenceBlock = "\n\nSee [AGENTS-VIBEWARDEN.md](./AGENTS-VIBEWARDEN.md) for VibeWarden sidecar instructions.\n"
 	if _, writeErr := f.WriteString(referenceBlock); writeErr != nil {
+		_ = f.Close()
 		return fmt.Errorf("appending reference to AGENTS.md: %w", writeErr)
+	}
+	if closeErr := f.Close(); closeErr != nil {
+		return fmt.Errorf("closing AGENTS.md after write: %w", closeErr)
 	}
 	return nil
 }

--- a/internal/plugins/tls/monitor.go
+++ b/internal/plugins/tls/monitor.go
@@ -158,8 +158,9 @@ type CertMonitor struct {
 	degraded    bool
 	degradedMsg string
 
-	stopCh chan struct{}
-	wg     sync.WaitGroup
+	stopCh   chan struct{}
+	stopOnce sync.Once // guards close(stopCh) to prevent panic on double Stop
+	wg       sync.WaitGroup
 }
 
 // NewCertMonitor creates a CertMonitor for the given TLS configuration.
@@ -207,8 +208,10 @@ func (m *CertMonitor) Start(ctx context.Context) {
 }
 
 // Stop signals the monitor to stop and waits for the goroutine to finish.
+// It is safe to call Stop multiple times; only the first call closes the
+// stop channel (guarded by sync.Once to prevent a panic on double-close).
 func (m *CertMonitor) Stop() {
-	close(m.stopCh)
+	m.stopOnce.Do(func() { close(m.stopCh) })
 	m.wg.Wait()
 }
 


### PR DESCRIPTION
## Summary

Three small fixes from the reviewer audit, bundled into one PR.

1. **\`CertMonitor.Stop\` — \`sync.Once\` guard.** \`close(m.stopCh)\` panics on double invocation. Now guarded by \`sync.Once\` so Stop is idempotent.

2. **\`fsnotify/watcher.go\` — race discipline documented.** The \`time.AfterFunc\` goroutine's \`select\` on \`done\` races with the outer loop closing \`done\`. All three outcomes are safe; added inline commentary explaining why (reviewer asked for either a comment or a synchronous drain — the comment is sufficient since the race is benign).

3. **\`scaffold/agent_context.go\` — flush errors propagated.** \`defer f.Close()\` with \`//nolint:errcheck // best-effort close on read path\` was wrong in two ways: it's a write path, and flush errors matter. Replaced with explicit close-after-write that returns the close error.

Closes #823.

## Test plan

- [x] \`make check\` green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)