### PR TITLE
docs(#817): document deploy, upgrade, migrate, plugins, secret generate commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,10 +273,20 @@ add VibeWarden. Use `vibew add` to enable individual features after the initial 
 | `vibew build` | Build the Docker image for the app |
 | `vibew dev` | Start local dev environment |
 | `vibew restart` | Restart containers without rebuilding the image |
+| `vibew deploy` | Deploy the stack to a remote server over SSH ([reference](docs/deploy-reference.md)) |
+| `vibew deploy status` | Show Docker Compose service status on the remote |
+| `vibew deploy logs` | Fetch Docker Compose logs from the remote (`--follow` for streaming) |
 | `vibew status` | Show health of all components |
 | `vibew doctor` | Diagnose common issues |
 | `vibew logs` | Pretty-print structured logs |
-| `vibew deploy logs --follow` | Stream remote logs in real-time |
+| `vibew migrate` | Apply all pending database migrations (alias for `migrate up`) |
+| `vibew migrate up` | Apply all pending database migrations |
+| `vibew migrate down` | Roll back the most recently applied migration |
+| `vibew migrate status` | Show current migration version and state |
+| `vibew upgrade` | Update the VibeWarden binary to the latest (or a specific) release |
+| `vibew plugins` | List available plugins and their enabled/disabled status |
+| `vibew plugins show <name>` | Show detailed configuration options for a plugin |
+| `vibew secret generate` | Generate a cryptographically secure random secret |
 | `vibew secret get <alias-or-path>` | Read a secret from OpenBao |
 | `vibew secret list` | List all managed secret paths |
 | `vibew token` | Generate a signed dev JWT for local testing |
@@ -370,6 +380,7 @@ Architectural decisions are documented in [DECISIONS.md](DECISIONS.md).
 | Rate limiting at scale | [docs/rate-limiting.md](docs/rate-limiting.md) |
 | Production deployment | [docs/production-deployment.md](docs/production-deployment.md) |
 | Hardening checklist | [docs/production-hardening.md](docs/production-hardening.md) |
+| Deploy command reference | [docs/deploy-reference.md](docs/deploy-reference.md) |
 | Architectural decisions | [DECISIONS.md](DECISIONS.md) |
 
 ---

--- a/docs/deploy-reference.md
+++ b/docs/deploy-reference.md
@@ -1,0 +1,195 @@
+# Deploy Command Reference
+
+`vibew deploy` deploys the VibeWarden stack to a remote server over SSH. It
+generates runtime configuration locally, transfers files via `rsync`, and starts
+Docker Compose on the remote host.
+
+For a full walkthrough of deploying to a VPS for the first time, see
+[Deploy to VPS](deploy-to-vps.md). This page is the command reference.
+
+---
+
+## Architecture
+
+All operations use your system `ssh` and `rsync` binaries. Your SSH agent and
+`~/.ssh/config` settings (IdentityFile, ProxyJump, etc.) are honoured
+automatically. No SSH libraries are embedded in the binary.
+
+Remote directory layout: `~/vibewarden/<project-name>/`
+
+The project name is derived from the absolute path of the `--config` file. When
+`--config` is omitted, the current directory name is used.
+
+---
+
+## Commands
+
+### `vibew deploy`
+
+Deploy (or redeploy) the stack to a remote server.
+
+```bash
+vibew deploy --target ssh://user@host --config vibewarden.prod.yaml
+```
+
+#### Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--target` | Yes | -- | Remote target in `ssh://user@host[:port]` format |
+| `--config` | No | `./vibewarden.yaml` | Path to the vibewarden.yaml config file |
+| `--ssh-key` | No | SSH agent / `~/.ssh/config` | Path to the SSH private key file |
+| `--secrets-from` | No | -- | Path to a `.env`-format file whose KEY=VALUE pairs are seeded into OpenBao |
+| `--rotate-secrets` | No | `false` | Re-seed secrets from `--secrets-from` on subsequent deploys |
+| `--unseal-key` | No | stored key | OpenBao unseal key; overrides the key stored in `~/vibewarden/<project>/.openbao-credentials` on the remote |
+
+#### What happens on first deploy
+
+1. Generates runtime config (Docker Compose files, Kratos config) locally.
+2. Transfers files to the remote via `rsync`.
+3. Runs `docker compose up -d` on the remote.
+4. When `secrets.enabled: true` in vibewarden.yaml, bootstraps OpenBao:
+   initialises, unseals, enables KV v2 and AppRole, creates the vibewarden
+   policy and role, and seeds secrets from `--secrets-from` if provided.
+5. Prints the unseal key, root token, role ID, and secret ID. Save the unseal
+   key -- it is not shown again.
+
+#### What happens on subsequent deploys
+
+1. Regenerates and transfers updated config.
+2. Restarts Docker Compose on the remote.
+3. Uses the stored unseal key from `~/vibewarden/<project>/.openbao-credentials`
+   unless `--unseal-key` is provided explicitly.
+4. Secrets are not re-seeded unless `--rotate-secrets` is passed.
+
+---
+
+### `vibew deploy status`
+
+Show Docker Compose service status on the remote.
+
+```bash
+vibew deploy status --target ssh://user@host
+```
+
+#### Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--target` | Yes | -- | Remote target in `ssh://user@host[:port]` format |
+| `--config` | No | `./vibewarden.yaml` | Path to vibewarden.yaml (used to derive the remote project directory) |
+| `--ssh-key` | No | SSH agent / `~/.ssh/config` | Path to the SSH private key file |
+
+---
+
+### `vibew deploy logs`
+
+Fetch Docker Compose logs from the remote.
+
+```bash
+vibew deploy logs --target ssh://user@host
+```
+
+#### Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--target` | Yes | -- | Remote target in `ssh://user@host[:port]` format |
+| `--config` | No | `./vibewarden.yaml` | Path to vibewarden.yaml (used to derive the remote project directory) |
+| `--ssh-key` | No | SSH agent / `~/.ssh/config` | Path to the SSH private key file |
+| `--lines` | No | `50` | Number of log lines to fetch (`0` = all) |
+| `--follow` / `-f` | No | `false` | Stream log output continuously until cancelled (Ctrl-C) |
+
+---
+
+## Examples
+
+### First deploy with secrets
+
+```bash
+vibew deploy \
+  --config vibewarden.prod.yaml \
+  --target ssh://ubuntu@203.0.113.10 \
+  --secrets-from .env.prod
+```
+
+Save the unseal key from the output immediately.
+
+### Subsequent deploy (config change, no secret rotation)
+
+```bash
+vibew deploy \
+  --config vibewarden.prod.yaml \
+  --target ssh://ubuntu@203.0.113.10
+```
+
+### Rotate secrets on redeploy
+
+```bash
+vibew deploy \
+  --config vibewarden.prod.yaml \
+  --target ssh://ubuntu@203.0.113.10 \
+  --rotate-secrets \
+  --secrets-from .env.prod
+```
+
+### Deploy with explicit unseal key
+
+Use this when redeploying to a sealed OpenBao instance (e.g. after a server
+restart) if the stored credentials file was lost:
+
+```bash
+vibew deploy \
+  --config vibewarden.prod.yaml \
+  --target ssh://ubuntu@203.0.113.10 \
+  --unseal-key "YOUR_UNSEAL_KEY_HERE"
+```
+
+### Deploy via non-standard SSH port with explicit key
+
+```bash
+vibew deploy \
+  --config vibewarden.prod.yaml \
+  --target ssh://deploy@myserver.example.com:2222 \
+  --ssh-key ~/.ssh/deploy_ed25519
+```
+
+### Check service status
+
+```bash
+vibew deploy status --target ssh://ubuntu@203.0.113.10
+```
+
+### Tail last 100 log lines
+
+```bash
+vibew deploy logs --target ssh://ubuntu@203.0.113.10 --lines 100
+```
+
+### Stream logs in real-time
+
+```bash
+vibew deploy logs --target ssh://ubuntu@203.0.113.10 --follow
+```
+
+Press Ctrl-C to stop streaming.
+
+---
+
+## Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `--target is required (e.g. ssh://user@host)` | Missing `--target` flag | Add `--target ssh://user@host` |
+| `invalid --target: scheme must be "ssh"` | Wrong URL scheme (e.g. `http://`) | Use `ssh://user@host` format |
+| `openbao bootstrap: ...` | OpenBao initialisation failed | Check remote Docker logs; verify port 8200 is reachable on the remote |
+| `loading config: ...` | Invalid or missing vibewarden.yaml | Run `vibew validate --config <path>` locally |
+| `rsync: connection refused` | SSH not reachable | Verify `ssh user@host echo OK` works first |
+
+---
+
+## Related
+
+- [Deploy to VPS](deploy-to-vps.md) -- full first-deploy walkthrough
+- [Secret Management](secret-management.md) -- OpenBao configuration details
+- [Production Hardening](production-hardening.md) -- post-deploy security checklist

--- a/docs/deploy-to-vps.md
+++ b/docs/deploy-to-vps.md
@@ -383,11 +383,13 @@ ssh root@<server-ip> 'cd /opt/myapp && docker run --rm \
 
 ## Next steps
 
+- **Deploy command reference**: see [Deploy Reference](deploy-reference.md) for
+  the full `vibew deploy` flag reference, secret rotation, and unsealing.
 - **Production hardening**: see [Production Hardening Checklist](production-hardening.md)
   for a full checklist of security settings to review before going live.
 - **Backups**: see [Production Deployment](production-deployment.md) for Postgres
   backup scripts and TLS certificate backup procedures.
-- **Observability**: enable Prometheus metrics and Grafana dashboards —
+- **Observability**: enable Prometheus metrics and Grafana dashboards --
   see [Observability](observability.md).
 - **Fleet dashboard** (Pro): connect multiple instances to the VibeWarden fleet
   dashboard at `app.vibewarden.dev` for aggregated logs and metrics.

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -488,6 +488,75 @@ If you see `sorry, too many clients already` errors:
 
 ---
 
+## Schema migrations with `vibew migrate`
+
+VibeWarden ships database migrations managed by
+[golang-migrate](https://github.com/golang-migrate/migrate). The `vibew migrate`
+command applies, rolls back, or inspects the state of these migrations against
+the configured database.
+
+### Prerequisites
+
+- A database URL configured in `vibewarden.yaml` via `database.url` or
+  `database.external_url`, or the corresponding environment variable
+  `VIBEWARDEN_DATABASE_EXTERNAL_URL`.
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `vibew migrate` | Apply all pending migrations (same as `migrate up`) |
+| `vibew migrate up` | Apply all pending migrations |
+| `vibew migrate down` | Roll back the most recently applied migration |
+| `vibew migrate status` | Show current migration version and state |
+
+### Flags
+
+| Flag | Scope | Default | Description |
+|------|-------|---------|-------------|
+| `--config` | All subcommands (persistent) | `./vibewarden.yaml` | Path to the vibewarden.yaml config file |
+
+### Examples
+
+Apply all pending migrations:
+
+```bash
+vibew migrate up --config vibewarden.prod.yaml
+```
+
+Expected output on success:
+
+```
+Migrations applied successfully.
+```
+
+Check current migration version:
+
+```bash
+vibew migrate status --config vibewarden.prod.yaml
+```
+
+Roll back the last migration:
+
+```bash
+vibew migrate down --config vibewarden.prod.yaml
+```
+
+Expected output on success:
+
+```
+Last migration rolled back successfully.
+```
+
+### Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `no database URL configured; set database.url or database.external_url in vibewarden.yaml` | No database URL in config or environment | Add `database.external_url` to vibewarden.yaml or set `VIBEWARDEN_DATABASE_EXTERNAL_URL` |
+| `creating migration runner: ...` | Database unreachable or invalid URL | Verify the connection string and that the database server is running |
+
+---
+
 ## AI-agent notes
 
 This section is machine-readable context for AI coding agents working on

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -59,7 +59,39 @@ echo "v0.13.0" > .vibewarden-version
 Commit `.vibewarden-version` so everyone on your team, as well as your CI environment,
 uses the same version automatically.
 
-### Upgrading to the latest release
+### Upgrading with `vibew upgrade`
+
+`vibew upgrade` downloads and installs a new VibeWarden release, replacing the
+running binary in-place.
+
+```bash
+vibew upgrade            # install the latest release
+vibew upgrade v0.4.0     # install a specific version
+vibew upgrade --dry-run  # preview without writing files
+```
+
+The command:
+
+1. Resolves the target version (latest from the GitHub API, or the tag you
+   supplied).
+2. Downloads the binary archive for the current OS and architecture.
+3. Verifies the SHA-256 checksum.
+4. Replaces the running binary in-place (resolved via `os.Executable` +
+   symlink evaluation). Falls back to `~/.vibewarden/bin` if resolution fails.
+5. Updates `.vibewarden-version` if found in the current or a parent directory.
+6. Touches `vibew`, `vibew.ps1`, `vibew.cmd` in the current directory when present.
+
+If the target directory is not writable (e.g. `/usr/local/bin` without sudo),
+the command automatically retries with `sudo`.
+
+#### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | `false` | Print what would happen without writing any files |
+| `--install-dir` | path of running binary | Directory to install the binary into |
+
+### Upgrading to the latest release (alternative)
 
 ```bash
 ./vibew self-update

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -74,6 +74,73 @@ to inspect and manage a local sidecar. Tools:
 
 ---
 
+## CLI commands
+
+VibeWarden is operated via the `vibew` CLI. Below is the complete command list.
+
+| Command | Description |
+|---|---|
+| `vibew init` | Scaffold a new project with VibeWarden |
+| `vibew wrap` | Add VibeWarden sidecar to an existing project |
+| `vibew add <feature>` | Enable a feature (auth, rate-limiting, tls, metrics, admin) |
+| `vibew generate` | Regenerate docker-compose.yml from config |
+| `vibew build` | Build the Docker image for the app |
+| `vibew dev` | Start local dev environment |
+| `vibew restart` | Restart containers without rebuilding |
+| `vibew deploy --target ssh://user@host` | Deploy the stack to a remote server over SSH |
+| `vibew deploy status --target ssh://user@host` | Show remote Docker Compose service status |
+| `vibew deploy logs --target ssh://user@host` | Fetch remote Docker Compose logs (--follow/-f for streaming) |
+| `vibew status` | Show health of all components |
+| `vibew doctor` | Diagnose common issues |
+| `vibew logs` | Pretty-print structured logs |
+| `vibew migrate` | Apply all pending database migrations (alias for migrate up) |
+| `vibew migrate up` | Apply all pending database migrations |
+| `vibew migrate down` | Roll back the most recently applied migration |
+| `vibew migrate status` | Show current migration version and state |
+| `vibew upgrade` | Update the VibeWarden binary to the latest (or a specific) release |
+| `vibew upgrade v0.4.0` | Install a specific version |
+| `vibew plugins` | List available plugins and their enabled/disabled status |
+| `vibew plugins show <name>` | Show detailed config options for a plugin |
+| `vibew secret generate` | Generate a cryptographically secure random secret (hex) |
+| `vibew secret generate --admin-token` | Generate an admin API token (outputs VIBEWARDEN_ADMIN_TOKEN=...) |
+| `vibew secret generate --fleet-key` | Generate a fleet dashboard key (outputs VIBEWARDEN_FLEET_KEY=...) |
+| `vibew secret get <alias-or-path>` | Read a secret from OpenBao |
+| `vibew secret list` | List all managed secret paths |
+| `vibew token` | Generate a signed dev JWT for local testing |
+| `vibew cert export` | Export the local CA certificate |
+| `vibew validate` | Validate configuration |
+| `vibew context refresh` | Regenerate AI agent context files |
+| `vibew eject` | Export raw proxy config to graduate past VibeWarden |
+| `vibew mcp` | Start MCP server for AI agent integration |
+
+### deploy flags
+
+`vibew deploy` uses SSH to deploy the stack remotely. Key flags:
+
+- `--target` (required) -- `ssh://user@host[:port]`
+- `--config` -- path to vibewarden.yaml (default: ./vibewarden.yaml)
+- `--ssh-key` -- path to SSH private key (default: SSH agent / ~/.ssh/config)
+- `--secrets-from` -- .env file to seed into OpenBao on first deploy
+- `--rotate-secrets` -- re-seed secrets on subsequent deploys
+- `--unseal-key` -- OpenBao unseal key (overrides stored key)
+
+### migrate flags
+
+- `--config` (persistent) -- path to vibewarden.yaml
+
+### upgrade flags
+
+- `--dry-run` -- preview without writing files
+- `--install-dir` -- override installation directory
+
+### secret generate flags
+
+- `--length` (default 32) -- number of random bytes (result is 2x hex chars)
+- `--admin-token` -- generate a 32-byte admin token (outputs VIBEWARDEN_ADMIN_TOKEN=...)
+- `--fleet-key` -- generate a 32-byte fleet key (outputs VIBEWARDEN_FLEET_KEY=...)
+
+---
+
 ## Configuration
 
 VibeWarden is configured via `vibewarden.yaml`. Key sections:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
       - Performance: performance.md
       - Social Login: social-login.md
       - Deploy to VPS: deploy-to-vps.md
+      - Deploy Reference: deploy-reference.md
       - Production Deployment: production-deployment.md
       - Production Hardening: production-hardening.md
       - WebSockets: websockets.md


### PR DESCRIPTION
## Summary

- **README CLI Reference table**: add rows for `vibew deploy` (+ `status`, `logs`), `vibew migrate` (+ `up`, `down`, `status`), `vibew upgrade`, `vibew plugins` (+ `show`), and `vibew secret generate`.
- **llms-full.txt**: add a complete "CLI commands" section with all commands and per-command flag details for deploy, migrate, upgrade, and secret generate.
- **docs/deploy-reference.md**: new dedicated page covering first deploy, secret rotation (`--rotate-secrets`), unsealing (`--unseal-key`), SSH-based architecture, all 6 flags, and common errors.
- **docs/postgres.md**: add "Schema migrations with `vibew migrate`" section with commands, flags, examples with expected output, and common errors.
- **docs/upgrading.md**: add "Upgrading with `vibew upgrade`" section covering flags (`--dry-run`, `--install-dir`), step-by-step behavior, and sudo fallback.
- **docs/deploy-to-vps.md**: cross-reference the new deploy reference page in "Next steps".
- **mkdocs.yml**: add `deploy-reference.md` to navigation under Guides.

Closes #817.

## Test plan

- [ ] `make check` passes (lint, build, tests)
- [ ] All flag names match the Go source (`cmd.Flags()` registrations verified against deploy.go, upgrade.go, migrate.go, plugins.go, secret_generate.go)
- [ ] README CLI table has a row for every top-level `vibew` subcommand
- [ ] `docs/deploy-reference.md` renders correctly in mkdocs
- [ ] `llms-full.txt` CLI section lists all commands from `root.go`
- [ ] No broken relative links in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)