### PR TITLE
fix(#883): register Caddy handler modules for Kratos auth mode

### DIFF
--- a/internal/adapters/caddy/auth_handler.go
+++ b/internal/adapters/caddy/auth_handler.go
@@ -1,0 +1,239 @@
+package caddy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	gocaddy "github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+func init() {
+	gocaddy.RegisterModule(AuthHandler{})
+}
+
+// AuthHandlerConfig is the JSON-serialisable configuration for the
+// AuthHandler Caddy module.
+type AuthHandlerConfig struct {
+	// CookieName is the name of the Kratos session cookie.
+	CookieName string `json:"cookie_name"`
+
+	// LoginURL is the URL to redirect unauthenticated users to.
+	LoginURL string `json:"login_url"`
+
+	// PublicPaths is a list of path patterns that bypass authentication.
+	PublicPaths []string `json:"public_paths"`
+
+	// KratosURL is the base URL of the Kratos public API (e.g. "http://kratos:4433").
+	KratosURL string `json:"kratos_url"`
+}
+
+// AuthHandler is a Caddy HTTP handler module that validates Kratos session
+// cookies and enforces authentication. Unauthenticated requests are redirected
+// to the configured login URL. Authenticated requests have identity headers
+// (X-User-Id, X-User-Email, X-User-Verified) injected for the upstream app.
+//
+// The module is registered under the name "vibewarden_authentication" and referenced from
+// the Caddy JSON configuration as:
+//
+//	{"handler": "vibewarden_authentication", "cookie_name": "...", "login_url": "...", "public_paths": [...], "kratos_url": "..."}
+type AuthHandler struct {
+	Config AuthHandlerConfig `json:"config"`
+	logger *slog.Logger
+	client *http.Client
+}
+
+// CaddyModule returns the Caddy module information.
+func (AuthHandler) CaddyModule() gocaddy.ModuleInfo {
+	return gocaddy.ModuleInfo{
+		ID:  "http.handlers.vibewarden_authentication",
+		New: func() gocaddy.Module { return new(AuthHandler) },
+	}
+}
+
+// Provision sets up the handler.
+func (h *AuthHandler) Provision(_ gocaddy.Context) error {
+	h.logger = slog.Default()
+	h.client = &http.Client{Timeout: 5 * time.Second}
+	return nil
+}
+
+// UnmarshalJSON implements custom unmarshalling to support both nested
+// {"config": {...}} and flat {"cookie_name": "...", ...} JSON layouts.
+func (h *AuthHandler) UnmarshalJSON(data []byte) error {
+	// Try nested config first.
+	var nested struct {
+		Config AuthHandlerConfig `json:"config"`
+	}
+	if err := json.Unmarshal(data, &nested); err == nil && nested.Config.CookieName != "" {
+		h.Config = nested.Config
+		return nil
+	}
+	// Try flat structure.
+	return json.Unmarshal(data, &h.Config)
+}
+
+// isPublicPath checks if the request path matches any public path pattern.
+func (h *AuthHandler) isPublicPath(reqPath string) bool {
+	for _, p := range h.Config.PublicPaths {
+		if strings.HasSuffix(p, "/*") {
+			prefix := strings.TrimSuffix(p, "/*")
+			if strings.HasPrefix(reqPath, prefix) {
+				return true
+			}
+		}
+		matched, _ := path.Match(p, reqPath)
+		if matched {
+			return true
+		}
+		if p == reqPath {
+			return true
+		}
+	}
+	return false
+}
+
+// kratosWhoamiResponse mirrors the relevant fields from the Kratos
+// GET /sessions/whoami JSON response.
+type kratosWhoamiResponse struct {
+	Active   bool `json:"active"`
+	Identity struct {
+		ID                  string                 `json:"id"`
+		Traits              map[string]any         `json:"traits"`
+		VerifiableAddresses []kratosVerifiableAddr `json:"verifiable_addresses"`
+	} `json:"identity"`
+}
+
+// kratosVerifiableAddr mirrors one entry in verifiable_addresses.
+type kratosVerifiableAddr struct {
+	Value    string `json:"value"`
+	Via      string `json:"via"`
+	Verified bool   `json:"verified"`
+}
+
+// callWhoami sends a GET request to the Kratos whoami endpoint with the
+// session cookie and returns the parsed response. It returns an error if
+// the request fails or Kratos responds with non-200.
+func (h *AuthHandler) callWhoami(ctx context.Context, cookieValue string) (*kratosWhoamiResponse, error) {
+	url := h.Config.KratosURL + "/sessions/whoami"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building whoami request: %w", err)
+	}
+	req.Header.Set("Cookie", h.Config.CookieName+"="+cookieValue)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("kratos whoami request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("session invalid (401)")
+	}
+	if resp.StatusCode >= 500 {
+		return nil, fmt.Errorf("kratos server error (%d)", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected kratos status (%d)", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading whoami response: %w", err)
+	}
+
+	var whoami kratosWhoamiResponse
+	if err := json.Unmarshal(body, &whoami); err != nil {
+		return nil, fmt.Errorf("parsing whoami response: %w", err)
+	}
+
+	if !whoami.Active {
+		return nil, fmt.Errorf("session not active")
+	}
+
+	return &whoami, nil
+}
+
+// extractEmail extracts the primary email from the Kratos whoami response,
+// checking verifiable_addresses first, then falling back to traits["email"].
+func extractEmail(whoami *kratosWhoamiResponse) string {
+	for _, addr := range whoami.Identity.VerifiableAddresses {
+		if addr.Via == "email" {
+			return addr.Value
+		}
+	}
+	if email, ok := whoami.Identity.Traits["email"].(string); ok {
+		return email
+	}
+	return ""
+}
+
+// extractVerified extracts the email verification status from the Kratos
+// whoami response.
+func extractVerified(whoami *kratosWhoamiResponse) bool {
+	for _, addr := range whoami.Identity.VerifiableAddresses {
+		if addr.Via == "email" {
+			return addr.Verified
+		}
+	}
+	return false
+}
+
+// ServeHTTP implements caddyhttp.MiddlewareHandler.
+func (h *AuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+	// Skip public paths.
+	if h.isPublicPath(r.URL.Path) {
+		return next.ServeHTTP(w, r)
+	}
+
+	// Check for session cookie.
+	cookie, err := r.Cookie(h.Config.CookieName)
+	if err != nil {
+		// No cookie — redirect to login.
+		http.Redirect(w, r, h.Config.LoginURL, http.StatusFound)
+		return nil
+	}
+
+	// Validate session via Kratos whoami.
+	whoami, err := h.callWhoami(r.Context(), cookie.Value)
+	if err != nil {
+		h.logger.Error("authentication: kratos whoami failed",
+			slog.String("error", err.Error()),
+			slog.String("path", r.URL.Path),
+		)
+		http.Redirect(w, r, h.Config.LoginURL, http.StatusFound)
+		return nil
+	}
+
+	// Set identity headers for the upstream app.
+	if whoami.Identity.ID != "" {
+		r.Header.Set("X-User-Id", whoami.Identity.ID)
+	}
+	if email := extractEmail(whoami); email != "" {
+		r.Header.Set("X-User-Email", email)
+	}
+	if extractVerified(whoami) {
+		r.Header.Set("X-User-Verified", "true")
+	} else {
+		r.Header.Set("X-User-Verified", "false")
+	}
+
+	return next.ServeHTTP(w, r)
+}
+
+// Interface guards.
+var (
+	_ caddyhttp.MiddlewareHandler = (*AuthHandler)(nil)
+	_ gocaddy.Module              = (*AuthHandler)(nil)
+	_ gocaddy.Provisioner         = (*AuthHandler)(nil)
+)

