### PR TITLE
fix(#825): install PATH hint + dead-upstream error example in docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -212,6 +212,27 @@ This command:
 Your app is protected at `https://localhost:8443`. Nothing else is required for the
 first run.
 
+!!! warning "If your app image hasn't been built yet"
+    `vibew dev` checks for the app Docker image before starting. If the image
+    is missing you'll see an error like:
+
+    ```
+    app image "myapp:latest" not found in the local Docker daemon.
+    Build the image first, then run `vibew dev` again.
+
+    Build steps:
+      1. Build your application binary / artifact.
+      2. Run `vibew build` to build the Docker image.
+    ```
+
+    Run `vibew build` first, then retry `vibew dev`. If something else is
+    wrong, `vibew doctor` gives a full diagnostic:
+
+    ```bash
+    vibew doctor       # human-readable
+    vibew doctor --json  # machine-readable (for AI agents)
+    ```
+
 ---
 
 ### Mode 2 — Iterative development (faster rebuilds)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -170,6 +170,16 @@ main() {
     fi
 
     ok "Installed to ${DEST}"
+
+    # When installed to the current directory (not on PATH), tell the user
+    # to add it so the hints below work after cd-ing into a project dir.
+    if [ "$INSTALL_DIR" = "." ]; then
+        echo ""
+        warn "vibew was installed to the current directory."
+        warn "Add it to your PATH so it works after cd:"
+        warn "  export PATH=\"\$PWD:\$PATH\""
+    fi
+
     echo ""
     ok "Get started:"
     echo ""


### PR DESCRIPTION
## Summary

Two remaining items from the user-friction audit (#825). Item 2 (sample AGENTS-VIBEWARDEN.md) shipped in #861.

1. **Install PATH hint** — \`scripts/install.sh\` now warns when \`vibew\` is installed to the current directory (fallback when \`/usr/local/bin\` isn't writable) and suggests \`export PATH="\$PWD:\$PATH"\` so the hints that follow actually work after \`cd\`.

2. **Dead-upstream error example** — \`docs/getting-started.md\` Mode 1 first-run section now shows the actual error output when the app Docker image hasn't been built, plus the recovery path (\`vibew build\` + \`vibew doctor\`). This was friction point #3 from the user audit — users hitting the error without context had no clear forward path.

Closes #825.

## Test plan

- [x] \`make check\` green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)