### PR TITLE
feat(#873): multi-site directory watcher + hot-reload service per ADR-071

### DIFF
--- a/internal/adapters/fsnotify/site_watcher.go
+++ b/internal/adapters/fsnotify/site_watcher.go
@@ -1,0 +1,296 @@
+package fsnotify
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+const (
+	defaultSiteDebounce = 500 * time.Millisecond
+	siteConfigFilename  = "vibewarden.yaml"
+)
+
+// SiteWatcherOption configures the SiteWatcher adapter.
+type SiteWatcherOption func(*siteWatcherOptions)
+
+type siteWatcherOptions struct {
+	debounce time.Duration
+}
+
+// WithSiteDebounce sets the per-site debounce duration.
+// Default: 500ms.
+func WithSiteDebounce(d time.Duration) SiteWatcherOption {
+	return func(o *siteWatcherOptions) { o.debounce = d }
+}
+
+// SiteWatcher implements ports.SiteWatcher using fsnotify.
+// It watches the sites/ directory tree for per-site vibewarden.yaml changes
+// and emits typed SiteEvent values after per-site debouncing.
+type SiteWatcher struct {
+	debounce time.Duration
+	logger   *slog.Logger
+}
+
+// NewSiteWatcher creates a SiteWatcher with the given logger and options.
+func NewSiteWatcher(logger *slog.Logger, opts ...SiteWatcherOption) *SiteWatcher {
+	o := &siteWatcherOptions{debounce: defaultSiteDebounce}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return &SiteWatcher{
+		debounce: o.debounce,
+		logger:   logger,
+	}
+}
+
+// Watch implements ports.SiteWatcher.Watch.
+//
+// It watches sitesDir for subdirectory-level changes to vibewarden.yaml files.
+// Each detected change (after per-site debouncing) is sent as a SiteEvent on
+// the returned channel. The channel is closed when ctx is cancelled.
+func (sw *SiteWatcher) Watch(ctx context.Context, sitesDir string) (<-chan ports.SiteEvent, error) {
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("creating fsnotify watcher: %w", err)
+	}
+
+	// Watch the parent directory for new subdirectory creation.
+	if err := fw.Add(sitesDir); err != nil {
+		_ = fw.Close()
+		return nil, fmt.Errorf("watching sites directory %q: %w", sitesDir, err)
+	}
+
+	// Watch existing subdirectories.
+	entries, err := os.ReadDir(sitesDir)
+	if err != nil {
+		_ = fw.Close()
+		return nil, fmt.Errorf("reading sites directory %q: %w", sitesDir, err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		subDir := filepath.Join(sitesDir, entry.Name())
+		if addErr := fw.Add(subDir); addErr != nil {
+			sw.logger.Warn("failed to watch site subdirectory",
+				slog.String("path", subDir),
+				slog.String("error", addErr.Error()),
+			)
+		}
+	}
+
+	ch := make(chan ports.SiteEvent, 16)
+	done := make(chan struct{})
+
+	go sw.watchLoop(ctx, fw, sitesDir, ch, done)
+
+	return ch, nil
+}
+
+// watchLoop is the main goroutine that processes fsnotify events.
+func (sw *SiteWatcher) watchLoop(
+	ctx context.Context,
+	fw *fsnotify.Watcher,
+	sitesDir string,
+	ch chan<- ports.SiteEvent,
+	done chan struct{},
+) {
+	defer close(ch)
+	defer func() {
+		if closeErr := fw.Close(); closeErr != nil {
+			sw.logger.Warn("closing site watcher", slog.String("error", closeErr.Error()))
+		}
+	}()
+
+	var mu sync.Mutex
+	timers := make(map[string]*time.Timer) // site name -> debounce timer
+
+	cancelTimers := func() {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, t := range timers {
+			t.Stop()
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			cancelTimers()
+			close(done)
+			return
+
+		case event, ok := <-fw.Events:
+			if !ok {
+				sw.logger.Error("fsnotify events channel closed unexpectedly")
+				cancelTimers()
+				close(done)
+				return
+			}
+
+			sw.handleFSEvent(ctx, fw, event, sitesDir, ch, done, &mu, timers)
+
+		case watchErr, ok := <-fw.Errors:
+			if !ok {
+				sw.logger.Error("fsnotify errors channel closed unexpectedly")
+				cancelTimers()
+				close(done)
+				return
+			}
+			sw.logger.Warn("site watcher fsnotify error", slog.String("error", watchErr.Error()))
+		}
+	}
+}
+
+// handleFSEvent processes a single fsnotify event and maps it to a SiteEvent.
+func (sw *SiteWatcher) handleFSEvent(
+	ctx context.Context,
+	fw *fsnotify.Watcher,
+	event fsnotify.Event,
+	sitesDir string,
+	ch chan<- ports.SiteEvent,
+	done chan struct{},
+	mu *sync.Mutex,
+	timers map[string]*time.Timer,
+) {
+	// Determine if this event is for a vibewarden.yaml in a site subdirectory.
+	siteName, configPath, ok := sw.parseSitePath(event.Name, sitesDir)
+	if !ok {
+		// Might be a new subdirectory being created. If so, start watching it.
+		if event.Has(fsnotify.Create) {
+			sw.maybeWatchNewDir(fw, event.Name, sitesDir)
+		}
+		return
+	}
+
+	var kind ports.SiteEventKind
+
+	switch {
+	case event.Has(fsnotify.Create):
+		kind = ports.SiteEventCreated
+	case event.Has(fsnotify.Write):
+		kind = ports.SiteEventModified
+	case event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename):
+		kind = ports.SiteEventRemoved
+	default:
+		return
+	}
+
+	sw.logger.Debug("site config change detected",
+		slog.String("site", siteName),
+		slog.String("op", event.Op.String()),
+		slog.String("path", event.Name),
+	)
+
+	siteEvent := ports.SiteEvent{
+		Kind:       kind,
+		SiteName:   siteName,
+		ConfigPath: configPath,
+	}
+
+	sw.debounceSend(ctx, siteEvent, ch, done, mu, timers)
+}
+
+// debounceSend debounces SiteEvent sends per site name.
+func (sw *SiteWatcher) debounceSend(
+	ctx context.Context,
+	event ports.SiteEvent,
+	ch chan<- ports.SiteEvent,
+	done chan struct{},
+	mu *sync.Mutex,
+	timers map[string]*time.Timer,
+) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	_ = ctx // used indirectly via done channel
+
+	if existing, ok := timers[event.SiteName]; ok {
+		existing.Stop()
+	}
+
+	timers[event.SiteName] = time.AfterFunc(sw.debounce, func() {
+		select {
+		case <-done:
+			return
+		case ch <- event:
+		}
+	})
+}
+
+// parseSitePath extracts the site name and config path from an fsnotify event path.
+// It returns the site name, full config path, and true if the path matches
+// the pattern sitesDir/<site-name>/vibewarden.yaml.
+func (sw *SiteWatcher) parseSitePath(eventPath, sitesDir string) (string, string, bool) {
+	// Normalise to absolute paths for reliable comparison.
+	absEvent, err := filepath.Abs(eventPath)
+	if err != nil {
+		return "", "", false
+	}
+	absSites, err := filepath.Abs(sitesDir)
+	if err != nil {
+		return "", "", false
+	}
+
+	rel, err := filepath.Rel(absSites, absEvent)
+	if err != nil {
+		return "", "", false
+	}
+
+	// We expect exactly: <site-name>/vibewarden.yaml
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) != 2 || parts[1] != siteConfigFilename {
+		return "", "", false
+	}
+
+	siteName := parts[0]
+	configPath := filepath.Join(absSites, siteName, siteConfigFilename)
+	return siteName, configPath, true
+}
+
+// maybeWatchNewDir adds a newly created subdirectory to the watcher.
+func (sw *SiteWatcher) maybeWatchNewDir(fw *fsnotify.Watcher, path, sitesDir string) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return
+	}
+	absSites, err := filepath.Abs(sitesDir)
+	if err != nil {
+		return
+	}
+
+	rel, err := filepath.Rel(absSites, absPath)
+	if err != nil {
+		return
+	}
+
+	// Must be a direct child (no path separator).
+	if strings.Contains(rel, string(filepath.Separator)) || rel == "." {
+		return
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil || !info.IsDir() {
+		return
+	}
+
+	if addErr := fw.Add(absPath); addErr != nil {
+		sw.logger.Warn("failed to watch new site directory",
+			slog.String("path", absPath),
+			slog.String("error", addErr.Error()),
+		)
+		return
+	}
+
+	sw.logger.Debug("watching new site directory", slog.String("path", absPath))
+}

