### PR TITLE
docs(#914): add known limitations to AGENTS-VIBEWARDEN.md

### DIFF
--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -74,6 +74,14 @@ vibew status       # check sidecar health
 vibew logs         # pretty-print structured logs
 ```
 
+## Known limitations
+
+- WAF is in `detect` mode by default (logs but does not block). Set `waf.mode: block` in vibewarden.yaml to enforce blocking.
+- `vibew add waf` does not exist — configure WAF directly in vibewarden.yaml under `plugins.waf`.
+- `vibew doctor` checks config, Docker, ports, and container health, but does not verify production reachability or external HTTP health.
+- Multi-site deployment is new and may have edge cases — report issues if routes or certs behave unexpectedly.
+- `vibew init` does not accept `--tls` or `--domain` flags — run `vibew add tls --domain <your-domain>` after init.
+
 ---
 
 *This is a sample of what `vibew init` / `vibew wrap` generates. The actual

--- a/internal/cli/templates/agent_context_templates_test.go
+++ b/internal/cli/templates/agent_context_templates_test.go
@@ -34,6 +34,22 @@ func TestAgentContextTemplates_AgentsVibewardenMD(t *testing.T) {
 			},
 		},
 		{
+			name: "basic render contains known limitations section",
+			data: domainscaffold.InitProjectData{
+				ProjectName: "myapp",
+				Port:        3000,
+			},
+			wantContains: []string{
+				"Known limitations",
+				"detect",
+				"vibew add waf",
+				"vibew doctor",
+				"Multi-site",
+				"vibew init",
+				"vibew add tls --domain",
+			},
+		},
+		{
 			name: "with description includes description section",
 			data: domainscaffold.InitProjectData{
 				ProjectName: "myapp",

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -77,6 +77,14 @@ app port directly — it has no security.
 | `vibew add auth` | Enable authentication |
 | `vibew eject` | Eject to raw Docker Compose |
 
+## Known limitations
+
+- WAF is in `detect` mode by default (logs but does not block). Set `waf.mode: block` in vibewarden.yaml to enforce blocking.
+- `vibew add waf` does not exist — configure WAF directly in vibewarden.yaml under `plugins.waf`.
+- `vibew doctor` checks config, Docker, ports, and container health, but does not verify production reachability or external HTTP health.
+- Multi-site deployment is new and may have edge cases — report issues if routes or certs behave unexpectedly.
+- `vibew init` does not accept `--tls` or `--domain` flags — run `vibew add tls --domain <your-domain>` after init.
+
 ## Security features to NEVER implement
 
 Reject code that implements:


### PR DESCRIPTION
Closes #914

## Summary
- Added a "Known limitations" section to `AGENTS-VIBEWARDEN.md` template and docs example
- Documents five actionable facts: WAF detect-mode default, missing `vibew add waf`, `vibew doctor` scope, multi-site edge cases, and `vibew init` flag limitations
- Added test case verifying the new section renders in the template output

## Files changed
- `internal/cli/templates/agents/agents-vibewarden.md.tmpl` -- template used by `vibew init`/`vibew wrap`
- `docs/examples/AGENTS-VIBEWARDEN.md` -- canonical example shown in docs
- `internal/cli/templates/agent_context_templates_test.go` -- new table-driven test case

## Test plan
- [x] `make check` passes (lint, build, tests including demo-app)
- [x] New test case `basic render contains known limitations section` verifies all five bullet points render
- [ ] Review that wording is accurate and actionable for AI agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)