### PR TITLE
fix(#884): language-aware Docker health check probes

### DIFF
--- a/examples/demo-app/vibewarden.yaml
+++ b/examples/demo-app/vibewarden.yaml
@@ -14,6 +14,7 @@ profile: dev
 app:
   # Build from local Dockerfile (dev mode)
   build: .
+  language: go
   # Image for production (overridable via VIBEWARDEN_APP_IMAGE):
   # image: ghcr.io/vibewarden/demo-app:latest
 

--- a/examples/nextjs/vibewarden.yaml
+++ b/examples/nextjs/vibewarden.yaml
@@ -8,6 +8,7 @@ profile: dev
 
 app:
   build: .
+  language: typescript
 
 server:
   host: "0.0.0.0"

--- a/examples/node-express/vibewarden.yaml
+++ b/examples/node-express/vibewarden.yaml
@@ -8,6 +8,7 @@ profile: dev
 
 app:
   build: .
+  language: typescript
 
 server:
   host: "0.0.0.0"

--- a/examples/python-flask/vibewarden.yaml
+++ b/examples/python-flask/vibewarden.yaml
@@ -8,6 +8,7 @@ profile: dev
 
 app:
   build: .
+  language: python
 
 server:
   host: "0.0.0.0"

--- a/examples/spring-boot/vibewarden.yaml
+++ b/examples/spring-boot/vibewarden.yaml
@@ -11,6 +11,7 @@ upstream:
 
 app:
   build: .
+  language: kotlin
 
 tls:
   enabled: true

--- a/internal/adapters/template/renderer.go
+++ b/internal/adapters/template/renderer.go
@@ -38,11 +38,36 @@ func NewRenderer(f fs.ReadFileFS) *Renderer {
 	return &Renderer{fs: f}
 }
 
+// SharedFuncMap returns the custom template functions so that callers outside
+// this package (e.g. deploy) can register them on their own templates.
+func SharedFuncMap() template.FuncMap { return funcMap }
+
 // funcMap defines the custom template functions available to all templates.
 var funcMap = template.FuncMap{
 	// mul multiplies two integers and returns the product.
 	// Used in loki-config.yml.tmpl to convert retention days to hours.
 	"mul": func(a, b int) int { return a * b },
+
+	// healthcheckCmd returns a Docker health check command appropriate for
+	// the given language runtime. Images based on Alpine (Go, Kotlin) ship
+	// wget; Python and Node slim images do not but always have their own
+	// runtime available. Falls back to wget for unknown languages.
+	"healthcheckCmd": func(lang string, port int) string {
+		switch lang {
+		case "python":
+			return fmt.Sprintf(
+				`python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:%d/health')"`,
+				port)
+		case "typescript", "javascript":
+			return fmt.Sprintf(
+				`node -e "const h=require('http');h.get('http://127.0.0.1:%d/health',r=>{process.exit(r.statusCode===200?0:1)}).on('error',()=>process.exit(1))"`,
+				port)
+		default: // go, kotlin, alpine-based, unknown
+			return fmt.Sprintf(
+				`wget -q --spider http://127.0.0.1:%d/health || exit 1`,
+				port)
+		}
+	},
 }
 
 // Render executes the named template with data and returns the rendered bytes.

--- a/internal/app/deploy/multiapp.go
+++ b/internal/app/deploy/multiapp.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"text/template"
 
+	templateadapter "github.com/vibewarden/vibewarden/internal/adapters/template"
 	"github.com/vibewarden/vibewarden/internal/config"
 	"github.com/vibewarden/vibewarden/internal/config/templates"
 )
@@ -50,6 +51,9 @@ type AppComposeData struct {
 
 	// UpstreamPort is the port the app listens on inside the container.
 	UpstreamPort int
+
+	// AppLanguage is the app's language/runtime for health check probe selection.
+	AppLanguage string
 }
 
 // BootstrapSidecar creates the full multi-app directory layout on the remote
@@ -257,7 +261,7 @@ func renderSidecarCompose(listenPort int) (string, error) {
 		return "", fmt.Errorf("reading sidecar compose template: %w", err)
 	}
 
-	tmpl, err := template.New("sidecar-compose").Parse(string(tmplContent))
+	tmpl, err := template.New("sidecar-compose").Funcs(templateadapter.SharedFuncMap()).Parse(string(tmplContent))
 	if err != nil {
 		return "", fmt.Errorf("parsing sidecar compose template: %w", err)
 	}
@@ -278,7 +282,7 @@ func renderAppCompose(cfg *config.Config, projectName string) (string, error) {
 		return "", fmt.Errorf("reading app compose template: %w", err)
 	}
 