--- a/internal/adapters/fsnotify/site_watcher_test.go
+++ b/internal/adapters/fsnotify/site_watcher_test.go
@@ -1,0 +1,267 @@
+package fsnotify_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	fsnotifyadapter "github.com/vibewarden/vibewarden/internal/adapters/fsnotify"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// helper creates a sites/ directory with optional subdirs, each containing a
+// vibewarden.yaml with the given content.
+func setupSitesDir(t *testing.T, sites map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range sites {
+		siteDir := filepath.Join(dir, name)
+		if err := os.MkdirAll(siteDir, 0755); err != nil {
+			t.Fatalf("creating site dir %q: %v", name, err)
+		}
+		if content != "" {
+			if err := os.WriteFile(filepath.Join(siteDir, "vibewarden.yaml"), []byte(content), 0644); err != nil {
+				t.Fatalf("writing config for %q: %v", name, err)
+			}
+		}
+	}
+	return dir
+}
+
+func TestSiteWatcher_DetectsCreatedEvent(t *testing.T) {
+	sitesDir := setupSitesDir(t, map[string]string{})
+
+	watcher := fsnotifyadapter.NewSiteWatcher(slog.Default(), fsnotifyadapter.WithSiteDebounce(50*time.Millisecond))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ch, err := watcher.Watch(ctx, sitesDir)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	// Allow watcher to settle.
+	time.Sleep(50 * time.Millisecond)
+
+	// Create a new site directory with a config file.
+	siteDir := filepath.Join(sitesDir, "new-app")
+	if err := os.MkdirAll(siteDir, 0755); err != nil {
+		t.Fatalf("creating new site dir: %v", err)
+	}
+	// Small delay to let the watcher pick up the new directory.
+	time.Sleep(100 * time.Millisecond)
+
+	if err := os.WriteFile(filepath.Join(siteDir, "vibewarden.yaml"), []byte("profile: dev\n"), 0644); err != nil {
+		t.Fatalf("writing new site config: %v", err)
+	}
+
+	select {
+	case ev := <-ch:
+		// On some OS/editor combos the watcher may report Write instead of Create
+		// when the file appears in a newly watched directory.
+		if ev.Kind != ports.SiteEventCreated && ev.Kind != ports.SiteEventModified {
+			t.Errorf("Kind = %v, want SiteEventCreated or SiteEventModified", ev.Kind)
+		}
+		if ev.SiteName != "new-app" {
+			t.Errorf("SiteName = %q, want %q", ev.SiteName, "new-app")
+		}
+	case <-ctx.Done():
+		t.Fatal("timeout: no event received for new site creation")
+	}
+}
+
+func TestSiteWatcher_DetectsModifiedEvent(t *testing.T) {
+	sitesDir := setupSitesDir(t, map[string]string{
+		"app1": "profile: dev\n",
+	})
+
+	watcher := fsnotifyadapter.NewSiteWatcher(slog.Default(), fsnotifyadapter.WithSiteDebounce(50*time.Millisecond))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ch, err := watcher.Watch(ctx, sitesDir)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	// Allow watcher to settle.
+	time.Sleep(50 * time.Millisecond)
+
+	// Modify the existing config.
+	if err := os.WriteFile(filepath.Join(sitesDir, "app1", "vibewarden.yaml"), []byte("profile: prod\n"), 0644); err != nil {
+		t.Fatalf("modifying config: %v", err)
+	}
+
+	select {
+	case ev := <-ch:
+		if ev.Kind != ports.SiteEventModified && ev.Kind != ports.SiteEventCreated {
+			// Some OS/editor combos emit Create instead of Write.
+			t.Errorf("Kind = %v, want SiteEventModified or SiteEventCreated", ev.Kind)
+		}
+		if ev.SiteName != "app1" {
+			t.Errorf("SiteName = %q, want %q", ev.SiteName, "app1")
+		}
+	case <-ctx.Done():
+		t.Fatal("timeout: no event received for config modification")
+	}
+}
+
+func TestSiteWatcher_DetectsRemovedEvent(t *testing.T) {
+	sitesDir := setupSitesDir(t, map[string]string{
+		"doomed": "profile: dev\n",
+	})
+
+	watcher := fsnotifyadapter.NewSiteWatcher(slog.Default(), fsnotifyadapter.WithSiteDebounce(50*time.Millisecond))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ch, err := watcher.Watch(ctx, sitesDir)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	// Allow watcher to settle.
+	time.Sleep(50 * time.Millisecond)
+
+	// Delete the config file.
+	if err := os.Remove(filepath.Join(sitesDir, "doomed", "vibewarden.yaml")); err != nil {
+		t.Fatalf("removing config: %v", err)
+	}
+
+	select {
+	case ev := <-ch:
+		if ev.Kind != ports.SiteEventRemoved {
+			t.Errorf("Kind = %v, want SiteEventRemoved", ev.Kind)
+		}
+		if ev.SiteName != "doomed" {
+			t.Errorf("SiteName = %q, want %q", ev.SiteName, "doomed")
+		}
+	case <-ctx.Done():
+		t.Fatal("timeout: no event received for config removal")
+	}
+}
+
+func TestSiteWatcher_DebouncesRapidWrites(t *testing.T) {
+	sitesDir := setupSitesDir(t, map[string]string{
+		"app1": "v: 1\n",
+	})
+
+	const debounce = 200 * time.Millisecond
+	watcher := fsnotifyadapter.NewSiteWatcher(slog.Default(), fsnotifyadapter.WithSiteDebounce(debounce))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ch, err := watcher.Watch(ctx, sitesDir)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Perform 5 rapid writes.
+	for i := range 5 {
+		time.Sleep(10 * time.Millisecond)
+		content := []byte("v: " + string(rune('1'+i)) + "\n")
+		if err := os.WriteFile(filepath.Join(sitesDir, "app1", "vibewarden.yaml"), content, 0644); err != nil {
+			t.Fatalf("writing change %d: %v", i, err)
+		}
+	}
+
+	// Wait for debounce window plus buffer.
+	time.Sleep(debounce + 200*time.Millisecond)
+
+	// Drain and count events.
+	count := 0
+drain:
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				break drain
+			}
+			count++
+		default:
+			break drain
+		}
+	}
+
+	if count == 0 {
+		t.Error("expected at least one event, got none")
+	}
+	if count > 2 {
+		t.Errorf("debounce failed: received %d events for 5 rapid writes, want <= 2", count)
+	}
+}
+
+func TestSiteWatcher_ContextCancellation(t *testing.T) {
+	sitesDir := setupSitesDir(t, map[string]string{
+		"app1": "v: 1\n",
+	})
+
+	watcher := fsnotifyadapter.NewSiteWatcher(slog.Default(), fsnotifyadapter.WithSiteDebounce(50*time.Millisecond))
+	ctx, cancel := context.WithCancel(context.Background())
+
+	ch, err := watcher.Watch(ctx, sitesDir)
+	if err != nil {
+		cancel()
+		t.Fatalf("Watch: %v", err)
+	}
+
+	cancel()
+
+	// Channel should close after cancellation.
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return // channel closed as expected
+			}
+		case <-timeout:
+			t.Fatal("timeout waiting for channel to close after context cancellation")
+		}
+	}
+}
+
+func TestSiteWatcher_NonExistentDirectory(t *testing.T) {
+	watcher := fsnotifyadapter.NewSiteWatcher(slog.Default())
+	ctx := context.Background()
+
+	_, err := watcher.Watch(ctx, "/does/not/exist/sites")
+	if err == nil {
+		t.Fatal("expected error watching non-existent directory, got nil")
+	}
+}
+
+func TestSiteWatcher_IgnoresNonConfigFiles(t *testing.T) {
+	sitesDir := setupSitesDir(t, map[string]string{
+		"app1": "profile: dev\n",
+	})
+
+	watcher := fsnotifyadapter.NewSiteWatcher(slog.Default(), fsnotifyadapter.WithSiteDebounce(50*time.Millisecond))
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	ch, err := watcher.Watch(ctx, sitesDir)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Write a non-config file in the site directory.
+	if err := os.WriteFile(filepath.Join(sitesDir, "app1", "README.md"), []byte("# App1\n"), 0644); err != nil {
+		t.Fatalf("writing non-config file: %v", err)
+	}
+
+	// Expect no events (wait a bit to verify silence).
+	select {
+	case ev := <-ch:
+		t.Errorf("unexpected event received: %+v", ev)
+	case <-time.After(500 * time.Millisecond):
+		// No event received, as expected.
+	}
+}

