### PR TITLE
fix(#907): use HTTPS for deploy health check when TLS is enabled

### DIFF
--- a/internal/app/deploy/multiapp.go
+++ b/internal/app/deploy/multiapp.go
@@ -134,9 +134,9 @@ func (s *Service) BootstrapSidecar(ctx context.Context, cfg *config.Config, opts
 	if port == 0 {
 		port = defaultHealthPort
 	}
-	healthURL := fmt.Sprintf("http://localhost:%d/_vibewarden/health", port)
+	healthURL := healthCheckURL(port, cfg.TLS.Enabled)
 	fmt.Fprintf(out, "Waiting for sidecar health check at %s (via SSH)...\n", healthURL)
-	s.waitHealthy(ctx, port, out)
+	s.waitHealthy(ctx, port, cfg.TLS.Enabled, out)
 
 	fmt.Fprintln(out, "Bootstrap complete.")
 	return nil
@@ -177,9 +177,9 @@ func (s *Service) DeployMultiApp(ctx context.Context, cfg *config.Config, opts R
 	if port == 0 {
 		port = defaultHealthPort
 	}
-	healthURL := fmt.Sprintf("http://localhost:%d/_vibewarden/health", port)
+	healthURL := healthCheckURL(port, cfg.TLS.Enabled)
 	fmt.Fprintf(out, "Waiting for sidecar health check at %s (via SSH)...\n", healthURL)
-	s.waitHealthy(ctx, port, out)
+	s.waitHealthy(ctx, port, cfg.TLS.Enabled, out)
 
 	fmt.Fprintln(out, "Site deployed.")
 	return nil

--- a/internal/app/deploy/multiapp_test.go
+++ b/internal/app/deploy/multiapp_test.go
@@ -20,6 +20,16 @@ func multiappConfig() *config.Config {
 	}
 }
 
+// multiappTLSConfig returns a Config with TLS enabled for multi-app deploy tests.
+func multiappTLSConfig() *config.Config {
+	return &config.Config{
+		Server:   config.ServerConfig{Port: 443},
+		Upstream: config.UpstreamConfig{Port: 3000},
+		App:      config.AppConfig{Image: "myapp:latest"},
+		TLS:      config.TLSConfig{Enabled: true},
+	}
+}
+
 func TestBootstrapSidecar_HappyPath(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{}
@@ -468,5 +478,127 @@ func TestBootstrapSidecar_DeriveProjectName(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected site directory to use derived name 'my-awesome-app', got run calls: %v", executor.runCalls)
+	}
+}
+
+func TestBootstrapSidecar_TLSHealthCheck(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *config.Config
+		wantCurlCmd string
+		wantScheme  string
+	}{
+		{
+			name:        "TLS disabled uses HTTP with -sf",
+			cfg:         multiappConfig(),
+			wantCurlCmd: "curl -sf http://localhost:443/_vibewarden/health",
+			wantScheme:  "http://",
+		},
+		{
+			name:        "TLS enabled uses HTTPS with -sfk",
+			cfg:         multiappTLSConfig(),
+			wantCurlCmd: "curl -sfk https://localhost:443/_vibewarden/health",
+			wantScheme:  "https://",
+		},
+		{
+			name: "TLS enabled with custom port uses HTTPS with -sfk",
+			cfg: &config.Config{
+				Server:   config.ServerConfig{Port: 8443},
+				Upstream: config.UpstreamConfig{Port: 3000},
+				App:      config.AppConfig{Image: "myapp:latest"},
+				TLS:      config.TLSConfig{Enabled: true},
+			},
+			wantCurlCmd: "curl -sfk https://localhost:8443/_vibewarden/health",
+			wantScheme:  "https://",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &fakeExecutor{}
+			generator := &fakeGenerator{}
+
+			svc := deployapp.NewService(executor, generator)
+
+			var buf bytes.Buffer
+			err := svc.BootstrapSidecar(context.Background(), tt.cfg, deployapp.RunOptions{
+				ConfigPath:  "/tmp/proj/vibewarden.yaml",
+				ProjectName: "myproject",
+				Out:         &buf,
+			})
+			if err != nil {
+				t.Fatalf("BootstrapSidecar() unexpected error: %v", err)
+			}
+
+			// Verify the correct curl command was executed.
+			assertRunCalled(t, executor.runCalls, tt.wantCurlCmd)
+
+			// Verify the output mentions the correct scheme in the health check URL.
+			out := buf.String()
+			if !strings.Contains(out, tt.wantScheme) {
+				t.Errorf("expected output to contain %q, got:\n%s", tt.wantScheme, out)
+			}
+		})
+	}
+}
+
+func TestDeployMultiApp_TLSHealthCheck(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *config.Config
+		wantCurlCmd string
+		wantScheme  string
+	}{
+		{
+			name:        "TLS disabled uses HTTP with -sf",
+			cfg:         multiappConfig(),
+			wantCurlCmd: "curl -sf http://localhost:443/_vibewarden/health",
+			wantScheme:  "http://",
+		},
+		{
+			name:        "TLS enabled uses HTTPS with -sfk",
+			cfg:         multiappTLSConfig(),
+			wantCurlCmd: "curl -sfk https://localhost:443/_vibewarden/health",
+			wantScheme:  "https://",
+		},
+		{
+			name: "TLS enabled with custom port uses HTTPS with -sfk",
+			cfg: &config.Config{
+				Server:   config.ServerConfig{Port: 8443},
+				Upstream: config.UpstreamConfig{Port: 3000},
+				App:      config.AppConfig{Image: "myapp:latest"},
+				TLS:      config.TLSConfig{Enabled: true},
+			},
+			wantCurlCmd: "curl -sfk https://localhost:8443/_vibewarden/health",
+			wantScheme:  "https://",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &fakeExecutor{}
+			generator := &fakeGenerator{}
+
+			svc := deployapp.NewService(executor, generator)
+
+			var buf bytes.Buffer
+			err := svc.DeployMultiApp(context.Background(), tt.cfg, deployapp.RunOptions{
+				ConfigPath:  "/tmp/site/vibewarden.yaml",
+				ProjectName: "mysite",
+				Out:         &buf,
+			})
+			if err != nil {
+				t.Fatalf("DeployMultiApp() unexpected error: %v", err)
+			}
+
+			// Verify the correct curl command was executed.
+			assertRunCalled(t, executor.runCalls, tt.wantCurlCmd)
+
+			// Verify the output mentions the correct scheme in the health check URL.
+			out := buf.String()
+			if !strings.Contains(out, tt.wantScheme) {
+				t.Errorf("expected output to contain %q, got:\n%s", tt.wantScheme, out)
+			}
+		})
 	}
 }