-	tmpl, err := template.New("app-compose").Parse(string(tmplContent))
+	tmpl, err := template.New("app-compose").Funcs(templateadapter.SharedFuncMap()).Parse(string(tmplContent))
 	if err != nil {
 		return "", fmt.Errorf("parsing app compose template: %w", err)
 	}
@@ -294,6 +298,7 @@ func renderAppCompose(cfg *config.Config, projectName string) (string, error) {
 		AppBuild:       cfg.App.Build,
 		AppHealthcheck: healthcheck,
 		UpstreamPort:   cfg.Upstream.Port,
+		AppLanguage:    cfg.App.Language,
 	}
 
 	var buf bytes.Buffer

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -364,10 +364,19 @@ type AppConfig struct {
 	Image string `mapstructure:"image"`
 
 	// Healthcheck is the Docker healthcheck command for the app container.
-	// Default: "wget -q --spider http://localhost:<port>/health || exit 1"
-	// Override for images without wget: "curl -sf http://localhost:<port>/health || exit 1"
+	// When empty, the default probe is chosen based on Language:
+	//   python     → python -c "import urllib.request; ..."
+	//   typescript → node -e "require('http').get(...)"
+	//   go/kotlin  → wget -q --spider ...  (Alpine images ship wget)
+	//   (default)  → wget -q --spider ...
 	// Set to "none" to disable the healthcheck entirely.
 	Healthcheck string `mapstructure:"healthcheck"`
+
+	// Language is the app's primary language/runtime. Used to select the
+	// appropriate Docker health check probe when Healthcheck is not set.
+	// Values: "go", "python", "typescript", "kotlin", or empty (auto-detect
+	// at init/wrap time; falls back to wget).
+	Language string `mapstructure:"language"`
 }
 
 // TLSCertMonitoringConfig holds configuration for the certificate expiry monitor.

--- a/internal/config/templates/app-compose.yml.tmpl
+++ b/internal/config/templates/app-compose.yml.tmpl
@@ -17,7 +17,7 @@ services:
 {{- end }}
 {{- if ne .AppHealthcheck "none" }}
     healthcheck:
-      test: ["CMD-SHELL", "{{ if .AppHealthcheck }}{{ .AppHealthcheck }}{{ else }}wget -q --spider http://127.0.0.1:{{ .UpstreamPort }}/health || exit 1{{ end }}"]
+      test: ["CMD-SHELL", "{{ if .AppHealthcheck }}{{ .AppHealthcheck }}{{ else }}{{ healthcheckCmd .AppLanguage .UpstreamPort }}{{ end }}"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/internal/config/templates/docker-compose.yml.tmpl
+++ b/internal/config/templates/docker-compose.yml.tmpl
@@ -52,7 +52,7 @@ services:
 {{- end }}
 {{- if ne .App.Healthcheck "none" }}
     healthcheck:
-      test: ["CMD-SHELL", "{{ if .App.Healthcheck }}{{ .App.Healthcheck }}{{ else }}wget -q --spider http://127.0.0.1:{{ .Upstream.Port }}/health || exit 1{{ end }}"]
+      test: ["CMD-SHELL", "{{ if .App.Healthcheck }}{{ .App.Healthcheck }}{{ else }}{{ healthcheckCmd .App.Language .Upstream.Port }}{{ end }}"]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Summary

The generated docker-compose health check always used \`wget\`, which isn't available on \`python:slim\`, \`node:slim\`, or distroless images. Now the template selects the probe based on \`app.language\`:

| Language | Probe |
|---|---|
| \`python\` | \`python -c "import urllib.request; ..."\` |
| \`typescript\` / \`javascript\` | \`node -e "require('http').get(...)"\` |
| \`go\` / \`kotlin\` / default | \`wget -q --spider ...\` (Alpine ships it) |

Closes #884.

## Changes

- \`internal/config/config.go\` — \`AppConfig.Language\` field
- \`internal/adapters/template/renderer.go\` — \`healthcheckCmd\` template function + \`SharedFuncMap()\` export
- \`internal/config/templates/docker-compose.yml.tmpl\` — uses \`healthcheckCmd\`
- \`internal/config/templates/app-compose.yml.tmpl\` — same
- \`internal/app/deploy/multiapp.go\` — passes \`AppLanguage\` to template, uses \`SharedFuncMap()\`
- All 5 examples — \`app.language\` set

## Test plan

- [x] \`make check\` green
- [x] \`vibew generate\` on python-flask → \`python -c\` probe
- [x] \`vibew generate\` on node-express → \`node -e\` probe
- [x] \`vibew generate\` on demo-app → \`wget\` probe (backward compat)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)