### PR TITLE
docs(#869): add multi-app deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ It never holds external secrets or connects directly to third-party APIs.
 | Maintenance mode | Serve a maintenance page with one config flag |
 | Response headers | Modify upstream response headers before forwarding |
 | Webhook verification | Signature verification for Stripe, GitHub, Slack, Twilio |
+| Multi-app deployment | Multiple apps on one VM with subdomain routing — [guide](docs/multi-app.md) |
 | Hot reload | File watcher + admin API — no restart required |
 | MCP server | `vibew mcp` — AI agent integration via Model Context Protocol; `vibewarden_stream_logs` tool for filtered real-time event streaming |
 | Config schema | JSON schema for `vibewarden.yaml` — editor autocomplete |
@@ -381,6 +382,7 @@ Architectural decisions are documented in [DECISIONS.md](DECISIONS.md).
 | Production deployment | [docs/production-deployment.md](docs/production-deployment.md) |
 | Hardening checklist | [docs/production-hardening.md](docs/production-hardening.md) |
 | Deploy command reference | [docs/deploy-reference.md](docs/deploy-reference.md) |
+| Multi-app deployment | [docs/multi-app.md](docs/multi-app.md) |
 | Architectural decisions | [DECISIONS.md](DECISIONS.md) |
 
 ---

--- a/docs/deploy-reference.md
+++ b/docs/deploy-reference.md
@@ -43,7 +43,22 @@ vibew deploy --target ssh://user@host --config vibewarden.prod.yaml
 | `--rotate-secrets` | No | `false` | Re-seed secrets from `--secrets-from` on subsequent deploys |
 | `--unseal-key` | No | stored key | OpenBao unseal key; overrides the key stored in `~/vibewarden/<project>/.openbao-credentials` on the remote |
 
-#### What happens on first deploy
+#### Deploy mode detection
+
+`vibew deploy` automatically detects whether the target has an existing
+VibeWarden sidecar and selects the right strategy:
+
+| Existing sidecar? | `tls.domain` set? | Behavior |
+|--------------------|-------------------|----------|
+| No | Yes | **Bootstrap**: creates sidecar + first site (multi-app) |
+| No | No | **Legacy deploy**: single-app mode (backward compatible) |
+| Yes | Yes | **Add site**: adds app alongside existing sites |
+| Yes | No | **Error**: `cannot add a site without a TLS domain` |
+
+Detection works by checking for `~/vibewarden/.sidecar/global.yaml` on the
+remote host via SSH (single round-trip).
+
+#### What happens on first deploy (single-app, no domain)
 
 1. Generates runtime config (Docker Compose files, Kratos config) locally.
 2. Transfers files to the remote via `rsync`.
@@ -54,7 +69,25 @@ vibew deploy --target ssh://user@host --config vibewarden.prod.yaml
 5. Prints the unseal key, root token, role ID, and secret ID. Save the unseal
    key -- it is not shown again.
 
-#### What happens on subsequent deploys
+#### What happens on first deploy (multi-app, with domain)
+
+1. Creates the directory layout: `~/vibewarden/.sidecar/` and
+   `~/vibewarden/sites/<project>/`.
+2. Creates the shared `vibewarden-multiapp` Docker network.
+3. Writes `global.yaml` and the sidecar `docker-compose.yml`.
+4. Copies your `vibewarden.yaml` to `sites/<project>/vibewarden.yaml`.
+5. Renders and starts the per-app Docker Compose stack.
+6. Starts the sidecar container.
+7. Runs a health check via SSH.
+
+#### What happens when adding a site
+
+1. Copies your `vibewarden.yaml` to `sites/<project>/vibewarden.yaml`.
+2. Renders and starts the per-app Docker Compose stack.
+3. Restarts the sidecar to pick up the new site configuration.
+4. Runs a health check via SSH.
+
+#### What happens on subsequent deploys (single-app)
 
 1. Regenerates and transfers updated config.
 2. Restarts Docker Compose on the remote.
@@ -72,6 +105,9 @@ Show Docker Compose service status on the remote.
 vibew deploy status --target ssh://user@host
 ```
 
+In multi-app mode (auto-detected), shows the sidecar status plus all sites.
+Use `--app` to target a specific site.
+
 #### Flags
 
 | Flag | Required | Default | Description |
@@ -79,6 +115,7 @@ vibew deploy status --target ssh://user@host
 | `--target` | Yes | -- | Remote target in `ssh://user@host[:port]` format |
 | `--config` | No | `./vibewarden.yaml` | Path to vibewarden.yaml (used to derive the remote project directory) |
 | `--ssh-key` | No | SSH agent / `~/.ssh/config` | Path to the SSH private key file |
+| `--app` | No | (all sites) | Target a specific site in multi-app mode (e.g. `--app blog`) |
 
 ---
 
@@ -90,6 +127,9 @@ Fetch Docker Compose logs from the remote.
 vibew deploy logs --target ssh://user@host
 ```
 
+In multi-app mode (auto-detected), shows sidecar logs by default. Use `--app`
+to view a specific site's logs.
+
 #### Flags
 
 | Flag | Required | Default | Description |
@@ -99,6 +139,7 @@ vibew deploy logs --target ssh://user@host
 | `--ssh-key` | No | SSH agent / `~/.ssh/config` | Path to the SSH private key file |
 | `--lines` | No | `50` | Number of log lines to fetch (`0` = all) |
 | `--follow` / `-f` | No | `false` | Stream log output continuously until cancelled (Ctrl-C) |
+| `--app` | No | (sidecar) | Target a specific site in multi-app mode (e.g. `--app blog`) |
 
 ---
 
@@ -174,6 +215,29 @@ vibew deploy logs --target ssh://ubuntu@203.0.113.10 --follow
 
 Press Ctrl-C to stop streaming.
 
+### Multi-app: deploy a second app to the same VM
+
+```bash
+vibew deploy \
+  --config vibewarden.yaml \
+  --target ssh://ubuntu@203.0.113.10
+```
+
+The CLI detects the existing sidecar and adds the new site. The config must
+have `tls.domain` set.
+
+### Multi-app: check all sites
+
+```bash
+vibew deploy status --target ssh://ubuntu@203.0.113.10
+```
+
+### Multi-app: view a specific site's logs
+
+```bash
+vibew deploy logs --target ssh://ubuntu@203.0.113.10 --app blog --follow
+```
+
 ---
 
 ## Common errors
@@ -184,6 +248,7 @@ Press Ctrl-C to stop streaming.
 | `invalid --target: scheme must be "ssh"` | Wrong URL scheme (e.g. `http://`) | Use `ssh://user@host` format |
 | `openbao bootstrap: ...` | OpenBao initialisation failed | Check remote Docker logs; verify port 8200 is reachable on the remote |
 | `loading config: ...` | Invalid or missing vibewarden.yaml | Run `vibew validate --config <path>` locally |
+| `cannot add a site without a TLS domain` | Adding a site to a multi-app host without `tls.domain` | Set `tls.domain` in vibewarden.yaml |
 | `rsync: connection refused` | SSH not reachable | Verify `ssh user@host echo OK` works first |
 
 ---
@@ -191,5 +256,6 @@ Press Ctrl-C to stop streaming.
 ## Related
 
 - [Deploy to VPS](deploy-to-vps.md) -- full first-deploy walkthrough
+- [Multi-App Deployment](multi-app.md) -- multiple apps on one VM
 - [Secret Management](secret-management.md) -- OpenBao configuration details
 - [Production Hardening](production-hardening.md) -- post-deploy security checklist

--- a/docs/deploy-to-vps.md
+++ b/docs/deploy-to-vps.md
@@ -381,10 +381,19 @@ ssh root@<server-ip> 'cd /opt/myapp && docker run --rm \
 
 ---
 
+## Multi-app deployment
+
+To deploy multiple apps to the same VM, each on its own subdomain behind a
+shared sidecar, see [Multi-App Deployment](multi-app.md).
+
+---
+
 ## Next steps
 
 - **Deploy command reference**: see [Deploy Reference](deploy-reference.md) for
   the full `vibew deploy` flag reference, secret rotation, and unsealing.
+- **Multi-app deployment**: see [Multi-App Deployment](multi-app.md) for
+  deploying multiple apps to one VM with subdomain routing.
 - **Production hardening**: see [Production Hardening Checklist](production-hardening.md)
   for a full checklist of security settings to review before going live.
 - **Backups**: see [Production Deployment](production-deployment.md) for Postgres

--- a/docs/multi-app.md
+++ b/docs/multi-app.md
@@ -1,0 +1,307 @@
+# Multi-App Deployment
+
+Deploy multiple apps to a single VM, each on its own subdomain, behind one
+shared VibeWarden sidecar. One VM, multiple apps, independent TLS certs.
+
+---
+
+## When to use this
+
+- **Demo hosting** -- deploy `app1.demo.example.com` and `app2.demo.example.com`
+  to one Hetzner VM instead of two.
+- **Early-stage startup** -- run 2-3 microservices on one box while budget is
+  tight; split to dedicated VMs later.
+- **Side projects** -- one VPS, multiple projects, each with full security.
+
+---
+
+## How it works
+
+Each app keeps its own `vibewarden.yaml` -- the same file you use locally with
+`vibew dev`. When you run `vibew deploy`, the CLI detects whether the target
+already has a VibeWarden sidecar:
+
+- **First deploy with a `tls.domain`**: creates the sidecar + the first site.
+- **Subsequent deploys**: adds the new app alongside existing ones.
+
+There is no config merging. Each app's `vibewarden.yaml` is copied as-is to a
+per-site directory on the server. The sidecar reads all site configs and
+generates one Caddy route block per app, with host-based routing.
+
+```
+                    +----------------------------------+
+  app1.example.com -->|                                  |--> app1 container :3000
+  app2.example.com -->|  Single VibeWarden sidecar       |--> app2 container :8080
+  app3.example.com -->|  TLS + routing + per-app config  |--> app3 container :3000
+                    +----------------------------------+
+```
+
+---
+
+## Server-side directory layout
+
+```
+~/vibewarden/
+  .sidecar/
+    global.yaml              # VM-wide settings (listen port, log level, ACME email)
+    docker-compose.yml       # sidecar container
+  sites/
+    blog/
+      vibewarden.yaml        # same file as local project
+      docker-compose.yml     # per-app container (generated)
+    api/
+      vibewarden.yaml
+      docker-compose.yml
+```
+
+- `global.yaml` is generated automatically on the first multi-app deploy.
+- Each `sites/<name>/vibewarden.yaml` is your project's config, copied verbatim.
+- Each `sites/<name>/docker-compose.yml` is generated from your config.
+
+---
+
+## Quick start
+
+### Prerequisites
+
+- A VM with Docker installed (see [Deploy to VPS](deploy-to-vps.md) steps 1-3)
+- DNS A records pointing each subdomain to the VM's IP
+- `vibew` CLI installed locally
+
+### 1. Deploy the first app
+
+From your first project's directory:
+
+```bash
+vibew deploy \
+  --target ssh://root@203.0.113.10 \
+  --config vibewarden.yaml
+```
+
+Your `vibewarden.yaml` must have `tls.domain` set. This is what triggers
+multi-app mode:
+
+```yaml
+# vibewarden.yaml (blog project)
+app:
+  image: ghcr.io/your-org/blog:latest
+
+upstream:
+  host: app
+  port: 3000
+
+tls:
+  enabled: true
+  provider: letsencrypt
+  domain: "blog.example.com"
+
+auth:
+  mode: jwt
+  jwt:
+    jwks_url: "https://your-idp/.well-known/jwks.json"
+    issuer: "https://your-idp/"
+    audience: "https://api.example.com"
+
+rate_limit:
+  enabled: true
+
+waf:
+  enabled: true
+```
+
+Expected output:
+
+```
+Creating multi-app directory layout...
+Creating shared Docker network...
+Writing global.yaml...
+Writing sidecar docker-compose.yml...
+Deploying site "blog"...
+Starting sidecar...
+Waiting for sidecar health check at http://localhost:443/_vibewarden/health (via SSH)...
+Bootstrap complete.
+```
+
+### 2. Deploy a second app
+
+From your second project's directory:
+
+```bash
+vibew deploy \
+  --target ssh://root@203.0.113.10 \
+  --config vibewarden.yaml
+```
+
+This time the CLI detects the existing sidecar and adds the new site:
+
+```
+Deploying site "api" to existing sidecar...
+Restarting sidecar to load new site...
+Waiting for sidecar health check at http://localhost:443/_vibewarden/health (via SSH)...
+Site deployed.
+```
+
+### 3. Verify both apps
+
+```bash
+curl https://blog.example.com/_vibewarden/health
+# {"status":"healthy"}
+
+curl https://api.example.com/_vibewarden/health
+# {"status":"healthy"}
+```
+
+---
+
+## Per-site configuration
+
+Each app's `vibewarden.yaml` is independent and self-contained. The file on
+the server is identical to the file in your local project. Each site can have
+its own:
+
+- Auth mode and settings
+- Rate limiting configuration
+- WAF mode (`block` or `detect`)
+- Security headers
+- Upstream host and port
+
+Changing one site's config does not affect other sites.
+
+---
+
+## Hot reload
+
+The sidecar watches `sites/*/vibewarden.yaml` for changes. When a config file
+is added, modified, or removed, the sidecar reloads the affected site's Caddy
+routes without dropping connections to other sites.
+
+Changes are debounced (500ms per site) to handle editors that write files in
+multiple steps.
+
+---
+
+## Error isolation
+
+A broken config in one site does not take down other sites:
+
+- If `sites/api/vibewarden.yaml` has a syntax error, the `api` site is marked
+  as errored. The `blog` site continues serving normally.
+- The errored site appears with `Error` status in `vibew deploy status`.
+- Fix the config file and the sidecar automatically reloads the corrected site.
+
+---
+
+## Managing sites
+
+### Check status of all sites
+
+```bash
+vibew deploy status --target ssh://root@203.0.113.10
+```
+
+Output:
+
+```
+=== Sidecar ===
+NAME              STATUS
+vibewarden        Up (healthy)
+
+=== Site: api ===
+NAME                    STATUS
+vibewarden-api-app      Up (healthy)
+
+=== Site: blog ===
+NAME                    STATUS
+vibewarden-blog-app     Up (healthy)
+```
+
+### Check status of a single site
+
+```bash
+vibew deploy status --target ssh://root@203.0.113.10 --app blog
+```
+
+### View sidecar logs
+
+```bash
+vibew deploy logs --target ssh://root@203.0.113.10
+```
+
+### View a specific site's logs
+
+```bash
+vibew deploy logs --target ssh://root@203.0.113.10 --app blog --follow
+```
+
+Press Ctrl-C to stop streaming.
+
+---
+
+## TLS
+
+Caddy auto-provisions a TLS certificate for each site's domain via ACME
+(Let's Encrypt). Each site can use a different TLS provider:
+
+```yaml
+# Site A: Let's Encrypt
+tls:
+  enabled: true
+  provider: letsencrypt
+  domain: "blog.example.com"
+
+# Site B: self-signed (for staging)
+tls:
+  enabled: true
+  provider: self-signed
+  domain: "staging.example.com"
+```
+
+DNS A records for all subdomains must point to the VM's IP before deploying.
+
+---
+
+## Global configuration
+
+The `global.yaml` file is generated automatically. It controls VM-wide settings:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `listen_port` | `443` | Port the sidecar binds to for HTTPS |
+| `log_level` | `info` | Sidecar log verbosity (`debug`, `info`, `warn`, `error`) |
+| `admin_token` | (empty) | Bearer token for the sidecar admin API |
+| `acme_email` | (empty) | Email for ACME certificate registration |
+| `listen_host` | `0.0.0.0` | Address the sidecar binds to |
+
+To customize, edit `~/vibewarden/.sidecar/global.yaml` on the server:
+
+```yaml
+# global.yaml
+listen_port: 443
+log_level: info
+acme_email: "ops@example.com"
+```
+
+---
+
+## Limitations
+
+These are planned for future phases:
+
+- **Shared Kratos** -- each site runs its own auth config. A shared Kratos
+  instance across sites is deferred to Phase 2.
+- **Migration tooling** -- no automated conversion from a single-app deployment
+  to multi-app layout. Phase 3.
+- **App removal** -- no `vibew deploy remove` command yet. To remove a site
+  manually, delete its directory (`rm -rf ~/vibewarden/sites/<name>`) and
+  restart the sidecar.
+- **Local multi-app** -- `vibew dev` remains single-app. Multi-app is
+  deploy-time only.
+
+---
+
+## Related
+
+- [Deploy to VPS](deploy-to-vps.md) -- single-app deploy walkthrough
+- [Deploy Reference](deploy-reference.md) -- full flag reference for all
+  `vibew deploy` commands
+- [Configuration](configuration.md) -- `vibewarden.yaml` field reference

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -113,6 +113,36 @@ VibeWarden is operated via the `vibew` CLI. Below is the complete command list.
 | `vibew eject` | Export raw proxy config to graduate past VibeWarden |
 | `vibew mcp` | Start MCP server for AI agent integration |
 
+### Multi-app deployment
+
+VibeWarden supports deploying multiple apps to a single VM, each on its own
+subdomain, behind one shared sidecar. `vibew deploy` automatically detects
+whether the target already has a sidecar:
+
+- First deploy with `tls.domain` set: bootstraps the sidecar and first site.
+- Subsequent deploys: adds new sites alongside existing ones.
+
+Each app keeps its own `vibewarden.yaml` (same file as local). No config
+merging. Server-side layout:
+
+```
+~/vibewarden/
+  .sidecar/global.yaml         # VM-wide settings
+  .sidecar/docker-compose.yml  # sidecar container
+  sites/<app>/vibewarden.yaml  # per-app config (copied from project)
+  sites/<app>/docker-compose.yml  # per-app container (generated)
+```
+
+The sidecar watches `sites/*/vibewarden.yaml` and hot-reloads on change.
+A broken site config does not affect other sites.
+
+Key commands:
+- `vibew deploy status --target ssh://user@host` -- shows all sites
+- `vibew deploy status --target ssh://user@host --app blog` -- single site
+- `vibew deploy logs --target ssh://user@host --app blog --follow` -- site logs
+
+Full guide: https://vibewarden.dev/docs/multi-app/
+
 ### deploy flags
 
 `vibew deploy` uses SSH to deploy the stack remotely. Key flags:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
       - Performance: performance.md
       - Social Login: social-login.md
       - Deploy to VPS: deploy-to-vps.md
+      - Multi-App Deployment: multi-app.md
       - Deploy Reference: deploy-reference.md
       - Production Deployment: production-deployment.md
       - Production Hardening: production-hardening.md


### PR DESCRIPTION
## Summary

- Add `docs/multi-app.md` -- the main guide for deploying multiple apps to a single VM with subdomain routing (stories #870-#874)
- Update `docs/deploy-reference.md` with deploy mode detection table, multi-app bootstrap/add-site flows, `--app` flag on `status` and `logs`, multi-app examples, and the `cannot add a site without a TLS domain` error
- Update `docs/deploy-to-vps.md` with cross-reference section to multi-app guide
- Update `README.md` feature matrix and docs table with multi-app entry
- Update `llms-full.txt` with multi-app section for AI agent discoverability
- Add `multi-app.md` to `mkdocs.yml` navigation under Guides

## Test plan

- [ ] Verify `docs/multi-app.md` renders correctly in mkdocs
- [ ] Verify all internal links resolve (multi-app.md, deploy-reference.md, deploy-to-vps.md)
- [ ] Verify deploy-reference.md flag tables include `--app` for `status` and `logs`
- [ ] Verify README.md feature matrix row and docs table row are visible
- [ ] Verify llms-full.txt includes the multi-app section between CLI commands and deploy flags
- [ ] Confirm `make check` passes (pre-existing Postgres integration test failure is unrelated)

Closes #869 (documentation portion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)