### PR TITLE
test(#824): fill 3 coverage gaps — waf/builtin, plugin/types, caddy Stop contract

### DIFF
--- a/internal/adapters/caddy/adapter_test.go
+++ b/internal/adapters/caddy/adapter_test.go
@@ -116,9 +116,10 @@ func TestAdapter_StopWithoutStart(t *testing.T) {
 	}
 	adapter := NewAdapter(cfg, slog.Default(), nil)
 
-	// Stopping without starting should not panic (Caddy handles this gracefully)
+	// Stopping without starting should not panic (Caddy handles this gracefully).
+	// Caddy returns nil when Stop is called on an unstarted instance.
 	err := adapter.Stop(context.Background())
-	// We don't assert on err here since Caddy may return an error
-	// when stopping without having been started — this is acceptable.
-	_ = err
+	if err != nil {
+		t.Errorf("Stop() on unstarted adapter returned unexpected error: %v", err)
+	}
 }

--- a/internal/domain/plugin/types_test.go
+++ b/internal/domain/plugin/types_test.go
@@ -1,0 +1,45 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/go-viper/mapstructure/v2"
+)
+
+// TestPluginConfig_SettingsCaptures_UnknownKeys verifies that the
+// mapstructure:",remain" tag on Settings captures plugin-specific keys
+// that are not part of the PluginConfig struct fields.
+func TestPluginConfig_SettingsCaptures_UnknownKeys(t *testing.T) {
+	input := map[string]any{
+		"enabled":    true,
+		"custom_key": "custom_value",
+		"nested": map[string]any{
+			"deep": true,
+		},
+	}
+
+	var cfg PluginConfig
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:  &cfg,
+		TagName: "mapstructure",
+	})
+	if err != nil {
+		t.Fatalf("NewDecoder: %v", err)
+	}
+	if err := decoder.Decode(input); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+
+	if !cfg.Enabled {
+		t.Error("Enabled should be true")
+	}
+	if cfg.Settings == nil {
+		t.Fatal("Settings is nil — mapstructure \",remain\" tag not working")
+	}
+	if cfg.Settings["custom_key"] != "custom_value" {
+		t.Errorf("Settings[custom_key] = %v, want %q", cfg.Settings["custom_key"], "custom_value")
+	}
+	if nested, ok := cfg.Settings["nested"].(map[string]any); !ok || nested["deep"] != true {
+		t.Errorf("Settings[nested][deep] = %v, want true", cfg.Settings["nested"])
+	}
+}

--- a/internal/domain/waf/builtin_test.go
+++ b/internal/domain/waf/builtin_test.go
@@ -1,0 +1,33 @@
+package waf
+
+import "testing"
+
+// TestBuiltinRules_Compile verifies that every built-in rule spec compiles
+// successfully and carries non-empty metadata (name, category, severity).
+// This is a compile-time invariant — builtinSpecs are hardcoded literals
+// that must all produce valid Rules. Previously only exercised transitively
+// via ruleset_test.go; making the check direct catches any new malformed
+// spec at the earliest possible moment.
+func TestBuiltinRules_Compile(t *testing.T) {
+	rules := BuiltinRules()
+	if len(rules) == 0 {
+		t.Fatal("BuiltinRules() returned no rules — at least the SQLi/XSS/path-traversal rules should exist")
+	}
+
+	seen := make(map[string]bool, len(rules))
+	for _, r := range rules {
+		if r.Name() == "" {
+			t.Error("built-in rule has empty Name()")
+		}
+		if r.Category() == "" {
+			t.Errorf("built-in rule %q has empty Category()", r.Name())
+		}
+		if r.Severity() == "" {
+			t.Errorf("built-in rule %q has empty Severity()", r.Name())
+		}
+		if seen[r.Name()] {
+			t.Errorf("duplicate built-in rule name %q", r.Name())
+		}
+		seen[r.Name()] = true
+	}
+}


### PR DESCRIPTION
## Summary

Three net-new tests filling gaps the reviewer audit identified.

1. **\`waf/builtin_test.go\`** — \`TestBuiltinRules_Compile\`: iterates every built-in spec, asserts compilation + non-empty metadata + no duplicates.
2. **\`plugin/types_test.go\`** — \`TestPluginConfig_SettingsCaptures_UnknownKeys\`: exercises the \`mapstructure:",remain"\` tag end-to-end via the real decoder.
3. **\`caddy/adapter_test.go\`** — \`TestStopWithoutStart\`: asserts \`err == nil\` instead of \`_ = err\`.

Item 4 (ringbuffer table-driven refactor) deferred — cleanup, not a gap.

Partially closes #824.

## Test plan

- [x] \`make check\` green (all 3 new tests pass)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)