--- a/internal/app/reload/multisite_service.go
+++ b/internal/app/reload/multisite_service.go
@@ -1,0 +1,312 @@
+package reload
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/domain/site"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ReloadFunc is called after registry mutations to rebuild the proxy config
+// from the current set of healthy sites. It receives the current context and
+// returns an error if the proxy reload fails.
+type ReloadFunc func(ctx context.Context) error
+
+// MultiSiteService consumes SiteEvent values from a SiteWatcher and maps them
+// to Registry mutations (Add, Remove, SetErr). After each mutation it calls
+// the ReloadFunc to apply the new state to the running proxy.
+//
+// Error isolation: a broken site's configuration never prevents healthy sites
+// from serving. If the proxy reload fails after a mutation, the service
+// performs a rollback (undo the registry change and re-reload).
+type MultiSiteService struct {
+	registry *site.Registry
+	eventLog ports.EventLogger
+	logger   *slog.Logger
+	reloadFn ReloadFunc
+}
+
+// NewMultiSiteService creates a MultiSiteService.
+//
+// registry is the shared site registry that holds the current set of sites.
+// eventLog emits structured domain events; may be nil (events are skipped).
+// reloadFn is called after each registry mutation to apply changes to the proxy.
+func NewMultiSiteService(
+	registry *site.Registry,
+	eventLog ports.EventLogger,
+	logger *slog.Logger,
+	reloadFn ReloadFunc,
+) *MultiSiteService {
+	return &MultiSiteService{
+		registry: registry,
+		eventLog: eventLog,
+		logger:   logger,
+		reloadFn: reloadFn,
+	}
+}
+
+// Run consumes events from the SiteWatcher channel until it is closed or ctx
+// is cancelled. Each event is handled in sequence. Run blocks until the
+// channel is closed.
+func (ms *MultiSiteService) Run(ctx context.Context, events <-chan ports.SiteEvent) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-events:
+			if !ok {
+				return
+			}
+			ms.handleEvent(ctx, ev)
+		}
+	}
+}
+
+// handleEvent dispatches a single SiteEvent to the appropriate handler.
+func (ms *MultiSiteService) handleEvent(ctx context.Context, ev ports.SiteEvent) {
+	switch ev.Kind {
+	case ports.SiteEventCreated:
+		ms.handleCreated(ctx, ev)
+	case ports.SiteEventModified:
+		ms.handleModified(ctx, ev)
+	case ports.SiteEventRemoved:
+		ms.handleRemoved(ctx, ev)
+	default:
+		ms.logger.Warn("unknown site event kind",
+			slog.String("site", ev.SiteName),
+			slog.Int("kind", int(ev.Kind)),
+		)
+	}
+}
+
+// handleCreated loads a new site config, adds it to the registry, validates
+// domains, and triggers a proxy reload.
+func (ms *MultiSiteService) handleCreated(ctx context.Context, ev ports.SiteEvent) {
+	ms.logger.Info("site created", slog.String("site", ev.SiteName), slog.String("config", ev.ConfigPath))
+
+	cfg, err := config.Load(ev.ConfigPath)
+	if err != nil {
+		ms.logger.Error("failed to load new site config",
+			slog.String("site", ev.SiteName),
+			slog.String("error", err.Error()),
+		)
+		ms.markSiteError(ev, fmt.Errorf("loading config: %w", err))
+		ms.emitSiteLoadFailed(ctx, ev, err.Error())
+		return
+	}
+
+	s, err := site.NewSite(ev.SiteName, ev.ConfigPath, cfg)
+	if err != nil {
+		ms.logger.Error("failed to create site entity",
+			slog.String("site", ev.SiteName),
+			slog.String("error", err.Error()),
+		)
+		ms.emitSiteLoadFailed(ctx, ev, err.Error())
+		return
+	}
+
+	ms.registry.Add(s)
+
+	// Validate that the new site does not introduce domain conflicts.
+	if domErr := ms.registry.ValidateDomains(); domErr != nil {
+		ms.logger.Error("domain validation failed after adding site",
+			slog.String("site", ev.SiteName),
+			slog.String("error", domErr.Error()),
+		)
+		// Roll back: remove the conflicting site.
+		ms.registry.Remove(ev.SiteName)
+		ms.emitSiteLoadFailed(ctx, ev, domErr.Error())
+		return
+	}
+
+	if err := ms.reloadFn(ctx); err != nil {
+		ms.logger.Error("proxy reload failed after site add",
+			slog.String("site", ev.SiteName),
+			slog.String("error", err.Error()),
+		)
+		// Roll back: remove the site that caused the failure.
+		ms.registry.Remove(ev.SiteName)
+		ms.emitSiteLoadFailed(ctx, ev, "proxy reload failed: "+err.Error())
+		return
+	}
+
+	domain := ""
+	if cfg.TLS.Domain != "" {
+		domain = cfg.TLS.Domain
+	}
+	ms.emitSiteAdded(ctx, ev, domain)
+}
+
+// handleModified reloads an existing site's config, updates the registry,
+// and triggers a proxy reload.
+func (ms *MultiSiteService) handleModified(ctx context.Context, ev ports.SiteEvent) {
+	ms.logger.Info("site modified", slog.String("site", ev.SiteName), slog.String("config", ev.ConfigPath))
+
+	cfg, err := config.Load(ev.ConfigPath)
+	if err != nil {
+		ms.logger.Error("failed to reload site config",
+			slog.String("site", ev.SiteName),
+			slog.String("error", err.Error()),
+		)
+		ms.markSiteError(ev, fmt.Errorf("loading config: %w", err))
+		ms.emitSiteLoadFailed(ctx, ev, err.Error())
+		return
+	}
+
+	newSite, err := site.NewSite(ev.SiteName, ev.ConfigPath, cfg)
+	if err != nil {
+		ms.logger.Error("failed to create updated site entity",
+			slog.String("site", ev.SiteName),
+			slog.String("error", err.Error()),
+		)
+		ms.emitSiteLoadFailed(ctx, ev, err.Error())
+		return
+	}
+
+	// Snapshot the previous site for rollback.
+	prevSite, hadPrevious := ms.registry.Get(ev.SiteName)
+
+	ms.registry.Add(newSite)
+
+	// Validate domains after update.
+	if domErr := ms.registry.ValidateDomains(); domErr != nil {
+		ms.logger.Error("domain validation failed after updating site",
+			slog.String("site", ev.SiteName),
+			slog.String("error", domErr.Error()),
+		)
+		ms.rollbackSite(prevSite, hadPrevious, ev.SiteName)
+		ms.emitSiteLoadFailed(ctx, ev, domErr.Error())
+		return
+	}
+
+	if err := ms.reloadFn(ctx); err != nil {
+		ms.logger.Error("proxy reload failed after site update",
+			slog.String("site", ev.SiteName),
+			slog.String("error", err.Error()),
+		)
+		ms.rollbackSite(prevSite, hadPrevious, ev.SiteName)
+		ms.emitSiteLoadFailed(ctx, ev, "proxy reload failed: "+err.Error())
+		return
+	}
+
+	domain := ""
+	if cfg.TLS.Domain != "" {
+		domain = cfg.TLS.Domain
+	}
+	ms.emitSiteUpdated(ctx, ev, domain)
+}
+
+// handleRemoved removes a site from the registry and triggers a proxy reload.
+func (ms *MultiSiteService) handleRemoved(ctx context.Context, ev ports.SiteEvent) {
+	ms.logger.Info("site removed", slog.String("site", ev.SiteName), slog.String("config", ev.ConfigPath))
+
+	// Snapshot for rollback.
+	prevSite, hadPrevious := ms.registry.Get(ev.SiteName)
+
+	existed := ms.registry.Remove(ev.SiteName)
+	if !existed {
+		ms.logger.Debug("removed site was not in registry",
+			slog.String("site", ev.SiteName),
+		)
+		return
+	}
+
+	if err := ms.reloadFn(ctx); err != nil {
+		ms.logger.Error("proxy reload failed after site removal",
+			slog.String("site", ev.SiteName),
+			slog.String("error", err.Error()),
+		)
+		// Roll back: re-add the site.
+		ms.rollbackSite(prevSite, hadPrevious, ev.SiteName)
+		return
+	}
+
+	ms.emitSiteRemoved(ctx, ev)
+}
+
+// markSiteError records an error site in the registry without triggering a
+// proxy reload. This ensures the site appears in status output as errored.
+func (ms *MultiSiteService) markSiteError(ev ports.SiteEvent, siteErr error) {
+	errSite, err := site.NewErrorSite(ev.SiteName, ev.ConfigPath, siteErr)
+	if err != nil {
+		ms.logger.Error("failed to create error site entity",
+			slog.String("site", ev.SiteName),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	ms.registry.Add(errSite)
+}
+
+// rollbackSite restores a previous site in the registry, or removes the
+// site if there was no previous version.
+func (ms *MultiSiteService) rollbackSite(prev *site.Site, hadPrevious bool, name string) {
+	if hadPrevious && prev != nil {
+		ms.registry.Add(prev)
+	} else {
+		ms.registry.Remove(name)
+	}
+}
+
+// ------------------------------------------------------------------
+// Domain event emission helpers
+// ------------------------------------------------------------------
+
+func (ms *MultiSiteService) emitSiteAdded(ctx context.Context, ev ports.SiteEvent, domain string) {
+	if ms.eventLog == nil {
+		return
+	}
+	e := events.NewSiteAdded(events.SiteAddedParams{
+		SiteName:   ev.SiteName,
+		ConfigPath: ev.ConfigPath,
+		Domain:     domain,
+	})
+	if err := ms.eventLog.Log(ctx, e); err != nil {
+		ms.logger.Error("failed to emit site.added event", slog.String("error", err.Error()))
+	}
+}
+
+func (ms *MultiSiteService) emitSiteUpdated(ctx context.Context, ev ports.SiteEvent, domain string) {
+	if ms.eventLog == nil {
+		return
+	}
+	e := events.NewSiteUpdated(events.SiteUpdatedParams{
+		SiteName:   ev.SiteName,
+		ConfigPath: ev.ConfigPath,
+		Domain:     domain,
+	})
+	if err := ms.eventLog.Log(ctx, e); err != nil {
+		ms.logger.Error("failed to emit site.updated event", slog.String("error", err.Error()))
+	}
+}
+
+func (ms *MultiSiteService) emitSiteRemoved(ctx context.Context, ev ports.SiteEvent) {
+	if ms.eventLog == nil {
+		return
+	}
+	e := events.NewSiteRemoved(events.SiteRemovedParams{
+		SiteName:   ev.SiteName,
+		ConfigPath: ev.ConfigPath,
+	})
+	if err := ms.eventLog.Log(ctx, e); err != nil {
+		ms.logger.Error("failed to emit site.removed event", slog.String("error", err.Error()))
+	}
+}
+
+func (ms *MultiSiteService) emitSiteLoadFailed(ctx context.Context, ev ports.SiteEvent, reason string) {
+	if ms.eventLog == nil {
+		return
+	}
+	e := events.NewSiteLoadFailed(events.SiteLoadFailedParams{
+		SiteName:   ev.SiteName,
+		ConfigPath: ev.ConfigPath,
+		Reason:     reason,
+	})
+	if err := ms.eventLog.Log(ctx, e); err != nil {
+		ms.logger.Error("failed to emit site.load_failed event", slog.String("error", err.Error()))
+	}
+}

--- a/internal/app/reload/multisite_service.go
+++ b/internal/app/reload/multisite_service.go
@@ -11,14 +11,14 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
-// ReloadFunc is called after registry mutations to rebuild the proxy config
+// ApplyFunc is called after registry mutations to rebuild the proxy config
 // from the current set of healthy sites. It receives the current context and
 // returns an error if the proxy reload fails.
-type ReloadFunc func(ctx context.Context) error
+type ApplyFunc func(ctx context.Context) error
 
 // MultiSiteService consumes SiteEvent values from a SiteWatcher and maps them
 // to Registry mutations (Add, Remove, SetErr). After each mutation it calls
-// the ReloadFunc to apply the new state to the running proxy.
+// the ApplyFunc to apply the new state to the running proxy.
 //
 // Error isolation: a broken site's configuration never prevents healthy sites
 // from serving. If the proxy reload fails after a mutation, the service
@@ -27,7 +27,7 @@ type MultiSiteService struct {
 	registry *site.Registry
 	eventLog ports.EventLogger
 	logger   *slog.Logger
-	reloadFn ReloadFunc
+	reloadFn ApplyFunc
 }
 
 // NewMultiSiteService creates a MultiSiteService.
@@ -39,7 +39,7 @@ func NewMultiSiteService(
 	registry *site.Registry,
 	eventLog ports.EventLogger,
 	logger *slog.Logger,
-	reloadFn ReloadFunc,
+	reloadFn ApplyFunc,
 ) *MultiSiteService {
 	return &MultiSiteService{
 		registry: registry,

--- a/internal/app/reload/multisite_service_test.go
+++ b/internal/app/reload/multisite_service_test.go
@@ -1,0 +1,540 @@
+package reload_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/app/reload"
+	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/domain/site"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ------------------------------------------------------------------
+// Test doubles for MultiSiteService
+// ------------------------------------------------------------------
+
+// fakeReloader tracks calls to the ReloadFunc.
+type fakeReloader struct {
+	err   error
+	count int
+}
+
+func (f *fakeReloader) Reload(_ context.Context) error {
+	f.count++
+	return f.err
+}
+
+// writeSiteConfig writes a minimal valid vibewarden.yaml under sitesDir/name/.
+func writeSiteConfig(t *testing.T, sitesDir, name, content string) string {
+	t.Helper()
+	siteDir := filepath.Join(sitesDir, name)
+	if err := os.MkdirAll(siteDir, 0755); err != nil {
+		t.Fatalf("creating site dir %q: %v", name, err)
+	}
+	path := filepath.Join(siteDir, "vibewarden.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("writing site config %q: %v", name, err)
+	}
+	return path
+}
+
+const siteMinimalConfig = `
+profile: dev
+server:
+  host: 127.0.0.1
+  port: 8443
+upstream:
+  host: 127.0.0.1
+  port: 3000
+`
+
+// ------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------
+
+func TestMultiSiteService_CreatedEvent_Success(t *testing.T) {
+	reg := site.NewRegistry()
+	eventLog := &fakeEventLogger{}
+	reloader := &fakeReloader{}
+	svc := reload.NewMultiSiteService(reg, eventLog, slog.Default(), reloader.Reload)
+
+	dir := t.TempDir()
+	configPath := writeSiteConfig(t, dir, "app1", siteMinimalConfig)
+
+	ch := make(chan ports.SiteEvent, 1)
+	ch <- ports.SiteEvent{
+		Kind:       ports.SiteEventCreated,
+		SiteName:   "app1",
+		ConfigPath: configPath,
+	}
+	close(ch)
+
+	svc.Run(context.Background(), ch)
+
+	// Verify site was added to registry.
+	s, ok := reg.Get("app1")
+	if !ok {
+		t.Fatal("site app1 not found in registry after Created event")
+	}
+	if !s.IsHealthy() {
+		t.Errorf("site status = %v, want healthy", s.Status())
+	}
+
+	// Verify reload was called.
+	if reloader.count != 1 {
+		t.Errorf("reload called %d times, want 1", reloader.count)
+	}
+
+	// Verify site.added event was emitted.
+	added := eventLog.eventsOfType(events.EventTypeSiteAdded)
+	if len(added) != 1 {
+		t.Errorf("got %d site.added events, want 1", len(added))
+	}
+}
+
+func TestMultiSiteService_CreatedEvent_LoadFailure(t *testing.T) {
+	reg := site.NewRegistry()
+	eventLog := &fakeEventLogger{}
+	reloader := &fakeReloader{}
+	svc := reload.NewMultiSiteService(reg, eventLog, slog.Default(), reloader.Reload)
+
+	ch := make(chan ports.SiteEvent, 1)
+	ch <- ports.SiteEvent{
+		Kind:       ports.SiteEventCreated,
+		SiteName:   "bad-app",
+		ConfigPath: "/does/not/exist/vibewarden.yaml",
+	}
+	close(ch)
+
+	svc.Run(context.Background(), ch)
+
+	// Site should be in error state, not healthy.
+	s, ok := reg.Get("bad-app")
+	if !ok {
+		t.Fatal("expected error site in registry")
+	}
+	if s.IsHealthy() {
+		t.Error("site should be in error state, not healthy")
+	}
+
+	// Reload should NOT have been called.
+	if reloader.count != 0 {
+		t.Errorf("reload called %d times, want 0 on load failure", reloader.count)
+	}
+
+	// Should emit site.load_failed event.
+	failed := eventLog.eventsOfType(events.EventTypeSiteLoadFailed)
+	if len(failed) != 1 {
+		t.Errorf("got %d site.load_failed events, want 1", len(failed))
+	}
+}
+
+func TestMultiSiteService_CreatedEvent_ReloadFailureRollback(t *testing.T) {
+	reg := site.NewRegistry()
+	eventLog := &fakeEventLogger{}
+	reloader := &fakeReloader{err: errors.New("caddy reload failed")}
+	svc := reload.NewMultiSiteService(reg, eventLog, slog.Default(), reloader.Reload)
+
+	dir := t.TempDir()
+	configPath := writeSiteConfig(t, dir, "app1", siteMinimalConfig)
+
+	ch := make(chan ports.SiteEvent, 1)
+	ch <- ports.SiteEvent{
+		Kind:       ports.SiteEventCreated,
+		SiteName:   "app1",
+		ConfigPath: configPath,
+	}
+	close(ch)
+
+	svc.Run(context.Background(), ch)
+
+	// Site should have been rolled back (removed).
+	_, ok := reg.Get("app1")
+	if ok {
+		t.Error("site app1 should have been removed after reload failure")
+	}
+
+	// Should emit site.load_failed event.
+	failed := eventLog.eventsOfType(events.EventTypeSiteLoadFailed)
+	if len(failed) != 1 {
+		t.Errorf("got %d site.load_failed events, want 1", len(failed))
+	}
+}
+
+func TestMultiSiteService_ModifiedEvent_Success(t *testing.T) {
+	reg := site.NewRegistry()
+	eventLog := &fakeEventLogger{}
+	reloader := &fakeReloader{}
+	svc := reload.NewMultiSiteService(reg, eventLog, slog.Default(), reloader.Reload)
+
+	dir := t.TempDir()
+	configPath := writeSiteConfig(t, dir, "app1", siteMinimalConfig)
+
+	// Pre-populate registry with existing site.
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	existing, _ := site.NewSite("app1", configPath, cfg)
+	reg.Add(existing)
+
+	// Now modify the config file.
+	newConfig := `
+profile: prod
+server:
+  host: 127.0.0.1
+  port: 9999
+upstream:
+  host: 127.0.0.1
+  port: 4000
+`
+	if err := os.WriteFile(configPath, []byte(newConfig), 0644); err != nil {
+		t.Fatalf("writing updated config: %v", err)
+	}
+
+	ch := make(chan ports.SiteEvent, 1)
+	ch <- ports.SiteEvent{
+		Kind:       ports.SiteEventModified,
+		SiteName:   "app1",
+		ConfigPath: configPath,
+	}
+	close(ch)
+
+	svc.Run(context.Background(), ch)
+
+	// Verify site was updated in registry.
+	s, ok := reg.Get("app1")
+	if !ok {
+		t.Fatal("site app1 not found in registry after Modified event")
+	}
+	if !s.IsHealthy() {
+		t.Errorf("site status = %v, want healthy", s.Status())
+	}
+
+	// Verify reload was called.
+	if reloader.count != 1 {
+		t.Errorf("reload called %d times, want 1", reloader.count)
+	}
+
+	// Verify site.updated event.
+	updated := eventLog.eventsOfType(events.EventTypeSiteUpdated)
+	if len(updated) != 1 {
+		t.Errorf("got %d site.updated events, want 1", len(updated))
+	}
+}
+
+func TestMultiSiteService_ModifiedEvent_ReloadFailureRollback(t *testing.T) {
+	reg := site.NewRegistry()
+	eventLog := &fakeEventLogger{}
+	reloader := &fakeReloader{err: errors.New("proxy error")}
+	svc := reload.NewMultiSiteService(reg, eventLog, slog.Default(), reloader.Reload)
+
+	dir := t.TempDir()
+	configPath := writeSiteConfig(t, dir, "app1", siteMinimalConfig)
+
+	// Pre-populate registry with existing site.
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	original, _ := site.NewSite("app1", configPath, cfg)
+	reg.Add(original)
+
+	// Modify the config (valid, so config.Load succeeds; reloader will fail).
+	newConfig := `
+profile: prod
+server:
+  host: 127.0.0.1
+  port: 9999
+upstream:
+  host: 127.0.0.1
+  port: 4000
+`
+	if err := os.WriteFile(configPath, []byte(newConfig), 0644); err != nil {
+		t.Fatalf("writing updated config: %v", err)
+	}
+
+	ch := make(chan ports.SiteEvent, 1)
+	ch <- ports.SiteEvent{
+		Kind:       ports.SiteEventModified,
+		SiteName:   "app1",
+		ConfigPath: configPath,
+	}
+	close(ch)
+
+	svc.Run(context.Background(), ch)
+
+	// After rollback, the original site should still be in the registry.
+	s, ok := reg.Get("app1")
+	if !ok {
+		t.Fatal("site app1 should still be in registry after rollback")
+	}
+	// The original had profile "dev".
+	if s.Config().Profile != "dev" {
+		t.Errorf("after rollback, profile = %q, want %q", s.Config().Profile, "dev")
+	}
+}
+
+func TestMultiSiteService_RemovedEvent_Success(t *testing.T) {
+	reg := site.NewRegistry()
+	eventLog := &fakeEventLogger{}
+	reloader := &fakeReloader{}
+	svc := reload.NewMultiSiteService(reg, eventLog, slog.Default(), reloader.Reload)
+
+	// Pre-populate registry.
+	existing, _ := site.NewSite("app1", "/srv/sites/app1/vibewarden.yaml", &config.Config{})
+	reg.Add(existing)
+
+	ch := make(chan ports.SiteEvent, 1)
+	ch <- ports.SiteEvent{
+		Kind:       ports.SiteEventRemoved,
+		SiteName:   "app1",
+		ConfigPath: "/srv/sites/app1/vibewarden.yaml",
+	}
+	close(ch)
+
+	svc.Run(context.Background(), ch)
+
+	// Site should be removed from registry.
+	_, ok := reg.Get("app1")
+	if ok {
+		t.Error("site app1 should have been removed from registry")
+	}
+
+	// Reload should be called.
+	if reloader.count != 1 {
+		t.Errorf("reload called %d times, want 1", reloader.count)
+	}
+
+	// site.removed event emitted.
+	removed := eventLog.eventsOfType(events.EventTypeSiteRemoved)
+	if len(removed) != 1 {
+		t.Errorf("got %d site.removed events, want 1", len(removed))
+	}
+}
+
+func TestMultiSiteService_RemovedEvent_ReloadFailureRollback(t *testing.T) {
+	reg := site.NewRegistry()
+	eventLog := &fakeEventLogger{}
+	reloader := &fakeReloader{err: errors.New("proxy error")}
+	svc := reload.NewMultiSiteService(reg, eventLog, slog.Default(), reloader.Reload)
+
+	// Pre-populate registry.
+	existing, _ := site.NewSite("app1", "/srv/sites/app1/vibewarden.yaml", &config.Config{})
+	reg.Add(existing)
+
+	ch := make(chan ports.SiteEvent, 1)
+	ch <- ports.SiteEvent{
+		Kind:       ports.SiteEventRemoved,
+		SiteName:   "app1",
+		ConfigPath: "/srv/sites/app1/vibewarden.yaml",
+	}
+	close(ch)
+
+	svc.Run(context.Background(), ch)
+
+	// After rollback, the site should be restored.
+	s, ok := reg.Get("app1")
+	if !ok {
+		t.Fatal("site app1 should be restored after reload rollback")
+	}
+	if !s.IsHealthy() {
+		t.Errorf("restored site status = %v, want healthy", s.Status())
+	}
+}
+
+func TestMultiSiteService_RemovedEvent_UnknownSite(t *testing.T) {
+	reg := site.NewRegistry()
+	eventLog := &fakeEventLogger{}
+	reloader := &fakeReloader{}
+	svc := reload.NewMultiSiteService(reg, eventLog, slog.Default(), reloader.Reload)
+
+	ch := make(chan ports.SiteEvent, 1)
+	ch <- ports.SiteEvent{
+		Kind:       ports.SiteEventRemoved,
+		SiteName:   "nonexistent",
+		ConfigPath: "/srv/sites/nonexistent/vibewarden.yaml",
+	}
+	close(ch)
+
+	svc.Run(context.Background(), ch)
+
+	// Reload should NOT be called for a site that was not in the registry.
+	if reloader.count != 0 {
+		t.Errorf("reload called %d times, want 0 for unknown site removal", reloader.count)
+	}
+}
+
+func TestMultiSiteService_ErrorIsolation(t *testing.T) {
+	// A broken site should not affect a healthy one.
+	reg := site.NewRegistry()
+	eventLog := &fakeEventLogger{}
+	reloader := &fakeReloader{}
+	svc := reload.NewMultiSiteService(reg, eventLog, slog.Default(), reloader.Reload)
+
+	// Add a healthy site first.
+	dir := t.TempDir()
+	configPath := writeSiteConfig(t, dir, "healthy-app", siteMinimalConfig)
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	healthy, _ := site.NewSite("healthy-app", configPath, cfg)
+	reg.Add(healthy)
+
+	// Now send a Created event for a broken site.
+	ch := make(chan ports.SiteEvent, 1)
+	ch <- ports.SiteEvent{
+		Kind:       ports.SiteEventCreated,
+		SiteName:   "broken-app",
+		ConfigPath: "/does/not/exist/vibewarden.yaml",
+	}
+	close(ch)
+
+	svc.Run(context.Background(), ch)
+
+	// Healthy site should still be healthy and in the registry.
+	s, ok := reg.Get("healthy-app")
+	if !ok {
+		t.Fatal("healthy-app should still be in registry")
+	}
+	if !s.IsHealthy() {
+		t.Errorf("healthy-app status = %v, want healthy", s.Status())
+	}
+
+	// Broken site should be in error state.
+	broken, ok := reg.Get("broken-app")
+	if !ok {
+		t.Fatal("broken-app should be in registry as error site")
+	}
+	if broken.IsHealthy() {
+		t.Error("broken-app should be in error state")
+	}
+}
+
+func TestMultiSiteService_ContextCancellation(t *testing.T) {
+	reg := site.NewRegistry()
+	reloader := &fakeReloader{}
+	svc := reload.NewMultiSiteService(reg, nil, slog.Default(), reloader.Reload)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan ports.SiteEvent, 1)
+
+	done := make(chan struct{})
+	go func() {
+		svc.Run(ctx, ch)
+		close(done)
+	}()
+
+	// Cancel context to stop Run.
+	cancel()
+
+	select {
+	case <-done:
+		// Run returned as expected.
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout: Run did not return after context cancellation")
+	}
+}
+
+func TestMultiSiteService_NilEventLog(t *testing.T) {
+	// Verify that nil eventLog does not panic.
+	reg := site.NewRegistry()
+	reloader := &fakeReloader{}
+	svc := reload.NewMultiSiteService(reg, nil, slog.Default(), reloader.Reload)
+
+	dir := t.TempDir()
+	configPath := writeSiteConfig(t, dir, "app1", siteMinimalConfig)
+
+	ch := make(chan ports.SiteEvent, 1)
+	ch <- ports.SiteEvent{
+		Kind:       ports.SiteEventCreated,
+		SiteName:   "app1",
+		ConfigPath: configPath,
+	}
+	close(ch)
+
+	// Should not panic.
+	svc.Run(context.Background(), ch)
+
+	_, ok := reg.Get("app1")
+	if !ok {
+		t.Fatal("site app1 should be in registry")
+	}
+}
+
+func TestMultiSiteService_DomainConflict_Rollback(t *testing.T) {
+	reg := site.NewRegistry()
+	eventLog := &fakeEventLogger{}
+	reloader := &fakeReloader{}
+	svc := reload.NewMultiSiteService(reg, eventLog, slog.Default(), reloader.Reload)
+
+	dir := t.TempDir()
+
+	// Add first site with a domain.
+	cfg1Content := `
+profile: dev
+server:
+  host: 127.0.0.1
+  port: 8443
+upstream:
+  host: 127.0.0.1
+  port: 3000
+tls:
+  enabled: true
+  domain: shared.example.com
+`
+	path1 := writeSiteConfig(t, dir, "app1", cfg1Content)
+	cfg1, err := config.Load(path1)
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	s1, _ := site.NewSite("app1", path1, cfg1)
+	reg.Add(s1)
+
+	// Try to add a second site with the same domain.
+	path2 := writeSiteConfig(t, dir, "app2", cfg1Content)
+
+	ch := make(chan ports.SiteEvent, 1)
+	ch <- ports.SiteEvent{
+		Kind:       ports.SiteEventCreated,
+		SiteName:   "app2",
+		ConfigPath: path2,
+	}
+	close(ch)
+
+	svc.Run(context.Background(), ch)
+
+	// app2 should have been rolled back due to domain conflict.
+	_, ok := reg.Get("app2")
+	if ok {
+		t.Error("app2 should not be in registry after domain conflict")
+	}
+
+	// app1 should still be healthy.
+	s, ok := reg.Get("app1")
+	if !ok {
+		t.Fatal("app1 should still be in registry")
+	}
+	if !s.IsHealthy() {
+		t.Errorf("app1 status = %v, want healthy", s.Status())
+	}
+
+	// Reload should NOT have been called (domain validation fails before reload).
+	if reloader.count != 0 {
+		t.Errorf("reload called %d times, want 0 (domain conflict should prevent reload)", reloader.count)
+	}
+
+	// site.load_failed should be emitted.
+	failed := eventLog.eventsOfType(events.EventTypeSiteLoadFailed)
+	if len(failed) != 1 {
+		t.Errorf("got %d site.load_failed events, want 1", len(failed))
+	}
+}

--- a/internal/domain/events/site.go
+++ b/internal/domain/events/site.go
@@ -1,0 +1,173 @@
+package events
+
+import (
+	"fmt"
+	"time"
+)
+
+// Site event type constants.
+const (
+	// EventTypeSiteAdded is emitted when a new site is discovered and
+	// successfully loaded into the registry.
+	EventTypeSiteAdded = "site.added"
+
+	// EventTypeSiteUpdated is emitted when an existing site's configuration
+	// is reloaded after a file change.
+	EventTypeSiteUpdated = "site.updated"
+
+	// EventTypeSiteRemoved is emitted when a site's configuration file is
+	// deleted and the site is removed from the registry.
+	EventTypeSiteRemoved = "site.removed"
+
+	// EventTypeSiteLoadFailed is emitted when a site's configuration cannot
+	// be loaded or validated. The site is marked as errored but healthy
+	// sites are not disrupted.
+	EventTypeSiteLoadFailed = "site.load_failed"
+)
+
+// SiteAddedParams holds the parameters for a site.added event.
+type SiteAddedParams struct {
+	// SiteName is the DNS-safe directory name of the site.
+	SiteName string
+
+	// ConfigPath is the absolute path to the site's vibewarden.yaml.
+	ConfigPath string
+
+	// Domain is the TLS domain configured for the site, if any.
+	Domain string
+}
+
+// NewSiteAdded creates a site.added event.
+func NewSiteAdded(params SiteAddedParams) Event {
+	summary := fmt.Sprintf("Site %q added from %s", params.SiteName, params.ConfigPath)
+	if params.Domain != "" {
+		summary = fmt.Sprintf("Site %q (domain: %s) added from %s", params.SiteName, params.Domain, params.ConfigPath)
+	}
+	if len(summary) > 200 {
+		summary = summary[:200]
+	}
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeSiteAdded,
+		Timestamp:     time.Now().UTC(),
+		Severity:      SeverityInfo,
+		Category:      CategoryAudit,
+		AISummary:     summary,
+		Payload: map[string]any{
+			"site_name":   params.SiteName,
+			"config_path": params.ConfigPath,
+			"domain":      params.Domain,
+		},
+		Actor:       Actor{Type: ActorTypeSystem},
+		Resource:    Resource{Type: ResourceTypeConfig, Path: params.ConfigPath},
+		Outcome:     OutcomeAllowed,
+		TriggeredBy: "site_watcher",
+	}
+}
+
+// SiteUpdatedParams holds the parameters for a site.updated event.
+type SiteUpdatedParams struct {
+	// SiteName is the DNS-safe directory name of the site.
+	SiteName string
+
+	// ConfigPath is the absolute path to the site's vibewarden.yaml.
+	ConfigPath string
+
+	// Domain is the TLS domain configured for the site, if any.
+	Domain string
+}
+
+// NewSiteUpdated creates a site.updated event.
+func NewSiteUpdated(params SiteUpdatedParams) Event {
+	summary := fmt.Sprintf("Site %q config updated from %s", params.SiteName, params.ConfigPath)
+	if len(summary) > 200 {
+		summary = summary[:200]
+	}
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeSiteUpdated,
+		Timestamp:     time.Now().UTC(),
+		Severity:      SeverityInfo,
+		Category:      CategoryAudit,
+		AISummary:     summary,
+		Payload: map[string]any{
+			"site_name":   params.SiteName,
+			"config_path": params.ConfigPath,
+			"domain":      params.Domain,
+		},
+		Actor:       Actor{Type: ActorTypeSystem},
+		Resource:    Resource{Type: ResourceTypeConfig, Path: params.ConfigPath},
+		Outcome:     OutcomeAllowed,
+		TriggeredBy: "site_watcher",
+	}
+}
+
+// SiteRemovedParams holds the parameters for a site.removed event.
+type SiteRemovedParams struct {
+	// SiteName is the DNS-safe directory name of the site.
+	SiteName string
+
+	// ConfigPath is the absolute path to the site's vibewarden.yaml.
+	ConfigPath string
+}
+
+// NewSiteRemoved creates a site.removed event.
+func NewSiteRemoved(params SiteRemovedParams) Event {
+	summary := fmt.Sprintf("Site %q removed (config: %s)", params.SiteName, params.ConfigPath)
+	if len(summary) > 200 {
+		summary = summary[:200]
+	}
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeSiteRemoved,
+		Timestamp:     time.Now().UTC(),
+		Severity:      SeverityInfo,
+		Category:      CategoryAudit,
+		AISummary:     summary,
+		Payload: map[string]any{
+			"site_name":   params.SiteName,
+			"config_path": params.ConfigPath,
+		},
+		Actor:       Actor{Type: ActorTypeSystem},
+		Resource:    Resource{Type: ResourceTypeConfig, Path: params.ConfigPath},
+		Outcome:     OutcomeAllowed,
+		TriggeredBy: "site_watcher",
+	}
+}
+
+// SiteLoadFailedParams holds the parameters for a site.load_failed event.
+type SiteLoadFailedParams struct {
+	// SiteName is the DNS-safe directory name of the site.
+	SiteName string
+
+	// ConfigPath is the absolute path to the site's vibewarden.yaml.
+	ConfigPath string
+
+	// Reason is a human-readable description of the failure.
+	Reason string
+}
+
+// NewSiteLoadFailed creates a site.load_failed event.
+func NewSiteLoadFailed(params SiteLoadFailedParams) Event {
+	summary := fmt.Sprintf("Site %q load failed: %s", params.SiteName, params.Reason)
+	if len(summary) > 200 {
+		summary = summary[:200]
+	}
+	return Event{
+		SchemaVersion: SchemaVersion,
+		EventType:     EventTypeSiteLoadFailed,
+		Timestamp:     time.Now().UTC(),
+		Severity:      SeverityMedium,
+		Category:      CategoryAudit,
+		AISummary:     summary,
+		Payload: map[string]any{
+			"site_name":   params.SiteName,
+			"config_path": params.ConfigPath,
+			"reason":      params.Reason,
+		},
+		Actor:       Actor{Type: ActorTypeSystem},
+		Resource:    Resource{Type: ResourceTypeConfig, Path: params.ConfigPath},
+		Outcome:     OutcomeFailed,
+		TriggeredBy: "site_watcher",
+	}
+}

