### PR TITLE
feat(#871): Caddy multi-host route generation per ADR-069

### DIFF
--- a/internal/adapters/caddy/adapter.go
+++ b/internal/adapters/caddy/adapter.go
@@ -13,22 +13,45 @@ import (
 	_ "github.com/caddyserver/caddy/v2/modules/standard"
 
 	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/domain/site"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
 // Adapter implements ports.ProxyServer using embedded Caddy.
+//
+// When registry is non-nil, the adapter operates in multi-site mode:
+// buildConfigJSON delegates to BuildMultiSiteConfig, producing per-host
+// routes from the registry's healthy sites. When registry is nil, the
+// adapter falls back to single-site mode using BuildCaddyConfig.
 type Adapter struct {
 	config      *ports.ProxyConfig
+	registry    *site.Registry
 	logger      *slog.Logger
 	eventLogger ports.EventLogger
 }
 
-// NewAdapter creates a new Caddy adapter with the given configuration.
+// NewAdapter creates a new Caddy adapter in single-site mode.
 // The eventLogger parameter is optional: pass nil to disable structured event
 // logging (the adapter will still emit plain slog lines).
 func NewAdapter(cfg *ports.ProxyConfig, logger *slog.Logger, eventLogger ports.EventLogger) *Adapter {
 	return &Adapter{
 		config:      cfg,
+		logger:      logger,
+		eventLogger: eventLogger,
+	}
+}
+
+// NewMultiSiteAdapter creates a Caddy adapter in multi-site mode.
+// The registry holds all managed sites and the global configuration.
+// When buildConfigJSON is called, it reads the registry's healthy sites
+// and global config to produce per-host Caddy routes.
+//
+// The cfg parameter is still required for backward-compatible fields
+// (version, event logging params) that are sidecar-global, not per-site.
+func NewMultiSiteAdapter(cfg *ports.ProxyConfig, registry *site.Registry, logger *slog.Logger, eventLogger ports.EventLogger) *Adapter {
+	return &Adapter{
+		config:      cfg,
+		registry:    registry,
 		logger:      logger,
 		eventLogger: eventLogger,
 	}
@@ -100,8 +123,25 @@ func (a *Adapter) UpdateConfig(cfg *ports.ProxyConfig) {
 }
 
 // buildConfigJSON constructs and marshals the Caddy JSON configuration.
+// When a registry is present, multi-site mode is used. Otherwise, the
+// adapter falls back to single-site mode for backward compatibility.
 func (a *Adapter) buildConfigJSON() ([]byte, error) {
-	cfg, err := BuildCaddyConfig(a.config)
+	var (
+		cfg map[string]any
+		err error
+	)
+
+	if a.registry != nil {
+		global := a.registry.Global()
+		if global == nil {
+			g := site.DefaultGlobalConfig()
+			global = &g
+		}
+		cfg, err = BuildMultiSiteConfig(a.registry.HealthySites(), *global)
+	} else {
+		cfg, err = BuildCaddyConfig(a.config)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapters/caddy/adapter.go
+++ b/internal/adapters/caddy/adapter.go
@@ -137,7 +137,7 @@ func (a *Adapter) buildConfigJSON() ([]byte, error) {
 			g := site.DefaultGlobalConfig()
 			global = &g
 		}
-		cfg, err = BuildMultiSiteConfig(a.registry.HealthySites(), *global)
+		cfg, err = BuildMultiSiteConfig(a.registry.HealthySites(), *global, a.logger)
 	} else {
 		cfg, err = BuildCaddyConfig(a.config)
 	}

--- a/internal/adapters/caddy/adapter_test.go
+++ b/internal/adapters/caddy/adapter_test.go
@@ -5,7 +5,9 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/vibewarden/vibewarden/internal/config"
 	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/domain/site"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
@@ -106,6 +108,144 @@ func TestAdapter_BuildConfigJSON(t *testing.T) {
 				t.Error("buildConfigJSON() returned empty data")
 			}
 		})
+	}
+}
+
+func TestNewMultiSiteAdapter(t *testing.T) {
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "127.0.0.1:8080",
+		UpstreamAddr: "127.0.0.1:3000",
+	}
+	registry := site.NewRegistry()
+	logger := slog.Default()
+
+	adapter := NewMultiSiteAdapter(cfg, registry, logger, nil)
+
+	if adapter == nil {
+		t.Fatal("NewMultiSiteAdapter() returned nil")
+	}
+	if adapter.config != cfg {
+		t.Error("NewMultiSiteAdapter() did not set config correctly")
+	}
+	if adapter.registry != registry {
+		t.Error("NewMultiSiteAdapter() did not set registry correctly")
+	}
+	if adapter.logger != logger {
+		t.Error("NewMultiSiteAdapter() did not set logger correctly")
+	}
+}
+
+func TestNewMultiSiteAdapter_WithEventLogger(t *testing.T) {
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "127.0.0.1:8080",
+		UpstreamAddr: "127.0.0.1:3000",
+	}
+	registry := site.NewRegistry()
+	spy := &fakeEventLogger{}
+
+	adapter := NewMultiSiteAdapter(cfg, registry, slog.Default(), spy)
+
+	if adapter == nil {
+		t.Fatal("NewMultiSiteAdapter() returned nil")
+	}
+	if adapter.eventLogger != spy {
+		t.Error("NewMultiSiteAdapter() did not set eventLogger correctly")
+	}
+}
+
+func TestAdapter_BuildConfigJSON_MultiSiteMode(t *testing.T) {
+	registry := site.NewRegistry()
+	global := site.DefaultGlobalConfig()
+	registry.SetGlobal(global)
+
+	siteCfg := &config.Config{
+		Upstream: config.UpstreamConfig{
+			Host: "127.0.0.1",
+			Port: 3001,
+		},
+		TLS: config.TLSConfig{
+			Enabled:  true,
+			Provider: "letsencrypt",
+			Domain:   "app1.example.com",
+		},
+	}
+	s, err := site.NewSite("app1", "/tmp/app1/vibewarden.yaml", siteCfg)
+	if err != nil {
+		t.Fatalf("NewSite() error = %v", err)
+	}
+	registry.Add(s)
+
+	proxyCfg := &ports.ProxyConfig{
+		ListenAddr:   "0.0.0.0:443",
+		UpstreamAddr: "127.0.0.1:3000",
+	}
+	adapter := NewMultiSiteAdapter(proxyCfg, registry, slog.Default(), nil)
+
+	data, err := adapter.buildConfigJSON()
+	if err != nil {
+		t.Fatalf("buildConfigJSON() in multi-site mode error = %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("buildConfigJSON() returned empty data in multi-site mode")
+	}
+}
+
+func TestAdapter_BuildConfigJSON_BackwardCompat_NoRegistry(t *testing.T) {
+	// When registry is nil, the adapter uses single-site mode (BuildCaddyConfig).
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "127.0.0.1:8080",
+		UpstreamAddr: "127.0.0.1:3000",
+	}
+	adapter := NewAdapter(cfg, slog.Default(), nil)
+
+	data, err := adapter.buildConfigJSON()
+	if err != nil {
+		t.Fatalf("buildConfigJSON() in single-site mode error = %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("buildConfigJSON() returned empty data in single-site mode")
+	}
+
+	// Verify the adapter does NOT have a registry set.
+	if adapter.registry != nil {
+		t.Error("NewAdapter() should not set a registry")
+	}
+}
+
+func TestAdapter_BuildConfigJSON_MultiSite_DefaultGlobal(t *testing.T) {
+	// When the registry has no explicit global config, defaults should be used.
+	registry := site.NewRegistry()
+	// Do NOT call registry.SetGlobal() — test the fallback path.
+
+	siteCfg := &config.Config{
+		Upstream: config.UpstreamConfig{
+			Host: "127.0.0.1",
+			Port: 3001,
+		},
+		TLS: config.TLSConfig{
+			Enabled:  true,
+			Provider: "letsencrypt",
+			Domain:   "app.example.com",
+		},
+	}
+	s, err := site.NewSite("app", "/tmp/app/vibewarden.yaml", siteCfg)
+	if err != nil {
+		t.Fatalf("NewSite() error = %v", err)
+	}
+	registry.Add(s)
+
+	proxyCfg := &ports.ProxyConfig{
+		ListenAddr:   "0.0.0.0:443",
+		UpstreamAddr: "127.0.0.1:3000",
+	}
+	adapter := NewMultiSiteAdapter(proxyCfg, registry, slog.Default(), nil)
+
+	data, err := adapter.buildConfigJSON()
+	if err != nil {
+		t.Fatalf("buildConfigJSON() with default global error = %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("buildConfigJSON() returned empty data with default global")
 	}
 }
 

--- a/internal/adapters/caddy/multisite_config.go
+++ b/internal/adapters/caddy/multisite_config.go
@@ -1,0 +1,249 @@
+package caddy
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/vibewarden/vibewarden/internal/domain/site"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// BuildMultiSiteConfig constructs a Caddy JSON configuration that serves
+// multiple sites, each with host-matched routes and independent middleware
+// chains. Sites in error state or without a TLS domain are skipped — broken
+// sites do not prevent healthy ones from serving.
+//
+// The globalCfg provides sidecar-wide settings (listen address, ACME email).
+// Each site's config.Config is converted to a per-site ProxyConfig and then
+// to a Caddy route with a host matcher restricting it to that site's domain.
+//
+// TLS automation policies are generated per domain so that each site gets
+// its own ACME certificate. A single Caddy server instance handles all
+// sites on the same listen address.
+func BuildMultiSiteConfig(sites []*site.Site, globalCfg site.GlobalConfig) (map[string]any, error) {
+	if len(sites) == 0 {
+		return nil, fmt.Errorf("no sites provided")
+	}
+
+	listenAddr := fmt.Sprintf("%s:%d", globalCfg.ListenHost, globalCfg.ListenPort)
+
+	var (
+		routes     []map[string]any
+		tlsDomains []string
+		skipped    int
+	)
+
+	for _, s := range sites {
+		if !s.IsHealthy() {
+			slog.Default().Warn("skipping unhealthy site",
+				slog.String("site", s.Name()),
+				slog.String("status", s.Status().String()),
+			)
+			skipped++
+			continue
+		}
+
+		cfg := s.Config()
+		if cfg == nil {
+			slog.Default().Warn("skipping site with nil config",
+				slog.String("site", s.Name()),
+			)
+			skipped++
+			continue
+		}
+
+		domain := cfg.TLS.Domain
+		if domain == "" {
+			slog.Default().Warn("skipping site without TLS domain",
+				slog.String("site", s.Name()),
+			)
+			skipped++
+			continue
+		}
+
+		siteRoutes, err := buildSiteRoutes(s, domain)
+		if err != nil {
+			slog.Default().Error("skipping site due to route build error",
+				slog.String("site", s.Name()),
+				slog.String("error", err.Error()),
+			)
+			skipped++
+			continue
+		}
+
+		routes = append(routes, siteRoutes...)
+		tlsDomains = append(tlsDomains, domain)
+	}
+
+	if len(routes) == 0 {
+		return nil, fmt.Errorf("no healthy sites with valid domains (skipped %d)", skipped)
+	}
+
+	// Build the main HTTPS server.
+	server := map[string]any{
+		"listen": []string{listenAddr},
+		"routes": routes,
+	}
+
+	httpServers := map[string]any{
+		"vibewarden": server,
+	}
+
+	apps := map[string]any{
+		"http": map[string]any{
+			"servers": httpServers,
+		},
+	}
+
+	// Build TLS app with per-domain ACME policies.
+	tlsApp := buildMultiSiteTLSApp(tlsDomains, globalCfg.ACMEEmail)
+	if tlsApp != nil {
+		apps["tls"] = tlsApp
+	}
+
+	caddyCfg := map[string]any{
+		"apps": apps,
+	}
+
+	return caddyCfg, nil
+}
+
+// buildSiteRoutes generates Caddy routes for a single site. Each route is
+// host-matched to the site's domain so that requests to different domains
+// are routed to different upstreams with independent middleware chains.
+//
+// The returned slice contains the site's health check route and catch-all
+// proxy route, both scoped to the site's domain via host matchers.
+func buildSiteRoutes(s *site.Site, domain string) ([]map[string]any, error) {
+	cfg := s.Config()
+
+	upstreamAddr := fmt.Sprintf("%s:%d", cfg.Upstream.Host, cfg.Upstream.Port)
+	if cfg.Upstream.Host == "" || cfg.Upstream.Port == 0 {
+		return nil, fmt.Errorf("site %q has invalid upstream address", s.Name())
+	}
+
+	// Build the reverse proxy handler for this site's upstream.
+	reverseProxyHandler := map[string]any{
+		"handler": "reverse_proxy",
+		"upstreams": []map[string]any{
+			{"dial": upstreamAddr},
+		},
+	}
+
+	// Build the middleware chain — same order as single-site mode.
+	handlers := []map[string]any{buildUserHeaderStripHandler()}
+
+	if cfg.SecurityHeaders.Enabled {
+		// Multi-site always has TLS enabled (domain is required).
+		handlers = append(handlers, buildSecurityHeadersHandler(ports.SecurityHeadersConfig{
+			Enabled:                      cfg.SecurityHeaders.Enabled,
+			HSTSMaxAge:                   cfg.SecurityHeaders.HSTSMaxAge,
+			HSTSIncludeSubDomains:        cfg.SecurityHeaders.HSTSIncludeSubDomains,
+			HSTSPreload:                  cfg.SecurityHeaders.HSTSPreload,
+			ContentTypeNosniff:           cfg.SecurityHeaders.ContentTypeNosniff,
+			FrameOption:                  cfg.SecurityHeaders.FrameOption,
+			ContentSecurityPolicy:        cfg.SecurityHeaders.ContentSecurityPolicy,
+			ReferrerPolicy:               cfg.SecurityHeaders.ReferrerPolicy,
+			PermissionsPolicy:            cfg.SecurityHeaders.PermissionsPolicy,
+			CrossOriginOpenerPolicy:      cfg.SecurityHeaders.CrossOriginOpenerPolicy,
+			CrossOriginResourcePolicy:    cfg.SecurityHeaders.CrossOriginResourcePolicy,
+			PermittedCrossDomainPolicies: cfg.SecurityHeaders.PermittedCrossDomainPolicies,
+			SuppressViaHeader:            cfg.SecurityHeaders.SuppressViaHeader,
+		}, true))
+	}
+
+	if cfg.RateLimit.Enabled {
+		rlHandler, err := buildRateLimitHandlerJSON(ports.RateLimitConfig{
+			Enabled:           cfg.RateLimit.Enabled,
+			TrustProxyHeaders: cfg.RateLimit.TrustProxyHeaders,
+			ExemptPaths:       cfg.RateLimit.ExemptPaths,
+			PerIP: ports.RateLimitRule{
+				RequestsPerSecond: cfg.RateLimit.PerIP.RequestsPerSecond,
+				Burst:             cfg.RateLimit.PerIP.Burst,
+			},
+			PerUser: ports.RateLimitRule{
+				RequestsPerSecond: cfg.RateLimit.PerUser.RequestsPerSecond,
+				Burst:             cfg.RateLimit.PerUser.Burst,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("building rate limit handler for site %q: %w", s.Name(), err)
+		}
+		handlers = append(handlers, rlHandler)
+	}
+
+	if cfg.Compression.Enabled {
+		handlers = append(handlers, buildCompressionHandlerJSON(ports.CompressionConfig{
+			Enabled:    cfg.Compression.Enabled,
+			Algorithms: cfg.Compression.Algorithms,
+		}))
+	}
+
+	// Add reverse proxy as final handler.
+	handlers = append(handlers, reverseProxyHandler)
+
+	// Per-site health check route scoped to the site's domain.
+	healthBody := fmt.Sprintf(`{"status":"ok","site":%q,"components":{"sidecar":"ok","upstream":"unknown"}}`, s.Name())
+	healthRoute := map[string]any{
+		"match": []map[string]any{
+			{
+				"host": []string{domain},
+				"path": []string{"/_vibewarden/health"},
+			},
+		},
+		"handle": []map[string]any{
+			{
+				"handler": "static_response",
+				"headers": map[string][]string{
+					"Content-Type": {"application/json"},
+				},
+				"body":        healthBody,
+				"status_code": 200,
+			},
+		},
+	}
+
+	// Catch-all proxy route scoped to the site's domain.
+	catchAllRoute := map[string]any{
+		"match": []map[string]any{
+			{"host": []string{domain}},
+		},
+		"handle": handlers,
+	}
+
+	return []map[string]any{healthRoute, catchAllRoute}, nil
+}
+
+// buildMultiSiteTLSApp constructs the Caddy TLS app with per-domain ACME
+// automation policies. Each domain gets its own policy entry so Caddy
+// obtains separate certificates for each site.
+//
+// When acmeEmail is non-empty, it is included in the ACME issuer
+// configuration for all policies.
+func buildMultiSiteTLSApp(domains []string, acmeEmail string) map[string]any {
+	if len(domains) == 0 {
+		return nil
+	}
+
+	var policies []map[string]any
+	for _, domain := range domains {
+		issuer := map[string]any{
+			"module": "acme",
+		}
+		if acmeEmail != "" {
+			issuer["email"] = acmeEmail
+		}
+
+		policy := map[string]any{
+			"subjects": []string{domain},
+			"issuers":  []map[string]any{issuer},
+		}
+		policies = append(policies, policy)
+	}
+
+	return map[string]any{
+		"automation": map[string]any{
+			"policies": policies,
+		},
+	}
+}

--- a/internal/adapters/caddy/multisite_config.go
+++ b/internal/adapters/caddy/multisite_config.go
@@ -20,7 +20,7 @@ import (
 // TLS automation policies are generated per domain so that each site gets
 // its own ACME certificate. A single Caddy server instance handles all
 // sites on the same listen address.
-func BuildMultiSiteConfig(sites []*site.Site, globalCfg site.GlobalConfig) (map[string]any, error) {
+func BuildMultiSiteConfig(sites []*site.Site, globalCfg site.GlobalConfig, logger *slog.Logger) (map[string]any, error) {
 	if len(sites) == 0 {
 		return nil, fmt.Errorf("no sites provided")
 	}
@@ -35,7 +35,7 @@ func BuildMultiSiteConfig(sites []*site.Site, globalCfg site.GlobalConfig) (map[
 
 	for _, s := range sites {
 		if !s.IsHealthy() {
-			slog.Default().Warn("skipping unhealthy site",
+			logger.Warn("skipping unhealthy site",
 				slog.String("site", s.Name()),
 				slog.String("status", s.Status().String()),
 			)
@@ -45,7 +45,7 @@ func BuildMultiSiteConfig(sites []*site.Site, globalCfg site.GlobalConfig) (map[
 
 		cfg := s.Config()
 		if cfg == nil {
-			slog.Default().Warn("skipping site with nil config",
+			logger.Warn("skipping site with nil config",
 				slog.String("site", s.Name()),
 			)
 			skipped++
@@ -54,7 +54,7 @@ func BuildMultiSiteConfig(sites []*site.Site, globalCfg site.GlobalConfig) (map[
 
 		domain := cfg.TLS.Domain
 		if domain == "" {
-			slog.Default().Warn("skipping site without TLS domain",
+			logger.Warn("skipping site without TLS domain",
 				slog.String("site", s.Name()),
 			)
 			skipped++
@@ -63,7 +63,7 @@ func BuildMultiSiteConfig(sites []*site.Site, globalCfg site.GlobalConfig) (map[
 
 		siteRoutes, err := buildSiteRoutes(s, domain)
 		if err != nil {
-			slog.Default().Error("skipping site due to route build error",
+			logger.Error("skipping site due to route build error",
 				slog.String("site", s.Name()),
 				slog.String("error", err.Error()),
 			)

--- a/internal/adapters/caddy/multisite_config_test.go
+++ b/internal/adapters/caddy/multisite_config_test.go
@@ -3,6 +3,7 @@ package caddy
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"testing"
 
 	"github.com/vibewarden/vibewarden/internal/config"
@@ -51,7 +52,7 @@ func TestBuildMultiSiteConfig_SingleSite(t *testing.T) {
 	s := helperNewSite(t, "app1", cfg)
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{s}, global)
+	result, err := BuildMultiSiteConfig([]*site.Site{s}, global, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -106,7 +107,7 @@ func TestBuildMultiSiteConfig_TwoSitesDifferentDomains(t *testing.T) {
 	s2 := helperNewSite(t, "app2", cfg2)
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global)
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -161,7 +162,7 @@ func TestBuildMultiSiteConfig_SiteWithNoDomainSkipped(t *testing.T) {
 	s2 := helperNewSite(t, "app2", cfg2)
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global)
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -189,7 +190,7 @@ func TestBuildMultiSiteConfig_ErrorSiteSkipped(t *testing.T) {
 	s2 := helperNewErrorSite(t, "app2")
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global)
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -212,7 +213,7 @@ func TestBuildMultiSiteConfig_ErrorSiteSkipped(t *testing.T) {
 
 func TestBuildMultiSiteConfig_EmptySitesList(t *testing.T) {
 	global := site.DefaultGlobalConfig()
-	_, err := BuildMultiSiteConfig([]*site.Site{}, global)
+	_, err := BuildMultiSiteConfig([]*site.Site{}, global, slog.Default())
 	if err == nil {
 		t.Fatal("expected error for empty sites list, got nil")
 	}
@@ -220,7 +221,7 @@ func TestBuildMultiSiteConfig_EmptySitesList(t *testing.T) {
 
 func TestBuildMultiSiteConfig_NilSitesList(t *testing.T) {
 	global := site.DefaultGlobalConfig()
-	_, err := BuildMultiSiteConfig(nil, global)
+	_, err := BuildMultiSiteConfig(nil, global, slog.Default())
 	if err == nil {
 		t.Fatal("expected error for nil sites list, got nil")
 	}
@@ -231,7 +232,7 @@ func TestBuildMultiSiteConfig_AllSitesUnhealthy(t *testing.T) {
 	s2 := helperNewErrorSite(t, "app2")
 
 	global := site.DefaultGlobalConfig()
-	_, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global)
+	_, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global, slog.Default())
 	if err == nil {
 		t.Fatal("expected error when all sites are unhealthy, got nil")
 	}
@@ -256,7 +257,7 @@ func TestBuildMultiSiteConfig_PerSiteMiddlewareIndependence(t *testing.T) {
 	sB := helperNewSite(t, "site-b", cfgB)
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{sA, sB}, global)
+	result, err := BuildMultiSiteConfig([]*site.Site{sA, sB}, global, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -313,7 +314,7 @@ func TestBuildMultiSiteConfig_TLSPolicyPerDomain(t *testing.T) {
 
 	global := site.DefaultGlobalConfig()
 	global.ACMEEmail = "admin@example.com"
-	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2, s3}, global)
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2, s3}, global, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -377,7 +378,7 @@ func TestBuildMultiSiteConfig_ListenAddress(t *testing.T) {
 		ListenPort: 8443,
 		LogLevel:   "info",
 	}
-	result, err := BuildMultiSiteConfig([]*site.Site{s}, global)
+	result, err := BuildMultiSiteConfig([]*site.Site{s}, global, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -405,7 +406,7 @@ func TestBuildMultiSiteConfig_HealthRoutePerSite(t *testing.T) {
 	s2 := helperNewSite(t, "app2", cfg2)
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global)
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -460,7 +461,7 @@ func TestBuildMultiSiteConfig_ErrorIsolation(t *testing.T) {
 	s3 := helperNewErrorSite(t, "broken")
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2, s3}, global)
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2, s3}, global, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -494,7 +495,7 @@ func TestBuildMultiSiteConfig_ValidJSON(t *testing.T) {
 	s := helperNewSite(t, "valid", cfg)
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{s}, global)
+	result, err := BuildMultiSiteConfig([]*site.Site{s}, global, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}

--- a/internal/adapters/caddy/multisite_config_test.go
+++ b/internal/adapters/caddy/multisite_config_test.go
@@ -1,0 +1,651 @@
+package caddy
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/domain/site"
+)
+
+// helperNewSite creates a healthy Site for testing. It panics on error
+// because test helper failures should abort the test immediately.
+func helperNewSite(t *testing.T, name string, cfg *config.Config) *site.Site {
+	t.Helper()
+	s, err := site.NewSite(name, "/tmp/"+name+"/vibewarden.yaml", cfg)
+	if err != nil {
+		t.Fatalf("helperNewSite(%q): %v", name, err)
+	}
+	return s
+}
+
+// helperNewErrorSite creates an error Site for testing.
+func helperNewErrorSite(t *testing.T, name string) *site.Site {
+	t.Helper()
+	s, err := site.NewErrorSite(name, "/tmp/"+name+"/vibewarden.yaml", errors.New("broken config"))
+	if err != nil {
+		t.Fatalf("helperNewErrorSite(%q): %v", name, err)
+	}
+	return s
+}
+
+// helperMinimalConfig returns a minimal config.Config with the given domain
+// and upstream port.
+func helperMinimalConfig(domain string, upstreamPort int) *config.Config {
+	return &config.Config{
+		Upstream: config.UpstreamConfig{
+			Host: "127.0.0.1",
+			Port: upstreamPort,
+		},
+		TLS: config.TLSConfig{
+			Enabled:  true,
+			Provider: "letsencrypt",
+			Domain:   domain,
+		},
+	}
+}
+
+func TestBuildMultiSiteConfig_SingleSite(t *testing.T) {
+	cfg := helperMinimalConfig("app1.example.com", 3000)
+	s := helperNewSite(t, "app1", cfg)
+
+	global := site.DefaultGlobalConfig()
+	result, err := BuildMultiSiteConfig([]*site.Site{s}, global)
+	if err != nil {
+		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
+	}
+
+	// Verify the result is valid JSON.
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	// Parse back and verify structure.
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	// Verify apps.http.servers.vibewarden exists.
+	apps := parsed["apps"].(map[string]any)
+	httpApp := apps["http"].(map[string]any)
+	servers := httpApp["servers"].(map[string]any)
+	vw := servers["vibewarden"].(map[string]any)
+	routes := vw["routes"].([]any)
+
+	// Single site: health route + catch-all route = 2 routes.
+	if len(routes) != 2 {
+		t.Errorf("expected 2 routes, got %d", len(routes))
+	}
+
+	// Verify host matcher on the catch-all route.
+	catchAll := routes[1].(map[string]any)
+	matches := catchAll["match"].([]any)
+	match := matches[0].(map[string]any)
+	hosts := match["host"].([]any)
+	if hosts[0].(string) != "app1.example.com" {
+		t.Errorf("expected host matcher for app1.example.com, got %v", hosts[0])
+	}
+
+	// Verify TLS app exists with the domain.
+	tlsApp := apps["tls"].(map[string]any)
+	automation := tlsApp["automation"].(map[string]any)
+	policies := automation["policies"].([]any)
+	if len(policies) != 1 {
+		t.Errorf("expected 1 TLS policy, got %d", len(policies))
+	}
+}
+
+func TestBuildMultiSiteConfig_TwoSitesDifferentDomains(t *testing.T) {
+	cfg1 := helperMinimalConfig("app1.example.com", 3001)
+	cfg2 := helperMinimalConfig("app2.example.com", 3002)
+
+	s1 := helperNewSite(t, "app1", cfg1)
+	s2 := helperNewSite(t, "app2", cfg2)
+
+	global := site.DefaultGlobalConfig()
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global)
+	if err != nil {
+		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
+	}
+
+	data, _ := json.Marshal(result)
+	var parsed map[string]any
+	_ = json.Unmarshal(data, &parsed)
+
+	apps := parsed["apps"].(map[string]any)
+	httpApp := apps["http"].(map[string]any)
+	servers := httpApp["servers"].(map[string]any)
+	vw := servers["vibewarden"].(map[string]any)
+	routes := vw["routes"].([]any)
+
+	// Two sites: (health + catch-all) x 2 = 4 routes.
+	if len(routes) != 4 {
+		t.Errorf("expected 4 routes, got %d", len(routes))
+	}
+
+	// Verify each site's catch-all route has the correct host matcher.
+	verifyHostInRoutes(t, routes, "app1.example.com")
+	verifyHostInRoutes(t, routes, "app2.example.com")
+
+	// Verify upstream addresses are different.
+	verifyUpstreamInRoutes(t, routes, "127.0.0.1:3001")
+	verifyUpstreamInRoutes(t, routes, "127.0.0.1:3002")
+
+	// Verify TLS policies: one per domain.
+	tlsApp := apps["tls"].(map[string]any)
+	automation := tlsApp["automation"].(map[string]any)
+	policies := automation["policies"].([]any)
+	if len(policies) != 2 {
+		t.Errorf("expected 2 TLS policies, got %d", len(policies))
+	}
+}
+
+func TestBuildMultiSiteConfig_SiteWithNoDomainSkipped(t *testing.T) {
+	// Site with a domain.
+	cfg1 := helperMinimalConfig("app1.example.com", 3001)
+	s1 := helperNewSite(t, "app1", cfg1)
+
+	// Site without a domain (empty TLS.Domain).
+	cfg2 := &config.Config{
+		Upstream: config.UpstreamConfig{
+			Host: "127.0.0.1",
+			Port: 3002,
+		},
+		TLS: config.TLSConfig{
+			Enabled: false,
+		},
+	}
+	s2 := helperNewSite(t, "app2", cfg2)
+
+	global := site.DefaultGlobalConfig()
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global)
+	if err != nil {
+		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
+	}
+
+	data, _ := json.Marshal(result)
+	var parsed map[string]any
+	_ = json.Unmarshal(data, &parsed)
+
+	apps := parsed["apps"].(map[string]any)
+	httpApp := apps["http"].(map[string]any)
+	servers := httpApp["servers"].(map[string]any)
+	vw := servers["vibewarden"].(map[string]any)
+	routes := vw["routes"].([]any)
+
+	// Only the site with a domain should produce routes.
+	if len(routes) != 2 {
+		t.Errorf("expected 2 routes (1 site), got %d", len(routes))
+	}
+}
+
+func TestBuildMultiSiteConfig_ErrorSiteSkipped(t *testing.T) {
+	cfg1 := helperMinimalConfig("app1.example.com", 3001)
+	s1 := helperNewSite(t, "app1", cfg1)
+
+	s2 := helperNewErrorSite(t, "app2")
+
+	global := site.DefaultGlobalConfig()
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global)
+	if err != nil {
+		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
+	}
+
+	data, _ := json.Marshal(result)
+	var parsed map[string]any
+	_ = json.Unmarshal(data, &parsed)
+
+	apps := parsed["apps"].(map[string]any)
+	httpApp := apps["http"].(map[string]any)
+	servers := httpApp["servers"].(map[string]any)
+	vw := servers["vibewarden"].(map[string]any)
+	routes := vw["routes"].([]any)
+
+	// Only the healthy site should produce routes.
+	if len(routes) != 2 {
+		t.Errorf("expected 2 routes (1 healthy site), got %d", len(routes))
+	}
+}
+
+func TestBuildMultiSiteConfig_EmptySitesList(t *testing.T) {
+	global := site.DefaultGlobalConfig()
+	_, err := BuildMultiSiteConfig([]*site.Site{}, global)
+	if err == nil {
+		t.Fatal("expected error for empty sites list, got nil")
+	}
+}
+
+func TestBuildMultiSiteConfig_NilSitesList(t *testing.T) {
+	global := site.DefaultGlobalConfig()
+	_, err := BuildMultiSiteConfig(nil, global)
+	if err == nil {
+		t.Fatal("expected error for nil sites list, got nil")
+	}
+}
+
+func TestBuildMultiSiteConfig_AllSitesUnhealthy(t *testing.T) {
+	s1 := helperNewErrorSite(t, "app1")
+	s2 := helperNewErrorSite(t, "app2")
+
+	global := site.DefaultGlobalConfig()
+	_, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global)
+	if err == nil {
+		t.Fatal("expected error when all sites are unhealthy, got nil")
+	}
+}
+
+func TestBuildMultiSiteConfig_PerSiteMiddlewareIndependence(t *testing.T) {
+	// Site A: security headers enabled.
+	cfgA := helperMinimalConfig("a.example.com", 3001)
+	cfgA.SecurityHeaders = config.SecurityHeadersConfig{
+		Enabled:            true,
+		ContentTypeNosniff: true,
+		FrameOption:        "DENY",
+		HSTSMaxAge:         31536000,
+	}
+	sA := helperNewSite(t, "site-a", cfgA)
+
+	// Site B: security headers disabled.
+	cfgB := helperMinimalConfig("b.example.com", 3002)
+	cfgB.SecurityHeaders = config.SecurityHeadersConfig{
+		Enabled: false,
+	}
+	sB := helperNewSite(t, "site-b", cfgB)
+
+	global := site.DefaultGlobalConfig()
+	result, err := BuildMultiSiteConfig([]*site.Site{sA, sB}, global)
+	if err != nil {
+		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
+	}
+
+	data, _ := json.Marshal(result)
+	var parsed map[string]any
+	_ = json.Unmarshal(data, &parsed)
+
+	apps := parsed["apps"].(map[string]any)
+	httpApp := apps["http"].(map[string]any)
+	servers := httpApp["servers"].(map[string]any)
+	vw := servers["vibewarden"].(map[string]any)
+	routes := vw["routes"].([]any)
+
+	// 4 routes total: 2 per site.
+	if len(routes) != 4 {
+		t.Fatalf("expected 4 routes, got %d", len(routes))
+	}
+
+	// Catch-all routes are at indices 1 (site-a) and 3 (site-b).
+	catchAllA := routes[1].(map[string]any)
+	handlersA := catchAllA["handle"].([]any)
+
+	catchAllB := routes[3].(map[string]any)
+	handlersB := catchAllB["handle"].([]any)
+
+	// Site A should have more handlers (header strip + security headers + reverse proxy).
+	// Site B should have fewer handlers (header strip + reverse proxy).
+	if len(handlersA) <= len(handlersB) {
+		t.Errorf("site A should have more handlers (%d) than site B (%d)",
+			len(handlersA), len(handlersB))
+	}
+
+	// Site B's catch-all should not contain a "headers" handler with security headers.
+	for _, h := range handlersB {
+		handler := h.(map[string]any)
+		if handler["handler"] == "headers" {
+			// The only headers handler in site B should be the user-header strip handler.
+			if _, hasResponse := handler["response"]; hasResponse {
+				t.Error("site B should not have security headers handler")
+			}
+		}
+	}
+}
+
+func TestBuildMultiSiteConfig_TLSPolicyPerDomain(t *testing.T) {
+	cfg1 := helperMinimalConfig("alpha.example.com", 3001)
+	cfg2 := helperMinimalConfig("beta.example.com", 3002)
+	cfg3 := helperMinimalConfig("gamma.example.com", 3003)
+
+	s1 := helperNewSite(t, "alpha", cfg1)
+	s2 := helperNewSite(t, "beta", cfg2)
+	s3 := helperNewSite(t, "gamma", cfg3)
+
+	global := site.DefaultGlobalConfig()
+	global.ACMEEmail = "admin@example.com"
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2, s3}, global)
+	if err != nil {
+		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
+	}
+
+	data, _ := json.Marshal(result)
+	var parsed map[string]any
+	_ = json.Unmarshal(data, &parsed)
+
+	apps := parsed["apps"].(map[string]any)
+	tlsApp := apps["tls"].(map[string]any)
+	automation := tlsApp["automation"].(map[string]any)
+	policies := automation["policies"].([]any)
+
+	if len(policies) != 3 {
+		t.Fatalf("expected 3 TLS policies, got %d", len(policies))
+	}
+
+	// Verify each policy has exactly one subject and an ACME issuer with email.
+	expectedDomains := map[string]bool{
+		"alpha.example.com": false,
+		"beta.example.com":  false,
+		"gamma.example.com": false,
+	}
+	for _, p := range policies {
+		policy := p.(map[string]any)
+		subjects := policy["subjects"].([]any)
+		if len(subjects) != 1 {
+			t.Errorf("expected 1 subject per policy, got %d", len(subjects))
+			continue
+		}
+		domain := subjects[0].(string)
+		if _, ok := expectedDomains[domain]; !ok {
+			t.Errorf("unexpected domain in TLS policy: %s", domain)
+			continue
+		}
+		expectedDomains[domain] = true
+
+		issuers := policy["issuers"].([]any)
+		issuer := issuers[0].(map[string]any)
+		if issuer["module"] != "acme" {
+			t.Errorf("expected ACME issuer module, got %v", issuer["module"])
+		}
+		if issuer["email"] != "admin@example.com" {
+			t.Errorf("expected email admin@example.com, got %v", issuer["email"])
+		}
+	}
+
+	for domain, found := range expectedDomains {
+		if !found {
+			t.Errorf("missing TLS policy for domain %s", domain)
+		}
+	}
+}
+
+func TestBuildMultiSiteConfig_ListenAddress(t *testing.T) {
+	cfg := helperMinimalConfig("app.example.com", 3000)
+	s := helperNewSite(t, "app", cfg)
+
+	global := site.GlobalConfig{
+		ListenHost: "10.0.0.1",
+		ListenPort: 8443,
+		LogLevel:   "info",
+	}
+	result, err := BuildMultiSiteConfig([]*site.Site{s}, global)
+	if err != nil {
+		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
+	}
+
+	data, _ := json.Marshal(result)
+	var parsed map[string]any
+	_ = json.Unmarshal(data, &parsed)
+
+	apps := parsed["apps"].(map[string]any)
+	httpApp := apps["http"].(map[string]any)
+	servers := httpApp["servers"].(map[string]any)
+	vw := servers["vibewarden"].(map[string]any)
+	listen := vw["listen"].([]any)
+
+	if listen[0].(string) != "10.0.0.1:8443" {
+		t.Errorf("expected listen address 10.0.0.1:8443, got %v", listen[0])
+	}
+}
+
+func TestBuildMultiSiteConfig_HealthRoutePerSite(t *testing.T) {
+	cfg1 := helperMinimalConfig("app1.example.com", 3001)
+	cfg2 := helperMinimalConfig("app2.example.com", 3002)
+
+	s1 := helperNewSite(t, "app1", cfg1)
+	s2 := helperNewSite(t, "app2", cfg2)
+
+	global := site.DefaultGlobalConfig()
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global)
+	if err != nil {
+		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
+	}
+
+	data, _ := json.Marshal(result)
+	var parsed map[string]any
+	_ = json.Unmarshal(data, &parsed)
+
+	apps := parsed["apps"].(map[string]any)
+	httpApp := apps["http"].(map[string]any)
+	servers := httpApp["servers"].(map[string]any)
+	vw := servers["vibewarden"].(map[string]any)
+	routes := vw["routes"].([]any)
+
+	// Health routes are at even indices (0, 2).
+	healthRouteFound := make(map[string]bool)
+	for _, r := range routes {
+		route := r.(map[string]any)
+		matches, ok := route["match"].([]any)
+		if !ok || len(matches) == 0 {
+			continue
+		}
+		match := matches[0].(map[string]any)
+		paths, hasPaths := match["path"]
+		if !hasPaths {
+			continue
+		}
+		pathList := paths.([]any)
+		for _, p := range pathList {
+			if p.(string) == "/_vibewarden/health" {
+				hosts := match["host"].([]any)
+				healthRouteFound[hosts[0].(string)] = true
+			}
+		}
+	}
+
+	if !healthRouteFound["app1.example.com"] {
+		t.Error("missing health route for app1.example.com")
+	}
+	if !healthRouteFound["app2.example.com"] {
+		t.Error("missing health route for app2.example.com")
+	}
+}
+
+func TestBuildMultiSiteConfig_ErrorIsolation(t *testing.T) {
+	// 2 healthy sites + 1 error site.
+	cfg1 := helperMinimalConfig("good1.example.com", 3001)
+	cfg2 := helperMinimalConfig("good2.example.com", 3002)
+
+	s1 := helperNewSite(t, "good1", cfg1)
+	s2 := helperNewSite(t, "good2", cfg2)
+	s3 := helperNewErrorSite(t, "broken")
+
+	global := site.DefaultGlobalConfig()
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2, s3}, global)
+	if err != nil {
+		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
+	}
+
+	data, _ := json.Marshal(result)
+	var parsed map[string]any
+	_ = json.Unmarshal(data, &parsed)
+
+	apps := parsed["apps"].(map[string]any)
+	httpApp := apps["http"].(map[string]any)
+	servers := httpApp["servers"].(map[string]any)
+	vw := servers["vibewarden"].(map[string]any)
+	routes := vw["routes"].([]any)
+
+	// Only 2 healthy sites should generate routes: (health + catch-all) x 2 = 4.
+	if len(routes) != 4 {
+		t.Errorf("expected 4 routes (2 healthy sites), got %d", len(routes))
+	}
+
+	// Verify the two TLS policies are for the healthy domains only.
+	tlsApp := apps["tls"].(map[string]any)
+	automation := tlsApp["automation"].(map[string]any)
+	policies := automation["policies"].([]any)
+	if len(policies) != 2 {
+		t.Errorf("expected 2 TLS policies, got %d", len(policies))
+	}
+}
+
+func TestBuildMultiSiteConfig_ValidJSON(t *testing.T) {
+	cfg := helperMinimalConfig("valid.example.com", 3000)
+	s := helperNewSite(t, "valid", cfg)
+
+	global := site.DefaultGlobalConfig()
+	result, err := BuildMultiSiteConfig([]*site.Site{s}, global)
+	if err != nil {
+		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
+	}
+
+	// The result must be valid JSON that can round-trip through
+	// marshal/unmarshal without loss.
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var roundTrip map[string]any
+	if err := json.Unmarshal(data, &roundTrip); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	// Re-marshal and compare sizes (approximate equality check).
+	data2, _ := json.Marshal(roundTrip)
+	if len(data) != len(data2) {
+		t.Errorf("JSON round-trip changed size: %d -> %d", len(data), len(data2))
+	}
+}
+
+func TestBuildMultiSiteTLSApp(t *testing.T) {
+	tests := []struct {
+		name      string
+		domains   []string
+		acmeEmail string
+		wantNil   bool
+		wantCount int
+		wantEmail bool
+	}{
+		{
+			name:    "no domains",
+			domains: nil,
+			wantNil: true,
+		},
+		{
+			name:      "single domain without email",
+			domains:   []string{"example.com"},
+			wantCount: 1,
+			wantEmail: false,
+		},
+		{
+			name:      "two domains with email",
+			domains:   []string{"a.com", "b.com"},
+			acmeEmail: "admin@example.com",
+			wantCount: 2,
+			wantEmail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildMultiSiteTLSApp(tt.domains, tt.acmeEmail)
+			if tt.wantNil {
+				if result != nil {
+					t.Error("expected nil TLS app")
+				}
+				return
+			}
+			if result == nil {
+				t.Fatal("expected non-nil TLS app")
+			}
+
+			automation := result["automation"].(map[string]any)
+			policies := automation["policies"].([]map[string]any)
+			if len(policies) != tt.wantCount {
+				t.Errorf("expected %d policies, got %d", tt.wantCount, len(policies))
+			}
+
+			if tt.wantEmail {
+				for _, p := range policies {
+					issuers := p["issuers"].([]map[string]any)
+					if issuers[0]["email"] != tt.acmeEmail {
+						t.Errorf("expected email %q, got %v", tt.acmeEmail, issuers[0]["email"])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestBuildSiteRoutes_InvalidUpstream(t *testing.T) {
+	cfg := &config.Config{
+		Upstream: config.UpstreamConfig{
+			Host: "",
+			Port: 0,
+		},
+		TLS: config.TLSConfig{
+			Domain: "test.example.com",
+		},
+	}
+	s := helperNewSite(t, "broken-upstream", cfg)
+
+	_, err := buildSiteRoutes(s, "test.example.com")
+	if err == nil {
+		t.Fatal("expected error for invalid upstream, got nil")
+	}
+}
+
+// verifyHostInRoutes checks that at least one route has a host matcher
+// for the given domain.
+func verifyHostInRoutes(t *testing.T, routes []any, domain string) {
+	t.Helper()
+	for _, r := range routes {
+		route := r.(map[string]any)
+		matches, ok := route["match"].([]any)
+		if !ok || len(matches) == 0 {
+			continue
+		}
+		match := matches[0].(map[string]any)
+		hosts, ok := match["host"].([]any)
+		if !ok {
+			continue
+		}
+		for _, h := range hosts {
+			if h.(string) == domain {
+				return
+			}
+		}
+	}
+	t.Errorf("no route found with host matcher for %q", domain)
+}
+
+// verifyUpstreamInRoutes checks that at least one route has a reverse proxy
+// handler with the given upstream dial address.
+func verifyUpstreamInRoutes(t *testing.T, routes []any, upstream string) {
+	t.Helper()
+	for _, r := range routes {
+		route := r.(map[string]any)
+		handlers, ok := route["handle"].([]any)
+		if !ok {
+			continue
+		}
+		for _, h := range handlers {
+			handler := h.(map[string]any)
+			if handler["handler"] != "reverse_proxy" {
+				continue
+			}
+			upstreams, ok := handler["upstreams"].([]any)
+			if !ok {
+				continue
+			}
+			for _, u := range upstreams {
+				us := u.(map[string]any)
+				if us["dial"] == upstream {
+					return
+				}
+			}
+		}
+	}
+	t.Errorf("no route found with upstream %q", upstream)
+}


### PR DESCRIPTION
Closes #871

## Summary

- **`multisite_config.go`**: New `BuildMultiSiteConfig` function takes `[]*site.Site` + `site.GlobalConfig` and produces Caddy JSON with per-host routes and per-domain ACME TLS policies. Helper functions `buildSiteRoutes` (per-site health check + catch-all proxy with independent middleware chain) and `buildMultiSiteTLSApp` (per-domain ACME automation policies with optional email).
- **`multisite_config_test.go`**: 15 test cases covering single site, two sites with different domains, domain-less site skip, error site skip, empty/nil lists, per-site middleware independence, TLS policy per domain, custom listen address, per-site health routes, error isolation (2 healthy + 1 broken), JSON validity, and buildSiteRoutes/buildMultiSiteTLSApp unit tests.
- **`adapter.go`**: New `NewMultiSiteAdapter` constructor with `site.Registry` field; `buildConfigJSON` branches on registry presence (multi-site vs single-site). Backward compatible: `NewAdapter` (no registry) uses existing `BuildCaddyConfig`.
- **`adapter_test.go`**: 5 new tests for multi-site adapter constructor, event logger wiring, multi-site config generation, backward compat (no registry), and default global config fallback.

### Error isolation

Unhealthy sites, sites without TLS domains, and sites with invalid upstreams are skipped with log warnings. Broken sites never prevent healthy ones from serving.

### Backward compatibility

`NewAdapter` (single-site mode) is unchanged. The adapter only enters multi-site mode when constructed via `NewMultiSiteAdapter` with a non-nil registry.

### ADR deviation

None. ADR-069 specified `buildSiteProxyConfig` as a helper, but the per-site ProxyConfig conversion was inlined directly into `buildSiteRoutes` since it was only used in one place. The unused helper was removed per golangci-lint.

## Test plan

- [x] `make check` passes (lint, build, all tests)
- [x] `go test -race -v ./internal/adapters/caddy/...` -- all 15 new multisite tests + 5 adapter tests pass
- [x] Existing single-site tests unaffected (backward compat preserved)
- [ ] Verify generated Caddy JSON structure: route count, host matchers, upstream addresses, TLS policies

Generated with [Claude Code](https://claude.com/claude-code)