--- a/internal/app/deploy/service.go
+++ b/internal/app/deploy/service.go
@@ -187,9 +187,9 @@ func (s *Service) Deploy(ctx context.Context, cfg *config.Config, opts RunOption
 	if port == 0 {
 		port = defaultHealthPort
 	}
-	healthURL := fmt.Sprintf("http://localhost:%d/_vibewarden/health", port)
+	healthURL := healthCheckURL(port, cfg.TLS.Enabled)
 	fmt.Fprintf(out, "Waiting for sidecar health check at %s (via SSH)...\n", healthURL)
-	s.waitHealthy(ctx, port, out)
+	s.waitHealthy(ctx, port, cfg.TLS.Enabled, out)
 
 	fmt.Fprintln(out, "Deploy complete.")
 	return nil
@@ -402,6 +402,10 @@ func (s *Service) checkRemotePrerequisites(ctx context.Context) error {
 // until curl reports success (exit code 0) or the context deadline /
 // healthCheckTimeout expires.
 //
+// When tlsEnabled is true the probe uses HTTPS with the -k flag (skip TLS
+// certificate verification) because we are hitting localhost, not the public
+// domain. When TLS is disabled the probe uses plain HTTP.
+//
 // Running the probe over SSH avoids all DNS propagation, firewall, and TLS
 // certificate issuance dependencies — the request is made from inside the
 // server to its own localhost interface.
@@ -409,8 +413,8 @@ func (s *Service) checkRemotePrerequisites(ctx context.Context) error {
 // On timeout or context cancellation the function prints a warning and returns
 // without error — the deploy is considered successful because services may still
 // be starting up. The operator can run "vibew deploy status" to check manually.
-func (s *Service) waitHealthy(ctx context.Context, port int, out io.Writer) {
-	cmd := fmt.Sprintf("curl -sf http://localhost:%d/_vibewarden/health", port)
+func (s *Service) waitHealthy(ctx context.Context, port int, tlsEnabled bool, out io.Writer) {
+	cmd := healthCheckCmd(port, tlsEnabled)
 	deadline := time.Now().Add(healthCheckTimeout)
 	attempt := 0
 	var lastErr error
@@ -437,6 +441,27 @@ func (s *Service) waitHealthy(ctx context.Context, port int, out io.Writer) {
 		case <-time.After(healthCheckInterval):
 		}
 	}
+}
+
+// healthCheckURL returns the health check URL using HTTPS when TLS is enabled
+// and HTTP otherwise. The host is always localhost because the probe runs on
+// the remote server itself via SSH.
+func healthCheckURL(port int, tlsEnabled bool) string {
+	scheme := "http"
+	if tlsEnabled {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://localhost:%d/_vibewarden/health", scheme, port)
+}
+
+// healthCheckCmd returns the curl command used to probe the health endpoint.
+// When TLS is enabled it adds the -k flag to skip certificate verification,
+// since the probe targets localhost rather than the public domain.
+func healthCheckCmd(port int, tlsEnabled bool) string {
+	if tlsEnabled {
+		return fmt.Sprintf("curl -sfk https://localhost:%d/_vibewarden/health", port)
+	}
+	return fmt.Sprintf("curl -sf http://localhost:%d/_vibewarden/health", port)
 }
 
 // ProjectNameFromConfig derives a project name from the config file path.

--- a/internal/app/deploy/service_test.go
+++ b/internal/app/deploy/service_test.go
@@ -1292,9 +1292,10 @@ func TestService_Deploy_HealthCheckWarnOnTimeout(t *testing.T) {
 }
 
 // TestService_Deploy_HealthCheckAlwaysUsesLocalhost verifies that the health
-// check always probes http://localhost:<port> via SSH, regardless of TLS
-// configuration or domain. This avoids DNS propagation, firewall, and TLS
-// certificate issuance dependencies.
+// check always probes localhost via SSH, regardless of TLS configuration or
+// domain. When TLS is enabled, it uses https with -k; when disabled, plain http.
+// This avoids DNS propagation, firewall, and TLS certificate issuance
+// dependencies.
 func TestService_Deploy_HealthCheckAlwaysUsesLocalhost(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -1302,22 +1303,22 @@ func TestService_Deploy_HealthCheckAlwaysUsesLocalhost(t *testing.T) {
 		wantCurlCmd string
 	}{
 		{
-			name: "TLS disabled uses localhost",
+			name: "TLS disabled uses HTTP localhost",
 			cfg: &config.Config{
 				Server: config.ServerConfig{Port: 8080},
 			},
 			wantCurlCmd: "curl -sf http://localhost:8080/_vibewarden/health",
 		},
 		{
-			name: "TLS enabled without domain still uses localhost",
+			name: "TLS enabled without domain uses HTTPS with -k",
 			cfg: &config.Config{
 				Server: config.ServerConfig{Port: 8443},
 				TLS:    config.TLSConfig{Enabled: true},
 			},
-			wantCurlCmd: "curl -sf http://localhost:8443/_vibewarden/health",
+			wantCurlCmd: "curl -sfk https://localhost:8443/_vibewarden/health",
 		},
 		{
-			name: "TLS enabled with domain still uses localhost",
+			name: "TLS enabled with domain uses HTTPS with -k on localhost",
 			cfg: &config.Config{
 				Server: config.ServerConfig{Port: 443},
 				TLS: config.TLSConfig{
@@ -1326,7 +1327,7 @@ func TestService_Deploy_HealthCheckAlwaysUsesLocalhost(t *testing.T) {
 					Domain:   "app.example.com",
 				},
 			},
-			wantCurlCmd: "curl -sf http://localhost:443/_vibewarden/health",
+			wantCurlCmd: "curl -sfk https://localhost:443/_vibewarden/health",
 		},
 	}
 


### PR DESCRIPTION
Closes #907

## Summary
- When TLS is enabled (`cfg.TLS.Enabled`), deploy health checks now use `https://localhost:<port>` with `curl -sfk` (the `-k` flag skips TLS cert verification since we are hitting localhost, not the public domain)
- When TLS is disabled, behavior is unchanged: `http://localhost:<port>` with `curl -sf`
- Extracted `healthCheckURL()` and `healthCheckCmd()` helpers to eliminate the duplicated URL construction across `service.go` and `multiapp.go`
- Updated all three callers: `Deploy()`, `BootstrapSidecar()`, and `DeployMultiApp()`
- Fixed the existing test `TestService_Deploy_HealthCheckAlwaysUsesLocalhost` to expect the correct HTTPS URLs when TLS is enabled

## Test plan
- [x] `make check` passes (formatting, golangci-lint, build, all tests)
- [x] `TestService_Deploy_HealthCheckAlwaysUsesLocalhost` covers TLS disabled (HTTP), TLS enabled without domain (HTTPS -k), and TLS enabled with domain (HTTPS -k)
- [x] `TestService_Deploy_HealthCheckTimeout` and `TestService_Deploy_HealthCheckWarnOnTimeout` continue to pass (default config has TLS disabled, so they still match the `http://` curl command)
- [x] All multiapp tests pass unchanged (fakeExecutor returns success for unknown commands, so the new `https` curl is accepted)

Generated with [Claude Code](https://claude.com/claude-code)