--- a/internal/domain/events/site_test.go
+++ b/internal/domain/events/site_test.go
@@ -1,0 +1,172 @@
+package events_test
+
+import (
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+)
+
+func TestNewSiteAdded(t *testing.T) {
+	tests := []struct {
+		name   string
+		params events.SiteAddedParams
+	}{
+		{
+			name: "with domain",
+			params: events.SiteAddedParams{
+				SiteName:   "app1",
+				ConfigPath: "/srv/sites/app1/vibewarden.yaml",
+				Domain:     "app1.example.com",
+			},
+		},
+		{
+			name: "without domain",
+			params: events.SiteAddedParams{
+				SiteName:   "app2",
+				ConfigPath: "/srv/sites/app2/vibewarden.yaml",
+				Domain:     "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := events.NewSiteAdded(tt.params)
+
+			assertEvent(t, ev, events.EventTypeSiteAdded)
+			requireSummaryContains(t, ev.AISummary, tt.params.SiteName)
+			requirePayloadString(t, ev.Payload, "site_name", tt.params.SiteName)
+			requirePayloadString(t, ev.Payload, "config_path", tt.params.ConfigPath)
+			requirePayloadString(t, ev.Payload, "domain", tt.params.Domain)
+
+			if ev.Actor.Type != events.ActorTypeSystem {
+				t.Errorf("Actor.Type = %q, want %q", ev.Actor.Type, events.ActorTypeSystem)
+			}
+			if ev.Resource.Type != events.ResourceTypeConfig {
+				t.Errorf("Resource.Type = %q, want %q", ev.Resource.Type, events.ResourceTypeConfig)
+			}
+			if ev.Outcome != events.OutcomeAllowed {
+				t.Errorf("Outcome = %q, want %q", ev.Outcome, events.OutcomeAllowed)
+			}
+			if ev.TriggeredBy != "site_watcher" {
+				t.Errorf("TriggeredBy = %q, want %q", ev.TriggeredBy, "site_watcher")
+			}
+		})
+	}
+}
+
+func TestNewSiteUpdated(t *testing.T) {
+	tests := []struct {
+		name   string
+		params events.SiteUpdatedParams
+	}{
+		{
+			name: "standard update",
+			params: events.SiteUpdatedParams{
+				SiteName:   "my-app",
+				ConfigPath: "/srv/sites/my-app/vibewarden.yaml",
+				Domain:     "my-app.example.com",
+			},
+		},
+		{
+			name: "update without domain",
+			params: events.SiteUpdatedParams{
+				SiteName:   "backend",
+				ConfigPath: "/srv/sites/backend/vibewarden.yaml",
+				Domain:     "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := events.NewSiteUpdated(tt.params)
+
+			assertEvent(t, ev, events.EventTypeSiteUpdated)
+			requireSummaryContains(t, ev.AISummary, tt.params.SiteName)
+			requirePayloadString(t, ev.Payload, "site_name", tt.params.SiteName)
+			requirePayloadString(t, ev.Payload, "config_path", tt.params.ConfigPath)
+			requirePayloadString(t, ev.Payload, "domain", tt.params.Domain)
+
+			if ev.Outcome != events.OutcomeAllowed {
+				t.Errorf("Outcome = %q, want %q", ev.Outcome, events.OutcomeAllowed)
+			}
+			if ev.TriggeredBy != "site_watcher" {
+				t.Errorf("TriggeredBy = %q, want %q", ev.TriggeredBy, "site_watcher")
+			}
+		})
+	}
+}
+
+func TestNewSiteRemoved(t *testing.T) {
+	tests := []struct {
+		name   string
+		params events.SiteRemovedParams
+	}{
+		{
+			name: "standard removal",
+			params: events.SiteRemovedParams{
+				SiteName:   "old-app",
+				ConfigPath: "/srv/sites/old-app/vibewarden.yaml",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := events.NewSiteRemoved(tt.params)
+
+			assertEvent(t, ev, events.EventTypeSiteRemoved)
+			requireSummaryContains(t, ev.AISummary, tt.params.SiteName)
+			requirePayloadString(t, ev.Payload, "site_name", tt.params.SiteName)
+			requirePayloadString(t, ev.Payload, "config_path", tt.params.ConfigPath)
+
+			if ev.Outcome != events.OutcomeAllowed {
+				t.Errorf("Outcome = %q, want %q", ev.Outcome, events.OutcomeAllowed)
+			}
+		})
+	}
+}
+
+func TestNewSiteLoadFailed(t *testing.T) {
+	tests := []struct {
+		name   string
+		params events.SiteLoadFailedParams
+	}{
+		{
+			name: "parse error",
+			params: events.SiteLoadFailedParams{
+				SiteName:   "broken-app",
+				ConfigPath: "/srv/sites/broken-app/vibewarden.yaml",
+				Reason:     "yaml: line 5: mapping values are not allowed here",
+			},
+		},
+		{
+			name: "domain conflict",
+			params: events.SiteLoadFailedParams{
+				SiteName:   "dup-app",
+				ConfigPath: "/srv/sites/dup-app/vibewarden.yaml",
+				Reason:     "duplicate domain \"example.com\"",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := events.NewSiteLoadFailed(tt.params)
+
+			assertEvent(t, ev, events.EventTypeSiteLoadFailed)
+			requireSummaryContains(t, ev.AISummary, tt.params.SiteName)
+			requirePayloadString(t, ev.Payload, "site_name", tt.params.SiteName)
+			requirePayloadString(t, ev.Payload, "config_path", tt.params.ConfigPath)
+			requirePayloadString(t, ev.Payload, "reason", tt.params.Reason)
+
+			if ev.Severity != events.SeverityMedium {
+				t.Errorf("Severity = %q, want %q", ev.Severity, events.SeverityMedium)
+			}
+			if ev.Outcome != events.OutcomeFailed {
+				t.Errorf("Outcome = %q, want %q", ev.Outcome, events.OutcomeFailed)
+			}
+		})
+	}
+}

