### PR TITLE
feat(#874): wire multi-app CLI + serve entry point per ADR-072

### DIFF
--- a/cmd/vibewarden/serve.go
+++ b/cmd/vibewarden/serve.go
@@ -2,11 +2,17 @@ package main
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
 
 // newServeCmd creates the serve subcommand.
+//
+// When a multi-site directory layout (sites/ subdirectory with at least one
+// child) is detected in the config directory, the command delegates to
+// runServeMultiSite. Otherwise it falls back to the standard single-site
+// runServe path.
 func newServeCmd() *cobra.Command {
 	var configPath string
 
@@ -16,8 +22,25 @@ func newServeCmd() *cobra.Command {
 		Long: `Start the VibeWarden security sidecar reverse proxy.
 
 Reads configuration from vibewarden.yaml (or the path specified with --config).
-Listens for SIGINT/SIGTERM and performs a graceful shutdown.`,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+Listens for SIGINT/SIGTERM and performs a graceful shutdown.
+
+In multi-site mode (detected by the presence of a sites/ directory with at
+least one subdirectory), the sidecar loads global.yaml and per-site
+vibewarden.yaml files, serves each site on its own domain, and watches for
+configuration changes in real time.`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			// Determine the base directory for multi-site detection.
+			// When --config points to a file, its parent directory is used.
+			// When --config is empty, the current working directory is used.
+			baseDir := "."
+			if configPath != "" {
+				baseDir = filepath.Dir(configPath)
+			}
+
+			if isMultiSiteDir(baseDir) {
+				return runServeMultiSite(context.Background(), baseDir, version)
+			}
+
 			return runServe(context.Background(), serveOptions{
 				configPath: configPath,
 				version:    version,

--- a/cmd/vibewarden/wiring_serve_multisite.go
+++ b/cmd/vibewarden/wiring_serve_multisite.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	caddyadapter "github.com/vibewarden/vibewarden/internal/adapters/caddy"
+	fsnotifyadapter "github.com/vibewarden/vibewarden/internal/adapters/fsnotify"
+	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
+	"github.com/vibewarden/vibewarden/internal/app/proxy"
+	reloadsvc "github.com/vibewarden/vibewarden/internal/app/reload"
+	"github.com/vibewarden/vibewarden/internal/config/sites"
+	"github.com/vibewarden/vibewarden/internal/domain/site"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// isMultiSiteDir reports whether the given directory contains a sites/
+// subdirectory with at least one child directory, indicating that the
+// sidecar should start in multi-site mode.
+func isMultiSiteDir(dir string) bool {
+	sitesDir := filepath.Join(dir, "sites")
+	entries, err := os.ReadDir(sitesDir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
+// runServeMultiSite loads global config and per-site configs from the sites/
+// directory, builds a site registry, validates domains, starts the site
+// watcher, and runs the multi-site Caddy proxy until shutdown.
+//
+// The directory layout is expected to be:
+//
+//	<baseDir>/
+//	  global.yaml           (optional, defaults applied if missing)
+//	  sites/
+//	    <site-name>/
+//	      vibewarden.yaml   (per-site config)
+//
+// This function is called from runServe when a multi-site directory layout
+// is detected.
+func runServeMultiSite(ctx context.Context, baseDir string, ver string) error {
+	// Step 1: Load global config.
+	globalPath := filepath.Join(baseDir, "global.yaml")
+	globalCfg, err := sites.LoadGlobal(globalPath)
+	if err != nil {
+		return fmt.Errorf("loading global config: %w", err)
+	}
+
+	logger := buildMultiSiteLogger(globalCfg.LogLevel)
+
+	logger.Info("VibeWarden multi-site mode starting",
+		slog.String("version", ver),
+		slog.String("base_dir", baseDir),
+		slog.String("listen", fmt.Sprintf("%s:%d", globalCfg.ListenHost, globalCfg.ListenPort)),
+	)
+
+	// Step 2: Load all per-site configs.
+	sitesDir := filepath.Join(baseDir, "sites")
+	loadedSites, loadErrs := sites.LoadSites(sitesDir)
+	for _, loadErr := range loadErrs {
+		logger.Warn("site load error", slog.String("error", loadErr.Error()))
+	}
+
+	// Step 3: Populate the registry.
+	registry := site.NewRegistry()
+	registry.SetGlobal(*globalCfg)
+
+	for _, s := range loadedSites {
+		registry.Add(s)
+	}
+
+	logger.Info("sites loaded",
+		slog.Int("total", registry.Len()),
+		slog.Int("healthy", len(registry.HealthySites())),
+		slog.Int("error", len(registry.ErrorSites())),
+	)
+
+	// Step 4: Validate domains.
+	if domErr := registry.ValidateDomains(); domErr != nil {
+		return fmt.Errorf("domain validation failed: %w", domErr)
+	}
+
+	// Step 5: Create the event logger.
+	eventLogger := logadapter.NewSlogEventLogger(os.Stdout)
+
+	// Step 6: Create the multi-site Caddy adapter.
+	// A minimal ProxyConfig is needed for backward-compatible fields (version).
+	minimalProxyCfg := &ports.ProxyConfig{
+		ListenAddr: fmt.Sprintf("%s:%d", globalCfg.ListenHost, globalCfg.ListenPort),
+		Version:    ver,
+	}
+	adapter := caddyadapter.NewMultiSiteAdapter(minimalProxyCfg, registry, logger, eventLogger)
+
+	// Step 7: Set up signal handling.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	go func() {
+		select {
+		case sig := <-sigCh:
+			logger.Info("received shutdown signal", slog.String("signal", sig.String()))
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	// Step 8: Start the site watcher for hot-reload.
+	siteWatcher := fsnotifyadapter.NewSiteWatcher(logger)
+	watchCh, watchErr := siteWatcher.Watch(ctx, sitesDir)
+	if watchErr != nil {
+		logger.Warn("site watcher failed to start",
+			slog.String("path", sitesDir),
+			slog.String("error", watchErr.Error()),
+		)
+	} else {
+		// Step 9: Create the MultiSiteService event loop.
+		reloadFn := func(reloadCtx context.Context) error {
+			return adapter.Reload(reloadCtx)
+		}
+		multiSiteSvc := reloadsvc.NewMultiSiteService(registry, eventLogger, logger, reloadFn)
+		go multiSiteSvc.Run(ctx, watchCh)
+	}
+
+	// Step 10: Run the proxy until shutdown.
+	svc := proxy.NewService(adapter, logger)
+	if err := svc.Run(ctx); err != nil {
+		return fmt.Errorf("proxy service: %w", err)
+	}
+
+	return nil
+}
+
+// buildMultiSiteLogger creates an slog.Logger from the global log level string.
+func buildMultiSiteLogger(level string) *slog.Logger {
+	var slogLevel slog.Level
+	switch level {
+	case "debug":
+		slogLevel = slog.LevelDebug
+	case "warn":
+		slogLevel = slog.LevelWarn
+	case "error":
+		slogLevel = slog.LevelError
+	default:
+		slogLevel = slog.LevelInfo
+	}
+	opts := &slog.HandlerOptions{Level: slogLevel}
+	return slog.New(slog.NewJSONHandler(os.Stderr, opts))
+}

--- a/cmd/vibewarden/wiring_serve_multisite_test.go
+++ b/cmd/vibewarden/wiring_serve_multisite_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsMultiSiteDir_WithSites(t *testing.T) {
+	dir := t.TempDir()
+	sitesDir := filepath.Join(dir, "sites")
+	if err := os.Mkdir(sitesDir, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	// Create a child directory.
+	if err := os.Mkdir(filepath.Join(sitesDir, "blog"), 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	if !isMultiSiteDir(dir) {
+		t.Error("isMultiSiteDir() = false, want true when sites/ has a subdirectory")
+	}
+}
+
+func TestIsMultiSiteDir_EmptySites(t *testing.T) {
+	dir := t.TempDir()
+	sitesDir := filepath.Join(dir, "sites")
+	if err := os.Mkdir(sitesDir, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	if isMultiSiteDir(dir) {
+		t.Error("isMultiSiteDir() = true, want false when sites/ is empty")
+	}
+}
+
+func TestIsMultiSiteDir_NoSitesDir(t *testing.T) {
+	dir := t.TempDir()
+
+	if isMultiSiteDir(dir) {
+		t.Error("isMultiSiteDir() = true, want false when no sites/ directory exists")
+	}
+}
+
+func TestIsMultiSiteDir_SitesIsFile(t *testing.T) {
+	dir := t.TempDir()
+	// Create sites as a file, not a directory.
+	if err := os.WriteFile(filepath.Join(dir, "sites"), []byte("not a dir"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if isMultiSiteDir(dir) {
+		t.Error("isMultiSiteDir() = true, want false when sites is a file")
+	}
+}
+
+func TestIsMultiSiteDir_SitesWithOnlyFiles(t *testing.T) {
+	dir := t.TempDir()
+	sitesDir := filepath.Join(dir, "sites")
+	if err := os.Mkdir(sitesDir, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	// Create a file (not a directory) inside sites/.
+	if err := os.WriteFile(filepath.Join(sitesDir, "readme.txt"), []byte("info"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if isMultiSiteDir(dir) {
+		t.Error("isMultiSiteDir() = true, want false when sites/ contains only files")
+	}
+}
+
+func TestRunServeMultiSite_MissingGlobalConfig(t *testing.T) {
+	// runServeMultiSite should work even when global.yaml is missing
+	// (LoadGlobal returns defaults). However, it will fail at Caddy
+	// start because there are no sites. We verify that it at least
+	// gets past the global config loading step.
+	dir := t.TempDir()
+	sitesDir := filepath.Join(dir, "sites")
+	if err := os.Mkdir(sitesDir, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	// Create a site so we get past the "no healthy sites" error.
+	siteDir := filepath.Join(sitesDir, "testapp")
+	if err := os.Mkdir(siteDir, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	siteConfig := `
+server:
+  host: 127.0.0.1
+  port: 8443
+upstream:
+  host: 127.0.0.1
+  port: 3000
+tls:
+  domain: testapp.example.com
+`
+	if err := os.WriteFile(filepath.Join(siteDir, "vibewarden.yaml"), []byte(siteConfig), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// We cannot fully run the proxy (it needs a real Caddy instance), but we
+	// can verify that the function proceeds past config loading by checking
+	// that it does not return a "loading global config" error.
+	// The function will error at Caddy start which is expected in a test.
+	// Use a cancelled context to avoid blocking.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := runServeMultiSite(ctx, dir, "test")
+	// We expect an error from the proxy (context cancelled), not from config loading.
+	if err != nil && strings.Contains(err.Error(), "loading global config") {
+		t.Errorf("unexpected global config error: %v", err)
+	}
+}
+
+func TestRunServeMultiSite_DomainConflict(t *testing.T) {
+	dir := t.TempDir()
+	sitesDir := filepath.Join(dir, "sites")
+	if err := os.Mkdir(sitesDir, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	sameConfig := `
+server:
+  host: 127.0.0.1
+  port: 8443
+upstream:
+  host: 127.0.0.1
+  port: 3000
+tls:
+  domain: same.example.com
+`
+	for _, name := range []string{"app1", "app2"} {
+		siteDir := filepath.Join(sitesDir, name)
+		if err := os.Mkdir(siteDir, 0o755); err != nil {
+			t.Fatalf("Mkdir(%s): %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(siteDir, "vibewarden.yaml"), []byte(sameConfig), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", name, err)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := runServeMultiSite(ctx, dir, "test")
+	if err == nil {
+		t.Fatal("expected error for duplicate domain")
+	}
+	if !strings.Contains(err.Error(), "domain validation failed") {
+		t.Errorf("expected domain validation error, got: %v", err)
+	}
+}
+
+func TestBuildMultiSiteLogger(t *testing.T) {
+	tests := []struct {
+		name  string
+		level string
+	}{
+		{"debug", "debug"},
+		{"info", "info"},
+		{"warn", "warn"},
+		{"error", "error"},
+		{"default", ""},
+		{"unknown", "invalid"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := buildMultiSiteLogger(tt.level)
+			if logger == nil {
+				t.Error("buildMultiSiteLogger returned nil")
+			}
+		})
+	}
+}

--- a/internal/app/deploy/detect.go
+++ b/internal/app/deploy/detect.go
@@ -67,3 +67,23 @@ func Detect(ctx context.Context, executor ports.RemoteExecutor) (Mode, error) {
 
 	return 0, fmt.Errorf("detecting deploy mode via SSH: %w", err)
 }
+
+// IsMultiApp checks whether the remote host has a multi-app sidecar layout
+// by testing for the existence of the sites/ directory under ~/vibewarden/.
+// Returns true when at least one site subdirectory exists, false otherwise.
+//
+// Any SSH error that is not a "directory not found" condition is propagated
+// to the caller.
+func IsMultiApp(ctx context.Context, executor ports.RemoteExecutor) (bool, error) {
+	cmd := fmt.Sprintf("test -d %s", sitesDir)
+	_, err := executor.Run(ctx, cmd)
+	if err == nil {
+		return true, nil
+	}
+
+	if strings.Contains(err.Error(), "exit status 1") {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("checking multi-app layout via SSH: %w", err)
+}

--- a/internal/app/deploy/detect_test.go
+++ b/internal/app/deploy/detect_test.go
@@ -69,6 +69,58 @@ func TestDetect(t *testing.T) {
 	}
 }
 
+func TestIsMultiApp(t *testing.T) {
+	tests := []struct {
+		name     string
+		executor *fakeExecutor
+		want     bool
+		wantErr  bool
+	}{
+		{
+			name: "sites dir exists returns true",
+			executor: &fakeExecutor{
+				runResponses: map[string]runResponse{
+					"test -d ~/vibewarden/sites/": {output: "", err: nil},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "sites dir missing returns false",
+			executor: &fakeExecutor{
+				runResponses: map[string]runResponse{
+					"test -d ~/vibewarden/sites/": {err: errors.New("exit status 1")},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "SSH error is propagated",
+			executor: &fakeExecutor{
+				runResponses: map[string]runResponse{
+					"test -d ~/vibewarden/sites/": {err: errors.New("ssh: connection refused")},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := deployapp.IsMultiApp(context.Background(), tt.executor)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("IsMultiApp() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("IsMultiApp() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMode_String(t *testing.T) {
 	tests := []struct {
 		mode deployapp.Mode

--- a/internal/app/deploy/service.go
+++ b/internal/app/deploy/service.go
@@ -290,6 +290,102 @@ func (s *Service) Logs(ctx context.Context, opts LogsOptions) error {
 	return nil
 }
 
+// ListSites returns the names of all site subdirectories under
+// ~/vibewarden/sites/ on the remote host. An empty slice is returned
+// when no sites exist or the directory is missing.
+func (s *Service) ListSites(ctx context.Context) ([]string, error) {
+	output, err := s.executor.Run(ctx, "ls -1 "+sitesDir+" 2>/dev/null || true")
+	if err != nil {
+		return nil, fmt.Errorf("listing remote sites: %w", err)
+	}
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil, nil
+	}
+	return strings.Split(output, "\n"), nil
+}
+
+// StatusMultiApp fetches Docker Compose service state for multi-app deployments.
+// When app is non-empty, it targets that specific site. When app is empty, it
+// shows the sidecar status plus all site statuses.
+func (s *Service) StatusMultiApp(ctx context.Context, app string, out io.Writer) error {
+	if out == nil {
+		out = io.Discard
+	}
+
+	if app != "" {
+		siteDir := sitesDir + app + "/"
+		output, err := s.executor.Run(ctx, "docker compose --project-directory "+siteDir+" ps")
+		if err != nil {
+			return fmt.Errorf("fetching status for site %q: %w", app, err)
+		}
+		fmt.Fprintf(out, "=== Site: %s ===\n", app)
+		fmt.Fprintln(out, output)
+		return nil
+	}
+
+	// Show sidecar status.
+	sidecarOutput, err := s.executor.Run(ctx, "docker compose --project-directory "+sidecarDir+" ps")
+	if err != nil {
+		return fmt.Errorf("fetching sidecar status: %w", err)
+	}
+	fmt.Fprintln(out, "=== Sidecar ===")
+	fmt.Fprintln(out, sidecarOutput)
+
+	// Enumerate and show each site.
+	sites, err := s.ListSites(ctx)
+	if err != nil {
+		return err
+	}
+	for _, name := range sites {
+		siteDir := sitesDir + name + "/"
+		output, siteErr := s.executor.Run(ctx, "docker compose --project-directory "+siteDir+" ps")
+		fmt.Fprintf(out, "=== Site: %s ===\n", name)
+		if siteErr != nil {
+			fmt.Fprintf(out, "  error: %v\n", siteErr)
+			continue
+		}
+		fmt.Fprintln(out, output)
+	}
+	return nil
+}
+
+// LogsMultiApp fetches Docker Compose logs for multi-app deployments.
+// When app is non-empty, it targets that specific site. When app is empty, it
+// shows logs from the sidecar container.
+func (s *Service) LogsMultiApp(ctx context.Context, app string, opts LogsOptions) error {
+	out := opts.Out
+	if out == nil {
+		out = io.Discard
+	}
+
+	var dir string
+	if app != "" {
+		dir = sitesDir + app + "/"
+	} else {
+		dir = sidecarDir
+	}
+
+	cmd := "docker compose --project-directory " + dir + " logs"
+	if opts.Lines > 0 {
+		cmd += fmt.Sprintf(" --tail=%d", opts.Lines)
+	}
+	if opts.Follow {
+		cmd += " -f"
+		if err := s.executor.RunStream(ctx, cmd, out, out); err != nil {
+			return fmt.Errorf("streaming remote logs: %w", err)
+		}
+		return nil
+	}
+
+	output, err := s.executor.Run(ctx, cmd)
+	if err != nil {
+		return fmt.Errorf("fetching remote logs: %w", err)
+	}
+	fmt.Fprintln(out, output)
+	return nil
+}
+
 // checkRemotePrerequisites verifies that docker and docker compose are available
 // on the remote host.
 func (s *Service) checkRemotePrerequisites(ctx context.Context) error {

--- a/internal/app/deploy/service_test.go
+++ b/internal/app/deploy/service_test.go
@@ -975,6 +975,218 @@ func TestProjectNameFromConfig_RelativeDoesNotReturnDot(t *testing.T) {
 	}
 }
 
+func TestService_ListSites(t *testing.T) {
+	tests := []struct {
+		name     string
+		executor *fakeExecutor
+		want     []string
+		wantErr  bool
+	}{
+		{
+			name: "lists multiple sites",
+			executor: &fakeExecutor{
+				runResponses: map[string]runResponse{
+					"ls -1 ~/vibewarden/sites/ 2>/dev/null || true": {output: "blog\napi\nshop"},
+				},
+			},
+			want: []string{"blog", "api", "shop"},
+		},
+		{
+			name: "empty directory returns nil",
+			executor: &fakeExecutor{
+				runResponses: map[string]runResponse{
+					"ls -1 ~/vibewarden/sites/ 2>/dev/null || true": {output: ""},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "missing directory returns nil via || true",
+			executor: &fakeExecutor{
+				runResponses: map[string]runResponse{
+					"ls -1 ~/vibewarden/sites/ 2>/dev/null || true": {output: ""},
+				},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := deployapp.NewService(tt.executor, nil)
+			got, err := svc.ListSites(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ListSites() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("ListSites() returned %d sites, want %d", len(got), len(tt.want))
+			}
+			for i, name := range got {
+				if name != tt.want[i] {
+					t.Errorf("ListSites()[%d] = %q, want %q", i, name, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestService_StatusMultiApp_SpecificApp(t *testing.T) {
+	executor := &fakeExecutor{
+		runResponses: map[string]runResponse{
+			"docker compose --project-directory ~/vibewarden/sites/blog/ ps": {output: "blog container running"},
+		},
+	}
+
+	svc := deployapp.NewService(executor, nil)
+
+	var buf bytes.Buffer
+	err := svc.StatusMultiApp(context.Background(), "blog", &buf)
+	if err != nil {
+		t.Fatalf("StatusMultiApp() unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "=== Site: blog ===") {
+		t.Errorf("expected site header in output, got:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "blog container running") {
+		t.Errorf("expected site status in output, got:\n%s", buf.String())
+	}
+}
+
+func TestService_StatusMultiApp_AllSites(t *testing.T) {
+	executor := &fakeExecutor{
+		runResponses: map[string]runResponse{
+			"docker compose --project-directory ~/vibewarden/.sidecar/ ps":   {output: "sidecar running"},
+			"ls -1 ~/vibewarden/sites/ 2>/dev/null || true":                  {output: "app1\napp2"},
+			"docker compose --project-directory ~/vibewarden/sites/app1/ ps": {output: "app1 running"},
+			"docker compose --project-directory ~/vibewarden/sites/app2/ ps": {output: "app2 running"},
+		},
+	}
+
+	svc := deployapp.NewService(executor, nil)
+
+	var buf bytes.Buffer
+	err := svc.StatusMultiApp(context.Background(), "", &buf)
+	if err != nil {
+		t.Fatalf("StatusMultiApp() unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "=== Sidecar ===") {
+		t.Errorf("expected sidecar header in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "=== Site: app1 ===") {
+		t.Errorf("expected app1 header in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "=== Site: app2 ===") {
+		t.Errorf("expected app2 header in output, got:\n%s", out)
+	}
+}
+
+func TestService_StatusMultiApp_Error(t *testing.T) {
+	executor := &fakeExecutor{
+		runResponses: map[string]runResponse{
+			"docker compose --project-directory ~/vibewarden/sites/bad/ ps": {err: errors.New("not found")},
+		},
+	}
+
+	svc := deployapp.NewService(executor, nil)
+
+	err := svc.StatusMultiApp(context.Background(), "bad", io.Discard)
+	if err == nil {
+		t.Fatal("expected error when fetching status for a bad site")
+	}
+	if !strings.Contains(err.Error(), "fetching status for site") {
+		t.Errorf("error should mention site, got: %v", err)
+	}
+}
+
+func TestService_LogsMultiApp_SpecificApp(t *testing.T) {
+	executor := &fakeExecutor{
+		runResponses: map[string]runResponse{
+			"docker compose --project-directory ~/vibewarden/sites/blog/ logs --tail=20": {output: "blog log line"},
+		},
+	}
+
+	svc := deployapp.NewService(executor, nil)
+
+	var buf bytes.Buffer
+	err := svc.LogsMultiApp(context.Background(), "blog", deployapp.LogsOptions{
+		Lines: 20,
+		Out:   &buf,
+	})
+	if err != nil {
+		t.Fatalf("LogsMultiApp() unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "blog log line") {
+		t.Errorf("expected blog logs in output, got:\n%s", buf.String())
+	}
+}
+
+func TestService_LogsMultiApp_Sidecar(t *testing.T) {
+	executor := &fakeExecutor{
+		runResponses: map[string]runResponse{
+			"docker compose --project-directory ~/vibewarden/.sidecar/ logs --tail=50": {output: "sidecar log"},
+		},
+	}
+
+	svc := deployapp.NewService(executor, nil)
+
+	var buf bytes.Buffer
+	err := svc.LogsMultiApp(context.Background(), "", deployapp.LogsOptions{
+		Lines: 50,
+		Out:   &buf,
+	})
+	if err != nil {
+		t.Fatalf("LogsMultiApp() unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "sidecar log") {
+		t.Errorf("expected sidecar logs in output, got:\n%s", buf.String())
+	}
+}
+
+func TestService_LogsMultiApp_Follow(t *testing.T) {
+	executor := &fakeExecutor{
+		runResponses: map[string]runResponse{
+			"docker compose --project-directory ~/vibewarden/sites/api/ logs --tail=10 -f": {output: "streaming"},
+		},
+	}
+
+	svc := deployapp.NewService(executor, nil)
+
+	var buf bytes.Buffer
+	err := svc.LogsMultiApp(context.Background(), "api", deployapp.LogsOptions{
+		Lines:  10,
+		Follow: true,
+		Out:    &buf,
+	})
+	if err != nil {
+		t.Fatalf("LogsMultiApp() unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "streaming") {
+		t.Errorf("expected streaming output, got:\n%s", buf.String())
+	}
+}
+
+func TestService_LogsMultiApp_Error(t *testing.T) {
+	executor := &fakeExecutor{
+		runResponses: map[string]runResponse{
+			"docker compose --project-directory ~/vibewarden/sites/bad/ logs --tail=50": {err: errors.New("not found")},
+		},
+	}
+
+	svc := deployapp.NewService(executor, nil)
+
+	err := svc.LogsMultiApp(context.Background(), "bad", deployapp.LogsOptions{
+		Lines: 50,
+	})
+	if err == nil {
+		t.Fatal("expected error when fetching logs for a bad site")
+	}
+	if !strings.Contains(err.Error(), "fetching remote logs") {
+		t.Errorf("error should mention 'fetching remote logs', got: %v", err)
+	}
+}
+
 // Ensure fmt is used (used in assertRunCalledContains via Errorf).
 var _ = fmt.Sprintf
 

--- a/internal/cli/cmd/deploy.go
+++ b/internal/cli/cmd/deploy.go
@@ -137,7 +137,33 @@ Examples:
 				}
 			}
 
-			return svc.Deploy(cmd.Context(), cfg, opts)
+			// Detect deploy mode: fresh install or add-site.
+			hasDomain := cfg.TLS.Domain != ""
+
+			mode, err := deployapp.Detect(cmd.Context(), executor)
+			if err != nil {
+				return fmt.Errorf("detecting deploy mode: %w", err)
+			}
+
+			switch mode {
+			case deployapp.ModeFreshInstall:
+				if hasDomain {
+					// Multi-app bootstrap: create sidecar + first site.
+					return svc.BootstrapSidecar(cmd.Context(), cfg, opts)
+				}
+				// Legacy single-app deploy (backward compatible).
+				return svc.Deploy(cmd.Context(), cfg, opts)
+
+			case deployapp.ModeAddSite:
+				if hasDomain {
+					// Add a new site to existing sidecar.
+					return svc.DeployMultiApp(cmd.Context(), cfg, opts)
+				}
+				return fmt.Errorf("cannot add a site without a TLS domain; set tls.domain in %s", absConfig)
+
+			default:
+				return fmt.Errorf("unexpected deploy mode: %v", mode)
+			}
 		},
 	}
 
@@ -175,6 +201,7 @@ func newDeployStatusCmd() *cobra.Command {
 		configPath string
 		target     string
 		sshKey     string
+		app        string
 	)
 
 	cmd := &cobra.Command{
@@ -186,9 +213,13 @@ The --config flag is used to derive the project name, which determines the
 remote directory (~/vibewarden/<project-name>/). It must match the value used
 when the project was deployed. When omitted the current directory name is used.
 
+In multi-app mode, use --app to target a specific site. Without --app, all
+sites and the sidecar status are shown.
+
 Examples:
   vibew deploy status --target ssh://ubuntu@203.0.113.10
-  vibew deploy status --config vibewarden.prod.yaml --target ssh://ubuntu@203.0.113.10`,
+  vibew deploy status --config vibewarden.prod.yaml --target ssh://ubuntu@203.0.113.10
+  vibew deploy status --target ssh://ubuntu@203.0.113.10 --app blog`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if target == "" {
 				return fmt.Errorf("--target is required (e.g. ssh://user@host)")
@@ -207,6 +238,16 @@ Examples:
 			}
 			svc := deployapp.NewService(executor, nil)
 
+			// Check if remote is multi-app.
+			isMulti, err := deployapp.IsMultiApp(cmd.Context(), executor)
+			if err != nil {
+				return fmt.Errorf("detecting multi-app mode: %w", err)
+			}
+
+			if isMulti || app != "" {
+				return svc.StatusMultiApp(cmd.Context(), app, cmd.OutOrStdout())
+			}
+
 			absConfig, err := filepath.Abs(configPath)
 			if err != nil {
 				absConfig = configPath
@@ -222,6 +263,7 @@ Examples:
 	cmd.Flags().StringVar(&configPath, "config", "", "path to vibewarden.yaml — used to derive the remote project directory (default: ./vibewarden.yaml)")
 	cmd.Flags().StringVar(&target, "target", "", "remote target in ssh://user@host[:port] format (required)")
 	cmd.Flags().StringVar(&sshKey, "ssh-key", "", "path to the SSH private key file (default: use SSH agent / ~/.ssh/config)")
+	cmd.Flags().StringVar(&app, "app", "", "target a specific site in multi-app mode (e.g. --app blog)")
 
 	if err := cmd.MarkFlagRequired("target"); err != nil {
 		fmt.Fprintln(os.Stderr, "warning: flag required registration failed:", err)
@@ -243,6 +285,7 @@ func newDeployLogsCmd() *cobra.Command {
 		sshKey     string
 		lines      int
 		follow     bool
+		app        string
 	)
 
 	cmd := &cobra.Command{
@@ -254,11 +297,15 @@ The --config flag is used to derive the project name, which determines the
 remote directory (~/vibewarden/<project-name>/). It must match the value used
 when the project was deployed. When omitted the current directory name is used.
 
+In multi-app mode, use --app to target a specific site's logs. Without --app,
+the sidecar logs are shown.
+
 Examples:
   vibew deploy logs --target ssh://ubuntu@203.0.113.10
   vibew deploy logs --config vibewarden.prod.yaml --target ssh://ubuntu@203.0.113.10
   vibew deploy logs --target ssh://ubuntu@203.0.113.10 --lines 100
-  vibew deploy logs --target ssh://ubuntu@203.0.113.10 --follow`,
+  vibew deploy logs --target ssh://ubuntu@203.0.113.10 --follow
+  vibew deploy logs --target ssh://ubuntu@203.0.113.10 --app blog --follow`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if target == "" {
 				return fmt.Errorf("--target is required (e.g. ssh://user@host)")
@@ -276,6 +323,20 @@ Examples:
 				executor = sshadapter.NewExecutor(t)
 			}
 			svc := deployapp.NewService(executor, nil)
+
+			// Check if remote is multi-app.
+			isMulti, err := deployapp.IsMultiApp(cmd.Context(), executor)
+			if err != nil {
+				return fmt.Errorf("detecting multi-app mode: %w", err)
+			}
+
+			if isMulti || app != "" {
+				return svc.LogsMultiApp(cmd.Context(), app, deployapp.LogsOptions{
+					Lines:  lines,
+					Follow: follow,
+					Out:    cmd.OutOrStdout(),
+				})
+			}
 
 			absConfig, err := filepath.Abs(configPath)
 			if err != nil {
@@ -296,6 +357,7 @@ Examples:
 	cmd.Flags().StringVar(&sshKey, "ssh-key", "", "path to the SSH private key file (default: use SSH agent / ~/.ssh/config)")
 	cmd.Flags().IntVar(&lines, "lines", 50, "number of log lines to fetch (0 = all)")
 	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "stream log output continuously until cancelled (Ctrl-C)")
+	cmd.Flags().StringVar(&app, "app", "", "target a specific site in multi-app mode (e.g. --app blog)")
 
 	if err := cmd.MarkFlagRequired("target"); err != nil {
 		fmt.Fprintln(os.Stderr, "warning: flag required registration failed:", err)


### PR DESCRIPTION
Closes #874

## Summary

- **Deploy RunE branching**: `vibew deploy` now calls `Detect()` and branches on a decision matrix. `FreshInstall + domain` calls `BootstrapSidecar`, `FreshInstall + no domain` falls back to legacy `Deploy` (backward compatible), `AddSite + domain` calls `DeployMultiApp`, `AddSite + no domain` returns an error requiring `tls.domain`.

- **`--app` flag on `deploy status` and `deploy logs`**: Adds `IsMultiApp()` helper that checks for `~/vibewarden/sites/` on the remote. When multi-app mode is detected (or `--app` is specified), delegates to `StatusMultiApp` / `LogsMultiApp` which target either a specific site or enumerate all sites plus the sidecar.

- **`vibew serve` multi-site path**: New `runServeMultiSite` in `cmd/vibewarden/wiring_serve_multisite.go`. Detection: `isMultiSiteDir()` checks for `sites/` with subdirectories. Startup sequence: `LoadGlobal` -> `LoadSites` -> Registry -> `ValidateDomains` -> multi-site Caddy adapter -> `SiteWatcher` -> `MultiSiteService` event loop -> block on `proxy.Run`.

## Files changed

**New files:**
- `cmd/vibewarden/wiring_serve_multisite.go` — `runServeMultiSite` + `isMultiSiteDir` + `buildMultiSiteLogger`
- `cmd/vibewarden/wiring_serve_multisite_test.go` — 8 tests for detection and startup

**Modified files:**
- `internal/app/deploy/detect.go` — added `IsMultiApp` helper
- `internal/app/deploy/detect_test.go` — 3 new table-driven tests for `IsMultiApp`
- `internal/app/deploy/service.go` — added `ListSites`, `StatusMultiApp`, `LogsMultiApp`
- `internal/app/deploy/service_test.go` — 10 new tests for multi-app service methods
- `internal/cli/cmd/deploy.go` — deploy RunE branching + `--app` flag on status/logs
- `cmd/vibewarden/serve.go` — multi-site detection delegating to `runServeMultiSite`

## Test plan

- [ ] `make check` passes (lint, build, tests)
- [ ] `go test ./internal/app/deploy/... -v` — all 40+ tests pass including new IsMultiApp, ListSites, StatusMultiApp, LogsMultiApp tests
- [ ] `go test ./cmd/vibewarden/... -v` — all isMultiSiteDir edge cases + runServeMultiSite startup + domain conflict detection
- [ ] Verify backward compatibility: single-app deploy without `tls.domain` still uses legacy path
- [ ] Verify error message when AddSite mode without domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)