### PR TITLE
chore: add integration tests to CI pipeline + make targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,24 @@ jobs:
       - name: Run demo-app tests
         run: cd examples/demo-app && go test -race ./...
 
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [test]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Run integration tests
+        run: go test -race -tags integration ./test/integration/ -v -timeout 300s
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
           go-version: "1.26"
           cache: true
 
+      - name: Build VibeWarden Docker image
+        run: docker build --tag ghcr.io/vibewarden/vibewarden:latest .
+
       - name: Run integration tests
         run: go test -race -tags integration ./test/integration/ -v -timeout 300s
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # VibeWarden Makefile
 
-.PHONY: build test lint run docker-up docker-down observability-up observability-down grafana-open prometheus-open loki-open clean check setup-hooks demo demo-build demo-tls demo-down demo-clean deploy-demo
+.PHONY: build test lint run docker-up docker-down observability-up observability-down grafana-open prometheus-open loki-open clean check integration check-all setup-hooks demo demo-build demo-tls demo-down demo-clean deploy-demo
 
 # Build variables
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -70,6 +70,17 @@ check: ## Run all quality checks (lint, build, tests)
 	@test -z "$$(cd examples/demo-app && gofmt -l .)" || (echo "gofmt: these demo-app files need formatting:" && cd examples/demo-app && gofmt -l . && exit 1)
 	cd examples/demo-app && go vet ./... && go build ./... && go test -race ./...
 	@echo "==> All checks passed!"
+
+# Run integration tests (requires Docker running).
+# These are gated behind //go:build integration and test multi-app routing,
+# deploy flows, and Docker-in-Docker scenarios.
+integration: ## Run integration tests (requires Docker)
+	@echo "==> Running integration tests..."
+	go test -race -tags integration ./test/integration/ -v -timeout 300s
+	@echo "==> Integration tests passed!"
+
+# Run all checks + integration tests.
+check-all: check integration ## Run all quality checks + integration tests
 
 # Build the VibeWarden Docker image locally and tag it so demo targets work
 # without pulling from ghcr.io. No Go toolchain required — Docker handles the build.


### PR DESCRIPTION
## Summary

Integration tests (#889 Tier 1, #890 Tier 3) existed but were never run — gated behind \`//go:build integration\` with no CI job or make target invoking them.

## Changes

**Makefile:**
- \`make integration\` — runs integration tests locally (requires Docker)
- \`make check-all\` — runs \`check\` + \`integration\`

**CI (\`.github/workflows/ci.yml\`):**
- New **Integration Tests** job, runs after unit tests pass (\`needs: [test]\`)
- \`ubuntu-latest\` (Docker pre-installed, \`--privileged\` supported for DinD)
- 15-min timeout (DinD startup + image pulls take time)

**Pre-push hook** stays as \`make check\` (fast, no Docker).

## What runs where

| Target | What | Docker? | When |
|---|---|---|---|
| \`make check\` | lint + build + unit tests | No | Pre-push hook, every commit |
| \`make integration\` | Tier 1 + Tier 3 integration | Yes | Manual, local dev |
| \`make check-all\` | Everything | Yes | Manual, full validation |
| CI: Test | Unit tests | No | Every PR |
| CI: Integration Tests | Tier 1 + Tier 3 | Yes | Every PR (after Test passes) |

## Test plan

- [x] \`make check\` green (doesn't run integration)
- [ ] CI green (first PR where integration tests run in CI!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)