### PR TITLE
fix: YAML quoting in language-aware health check commands

### DIFF
--- a/internal/adapters/template/renderer.go
+++ b/internal/adapters/template/renderer.go
@@ -52,15 +52,22 @@ var funcMap = template.FuncMap{
 	// the given language runtime. Images based on Alpine (Go, Kotlin) ship
 	// wget; Python and Node slim images do not but always have their own
 	// runtime available. Falls back to wget for unknown languages.
+	// healthcheckCmd returns a Docker health check command appropriate for
+	// the given language runtime.
+	//
+	// IMPORTANT: the returned string is placed inside a YAML double-quoted
+	// string (["CMD-SHELL", "..."]), so inner double quotes would break
+	// the YAML parse. Python and Node commands use single quotes for their
+	// code argument to avoid this.
 	"healthcheckCmd": func(lang string, port int) string {
 		switch lang {
 		case "python":
 			return fmt.Sprintf(
-				`python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:%d/health')"`,
+				`python -c 'import urllib.request; urllib.request.urlopen("http://127.0.0.1:%d/health")'`,
 				port)
 		case "typescript", "javascript":
 			return fmt.Sprintf(
-				`node -e "const h=require('http');h.get('http://127.0.0.1:%d/health',r=>{process.exit(r.statusCode===200?0:1)}).on('error',()=>process.exit(1))"`,
+				`node -e 'const h=require("http");h.get("http://127.0.0.1:%d/health",r=>{process.exit(r.statusCode===200?0:1)}).on("error",()=>process.exit(1))'`,
 				port)
 		default: // go, kotlin, alpine-based, unknown
 			return fmt.Sprintf(

--- a/internal/config/templates/app-compose.yml.tmpl
+++ b/internal/config/templates/app-compose.yml.tmpl
@@ -17,7 +17,9 @@ services:
 {{- end }}
 {{- if ne .AppHealthcheck "none" }}
     healthcheck:
-      test: ["CMD-SHELL", "{{ if .AppHealthcheck }}{{ .AppHealthcheck }}{{ else }}{{ healthcheckCmd .AppLanguage .UpstreamPort }}{{ end }}"]
+      test:
+        - CMD-SHELL
+        - {{ if .AppHealthcheck }}{{ .AppHealthcheck }}{{ else }}{{ healthcheckCmd .AppLanguage .UpstreamPort }}{{ end }}
       interval: 10s
       timeout: 5s
       retries: 10

--- a/internal/config/templates/docker-compose.yml.tmpl
+++ b/internal/config/templates/docker-compose.yml.tmpl
@@ -52,7 +52,9 @@ services:
 {{- end }}
 {{- if ne .App.Healthcheck "none" }}
     healthcheck:
-      test: ["CMD-SHELL", "{{ if .App.Healthcheck }}{{ .App.Healthcheck }}{{ else }}{{ healthcheckCmd .App.Language .Upstream.Port }}{{ end }}"]
+      test:
+        - CMD-SHELL
+        - {{ if .App.Healthcheck }}{{ .App.Healthcheck }}{{ else }}{{ healthcheckCmd .App.Language .Upstream.Port }}{{ end }}
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Summary

The Python and Node health check commands contained double quotes inside a YAML double-quoted string, causing \`docker compose\` to fail with a YAML parse error. Found during end-to-end demo testing of the python-flask example.

## Fix

1. **Template**: switched from YAML flow sequence \`["CMD-SHELL", "..."]\` to block sequence so inner quotes don't need escaping.
2. **Commands**: single-quoted shell argument wrapping the code, double quotes inside for URLs.

## Before (broken)

\`\`\`yaml
test: ["CMD-SHELL", "python -c 'import urllib.request; urllib.request.urlopen("http://...")'""]
\`\`\`

## After (valid)

\`\`\`yaml
test:
  - CMD-SHELL
  - python -c 'import urllib.request; urllib.request.urlopen("http://...")'
\`\`\`

## Test plan

- [x] \`make check\` green
- [x] python-flask demo: generates valid YAML, app healthy, sidecar proxying
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)