### PR TITLE
docs(#910): fix non-existent CLI flags in llms-full.txt

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -113,6 +113,41 @@ VibeWarden is operated via the `vibew` CLI. Below is the complete command list.
 | `vibew eject` | Export raw proxy config to graduate past VibeWarden |
 | `vibew mcp` | Start MCP server for AI agent integration |
 
+### init flags
+
+`vibew init` scaffolds a new project in the current directory. It does NOT
+support `--tls` or `--domain` — use `vibew add tls` after init for TLS.
+
+- `--port` (default 3000) -- HTTP port the app listens on
+- `--describe` -- one-line project description (written to PROJECT.md and agent files)
+- `--version` -- VibeWarden version to pin in .vibewarden-version (default: latest)
+- `--force` -- overwrite existing files
+
+### wrap flags
+
+`vibew wrap` adds the sidecar to an existing project.
+
+- `--upstream` (default auto-detected or 3000) -- upstream app port
+- `--auth` -- enable authentication (Ory Kratos)
+- `--rate-limit` -- enable rate limiting
+- `--tls` -- enable TLS (requires `--domain`)
+- `--domain` -- domain for TLS certificate (required with `--tls`)
+- `--force` -- overwrite existing files
+- `--skip-wrapper` -- skip vibew wrapper script generation
+- `--version` -- VibeWarden version to pin in .vibewarden-version (default: latest)
+
+### add flags
+
+`vibew add <feature>` enables features incrementally. Run after `vibew init`
+or `vibew wrap`.
+
+- `vibew add tls --domain <domain>` -- enable TLS (--domain is required)
+  - `--provider` (default letsencrypt) -- letsencrypt, self-signed, or external
+- `vibew add auth` -- enable Ory Kratos authentication (no extra flags)
+- `vibew add rate-limiting` -- enable rate limiting (no extra flags)
+- `vibew add metrics` -- enable Prometheus metrics (no extra flags)
+- `vibew add admin` -- enable admin API (no extra flags)
+
 ### Multi-app deployment
 
 VibeWarden supports deploying multiple apps to a single VM, each on its own


### PR DESCRIPTION
Closes #910

## Summary

- Added explicit `vibew init`, `vibew wrap`, and `vibew add` flag documentation sections to `llms-full.txt`
- The `init` section explicitly states that `--tls` and `--domain` are NOT valid flags on `vibew init`, directing agents to use `vibew add tls` instead
- All flags are cross-referenced against the actual CLI source code in `internal/cli/cmd/`
- No other incorrect flag references were found in the existing file content

## Audit results

Audited every command/flag combination in `llms-full.txt` against the actual CLI implementations:
- `vibew init` (init.go): `--port`, `--describe`, `--version`, `--force` -- now documented
- `vibew wrap` (wrap.go): `--upstream`, `--auth`, `--rate-limit`, `--tls`, `--domain`, `--force`, `--skip-wrapper`, `--version` -- now documented
- `vibew add tls` (add_tls.go): `--domain`, `--provider` -- now documented
- `vibew add auth/rate-limiting/metrics/admin`: no extra flags -- now documented
- `vibew deploy` (deploy.go): already documented, verified correct
- `vibew migrate` (migrate.go): already documented, verified correct
- `vibew upgrade` (upgrade.go): already documented, verified correct
- `vibew secret generate` (secret_generate.go): already documented, verified correct

## Test plan

- [ ] Verify `make check` passes (it does -- ran pre-push)
- [ ] Read `llms-full.txt` and confirm all flag sections match the actual CLI source code
- [ ] Confirm no AI agent would infer `--tls` or `--domain` work on `vibew init`

🤖 Generated with [Claude Code](https://claude.com/claude-code)