### PR TITLE
fix(#908): detect remote drift and require --force to overwrite

### DIFF
--- a/internal/adapters/ssh/args_test.go
+++ b/internal/adapters/ssh/args_test.go
@@ -166,3 +166,107 @@ func TestRsyncFileArgs_WithKey(t *testing.T) {
 		t.Errorf("expected '-i /home/user/.ssh/deploy_key' in rsync file -e ssh command, got: %v", args)
 	}
 }
+
+func TestRsyncDryRunArgs_ContainsDryRunAndItemize(t *testing.T) {
+	e := NewExecutor(Target{User: "ubuntu", Host: "10.0.0.1"})
+
+	args := e.rsyncDryRunArgs("/home/user/generated", "~/vibewarden/project/")
+
+	// Must contain --dry-run, --delete, --itemize-changes.
+	wantFlags := []string{"--dry-run", "--delete", "--itemize-changes"}
+	for _, flag := range wantFlags {
+		found := false
+		for _, a := range args {
+			if a == flag {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %q in rsyncDryRunArgs, got: %v", flag, args)
+		}
+	}
+
+	// Source must have trailing slash.
+	src := args[len(args)-2]
+	if src != "/home/user/generated/" {
+		t.Errorf("source = %q, want %q", src, "/home/user/generated/")
+	}
+
+	// Destination must be user@host:remoteDir.
+	dst := args[len(args)-1]
+	wantDst := "ubuntu@10.0.0.1:~/vibewarden/project/"
+	if dst != wantDst {
+		t.Errorf("destination = %q, want %q", dst, wantDst)
+	}
+}
+
+func TestRsyncDryRunArgs_WithKey(t *testing.T) {
+	e := NewExecutorWithKey(Target{User: "deploy", Host: "myserver.com", Port: 2222}, "/home/user/.ssh/key")
+
+	args := e.rsyncDryRunArgs("/local/dir", "~/remote/dir/")
+
+	// The -e flag value must contain -i <keyPath> and -p <port>.
+	found := false
+	for i, a := range args {
+		if a == "-e" && i+1 < len(args) {
+			sshCmd := args[i+1]
+			if strings.Contains(sshCmd, "-i /home/user/.ssh/key") &&
+				strings.Contains(sshCmd, "-p 2222") {
+				found = true
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected key and port in rsync dry-run ssh command, got: %v", args)
+	}
+}
+
+func TestParseDryRunOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   []string
+	}{
+		{
+			name:   "empty output returns nil",
+			output: "",
+			want:   nil,
+		},
+		{
+			name:   "only whitespace returns nil",
+			output: "  \n  \n  ",
+			want:   nil,
+		},
+		{
+			name:   "file changes are included",
+			output: ">f..T...... docker-compose.yml\n*deleting   custom-config.yml\n",
+			want:   []string{">f..T...... docker-compose.yml", "*deleting   custom-config.yml"},
+		},
+		{
+			name:   "directory metadata changes are filtered out",
+			output: ".d..t...... somedir/\n>f..T...... file.txt\n",
+			want:   []string{">f..T...... file.txt"},
+		},
+		{
+			name:   "mixed content with blank lines",
+			output: "\n>f+++++++++ new-file.yml\n\n*deleting   old-file.yml\n.d..t...... dir/\n\n",
+			want:   []string{">f+++++++++ new-file.yml", "*deleting   old-file.yml"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDryRunOutput(tt.output)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseDryRunOutput() returned %d items, want %d: got=%v", len(got), len(tt.want), got)
+			}
+			for i, g := range got {
+				if g != tt.want[i] {
+					t.Errorf("parseDryRunOutput()[%d] = %q, want %q", i, g, tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/adapters/ssh/executor.go
+++ b/internal/adapters/ssh/executor.go
@@ -172,6 +172,53 @@ func (e *Executor) TransferFile(ctx context.Context, localFile, remotePath strin
 	return nil
 }
 
+// DryRunTransfer performs a dry-run rsync between localDir and remoteDir with
+// --delete --itemize-changes to detect what would change without modifying any
+// files. It returns a list of human-readable change descriptions (one per
+// affected file). An empty slice means the directories are in sync.
+func (e *Executor) DryRunTransfer(ctx context.Context, localDir, remoteDir string) ([]string, error) {
+	args := e.rsyncDryRunArgs(localDir, remoteDir)
+	//nolint:gosec // localDir is constructed internally from config paths; remoteDir
+	// is a fixed pattern (~/vibewarden/<project>/). Safe in this context.
+	c := exec.CommandContext(ctx, "rsync", args...)
+
+	var buf bytes.Buffer
+	c.Stdout = &buf
+	c.Stderr = &buf
+
+	if err := c.Run(); err != nil {
+		return nil, fmt.Errorf("rsync dry-run %s → %s:%s: %w\noutput: %s",
+			localDir, e.target.Destination(), remoteDir, err, strings.TrimSpace(buf.String()))
+	}
+
+	return parseDryRunOutput(buf.String()), nil
+}
+
+// parseDryRunOutput extracts meaningful change lines from rsync --itemize-changes
+// dry-run output. Each non-empty line that starts with an itemize code (e.g.
+// ">f..T......", "*deleting") is included. Directory-only metadata changes and
+// blank lines are filtered out.
+func parseDryRunOutput(output string) []string {
+	var changes []string
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// rsync --itemize-changes prefixes each change with a code like:
+		//   >f..T...... filename   (file will be transferred)
+		//   *deleting   filename   (file will be deleted)
+		//   .d..t...... dirname/   (directory metadata change — skip)
+		// We include all lines except directory-only metadata changes
+		// (those starting with ".d").
+		if strings.HasPrefix(line, ".d") {
+			continue
+		}
+		changes = append(changes, line)
+	}
+	return changes
+}
+
 // sshArgs builds the ssh argument list for the given command.
 func (e *Executor) sshArgs(cmd string) []string {
 	args := []string{
@@ -213,6 +260,32 @@ func (e *Executor) rsyncArgs(localDir, remoteDir string, deleteExtra bool) []str
 	dst := e.target.Destination() + ":" + remoteDir
 	args = append(args, src, dst)
 	return args
+}
+
+// rsyncDryRunArgs builds the rsync argument list for a dry-run transfer with
+// --delete and --itemize-changes. This shows what would change without
+// modifying any files on the remote.
+func (e *Executor) rsyncDryRunArgs(localDir, remoteDir string) []string {
+	sshCmd := "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes"
+	if e.keyPath != "" {
+		sshCmd += " -i " + e.keyPath
+	}
+	if e.target.Port != 0 {
+		sshCmd += " -p " + strconv.Itoa(e.target.Port)
+	}
+
+	src := strings.TrimSuffix(localDir, "/") + "/"
+	dst := e.target.Destination() + ":" + remoteDir
+
+	return []string{
+		"-az",
+		"--dry-run",
+		"--delete",
+		"--itemize-changes",
+		"-e", sshCmd,
+		src,
+		dst,
+	}
 }
 
 // rsyncFileArgs builds the rsync argument list for a single-file transfer.

--- a/internal/app/deploy/openbao_test.go
+++ b/internal/app/deploy/openbao_test.go
@@ -366,3 +366,7 @@ func (w *wildcardExecutor) Transfer(_ context.Context, _, _ string, _ bool) erro
 func (w *wildcardExecutor) TransferFile(_ context.Context, _, _ string) error {
 	return nil
 }
+
+func (w *wildcardExecutor) DryRunTransfer(_ context.Context, _, _ string) ([]string, error) {
+	return nil, nil
+}

--- a/internal/app/deploy/service.go
+++ b/internal/app/deploy/service.go
@@ -15,6 +15,28 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
+// DriftError is returned when remote files have diverged from local files
+// and --force was not specified. It carries the list of changes that would
+// be applied so the CLI can display them to the user.
+type DriftError struct {
+	// Changes is a list of human-readable descriptions of files that would
+	// be modified or deleted on the remote host.
+	Changes []string
+}
+
+// Error implements the error interface.
+func (e *DriftError) Error() string {
+	var b strings.Builder
+	b.WriteString("remote files have been modified since last deploy:\n")
+	for _, c := range e.Changes {
+		b.WriteString("  ")
+		b.WriteString(c)
+		b.WriteString("\n")
+	}
+	b.WriteString("\nRun 'vibew deploy --force' to overwrite, or back up changes first.")
+	return b.String()
+}
+
 const (
 	// remoteBaseDir is the root directory on the remote host where all
 	// VibeWarden projects are deployed.
@@ -66,6 +88,12 @@ type RunOptions struct {
 	// before transfer. Defaults to ".vibewarden/generated" when empty.
 	GeneratedDir string
 
+	// Force, when true, skips the drift detection warning and overwrites
+	// remote files unconditionally. When false (the default), a dry-run rsync
+	// is performed before the real transfer and the deploy aborts with an
+	// actionable message if remote files have diverged.
+	Force bool
+
 	// Out is the writer used for progress messages. May be nil (output is
 	// discarded).
 	Out io.Writer
@@ -115,6 +143,19 @@ func (s *Service) Deploy(ctx context.Context, cfg *config.Config, opts RunOption
 	// Ensure the remote directory exists.
 	if _, err := s.executor.Run(ctx, "mkdir -p "+remoteDir); err != nil {
 		return fmt.Errorf("creating remote directory: %w", err)
+	}
+
+	// Drift detection: before overwriting remote files with --delete, check
+	// what would change and abort unless --force is set.
+	if !opts.Force {
+		changes, err := s.executor.DryRunTransfer(ctx, generatedDir, remoteDir)
+		if err != nil {
+			// If the dry-run fails (e.g. remote directory does not exist yet on
+			// first deploy), fall through — the real rsync will create it.
+			fmt.Fprintf(out, "Note: drift detection skipped (%v)\n", err)
+		} else if len(changes) > 0 {
+			return &DriftError{Changes: changes}
+		}
 	}
 
 	// rsync generated files.

--- a/internal/app/deploy/service_test.go
+++ b/internal/app/deploy/service_test.go
@@ -22,6 +22,10 @@ type fakeExecutor struct {
 	transferErr error
 	// transferFileErr is returned by every TransferFile call if set.
 	transferFileErr error
+	// dryRunChanges is returned by DryRunTransfer when non-nil.
+	dryRunChanges []string
+	// dryRunErr is returned by DryRunTransfer when non-nil.
+	dryRunErr error
 	// runCalls records every Run invocation for assertions.
 	runCalls []string
 	// transferCalls records every Transfer invocation for assertions.
@@ -74,6 +78,13 @@ func (f *fakeExecutor) Transfer(_ context.Context, localDir, remoteDir string, d
 func (f *fakeExecutor) TransferFile(_ context.Context, localFile, remotePath string) error {
 	f.transferFileCalls = append(f.transferFileCalls, transferFileCall{localFile: localFile, remotePath: remotePath})
 	return f.transferFileErr
+}
+
+func (f *fakeExecutor) DryRunTransfer(_ context.Context, _, _ string) ([]string, error) {
+	if f.dryRunErr != nil {
+		return nil, f.dryRunErr
+	}
+	return f.dryRunChanges, nil
 }
 
 // fakeGenerator is a test double for ports.ConfigGenerator.
@@ -655,6 +666,10 @@ func (m *mockRunExecutor) Transfer(_ context.Context, localDir, remoteDir string
 func (m *mockRunExecutor) TransferFile(_ context.Context, localFile, remotePath string) error {
 	m.transferFileCalls = append(m.transferFileCalls, transferFileCall{localFile: localFile, remotePath: remotePath})
 	return nil
+}
+
+func (m *mockRunExecutor) DryRunTransfer(_ context.Context, _, _ string) ([]string, error) {
+	return nil, nil
 }
 
 // TestService_Deploy_TransferFileCalledForConfig verifies that Deploy uses
@@ -1254,6 +1269,144 @@ func TestService_Deploy_PullsSidecarInImageMode(t *testing.T) {
 	// Both the targeted sidecar pull and the full pull must be present.
 	assertRunCalledContains(t, executor.runCalls, "docker compose pull vibewarden")
 	assertRunCalledContains(t, executor.runCalls, "docker compose pull")
+}
+
+// TestService_Deploy_DriftDetected_AbortsWithoutForce verifies that Deploy
+// returns a DriftError when remote files have diverged and --force is not set.
+func TestService_Deploy_DriftDetected_AbortsWithoutForce(t *testing.T) {
+	executor := &fakeExecutor{
+		dryRunChanges: []string{
+			">f..T...... docker-compose.yml",
+			"*deleting   custom-config.yml",
+		},
+	}
+	generator := &fakeGenerator{}
+
+	svc := deployapp.NewService(executor, generator)
+
+	err := svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
+		ConfigPath: "/tmp/proj/vibewarden.yaml",
+		Force:      false,
+	})
+	if err == nil {
+		t.Fatal("expected DriftError when drift is detected without --force")
+	}
+
+	var driftErr *deployapp.DriftError
+	if !errors.As(err, &driftErr) {
+		t.Fatalf("expected error to be *DriftError, got %T: %v", err, err)
+	}
+	if len(driftErr.Changes) != 2 {
+		t.Errorf("expected 2 changes, got %d", len(driftErr.Changes))
+	}
+	if !strings.Contains(err.Error(), "docker-compose.yml") {
+		t.Errorf("error message should list affected files, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "vibew deploy --force") {
+		t.Errorf("error message should suggest --force, got: %v", err)
+	}
+}
+
+// TestService_Deploy_DriftDetected_ProceedsWithForce verifies that Deploy
+// ignores drift when --force is set and completes successfully.
+func TestService_Deploy_DriftDetected_ProceedsWithForce(t *testing.T) {
+	executor := &fakeExecutor{
+		dryRunChanges: []string{
+			">f..T...... docker-compose.yml",
+		},
+	}
+	generator := &fakeGenerator{}
+
+	svc := deployapp.NewService(executor, generator)
+
+	var buf bytes.Buffer
+	err := svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
+		ConfigPath: "/tmp/proj/vibewarden.yaml",
+		Force:      true,
+		Out:        &buf,
+	})
+	if err != nil {
+		t.Fatalf("Deploy() with --force should succeed even with drift, got: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Deploy complete") {
+		t.Errorf("expected 'Deploy complete' in output, got:\n%s", buf.String())
+	}
+}
+
+// TestService_Deploy_NoDrift_ProceedsWithoutForce verifies that Deploy proceeds
+// normally when no drift is detected and --force is not set.
+func TestService_Deploy_NoDrift_ProceedsWithoutForce(t *testing.T) {
+	executor := &fakeExecutor{
+		dryRunChanges: nil, // no changes
+	}
+	generator := &fakeGenerator{}
+
+	svc := deployapp.NewService(executor, generator)
+
+	var buf bytes.Buffer
+	err := svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
+		ConfigPath: "/tmp/proj/vibewarden.yaml",
+		Force:      false,
+		Out:        &buf,
+	})
+	if err != nil {
+		t.Fatalf("Deploy() without drift should succeed, got: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Deploy complete") {
+		t.Errorf("expected 'Deploy complete' in output, got:\n%s", buf.String())
+	}
+}
+
+// TestService_Deploy_DryRunFails_FallsThrough verifies that a dry-run failure
+// (e.g. first deploy when the remote dir does not exist) prints a note but
+// does not abort the deploy.
+func TestService_Deploy_DryRunFails_FallsThrough(t *testing.T) {
+	executor := &fakeExecutor{
+		dryRunErr: errors.New("rsync: connection refused"),
+	}
+	generator := &fakeGenerator{}
+
+	svc := deployapp.NewService(executor, generator)
+
+	var buf bytes.Buffer
+	err := svc.Deploy(context.Background(), defaultConfig(), deployapp.RunOptions{
+		ConfigPath: "/tmp/proj/vibewarden.yaml",
+		Force:      false,
+		Out:        &buf,
+	})
+	if err != nil {
+		t.Fatalf("Deploy() should succeed when dry-run fails (first deploy), got: %v", err)
+	}
+	if !strings.Contains(buf.String(), "drift detection skipped") {
+		t.Errorf("expected note about skipped drift detection, got:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "Deploy complete") {
+		t.Errorf("expected 'Deploy complete' in output, got:\n%s", buf.String())
+	}
+}
+
+// TestDriftError_ErrorMessage verifies the DriftError message format.
+func TestDriftError_ErrorMessage(t *testing.T) {
+	err := &deployapp.DriftError{
+		Changes: []string{
+			">f..T...... docker-compose.yml",
+			"*deleting   custom-config.yml",
+		},
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "remote files have been modified") {
+		t.Errorf("expected 'remote files have been modified' in message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "docker-compose.yml") {
+		t.Errorf("expected 'docker-compose.yml' in message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "custom-config.yml") {
+		t.Errorf("expected 'custom-config.yml' in message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "vibew deploy --force") {
+		t.Errorf("expected '--force' suggestion in message, got: %s", msg)
+	}
 }
 
 // TestService_Deploy_HealthCheckWarnOnTimeout verifies the exact warning message

--- a/internal/cli/cmd/deploy.go
+++ b/internal/cli/cmd/deploy.go
@@ -30,6 +30,7 @@ func NewDeployCmd() *cobra.Command {
 		secretsFrom   string
 		rotateSecrets bool
 		unsealKey     string
+		force         bool
 	)
 
 	cmd := &cobra.Command{
@@ -105,6 +106,7 @@ Examples:
 
 			opts := deployapp.RunOptions{
 				ConfigPath: absConfig,
+				Force:      force,
 				Out:        cmd.OutOrStdout(),
 			}
 
@@ -173,6 +175,7 @@ Examples:
 	cmd.Flags().StringVar(&secretsFrom, "secrets-from", "", "path to a .env-format file whose KEY=VALUE pairs are seeded into OpenBao")
 	cmd.Flags().BoolVar(&rotateSecrets, "rotate-secrets", false, "re-seed secrets from --secrets-from on subsequent deploys")
 	cmd.Flags().StringVar(&unsealKey, "unseal-key", "", "OpenBao unseal key (required when redeploying a sealed instance); overrides stored key")
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite remote files even if they have been modified since last deploy")
 
 	if err := cmd.MarkFlagRequired("target"); err != nil {
 		fmt.Fprintln(os.Stderr, "warning: flag required registration failed:", err)

--- a/internal/ports/remote.go
+++ b/internal/ports/remote.go
@@ -34,4 +34,11 @@ type RemoteExecutor interface {
 	// trailing slash is appended to the source, so rsync treats it as a single
 	// file rather than a directory.
 	TransferFile(ctx context.Context, localFile, remotePath string) error
+
+	// DryRunTransfer performs a dry-run rsync between localDir and remoteDir
+	// with --delete --itemize-changes to detect what would change without
+	// actually modifying any files. It returns a list of human-readable change
+	// descriptions (one per affected file). An empty slice means the remote
+	// directory is already in sync with the local directory.
+	DryRunTransfer(ctx context.Context, localDir, remoteDir string) ([]string, error)
 }

--- a/test/integration/deploy_multisite_test.go
+++ b/test/integration/deploy_multisite_test.go
@@ -424,6 +424,13 @@ func (e *sshExecutor) TransferFile(_ context.Context, localFile, remotePath stri
 	return e.writeRemoteFile(remotePath, content)
 }
 
+// DryRunTransfer performs a dry-run comparison of localDir against remoteDir.
+// In integration tests this always returns no changes, since the test controls
+// the exact file content and drift detection is tested at the unit level.
+func (e *sshExecutor) DryRunTransfer(_ context.Context, _, _ string) ([]string, error) {
+	return nil, nil
+}
+
 // runCmd is an internal helper that runs a command and returns the output.
 func (e *sshExecutor) runCmd(cmd string) (string, error) {
 	session, err := e.client.NewSession()


### PR DESCRIPTION
Closes #908

## Summary

- Before this change, `vibew deploy` silently clobbered hand-edited files on the remote server via `rsync --delete` with no warning
- Added drift detection: before the real `rsync --delete`, a dry-run rsync (`--dry-run --itemize-changes --delete`) compares local vs remote files
- If remote files have diverged, the deploy aborts with a `DriftError` listing affected files and suggesting `vibew deploy --force`
- On first deploy (dry-run fails because remote dir does not exist), drift detection is gracefully skipped with a note

### Files changed

- `internal/ports/remote.go` -- added `DryRunTransfer` method to `RemoteExecutor` interface
- `internal/adapters/ssh/executor.go` -- implemented `DryRunTransfer` with `rsync --dry-run --itemize-changes --delete`, plus `parseDryRunOutput` helper
- `internal/app/deploy/service.go` -- added `DriftError` type, `Force` field on `RunOptions`, drift detection before `Transfer(..., true)`
- `internal/cli/cmd/deploy.go` -- added `--force` flag to `vibew deploy`
- All test doubles updated to implement `DryRunTransfer`

## Test plan

- [x] `TestService_Deploy_DriftDetected_AbortsWithoutForce` -- drift detected, no `--force`, returns `DriftError`
- [x] `TestService_Deploy_DriftDetected_ProceedsWithForce` -- drift detected, `--force` set, deploy completes
- [x] `TestService_Deploy_NoDrift_ProceedsWithoutForce` -- no drift, no `--force`, deploy completes normally
- [x] `TestService_Deploy_DryRunFails_FallsThrough` -- dry-run fails (first deploy), prints note, proceeds
- [x] `TestDriftError_ErrorMessage` -- verifies error message format and content
- [x] `TestRsyncDryRunArgs_ContainsDryRunAndItemize` -- verifies rsync arg construction
- [x] `TestRsyncDryRunArgs_WithKey` -- verifies key and port in dry-run args
- [x] `TestParseDryRunOutput` -- table-driven test for output parsing (empty, whitespace, file changes, directory filtering)
- [x] All existing tests pass unchanged
- [x] `make check` passes (golangci-lint, build, test, demo-app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)