### PR TITLE
fix(#865,#866): CLI help-text corrections for plugins + secret generate

### DIFF
--- a/internal/cli/cmd/plugins.go
+++ b/internal/cli/cmd/plugins.go
@@ -29,9 +29,9 @@ The enabled/disabled status is read from vibewarden.yaml (or the path
 supplied with --config). When no config file is found the defaults apply.
 
 Examples:
-  vibewarden plugins
-  vibewarden plugins --config ./my-vibewarden.yaml
-  vibewarden plugins show tls`,
+  vibew plugins
+  vibew plugins --config ./my-vibewarden.yaml
+  vibew plugins show tls`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg, err := config.Load(configPath)
 			if err != nil {
@@ -56,8 +56,8 @@ func newPluginsShowCmd() *cobra.Command {
 		Long: `Show the full configuration schema and an example for a single plugin.
 
 Examples:
-  vibewarden plugins show tls
-  vibewarden plugins show rate-limiting`,
+  vibew plugins show tls
+  vibew plugins show rate-limiting`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]

--- a/internal/cli/cmd/secret_generate.go
+++ b/internal/cli/cmd/secret_generate.go
@@ -87,9 +87,12 @@ Examples:
 		},
 	}
 
-	cmd.Flags().IntVar(&length, "length", defaultSecretLength, "number of random bytes to generate (result is 2x hex chars)")
-	cmd.Flags().BoolVar(&adminToken, "admin-token", false, "generate a 32-byte admin API token (outputs VIBEWARDEN_ADMIN_TOKEN=...)")
-	cmd.Flags().BoolVar(&fleetKey, "fleet-key", false, "generate a 32-byte fleet dashboard key (outputs VIBEWARDEN_FLEET_KEY=...)")
+	cmd.Flags().IntVar(&length, "length", defaultSecretLength,
+		fmt.Sprintf("number of random bytes to generate, %d–%d (result is 2x hex chars)", minSecretLength, maxSecretLength))
+	cmd.Flags().BoolVar(&adminToken, "admin-token", false,
+		"generate a 32-byte admin API token (outputs VIBEWARDEN_ADMIN_TOKEN=…); mutually exclusive with --fleet-key")
+	cmd.Flags().BoolVar(&fleetKey, "fleet-key", false,
+		"generate a 32-byte fleet dashboard key (outputs VIBEWARDEN_FLEET_KEY=…); mutually exclusive with --admin-token")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

Two CLI help-text fixes spotted by the writer agent during #864:

1. **\`plugins.go\`** (#865) — Examples in \`Long\` strings said \`vibewarden plugins\` instead of \`vibew plugins\`, inconsistent with every other command.

2. **\`secret_generate.go\`** (#866) — Flag descriptions now surface constraints that were previously only enforced in \`RunE\`:
   - \`--length\`: range 16–256 shown in the Usage string
   - \`--admin-token\` / \`--fleet-key\`: mutual exclusivity noted in each flag's help

Closes #865 and #866.

## Test plan

- [x] \`make check\` green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)