### PR TITLE
chore: rename test sidecar image to vibewarden:local-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
           go-version: "1.26"
           cache: true
 
-      - name: Build VibeWarden Docker image
-        run: docker build --tag ghcr.io/vibewarden/vibewarden:latest .
+      - name: Build VibeWarden Docker image (local test tag — never pushed)
+        run: docker build --tag vibewarden:local-test .
 
       - name: Run integration tests
         run: go test -race -tags integration ./test/integration/ -v -timeout 300s

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,8 @@ check: ## Run all quality checks (lint, build, tests)
 # These are gated behind //go:build integration and test multi-app routing,
 # deploy flows, and Docker-in-Docker scenarios.
 integration: ## Run integration tests (requires Docker)
+	@echo "==> Building VibeWarden image for integration tests (vibewarden:local-test)..."
+	docker build --tag vibewarden:local-test .
 	@echo "==> Running integration tests..."
 	go test -race -tags integration ./test/integration/ -v -timeout 300s
 	@echo "==> Integration tests passed!"

--- a/test/integration/deploy_multisite_test.go
+++ b/test/integration/deploy_multisite_test.go
@@ -51,11 +51,9 @@ const (
 	// high port to minimize the chance of conflict with services on the host.
 	testListenPort = 18443
 
-	// sidecarImageRef is the Docker image reference expected by the sidecar
-	// compose template. We tag a lightweight image with this name before the
-	// test so that docker compose pull succeeds without network access to
-	// the real registry.
-	sidecarImageRef = "ghcr.io/vibewarden/vibewarden:latest"
+	// sidecarImageRef is the Docker image reference used in cleanup.
+	// The deploy service uses the image name from the sidecar compose template.
+	sidecarImageRef = "vibewarden:local-test"
 
 	// stubBaseImage is the image we tag as the sidecar image.
 	stubBaseImage = "alpine:3.23"

--- a/test/integration/multisite_test.go
+++ b/test/integration/multisite_test.go
@@ -9,7 +9,7 @@
 //
 // Prerequisites:
 //   - Docker daemon running
-//   - ghcr.io/vibewarden/vibewarden:latest built locally (make demo-build)
+//   - vibewarden:local-test image built (make integration does this automatically)
 //
 // Run:
 //
@@ -37,8 +37,9 @@ import (
 
 const (
 	// sidecarImage is the Docker image used for the VibeWarden sidecar.
-	// It must be built locally before running integration tests (make demo-build).
-	sidecarImage = "ghcr.io/vibewarden/vibewarden:latest"
+	// Built locally as vibewarden:local-test (never pushed to a registry).
+	// Run `make integration` or `docker build -t vibewarden:local-test .`
+	sidecarImage = "vibewarden:local-test"
 
 	// echoImage is the Docker image used for upstream app containers.
 	// hashicorp/http-echo is MIT-licensed and returns a fixed text response.


### PR DESCRIPTION
## Summary

Integration tests and CI were tagging the Docker image as \`ghcr.io/vibewarden/vibewarden:latest\` — the same name GoReleaser pushes on release. The CI never pushes, but the name is confusing and an accident waiting to happen.

Renamed to \`vibewarden:local-test\` in all test/CI contexts. The \`ghcr.io\` name stays in the release pipeline, demo targets, and production deploy code where it belongs.

## Test plan

- [x] \`make check\` green
- [ ] CI green (integration tests use the new tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)