--- a/internal/ports/site_watcher.go
+++ b/internal/ports/site_watcher.go
@@ -1,0 +1,61 @@
+package ports
+
+import "context"
+
+// SiteEventKind identifies the type of filesystem change detected for a site.
+type SiteEventKind int
+
+const (
+	// SiteEventCreated indicates a new site's vibewarden.yaml was detected.
+	SiteEventCreated SiteEventKind = iota
+
+	// SiteEventModified indicates an existing site's vibewarden.yaml was changed.
+	SiteEventModified
+
+	// SiteEventRemoved indicates a site's vibewarden.yaml was deleted.
+	SiteEventRemoved
+)
+
+// String returns a human-readable name for the event kind.
+func (k SiteEventKind) String() string {
+	switch k {
+	case SiteEventCreated:
+		return "created"
+	case SiteEventModified:
+		return "modified"
+	case SiteEventRemoved:
+		return "removed"
+	default:
+		return "unknown"
+	}
+}
+
+// SiteEvent represents a filesystem change detected for a single site.
+// The SiteName is derived from the directory name under sites/.
+type SiteEvent struct {
+	// Kind identifies the type of change.
+	Kind SiteEventKind
+
+	// SiteName is the directory name (DNS-safe) under the sites/ folder.
+	SiteName string
+
+	// ConfigPath is the absolute path to the site's vibewarden.yaml.
+	ConfigPath string
+}
+
+// SiteWatcher watches the sites/ directory tree for per-site configuration
+// changes. It emits typed SiteEvent values on a channel, one per detected
+// change (after per-site debouncing).
+//
+// Implementations must:
+//   - Watch for Create, Write, Remove, and Rename events on sites/*/vibewarden.yaml.
+//   - Debounce rapid changes on a per-site basis.
+//   - Close the returned channel when ctx is cancelled.
+type SiteWatcher interface {
+	// Watch begins watching the directory at sitesDir for per-site config
+	// changes. The returned channel emits a SiteEvent for each detected
+	// change. The channel is closed when ctx is cancelled or an
+	// unrecoverable error occurs. Watch returns an error only if the
+	// watcher cannot be initialised.
+	Watch(ctx context.Context, sitesDir string) (<-chan SiteEvent, error)
+}