--- a/internal/adapters/caddy/auth_handler_test.go
+++ b/internal/adapters/caddy/auth_handler_test.go
@@ -1,0 +1,586 @@
+package caddy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gocaddy "github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+// TestAuthHandler_CaddyModule verifies the Caddy module metadata.
+func TestAuthHandler_CaddyModule(t *testing.T) {
+	info := AuthHandler{}.CaddyModule()
+
+	if info.ID != "http.handlers.vibewarden_authentication" {
+		t.Errorf("CaddyModule().ID = %q, want %q", info.ID, "http.handlers.vibewarden_authentication")
+	}
+	if info.New == nil {
+		t.Fatal("CaddyModule().New is nil")
+	}
+
+	mod := info.New()
+	if mod == nil {
+		t.Fatal("CaddyModule().New() returned nil")
+	}
+	if _, ok := mod.(*AuthHandler); !ok {
+		t.Errorf("CaddyModule().New() returned %T, want *AuthHandler", mod)
+	}
+}
+
+// TestAuthHandler_InterfaceGuards verifies the handler satisfies required Caddy interfaces.
+func TestAuthHandler_InterfaceGuards(t *testing.T) {
+	var _ gocaddy.Provisioner = (*AuthHandler)(nil)
+	var _ caddyhttp.MiddlewareHandler = (*AuthHandler)(nil)
+	var _ gocaddy.Module = (*AuthHandler)(nil)
+}
+
+// TestAuthHandler_Provision verifies that Provision initialises the handler.
+func TestAuthHandler_Provision(t *testing.T) {
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName: "ory_kratos_session",
+		LoginURL:   "/login",
+		KratosURL:  "http://kratos:4433",
+	}}
+
+	err := h.Provision(gocaddy.Context{})
+	if err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	if h.logger == nil {
+		t.Error("Provision() did not set logger")
+	}
+	if h.client == nil {
+		t.Error("Provision() did not set HTTP client")
+	}
+}
+
+// TestAuthHandler_UnmarshalJSON verifies both flat and nested JSON unmarshalling.
+func TestAuthHandler_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		wantCookieName string
+		wantLoginURL   string
+		wantKratosURL  string
+		wantErr        bool
+	}{
+		{
+			name:           "flat structure",
+			input:          `{"cookie_name":"sess","login_url":"/login","kratos_url":"http://k:4433","public_paths":["/pub"]}`,
+			wantCookieName: "sess",
+			wantLoginURL:   "/login",
+			wantKratosURL:  "http://k:4433",
+		},
+		{
+			name:           "nested config",
+			input:          `{"config":{"cookie_name":"sess","login_url":"/login","kratos_url":"http://k:4433"}}`,
+			wantCookieName: "sess",
+			wantLoginURL:   "/login",
+			wantKratosURL:  "http://k:4433",
+		},
+		{
+			name:    "invalid JSON",
+			input:   `{invalid}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var h AuthHandler
+			err := json.Unmarshal([]byte(tt.input), &h)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if h.Config.CookieName != tt.wantCookieName {
+				t.Errorf("CookieName = %q, want %q", h.Config.CookieName, tt.wantCookieName)
+			}
+			if h.Config.LoginURL != tt.wantLoginURL {
+				t.Errorf("LoginURL = %q, want %q", h.Config.LoginURL, tt.wantLoginURL)
+			}
+			if h.Config.KratosURL != tt.wantKratosURL {
+				t.Errorf("KratosURL = %q, want %q", h.Config.KratosURL, tt.wantKratosURL)
+			}
+		})
+	}
+}
+
+// TestAuthHandler_isPublicPath verifies public path matching.
+func TestAuthHandler_isPublicPath(t *testing.T) {
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		PublicPaths: []string{
+			"/_vibewarden/*",
+			"/self-service/*",
+			"/health",
+			"/api/docs",
+		},
+	}}
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/_vibewarden/health", true},
+		{"/_vibewarden/admin/users", true},
+		{"/self-service/login/browser", true},
+		{"/health", true},
+		{"/api/docs", true},
+		{"/app/page", false},
+		{"/", false},
+		{"/api/v1/users", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := h.isPublicPath(tt.path)
+			if got != tt.want {
+				t.Errorf("isPublicPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAuthHandler_ServeHTTP_PublicPathBypass verifies that public paths skip authentication.
+func TestAuthHandler_ServeHTTP_PublicPathBypass(t *testing.T) {
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName:  "ory_kratos_session",
+		LoginURL:    "/login",
+		PublicPaths: []string{"/_vibewarden/*", "/health"},
+		KratosURL:   "http://unreachable:4433", // should not be called
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	tests := []struct {
+		path string
+	}{
+		{"/_vibewarden/health"},
+		{"/health"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			nextCalled := false
+			next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+				return nil
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			w := httptest.NewRecorder()
+
+			err := h.ServeHTTP(w, req, next)
+			if err != nil {
+				t.Errorf("ServeHTTP() error = %v", err)
+			}
+			if !nextCalled {
+				t.Error("expected next handler to be called for public path")
+			}
+		})
+	}
+}
+
+// TestAuthHandler_ServeHTTP_NoCookie verifies redirect when no session cookie is present.
+func TestAuthHandler_ServeHTTP_NoCookie(t *testing.T) {
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName: "ory_kratos_session",
+		LoginURL:   "/self-service/login/browser",
+		KratosURL:  "http://unreachable:4433",
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	nextCalled := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+	if nextCalled {
+		t.Error("next handler should not be called without session cookie")
+	}
+	if w.Code != http.StatusFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusFound)
+	}
+	loc := w.Header().Get("Location")
+	if loc != "/self-service/login/browser" {
+		t.Errorf("Location = %q, want %q", loc, "/self-service/login/browser")
+	}
+}
+
+// TestAuthHandler_ServeHTTP_ValidSession verifies successful authentication
+// with identity headers set.
+func TestAuthHandler_ServeHTTP_ValidSession(t *testing.T) {
+	// Start a fake Kratos server.
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/sessions/whoami" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"identity": {
+				"id": "user-123",
+				"traits": {"email": "user@example.com"},
+				"verifiable_addresses": [
+					{"value": "user@example.com", "via": "email", "verified": true}
+				]
+			}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName: "ory_kratos_session",
+		LoginURL:   "/login",
+		KratosURL:  kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	var capturedHeaders http.Header
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		capturedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "valid-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	if capturedHeaders == nil {
+		t.Fatal("next handler was not called")
+	}
+	if got := capturedHeaders.Get("X-User-Id"); got != "user-123" {
+		t.Errorf("X-User-Id = %q, want %q", got, "user-123")
+	}
+	if got := capturedHeaders.Get("X-User-Email"); got != "user@example.com" {
+		t.Errorf("X-User-Email = %q, want %q", got, "user@example.com")
+	}
+	if got := capturedHeaders.Get("X-User-Verified"); got != "true" {
+		t.Errorf("X-User-Verified = %q, want %q", got, "true")
+	}
+}
+
+// TestAuthHandler_ServeHTTP_InvalidSession verifies redirect when Kratos
+// returns 401.
+func TestAuthHandler_ServeHTTP_InvalidSession(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer kratosServer.Close()
+
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName: "ory_kratos_session",
+		LoginURL:   "/login",
+		KratosURL:  kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	nextCalled := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "expired-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+	if nextCalled {
+		t.Error("next handler should not be called with invalid session")
+	}
+	if w.Code != http.StatusFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusFound)
+	}
+}
+
+// TestAuthHandler_ServeHTTP_KratosUnavailable verifies redirect when Kratos is unreachable.
+func TestAuthHandler_ServeHTTP_KratosUnavailable(t *testing.T) {
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName: "ory_kratos_session",
+		LoginURL:   "/login",
+		KratosURL:  "http://127.0.0.1:19999", // nothing listening
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	nextCalled := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "some-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+	if nextCalled {
+		t.Error("next handler should not be called when Kratos is unavailable")
+	}
+	if w.Code != http.StatusFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusFound)
+	}
+}
+
+// TestAuthHandler_ServeHTTP_InactiveSession verifies redirect when Kratos
+// returns an inactive session.
+func TestAuthHandler_ServeHTTP_InactiveSession(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": false,
+			"identity": {"id": "user-123", "traits": {}}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName: "ory_kratos_session",
+		LoginURL:   "/login",
+		KratosURL:  kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	nextCalled := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "inactive-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+	if nextCalled {
+		t.Error("next handler should not be called with inactive session")
+	}
+	if w.Code != http.StatusFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusFound)
+	}
+}
+
+// TestAuthHandler_ServeHTTP_UnverifiedEmail verifies that X-User-Verified is
+// "false" when the email is not verified.
+func TestAuthHandler_ServeHTTP_UnverifiedEmail(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"identity": {
+				"id": "user-456",
+				"traits": {"email": "new@example.com"},
+				"verifiable_addresses": [
+					{"value": "new@example.com", "via": "email", "verified": false}
+				]
+			}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName: "ory_kratos_session",
+		LoginURL:   "/login",
+		KratosURL:  kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	var capturedHeaders http.Header
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		capturedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "valid-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	if capturedHeaders == nil {
+		t.Fatal("next handler was not called")
+	}
+	if got := capturedHeaders.Get("X-User-Verified"); got != "false" {
+		t.Errorf("X-User-Verified = %q, want %q", got, "false")
+	}
+}
+
+// TestAuthHandler_ServeHTTP_EmailFromTraits verifies that the email is
+// extracted from traits when verifiable_addresses is absent.
+func TestAuthHandler_ServeHTTP_EmailFromTraits(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"identity": {
+				"id": "user-789",
+				"traits": {"email": "traits@example.com"}
+			}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName: "ory_kratos_session",
+		LoginURL:   "/login",
+		KratosURL:  kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	var capturedHeaders http.Header
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		capturedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "valid-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	if capturedHeaders == nil {
+		t.Fatal("next handler was not called")
+	}
+	if got := capturedHeaders.Get("X-User-Email"); got != "traits@example.com" {
+		t.Errorf("X-User-Email = %q, want %q", got, "traits@example.com")
+	}
+}
+
+// TestAuthHandler_ServeHTTP_ForwardsCookieToKratos verifies the handler sends
+// the correct cookie to the Kratos whoami endpoint.
+func TestAuthHandler_ServeHTTP_ForwardsCookieToKratos(t *testing.T) {
+	var receivedCookie string
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedCookie = r.Header.Get("Cookie")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"identity": {"id": "user-123", "traits": {"email": "u@e.com"}}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName: "my_session",
+		LoginURL:   "/login",
+		KratosURL:  kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.AddCookie(&http.Cookie{Name: "my_session", Value: "token-abc"})
+	w := httptest.NewRecorder()
+
+	_ = h.ServeHTTP(w, req, next)
+
+	want := "my_session=token-abc"
+	if receivedCookie != want {
+		t.Errorf("Kratos received cookie = %q, want %q", receivedCookie, want)
+	}
+}
+
+// TestAuthHandler_ServeHTTP_KratosServerError verifies redirect when Kratos
+// returns a 5xx error.
+func TestAuthHandler_ServeHTTP_KratosServerError(t *testing.T) {
+	statusCodes := []int{500, 502, 503}
+
+	for _, code := range statusCodes {
+		t.Run(fmt.Sprintf("status_%d", code), func(t *testing.T) {
+			kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(code)
+			}))
+			defer kratosServer.Close()
+
+			h := &AuthHandler{Config: AuthHandlerConfig{
+				CookieName: "ory_kratos_session",
+				LoginURL:   "/login",
+				KratosURL:  kratosServer.URL,
+			}}
+			if err := h.Provision(gocaddy.Context{}); err != nil {
+				t.Fatalf("Provision() error = %v", err)
+			}
+
+			nextCalled := false
+			next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+				nextCalled = true
+				return nil
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+			req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "token"})
+			w := httptest.NewRecorder()
+
+			_ = h.ServeHTTP(w, req, next)
+
+			if nextCalled {
+				t.Error("next handler should not be called on Kratos server error")
+			}
+			if w.Code != http.StatusFound {
+				t.Errorf("status = %d, want %d", w.Code, http.StatusFound)
+			}
+		})
+	}
+}

--- a/internal/adapters/caddy/identity_headers_handler.go
+++ b/internal/adapters/caddy/identity_headers_handler.go
@@ -1,0 +1,84 @@
+package caddy
+
+import (
+	"encoding/json"
+	"net/http"
+
+	gocaddy "github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+func init() {
+	gocaddy.RegisterModule(IdentityHeadersHandler{})
+}
+
+// IdentityHeadersHandlerConfig is the JSON-serialisable configuration for the
+// IdentityHeadersHandler Caddy module.
+type IdentityHeadersHandlerConfig struct {
+	// CookieName is the name of the Kratos session cookie.
+	CookieName string `json:"cookie_name"`
+
+	// KratosURL is the base URL of the Kratos public API (e.g. "http://kratos:4433").
+	KratosURL string `json:"kratos_url"`
+}
+
+// IdentityHeadersHandler is a Caddy HTTP handler module that sets upstream
+// identity headers (X-User-Id, X-User-Email, X-User-Verified) from a validated
+// Kratos session.
+//
+// In the current implementation the upstream AuthHandler (http.handlers.vibewarden_authentication)
+// already sets these headers after validating the session. This handler exists
+// as a no-op pass-through so that the auth plugin can emit both handlers without
+// Caddy rejecting the configuration for an unknown module. If the authentication
+// handler is ever refactored to not set identity headers, this handler can be
+// updated to call Kratos whoami and inject the headers itself.
+//
+// The module is registered under the name "vibewarden_identity_headers" and referenced from
+// the Caddy JSON configuration as:
+//
+//	{"handler": "vibewarden_identity_headers", "cookie_name": "...", "kratos_url": "..."}
+type IdentityHeadersHandler struct {
+	Config IdentityHeadersHandlerConfig `json:"config"`
+}
+
+// CaddyModule returns the Caddy module information.
+func (IdentityHeadersHandler) CaddyModule() gocaddy.ModuleInfo {
+	return gocaddy.ModuleInfo{
+		ID:  "http.handlers.vibewarden_identity_headers",
+		New: func() gocaddy.Module { return new(IdentityHeadersHandler) },
+	}
+}
+
+// Provision implements gocaddy.Provisioner.
+func (h *IdentityHeadersHandler) Provision(_ gocaddy.Context) error {
+	return nil
+}
+
+// UnmarshalJSON implements custom unmarshalling to support both nested
+// {"config": {...}} and flat {"cookie_name": "...", ...} JSON layouts.
+func (h *IdentityHeadersHandler) UnmarshalJSON(data []byte) error {
+	// Try nested config first.
+	var nested struct {
+		Config IdentityHeadersHandlerConfig `json:"config"`
+	}
+	if err := json.Unmarshal(data, &nested); err == nil && nested.Config.CookieName != "" {
+		h.Config = nested.Config
+		return nil
+	}
+	// Try flat structure.
+	return json.Unmarshal(data, &h.Config)
+}
+
+// ServeHTTP implements caddyhttp.MiddlewareHandler.
+// Identity headers are already set by the upstream AuthHandler. This handler
+// is a pass-through that delegates to the next handler in the chain.
+func (h *IdentityHeadersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+	return next.ServeHTTP(w, r)
+}
+
+// Interface guards.
+var (
+	_ caddyhttp.MiddlewareHandler = (*IdentityHeadersHandler)(nil)
+	_ gocaddy.Module              = (*IdentityHeadersHandler)(nil)
+	_ gocaddy.Provisioner         = (*IdentityHeadersHandler)(nil)
+)

--- a/internal/adapters/caddy/identity_headers_handler_test.go
+++ b/internal/adapters/caddy/identity_headers_handler_test.go
@@ -1,0 +1,173 @@
+package caddy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gocaddy "github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+// TestIdentityHeadersHandler_CaddyModule verifies the Caddy module metadata.
+func TestIdentityHeadersHandler_CaddyModule(t *testing.T) {
+	info := IdentityHeadersHandler{}.CaddyModule()
+
+	if info.ID != "http.handlers.vibewarden_identity_headers" {
+		t.Errorf("CaddyModule().ID = %q, want %q", info.ID, "http.handlers.vibewarden_identity_headers")
+	}
+	if info.New == nil {
+		t.Fatal("CaddyModule().New is nil")
+	}
+
+	mod := info.New()
+	if mod == nil {
+		t.Fatal("CaddyModule().New() returned nil")
+	}
+	if _, ok := mod.(*IdentityHeadersHandler); !ok {
+		t.Errorf("CaddyModule().New() returned %T, want *IdentityHeadersHandler", mod)
+	}
+}
+
+// TestIdentityHeadersHandler_InterfaceGuards verifies the handler satisfies required Caddy interfaces.
+func TestIdentityHeadersHandler_InterfaceGuards(t *testing.T) {
+	var _ gocaddy.Provisioner = (*IdentityHeadersHandler)(nil)
+	var _ caddyhttp.MiddlewareHandler = (*IdentityHeadersHandler)(nil)
+	var _ gocaddy.Module = (*IdentityHeadersHandler)(nil)
+}
+
+// TestIdentityHeadersHandler_Provision verifies that Provision succeeds.
+func TestIdentityHeadersHandler_Provision(t *testing.T) {
+	h := &IdentityHeadersHandler{Config: IdentityHeadersHandlerConfig{
+		CookieName: "ory_kratos_session",
+		KratosURL:  "http://kratos:4433",
+	}}
+
+	err := h.Provision(gocaddy.Context{})
+	if err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+}
+
+// TestIdentityHeadersHandler_UnmarshalJSON verifies both flat and nested JSON unmarshalling.
+func TestIdentityHeadersHandler_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		wantCookieName string
+		wantKratosURL  string
+		wantErr        bool
+	}{
+		{
+			name:           "flat structure",
+			input:          `{"cookie_name":"sess","kratos_url":"http://k:4433"}`,
+			wantCookieName: "sess",
+			wantKratosURL:  "http://k:4433",
+		},
+		{
+			name:           "nested config",
+			input:          `{"config":{"cookie_name":"sess","kratos_url":"http://k:4433"}}`,
+			wantCookieName: "sess",
+			wantKratosURL:  "http://k:4433",
+		},
+		{
+			name:    "invalid JSON",
+			input:   `{invalid}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var h IdentityHeadersHandler
+			err := json.Unmarshal([]byte(tt.input), &h)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if h.Config.CookieName != tt.wantCookieName {
+				t.Errorf("CookieName = %q, want %q", h.Config.CookieName, tt.wantCookieName)
+			}
+			if h.Config.KratosURL != tt.wantKratosURL {
+				t.Errorf("KratosURL = %q, want %q", h.Config.KratosURL, tt.wantKratosURL)
+			}
+		})
+	}
+}
+
+// TestIdentityHeadersHandler_ServeHTTP_PassThrough verifies the handler passes
+// through to the next handler without modifying the request.
+func TestIdentityHeadersHandler_ServeHTTP_PassThrough(t *testing.T) {
+	h := &IdentityHeadersHandler{Config: IdentityHeadersHandlerConfig{
+		CookieName: "ory_kratos_session",
+		KratosURL:  "http://kratos:4433",
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	nextCalled := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/page", nil)
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Errorf("ServeHTTP() error = %v", err)
+	}
+	if !nextCalled {
+		t.Error("expected next handler to be called")
+	}
+}
+
+// TestIdentityHeadersHandler_ServeHTTP_PreservesExistingHeaders verifies the
+// handler does not modify identity headers already set by the auth handler.
+func TestIdentityHeadersHandler_ServeHTTP_PreservesExistingHeaders(t *testing.T) {
+	h := &IdentityHeadersHandler{Config: IdentityHeadersHandlerConfig{
+		CookieName: "ory_kratos_session",
+		KratosURL:  "http://kratos:4433",
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	var capturedHeaders http.Header
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		capturedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/page", nil)
+	// Simulate headers already set by the auth handler.
+	req.Header.Set("X-User-Id", "user-123")
+	req.Header.Set("X-User-Email", "user@example.com")
+	req.Header.Set("X-User-Verified", "true")
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	if capturedHeaders == nil {
+		t.Fatal("next handler was not called")
+	}
+	if got := capturedHeaders.Get("X-User-Id"); got != "user-123" {
+		t.Errorf("X-User-Id = %q, want %q", got, "user-123")
+	}
+	if got := capturedHeaders.Get("X-User-Email"); got != "user@example.com" {
+		t.Errorf("X-User-Email = %q, want %q", got, "user@example.com")
+	}
+	if got := capturedHeaders.Get("X-User-Verified"); got != "true" {
+		t.Errorf("X-User-Verified = %q, want %q", got, "true")
+	}
+}

--- a/internal/plugins/auth/plugin.go
+++ b/internal/plugins/auth/plugin.go
@@ -631,11 +631,11 @@ func (p *Plugin) ContributeCaddyHandlers() []ports.CaddyHandler {
 	// For the Caddy JSON config we use the auth cookie validation approach:
 	// inject a handler that checks for the session cookie and redirects
 	// missing sessions to the login URL.
-	authHandler := buildAuthHandler(cookieName, loginURL, publicPaths)
+	authHandler := buildAuthHandler(cookieName, loginURL, publicPaths, p.cfg.KratosPublicURL)
 
 	// Identity-headers handler: sets upstream request headers from Kratos
 	// session data. These headers are consumed by the upstream application.
-	identityHeadersHandler := buildIdentityHeadersHandler(cookieName)
+	identityHeadersHandler := buildIdentityHeadersHandler(cookieName, p.cfg.KratosPublicURL)
 
 	return []ports.CaddyHandler{
 		{
@@ -693,12 +693,13 @@ func validateKratosConfig(cfg Config) error {
 // In the Caddy JSON config the auth enforcement is represented as a
 // forward_auth handler that delegates session validation to the Kratos
 // whoami endpoint. Public paths bypass auth via a path matcher.
-func buildAuthHandler(cookieName, loginURL string, publicPaths []string) map[string]any {
+func buildAuthHandler(cookieName, loginURL string, publicPaths []string, kratosURL string) map[string]any {
 	return map[string]any{
-		"handler":      "authentication",
+		"handler":      "vibewarden_authentication",
 		"cookie_name":  cookieName,
 		"login_url":    loginURL,
 		"public_paths": publicPaths,
+		"kratos_url":   kratosURL,
 	}
 }
 
@@ -708,10 +709,11 @@ func buildAuthHandler(cookieName, loginURL string, publicPaths []string) map[str
 //   - X-User-Id: Kratos identity UUID
 //   - X-User-Email: primary email address
 //   - X-User-Verified: "true" or "false"
-func buildIdentityHeadersHandler(cookieName string) map[string]any {
+func buildIdentityHeadersHandler(cookieName string, kratosURL string) map[string]any {
 	return map[string]any{
-		"handler":     "identity_headers",
+		"handler":     "vibewarden_identity_headers",
 		"cookie_name": cookieName,
+		"kratos_url":  kratosURL,
 	}
 }
 

--- a/internal/plugins/auth/plugin_test.go
+++ b/internal/plugins/auth/plugin_test.go
@@ -722,8 +722,8 @@ func TestPlugin_ContributeCaddyHandlers_AuthHandler(t *testing.T) {
 	if h.Priority != 40 {
 		t.Errorf("auth handler Priority = %d, want 40", h.Priority)
 	}
-	if h.Handler["handler"] != "authentication" {
-		t.Errorf("auth handler type = %q, want %q", h.Handler["handler"], "authentication")
+	if h.Handler["handler"] != "vibewarden_authentication" {
+		t.Errorf("auth handler type = %q, want %q", h.Handler["handler"], "vibewarden_authentication")
 	}
 	if _, ok := h.Handler["cookie_name"]; !ok {
 		t.Error("auth handler missing cookie_name field")
@@ -810,8 +810,8 @@ func TestPlugin_ContributeCaddyHandlers_IdentityHeadersHandler(t *testing.T) {
 	if h.Priority != 41 {
 		t.Errorf("identity-headers handler Priority = %d, want 41", h.Priority)
 	}
-	if h.Handler["handler"] != "identity_headers" {
-		t.Errorf("identity-headers handler type = %q, want %q", h.Handler["handler"], "identity_headers")
+	if h.Handler["handler"] != "vibewarden_identity_headers" {
+		t.Errorf("identity-headers handler type = %q, want %q", h.Handler["handler"], "vibewarden_identity_headers")
 	}
 	if _, ok := h.Handler["cookie_name"]; !ok {
 		t.Error("identity-headers handler missing cookie_name field")


### PR DESCRIPTION
Closes #883

## Summary

- Added two new Caddy handler modules in `internal/adapters/caddy/`:
  - **`vibewarden_authentication`** (`auth_handler.go`): Validates Kratos session cookies via the `/sessions/whoami` endpoint, redirects unauthenticated requests to the login URL, and injects `X-User-Id`, `X-User-Email`, `X-User-Verified` headers for the upstream app. Supports public path bypass.
  - **`vibewarden_identity_headers`** (`identity_headers_handler.go`): Pass-through handler that preserves the plugin's two-handler contract without double-calling Kratos (the auth handler already sets identity headers).
- Updated `buildAuthHandler()` and `buildIdentityHeadersHandler()` in `internal/plugins/auth/plugin.go` to emit the new `vibewarden_`-prefixed handler names and pass `kratos_url` into the config.
- Updated existing plugin tests to expect the new handler names.

**Why `vibewarden_` prefix?** Caddy has a built-in `http.handlers.authentication` module. Using that name caused a collision where Caddy tried to unmarshal our `cookie_name` field into its own module, producing the `unknown field "cookie_name"` crash.

## Test plan

- [x] `make check` passes (0 lint issues, all tests green)
- [x] Built local Docker image and verified demo-app starts without crash
- [x] Confirmed `proxy.started` event emitted (Caddy config loaded successfully)
- [x] Verified the sidecar responds to requests through the proxy
- [ ] Reviewer verifies test coverage on new handler modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)