### PR DESCRIPTION
Closes #873

## Summary
- Add `SiteWatcher` port interface with `SiteEvent`/`SiteEventKind` types in `internal/ports/site_watcher.go`
- Add four site domain events (`site.added`, `site.updated`, `site.removed`, `site.load_failed`) in `internal/domain/events/site.go`
- Implement fsnotify `SiteWatcher` adapter in `internal/adapters/fsnotify/site_watcher.go` that watches `sites/*/vibewarden.yaml` with per-site debouncing
- Implement `MultiSiteService` in `internal/app/reload/multisite_service.go` that consumes `SiteEvent` values, maps them to Registry operations, validates domains, calls proxy reload with rollback on failure
- Error isolation: a broken site never disrupts healthy ones
- Existing `ConfigWatcher` left untouched

## Test plan
- [x] Domain event tests: all four constructors verified (schema, payload, severity, outcome)
- [x] SiteWatcher adapter tests: create/modify/remove detection, debounce of rapid writes, context cancellation, non-config file filtering, non-existent directory error
- [x] MultiSiteService tests: created/modified/removed event handling, load failure error isolation, reload failure rollback, domain conflict rollback, unknown site removal, nil event logger safety, context cancellation
- [x] `make check` passes (golangci-lint, build, tests with race detector)

Generated with [Claude Code](https://claude.com/claude-code)