### PR TITLE
feat(#913): add local runtime and production checks to vibew doctor

### DIFF
--- a/internal/app/ops/doctor.go
+++ b/internal/app/ops/doctor.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -167,8 +168,8 @@ func (s *DoctorService) runChecks(ctx context.Context, cfg *config.Config, opts 
 		results = append(results, withSection(s.checkSSHConnectivity(ctx), sectionProduction))
 		results = append(results, withSection(s.checkRemoteContainerHealth(ctx), sectionProduction))
 		if cfg.TLS.Domain != "" {
-			results = append(results, withSection(checkDomainDNS(cfg.TLS.Domain, opts.Target), sectionProduction))
-			results = append(results, withSection(checkRemoteTLSCert(cfg.TLS.Domain), sectionProduction))
+			results = append(results, withSection(checkDomainDNS(ctx, cfg.TLS.Domain, opts.Target), sectionProduction))
+			results = append(results, withSection(checkRemoteTLSCert(ctx, cfg.TLS.Domain), sectionProduction))
 		}
 	}
 
@@ -517,9 +518,13 @@ func (s *DoctorService) checkRemoteContainerHealth(ctx context.Context) CheckRes
 }
 
 // checkDomainDNS resolves the configured TLS domain and verifies it points to
-// the target host IP. Uses net.LookupHost from stdlib.
-func checkDomainDNS(domain, target string) CheckResult {
-	addrs, err := net.LookupHost(domain)
+// the target host IP. Uses net.DefaultResolver.LookupHost for context-aware
+// DNS resolution.
+func checkDomainDNS(ctx context.Context, domain, target string) CheckResult {
+	dnsCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	addrs, err := net.DefaultResolver.LookupHost(dnsCtx, domain)
 	if err != nil {
 		return CheckResult{
 			Name:     "Domain DNS",
@@ -540,7 +545,7 @@ func checkDomainDNS(domain, target string) CheckResult {
 	targetIP := extractHostFromTarget(target)
 
 	// Resolve the target host in case it is a hostname rather than an IP.
-	targetAddrs, err := net.LookupHost(targetIP)
+	targetAddrs, err := net.DefaultResolver.LookupHost(dnsCtx, targetIP)
 	if err != nil {
 		targetAddrs = []string{targetIP}
 	}
@@ -568,38 +573,32 @@ func checkDomainDNS(domain, target string) CheckResult {
 }
 
 // extractHostFromTarget parses the host component from an ssh://user@host[:port]
-// URL. If parsing fails it returns the raw input.
+// URL. It uses net/url.Parse which correctly handles IPv6 addresses and edge
+// cases. If parsing fails it returns the raw input.
 func extractHostFromTarget(raw string) string {
-	// Try standard URL parsing: ssh://user@host:port
-	if strings.Contains(raw, "://") {
-		parts := strings.SplitN(raw, "://", 2)
-		if len(parts) == 2 {
-			after := parts[1]
-			// Remove user@ prefix
-			if idx := strings.Index(after, "@"); idx >= 0 {
-				after = after[idx+1:]
-			}
-			// Remove :port suffix
-			if host, _, err := net.SplitHostPort(after); err == nil {
-				return host
-			}
-			return after
-		}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return raw
 	}
-	return raw
+	host := u.Hostname()
+	if host == "" {
+		return raw
+	}
+	return host
 }
 
 // checkRemoteTLSCert connects to domain:443 and checks the certificate expiry.
-func checkRemoteTLSCert(domain string) CheckResult {
-	conn, err := tls.DialWithDialer(
-		&net.Dialer{Timeout: 10 * time.Second},
-		"tcp",
-		domain+":443",
-		&tls.Config{
+func checkRemoteTLSCert(ctx context.Context, domain string) CheckResult {
+	tlsCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	dialer := tls.Dialer{
+		Config: &tls.Config{
 			// We accept any cert — the purpose is to inspect expiry, not validate trust.
 			InsecureSkipVerify: true, //nolint:gosec
 		},
-	)
+	}
+	conn, err := dialer.DialContext(tlsCtx, "tcp", domain+":443")
 	if err != nil {
 		return CheckResult{
 			Name:     "Remote TLS cert",
@@ -609,7 +608,16 @@ func checkRemoteTLSCert(domain string) CheckResult {
 	}
 	defer conn.Close() //nolint:errcheck
 
-	certs := conn.ConnectionState().PeerCertificates
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		return CheckResult{
+			Name:     "Remote TLS cert",
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("unexpected connection type from %s:443", domain),
+		}
+	}
+
+	certs := tlsConn.ConnectionState().PeerCertificates
 	if len(certs) == 0 {
 		return CheckResult{
 			Name:     "Remote TLS cert",

--- a/internal/app/ops/doctor.go
+++ b/internal/app/ops/doctor.go
@@ -2,11 +2,16 @@ package ops
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/fatih/color"
@@ -35,6 +40,9 @@ type CheckResult struct {
 	Severity Severity `json:"severity"`
 	// Detail is an optional explanation (shown on success and failure).
 	Detail string `json:"detail,omitempty"`
+	// Section groups the check for display purposes (e.g. "Config & Docker",
+	// "Local Runtime", "Production"). Empty for legacy checks.
+	Section string `json:"section,omitempty"`
 }
 
 // OK returns true when the check severity is OK.
@@ -43,9 +51,10 @@ func (c CheckResult) OK() bool { return c.Severity == SeverityOK }
 // DoctorService orchestrates the "vibew doctor" use case.
 // Every check runs independently — a failing check does not stop subsequent ones.
 type DoctorService struct {
-	compose       ports.ComposeRunner
-	portChecker   ports.PortChecker
-	healthChecker ports.HealthChecker
+	compose        ports.ComposeRunner
+	portChecker    ports.PortChecker
+	healthChecker  ports.HealthChecker
+	remoteExecutor ports.RemoteExecutor
 }
 
 // NewDoctorService creates a new DoctorService.
@@ -57,6 +66,15 @@ func NewDoctorService(compose ports.ComposeRunner, portChecker ports.PortChecker
 	}
 }
 
+// WithRemoteExecutor returns a copy of the DoctorService with the given
+// RemoteExecutor set for production checks. When nil, production checks are
+// skipped.
+func (s *DoctorService) WithRemoteExecutor(executor ports.RemoteExecutor) *DoctorService {
+	cp := *s
+	cp.remoteExecutor = executor
+	return &cp
+}
+
 // DoctorOptions controls how Run behaves.
 type DoctorOptions struct {
 	// ConfigPath is the path to the vibewarden.yaml file (used in the report label).
@@ -66,6 +84,9 @@ type DoctorOptions struct {
 	WorkDir string
 	// JSON requests machine-readable JSON output instead of the human-readable table.
 	JSON bool
+	// Target is the SSH target for production checks (e.g. "ssh://user@host").
+	// When empty, production checks are skipped.
+	Target string
 }
 
 // Run executes all diagnostics and writes the report to out.
@@ -77,7 +98,7 @@ func (s *DoctorService) Run(ctx context.Context, cfg *config.Config, opts Doctor
 		workDir = "."
 	}
 
-	checks := s.runChecks(ctx, cfg, opts.ConfigPath, workDir)
+	checks := s.runChecks(ctx, cfg, opts, workDir)
 
 	if opts.JSON {
 		if err := printDoctorJSON(checks, out); err != nil {
@@ -97,20 +118,32 @@ func (s *DoctorService) Run(ctx context.Context, cfg *config.Config, opts Doctor
 	return allOK, nil
 }
 
+// sectionConfigDocker is the section header for config and Docker checks.
+const sectionConfigDocker = "Config & Docker"
+
+// sectionLocalRuntime is the section header for local runtime checks.
+const sectionLocalRuntime = "Local Runtime"
+
+// sectionProduction is the section header for production checks.
+const sectionProduction = "Production"
+
+// localTLSCertExpiryWarnDays is the number of days before expiry that triggers
+// a warning for local TLS certificates.
+const localTLSCertExpiryWarnDays = 7
+
+// remoteTLSCertExpiryWarnDays is the number of days before expiry that triggers
+// a warning for remote TLS certificates.
+const remoteTLSCertExpiryWarnDays = 30
+
 // runChecks executes every diagnostic check and returns the aggregated results.
-func (s *DoctorService) runChecks(ctx context.Context, cfg *config.Config, configPath, workDir string) []CheckResult {
+func (s *DoctorService) runChecks(ctx context.Context, cfg *config.Config, opts DoctorOptions, workDir string) []CheckResult {
 	var results []CheckResult
 
-	// 1. vibewarden.yaml present and valid
-	results = append(results, checkConfigFile(cfg, configPath))
+	// --- Layer 1: Config & Docker ---
+	results = append(results, withSection(checkConfigFile(cfg, opts.ConfigPath), sectionConfigDocker))
+	results = append(results, withSection(s.checkDockerRunning(ctx), sectionConfigDocker))
+	results = append(results, withSection(s.checkDockerCompose(ctx), sectionConfigDocker))
 
-	// 2. Is Docker running?
-	results = append(results, s.checkDockerRunning(ctx))
-
-	// 3. Is Docker Compose v2 available?
-	results = append(results, s.checkDockerCompose(ctx))
-
-	// 4. Required ports available
 	proxyPort := cfg.Server.Port
 	if proxyPort == 0 {
 		proxyPort = 8443
@@ -119,16 +152,33 @@ func (s *DoctorService) runChecks(ctx context.Context, cfg *config.Config, confi
 	if proxyHost == "" {
 		proxyHost = "127.0.0.1"
 	}
-	results = append(results, s.checkPort(ctx, "Proxy port", proxyHost, proxyPort))
+	results = append(results, withSection(s.checkPort(ctx, "Proxy port", proxyHost, proxyPort), sectionConfigDocker))
 
-	// 5. Generated files present
 	generatedCompose := filepath.Join(workDir, ".vibewarden", "generated", "docker-compose.yml")
-	results = append(results, checkGeneratedFiles(generatedCompose))
+	results = append(results, withSection(checkGeneratedFiles(generatedCompose), sectionConfigDocker))
+	results = append(results, withSection(s.checkContainerHealth(ctx, generatedCompose), sectionConfigDocker))
 
-	// 6. If stack is running: container health
-	results = append(results, s.checkContainerHealth(ctx, generatedCompose))
+	// --- Layer 2: Local Runtime ---
+	results = append(results, withSection(s.checkUpstreamReachable(ctx, cfg), sectionLocalRuntime))
+	results = append(results, withSection(checkTLSCertValid(cfg, workDir), sectionLocalRuntime))
+
+	// --- Layer 3: Production (only when target is set and executor is available) ---
+	if opts.Target != "" && s.remoteExecutor != nil {
+		results = append(results, withSection(s.checkSSHConnectivity(ctx), sectionProduction))
+		results = append(results, withSection(s.checkRemoteContainerHealth(ctx), sectionProduction))
+		if cfg.TLS.Domain != "" {
+			results = append(results, withSection(checkDomainDNS(cfg.TLS.Domain, opts.Target), sectionProduction))
+			results = append(results, withSection(checkRemoteTLSCert(cfg.TLS.Domain), sectionProduction))
+		}
+	}
 
 	return results
+}
+
+// withSection returns a copy of the CheckResult with the Section field set.
+func withSection(r CheckResult, section string) CheckResult {
+	r.Section = section
+	return r
 }
 
 func (s *DoctorService) checkDockerRunning(ctx context.Context) CheckResult {
@@ -275,17 +325,345 @@ func (s *DoctorService) checkContainerHealth(ctx context.Context, composePath st
 	}
 }
 
+// checkUpstreamReachable verifies that the upstream application responds to
+// HTTP health checks. This uses the HealthChecker port already injected into
+// the service.
+func (s *DoctorService) checkUpstreamReachable(ctx context.Context, cfg *config.Config) CheckResult {
+	host := cfg.Upstream.Host
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	port := cfg.Upstream.Port
+	if port == 0 {
+		port = 3000
+	}
+
+	url := fmt.Sprintf("http://%s:%d", host, port)
+
+	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	ok, statusCode, err := s.healthChecker.CheckHealth(checkCtx, url)
+	if err != nil {
+		return CheckResult{
+			Name:     "Upstream reachable",
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("%s — unreachable (app may not be started yet)", url),
+		}
+	}
+	if !ok {
+		return CheckResult{
+			Name:     "Upstream reachable",
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("%s — responded with HTTP %d", url, statusCode),
+		}
+	}
+	return CheckResult{
+		Name:     "Upstream reachable",
+		Severity: SeverityOK,
+		Detail:   fmt.Sprintf("%s — HTTP %d", url, statusCode),
+	}
+}
+
+// checkTLSCertValid checks the local self-signed TLS certificate for expiry.
+// It only runs when the TLS provider is "self-signed" and cert files exist in
+// the generated certs directory.
+func checkTLSCertValid(cfg *config.Config, workDir string) CheckResult {
+	if cfg.TLS.Provider != "self-signed" {
+		return CheckResult{
+			Name:     "TLS certificate",
+			Severity: SeverityOK,
+			Detail:   fmt.Sprintf("provider is %q — skipping local cert check", cfg.TLS.Provider),
+		}
+	}
+
+	certPath := filepath.Join(workDir, ".vibewarden", "generated", "certs", "server.crt")
+	certPEM, err := os.ReadFile(certPath) //nolint:gosec // path is built from workDir + fixed relative path
+	if err != nil {
+		return CheckResult{
+			Name:     "TLS certificate",
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("%s not found — run 'vibew generate' to create certs", certPath),
+		}
+	}
+
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return CheckResult{
+			Name:     "TLS certificate",
+			Severity: SeverityFail,
+			Detail:   fmt.Sprintf("%s — failed to decode PEM block", certPath),
+		}
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return CheckResult{
+			Name:     "TLS certificate",
+			Severity: SeverityFail,
+			Detail:   fmt.Sprintf("%s — failed to parse certificate: %v", certPath, err),
+		}
+	}
+
+	now := time.Now()
+	if now.After(cert.NotAfter) {
+		return CheckResult{
+			Name:     "TLS certificate",
+			Severity: SeverityFail,
+			Detail:   fmt.Sprintf("expired on %s", cert.NotAfter.Format(time.DateOnly)),
+		}
+	}
+
+	daysUntilExpiry := int(time.Until(cert.NotAfter).Hours() / 24)
+	if daysUntilExpiry <= localTLSCertExpiryWarnDays {
+		return CheckResult{
+			Name:     "TLS certificate",
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("expires in %d day(s) on %s", daysUntilExpiry, cert.NotAfter.Format(time.DateOnly)),
+		}
+	}
+
+	return CheckResult{
+		Name:     "TLS certificate",
+		Severity: SeverityOK,
+		Detail:   fmt.Sprintf("valid until %s (%d days)", cert.NotAfter.Format(time.DateOnly), daysUntilExpiry),
+	}
+}
+
+// checkSSHConnectivity tries to run a simple command on the remote host to
+// verify SSH access.
+func (s *DoctorService) checkSSHConnectivity(ctx context.Context) CheckResult {
+	checkCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	_, err := s.remoteExecutor.Run(checkCtx, "echo ok")
+	if err != nil {
+		return CheckResult{
+			Name:     "SSH connectivity",
+			Severity: SeverityFail,
+			Detail:   fmt.Sprintf("could not connect: %v", err),
+		}
+	}
+	return CheckResult{
+		Name:     "SSH connectivity",
+		Severity: SeverityOK,
+		Detail:   "connected successfully",
+	}
+}
+
+// checkRemoteContainerHealth runs "docker compose ps" on the remote host via
+// SSH and reports the health of each container.
+func (s *DoctorService) checkRemoteContainerHealth(ctx context.Context) CheckResult {
+	checkCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	output, err := s.remoteExecutor.Run(checkCtx, "docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null")
+	if err != nil {
+		return CheckResult{
+			Name:     "Remote containers",
+			Severity: SeverityFail,
+			Detail:   fmt.Sprintf("could not query remote containers: %v", err),
+		}
+	}
+
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return CheckResult{
+			Name:     "Remote containers",
+			Severity: SeverityWarn,
+			Detail:   "no containers found on remote host",
+		}
+	}
+
+	// Try to parse JSON lines output (docker compose ps --format json).
+	var unhealthy []string
+	var total int
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var info struct {
+			Service string `json:"Service"`
+			State   string `json:"State"`
+			Health  string `json:"Health"`
+		}
+		if err := json.Unmarshal([]byte(line), &info); err != nil {
+			// Not JSON — fallback to reporting raw output as OK.
+			return CheckResult{
+				Name:     "Remote containers",
+				Severity: SeverityOK,
+				Detail:   "containers found (non-JSON output)",
+			}
+		}
+		total++
+		if info.State != "running" || (info.Health != "" && info.Health != "healthy") {
+			unhealthy = append(unhealthy, fmt.Sprintf("%s (%s/%s)", info.Service, info.State, info.Health))
+		}
+	}
+
+	if len(unhealthy) > 0 {
+		return CheckResult{
+			Name:     "Remote containers",
+			Severity: SeverityFail,
+			Detail:   fmt.Sprintf("unhealthy containers: %v", unhealthy),
+		}
+	}
+	return CheckResult{
+		Name:     "Remote containers",
+		Severity: SeverityOK,
+		Detail:   fmt.Sprintf("%d container(s) running", total),
+	}
+}
+
+// checkDomainDNS resolves the configured TLS domain and verifies it points to
+// the target host IP. Uses net.LookupHost from stdlib.
+func checkDomainDNS(domain, target string) CheckResult {
+	addrs, err := net.LookupHost(domain)
+	if err != nil {
+		return CheckResult{
+			Name:     "Domain DNS",
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("could not resolve %s: %v", domain, err),
+		}
+	}
+
+	if len(addrs) == 0 {
+		return CheckResult{
+			Name:     "Domain DNS",
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("no DNS records found for %s", domain),
+		}
+	}
+
+	// Extract the host from the SSH target URL (ssh://user@host[:port]).
+	targetIP := extractHostFromTarget(target)
+
+	// Resolve the target host in case it is a hostname rather than an IP.
+	targetAddrs, err := net.LookupHost(targetIP)
+	if err != nil {
+		targetAddrs = []string{targetIP}
+	}
+
+	targetSet := make(map[string]bool, len(targetAddrs))
+	for _, a := range targetAddrs {
+		targetSet[a] = true
+	}
+
+	for _, a := range addrs {
+		if targetSet[a] {
+			return CheckResult{
+				Name:     "Domain DNS",
+				Severity: SeverityOK,
+				Detail:   fmt.Sprintf("%s resolves to %s (matches target)", domain, a),
+			}
+		}
+	}
+
+	return CheckResult{
+		Name:     "Domain DNS",
+		Severity: SeverityWarn,
+		Detail:   fmt.Sprintf("%s resolves to %s but target is %s", domain, strings.Join(addrs, ", "), targetIP),
+	}
+}
+
+// extractHostFromTarget parses the host component from an ssh://user@host[:port]
+// URL. If parsing fails it returns the raw input.
+func extractHostFromTarget(raw string) string {
+	// Try standard URL parsing: ssh://user@host:port
+	if strings.Contains(raw, "://") {
+		parts := strings.SplitN(raw, "://", 2)
+		if len(parts) == 2 {
+			after := parts[1]
+			// Remove user@ prefix
+			if idx := strings.Index(after, "@"); idx >= 0 {
+				after = after[idx+1:]
+			}
+			// Remove :port suffix
+			if host, _, err := net.SplitHostPort(after); err == nil {
+				return host
+			}
+			return after
+		}
+	}
+	return raw
+}
+
+// checkRemoteTLSCert connects to domain:443 and checks the certificate expiry.
+func checkRemoteTLSCert(domain string) CheckResult {
+	conn, err := tls.DialWithDialer(
+		&net.Dialer{Timeout: 10 * time.Second},
+		"tcp",
+		domain+":443",
+		&tls.Config{
+			// We accept any cert — the purpose is to inspect expiry, not validate trust.
+			InsecureSkipVerify: true, //nolint:gosec
+		},
+	)
+	if err != nil {
+		return CheckResult{
+			Name:     "Remote TLS cert",
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("could not connect to %s:443: %v", domain, err),
+		}
+	}
+	defer conn.Close() //nolint:errcheck
+
+	certs := conn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		return CheckResult{
+			Name:     "Remote TLS cert",
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("no certificates presented by %s:443", domain),
+		}
+	}
+
+	leaf := certs[0]
+	now := time.Now()
+
+	if now.After(leaf.NotAfter) {
+		return CheckResult{
+			Name:     "Remote TLS cert",
+			Severity: SeverityFail,
+			Detail:   fmt.Sprintf("expired on %s", leaf.NotAfter.Format(time.DateOnly)),
+		}
+	}
+
+	daysUntilExpiry := int(time.Until(leaf.NotAfter).Hours() / 24)
+	if daysUntilExpiry <= remoteTLSCertExpiryWarnDays {
+		return CheckResult{
+			Name:     "Remote TLS cert",
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("expires in %d day(s) on %s", daysUntilExpiry, leaf.NotAfter.Format(time.DateOnly)),
+		}
+	}
+
+	return CheckResult{
+		Name:     "Remote TLS cert",
+		Severity: SeverityOK,
+		Detail:   fmt.Sprintf("valid until %s (%d days)", leaf.NotAfter.Format(time.DateOnly), daysUntilExpiry),
+	}
+}
+
 // printDoctorReport renders the check results to out using ANSI colour codes.
+// Results are grouped by section with headers.
 func printDoctorReport(results []CheckResult, out io.Writer) {
 	green := color.New(color.FgGreen).SprintFunc()
 	yellow := color.New(color.FgYellow).SprintFunc()
 	red := color.New(color.FgRed).SprintFunc()
+	bold := color.New(color.Bold).SprintFunc()
 
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "VibeWarden Doctor")
 	fmt.Fprintln(out, "─────────────────────────────────────────")
 
+	currentSection := ""
 	for _, r := range results {
+		if r.Section != "" && r.Section != currentSection {
+			currentSection = r.Section
+			fmt.Fprintf(out, "\n  %s\n", bold(currentSection))
+		}
+
 		var badge string
 		switch r.Severity {
 		case SeverityOK:

--- a/internal/app/ops/doctor_internal_test.go
+++ b/internal/app/ops/doctor_internal_test.go
@@ -1,0 +1,68 @@
+package ops
+
+import (
+	"testing"
+)
+
+func TestExtractHostFromTarget(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "ssh URL with user and host",
+			input: "ssh://user@192.0.2.1",
+			want:  "192.0.2.1",
+		},
+		{
+			name:  "ssh URL with user, host, and port",
+			input: "ssh://user@192.0.2.1:2222",
+			want:  "192.0.2.1",
+		},
+		{
+			name:  "ssh URL with hostname",
+			input: "ssh://deploy@example.com",
+			want:  "example.com",
+		},
+		{
+			name:  "ssh URL with hostname and port",
+			input: "ssh://deploy@example.com:22",
+			want:  "example.com",
+		},
+		{
+			name:  "ssh URL without user",
+			input: "ssh://192.0.2.1",
+			want:  "192.0.2.1",
+		},
+		{
+			name:  "ssh URL with IPv6 address",
+			input: "ssh://user@[::1]:22",
+			want:  "::1",
+		},
+		{
+			name:  "ssh URL with IPv6 no port",
+			input: "ssh://user@[2001:db8::1]",
+			want:  "2001:db8::1",
+		},
+		{
+			name:  "bare hostname falls through",
+			input: "192.0.2.1",
+			want:  "192.0.2.1",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractHostFromTarget(tt.input)
+			if got != tt.want {
+				t.Errorf("extractHostFromTarget(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/app/ops/doctor_test.go
+++ b/internal/app/ops/doctor_test.go
@@ -73,6 +73,10 @@ func (f *fakeRemoteExecutor) TransferFile(_ context.Context, _, _ string) error 
 	return nil
 }
 
+func (f *fakeRemoteExecutor) DryRunTransfer(_ context.Context, _, _ string) ([]string, error) {
+	return nil, nil
+}
+
 // reachableHealthChecker is a fakeHealthChecker that reports upstream as reachable.
 func reachableHealthChecker() *fakeHealthChecker {
 	return &fakeHealthChecker{

--- a/internal/app/ops/doctor_test.go
+++ b/internal/app/ops/doctor_test.go
@@ -3,12 +3,21 @@ package ops_test
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
+	"io"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vibewarden/vibewarden/internal/app/ops"
 	"github.com/vibewarden/vibewarden/internal/ports"
@@ -16,7 +25,7 @@ import (
 
 // fakePortChecker is a test double for ports.PortChecker.
 type fakePortChecker struct {
-	// available maps port → available
+	// available maps port -> available
 	available map[int]bool
 }
 
@@ -27,12 +36,56 @@ func (f *fakePortChecker) IsPortAvailable(_ context.Context, _ string, port int)
 	return true, nil
 }
 
+// fakeRemoteExecutor is a test double for ports.RemoteExecutor.
+type fakeRemoteExecutor struct {
+	runResponses map[string]runResult
+	runErr       error
+}
+
+type runResult struct {
+	output string
+	err    error
+}
+
+func (f *fakeRemoteExecutor) Run(_ context.Context, cmd string) (string, error) {
+	if f.runErr != nil {
+		return "", f.runErr
+	}
+	if r, ok := f.runResponses[cmd]; ok {
+		return r.output, r.err
+	}
+	// Default: echo commands succeed
+	if strings.HasPrefix(cmd, "echo ") {
+		return "ok", nil
+	}
+	return "", errors.New("unknown command")
+}
+
+func (f *fakeRemoteExecutor) RunStream(_ context.Context, _ string, _, _ io.Writer) error {
+	return nil
+}
+
+func (f *fakeRemoteExecutor) Transfer(_ context.Context, _, _ string, _ bool) error {
+	return nil
+}
+
+func (f *fakeRemoteExecutor) TransferFile(_ context.Context, _, _ string) error {
+	return nil
+}
+
 // reachableHealthChecker is a fakeHealthChecker that reports upstream as reachable.
 func reachableHealthChecker() *fakeHealthChecker {
 	return &fakeHealthChecker{
 		responses: map[string]healthResponse{
 			"http://127.0.0.1:3000": {ok: true, statusCode: 200},
 		},
+	}
+}
+
+// unreachableHealthChecker returns a fakeHealthChecker where upstream is unreachable.
+func unreachableHealthChecker() *fakeHealthChecker {
+	return &fakeHealthChecker{
+		responses: map[string]healthResponse{},
 	}
 }
 
@@ -79,6 +132,38 @@ func optsWithGeneratedFile(t *testing.T) ops.DoctorOptions {
 	return ops.DoctorOptions{
 		ConfigPath: "vibewarden.yaml",
 		WorkDir:    dir,
+	}
+}
+
+// writeSelfSignedCert creates a self-signed certificate in the generated certs
+// directory under workDir with the given validity window.
+func writeSelfSignedCert(t *testing.T, workDir string, notBefore, notAfter time.Time) {
+	t.Helper()
+	certDir := filepath.Join(workDir, ".vibewarden", "generated", "certs")
+	if err := os.MkdirAll(certDir, 0o755); err != nil {
+		t.Fatalf("create certs dir: %v", err)
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	if err := os.WriteFile(filepath.Join(certDir, "server.crt"), certPEM, 0o644); err != nil {
+		t.Fatalf("write cert file: %v", err)
 	}
 }
 
@@ -377,5 +462,442 @@ func TestDoctorService_Run_ContainersHealthy_AllOK(t *testing.T) {
 	}
 	if !strings.Contains(out, "running") {
 		t.Errorf("expected 'running' in container health detail, got:\n%s", out)
+	}
+}
+
+// --- New tests for Layer 2: Local Runtime checks ---
+
+func TestDoctorService_Run_UpstreamReachable(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allOK {
+		t.Errorf("expected allOK = true when upstream is reachable\noutput:\n%s", buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Upstream reachable") {
+		t.Errorf("expected 'Upstream reachable' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "HTTP 200") {
+		t.Errorf("expected 'HTTP 200' in upstream detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_UpstreamUnreachable(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := unreachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	// Upstream unreachable is WARN, not FAIL, so allOK should still be true.
+	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allOK {
+		t.Errorf("expected allOK = true because upstream unreachable is WARN\noutput:\n%s", buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Upstream reachable") {
+		t.Errorf("expected 'Upstream reachable' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "unreachable") {
+		t.Errorf("expected 'unreachable' in upstream detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_TLSCertValid(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+
+	opts := defaultOpts(t)
+
+	// Write a valid cert that expires in 90 days.
+	writeSelfSignedCert(t, opts.WorkDir, time.Now().Add(-24*time.Hour), time.Now().Add(90*24*time.Hour))
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allOK {
+		t.Errorf("expected allOK = true with valid cert\noutput:\n%s", buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "TLS certificate") {
+		t.Errorf("expected 'TLS certificate' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "valid until") {
+		t.Errorf("expected 'valid until' in cert detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_TLSCertExpired(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+
+	opts := defaultOpts(t)
+
+	// Write an expired cert.
+	writeSelfSignedCert(t, opts.WorkDir, time.Now().Add(-48*time.Hour), time.Now().Add(-24*time.Hour))
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allOK {
+		t.Error("expected allOK = false when TLS cert is expired")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "expired") {
+		t.Errorf("expected 'expired' in cert detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_TLSCertExpiringSoon(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+
+	opts := defaultOpts(t)
+
+	// Write a cert that expires in 3 days (within 7-day warning window).
+	writeSelfSignedCert(t, opts.WorkDir, time.Now().Add(-24*time.Hour), time.Now().Add(3*24*time.Hour))
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// WARN does not cause allOK = false.
+	if !allOK {
+		t.Errorf("expected allOK = true because cert-expiring-soon is WARN\noutput:\n%s", buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "expires in") {
+		t.Errorf("expected 'expires in' in cert detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_TLSCertMissing(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+
+	// defaultOpts has no cert files at all.
+	opts := defaultOpts(t)
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Cert missing is WARN.
+	if !allOK {
+		t.Errorf("expected allOK = true because missing cert is WARN\noutput:\n%s", buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "TLS certificate") {
+		t.Errorf("expected 'TLS certificate' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "not found") {
+		t.Errorf("expected 'not found' in cert detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_TLSCertNonSelfSigned_Skipped(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+	cfg.TLS.Provider = "letsencrypt"
+	cfg.TLS.Domain = "example.com"
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allOK {
+		t.Errorf("expected allOK = true when TLS provider is letsencrypt\noutput:\n%s", buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "skipping local cert check") {
+		t.Errorf("expected 'skipping local cert check' in output, got:\n%s", out)
+	}
+}
+
+// --- New tests for Layer 3: Production checks ---
+
+func TestDoctorService_Run_SSHConnectivity_Success(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	executor := &fakeRemoteExecutor{
+		runResponses: map[string]runResult{
+			"echo ok": {output: "ok", err: nil},
+			"docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null": {
+				output: "", err: nil,
+			},
+		},
+	}
+	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
+	cfg := defaultConfig()
+
+	opts := defaultOpts(t)
+	opts.Target = "ssh://user@192.0.2.1"
+
+	var buf bytes.Buffer
+	_, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "SSH connectivity") {
+		t.Errorf("expected 'SSH connectivity' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "connected successfully") {
+		t.Errorf("expected 'connected successfully' in SSH detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_SSHConnectivity_Failure(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	executor := &fakeRemoteExecutor{
+		runErr: errors.New("connection refused"),
+	}
+	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
+	cfg := defaultConfig()
+
+	opts := defaultOpts(t)
+	opts.Target = "ssh://user@192.0.2.1"
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allOK {
+		t.Error("expected allOK = false when SSH connectivity fails")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "SSH connectivity") {
+		t.Errorf("expected 'SSH connectivity' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "could not connect") {
+		t.Errorf("expected 'could not connect' in SSH detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_NoTarget_NoRemoteChecks(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+
+	// No --target flag, no remote executor.
+	opts := defaultOpts(t)
+
+	var buf bytes.Buffer
+	_, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	// Production checks should not appear.
+	for _, absent := range []string{"SSH connectivity", "Remote containers", "Domain DNS", "Remote TLS cert"} {
+		if strings.Contains(out, absent) {
+			t.Errorf("expected %q to be absent when no target is set, but found in output:\n%s", absent, out)
+		}
+	}
+}
+
+func TestDoctorService_Run_RemoteContainerHealth_Unhealthy(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+
+	// Remote containers with one unhealthy.
+	unhealthyJSON := `{"Service":"proxy","State":"running","Health":"unhealthy"}
+{"Service":"app","State":"running","Health":"healthy"}`
+
+	executor := &fakeRemoteExecutor{
+		runResponses: map[string]runResult{
+			"echo ok": {output: "ok", err: nil},
+			"docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null": {
+				output: unhealthyJSON, err: nil,
+			},
+		},
+	}
+	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
+	cfg := defaultConfig()
+
+	opts := defaultOpts(t)
+	opts.Target = "ssh://user@192.0.2.1"
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allOK {
+		t.Error("expected allOK = false when remote container is unhealthy")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Remote containers") {
+		t.Errorf("expected 'Remote containers' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "unhealthy") {
+		t.Errorf("expected 'unhealthy' in remote containers detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_RemoteContainerHealth_AllHealthy(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+
+	healthyJSON := `{"Service":"proxy","State":"running","Health":"healthy"}
+{"Service":"app","State":"running","Health":"healthy"}`
+
+	executor := &fakeRemoteExecutor{
+		runResponses: map[string]runResult{
+			"echo ok": {output: "ok", err: nil},
+			"docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null": {
+				output: healthyJSON, err: nil,
+			},
+		},
+	}
+	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
+	cfg := defaultConfig()
+
+	opts := defaultOpts(t)
+	opts.Target = "ssh://user@192.0.2.1"
+
+	var buf bytes.Buffer
+	_, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "2 container(s) running") {
+		t.Errorf("expected '2 container(s) running' in remote containers detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_SectionHeaders(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	_, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Config & Docker") {
+		t.Errorf("expected 'Config & Docker' section header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Local Runtime") {
+		t.Errorf("expected 'Local Runtime' section header, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_ProductionSectionHeaders(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	executor := &fakeRemoteExecutor{
+		runResponses: map[string]runResult{
+			"echo ok": {output: "ok", err: nil},
+			"docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null": {
+				output: "", err: nil,
+			},
+		},
+	}
+	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
+	cfg := defaultConfig()
+
+	opts := defaultOpts(t)
+	opts.Target = "ssh://user@192.0.2.1"
+
+	var buf bytes.Buffer
+	_, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Production") {
+		t.Errorf("expected 'Production' section header, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_JSONOutput_IncludesSection(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	opts := defaultOpts(t)
+	opts.JSON = true
+	_, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var results []ops.CheckResult
+	if err := json.Unmarshal(buf.Bytes(), &results); err != nil {
+		t.Fatalf("output is not valid JSON: %v\ngot:\n%s", err, buf.String())
+	}
+
+	// All results should have a section.
+	for _, r := range results {
+		if r.Section == "" {
+			t.Errorf("check %q has empty section in JSON output", r.Name)
+		}
 	}
 }

--- a/internal/app/ops/doctor_test.go
+++ b/internal/app/ops/doctor_test.go
@@ -74,7 +74,7 @@ func (f *fakeRemoteExecutor) TransferFile(_ context.Context, _, _ string) error 
 }
 
 func (f *fakeRemoteExecutor) DryRunTransfer(_ context.Context, _, _ string) ([]string, error) {
-	return nil, nil
+	return []string{}, nil
 }
 
 // reachableHealthChecker is a fakeHealthChecker that reports upstream as reachable.

--- a/internal/cli/cmd/doctor.go
+++ b/internal/cli/cmd/doctor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	opsadapter "github.com/vibewarden/vibewarden/internal/adapters/ops"
+	sshadapter "github.com/vibewarden/vibewarden/internal/adapters/ssh"
 	opsapp "github.com/vibewarden/vibewarden/internal/app/ops"
 	"github.com/vibewarden/vibewarden/internal/config"
 )
@@ -22,6 +23,8 @@ func NewDoctorCmd() *cobra.Command {
 	var (
 		configPath string
 		jsonOutput bool
+		target     string
+		sshKey     string
 	)
 
 	cmd := &cobra.Command{
@@ -29,13 +32,25 @@ func NewDoctorCmd() *cobra.Command {
 		Short: "Diagnose common configuration and environment issues",
 		Long: `Run a series of independent diagnostics and report any issues found.
 
-Checks performed (in order):
-  - vibewarden.yaml is present and parses without errors
-  - Docker daemon is reachable (docker info)
-  - Docker Compose v2+ is available (docker compose version)
-  - Required ports are available (proxy port)
-  - Generated files are present (.vibewarden/generated/docker-compose.yml)
-  - If the stack is running: containers are healthy (docker compose ps)
+Checks are organised into three layers:
+
+  Config & Docker (always runs):
+    - vibewarden.yaml is present and parses without errors
+    - Docker daemon is reachable (docker info)
+    - Docker Compose v2+ is available (docker compose version)
+    - Required ports are available (proxy port)
+    - Generated files are present (.vibewarden/generated/docker-compose.yml)
+    - If the stack is running: containers are healthy (docker compose ps)
+
+  Local Runtime (always runs):
+    - Upstream application is reachable (HTTP GET)
+    - TLS certificate is valid (if self-signed)
+
+  Production (requires --target):
+    - SSH connectivity to the target host
+    - Remote container health
+    - Domain DNS resolves to target IP
+    - Remote TLS certificate expiry
 
 Each check runs independently — a failure does not stop subsequent checks.
 Exit code is 1 when any check fails.
@@ -43,7 +58,9 @@ Exit code is 1 when any check fails.
 Examples:
   vibew doctor
   vibew doctor --config ./my-vibewarden.yaml
-  vibew doctor --json`,
+  vibew doctor --json
+  vibew doctor --target ssh://ubuntu@203.0.113.10
+  vibew doctor --target ssh://ubuntu@myserver.example.com --ssh-key ~/.ssh/id_ed25519`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Load config — pass nil-safe; doctor will report missing config.
 			cfg, loadErr := config.Load(configPath)
@@ -69,6 +86,21 @@ Examples:
 			healthChecker := opsadapter.NewHTTPHealthChecker(httpClient)
 			svc := opsapp.NewDoctorService(compose, portChecker, healthChecker)
 
+			// When --target is provided, create an SSH executor for production checks.
+			if target != "" {
+				t, parseErr := sshadapter.ParseTarget(target)
+				if parseErr != nil {
+					return fmt.Errorf("invalid --target: %w", parseErr)
+				}
+				var executor *sshadapter.Executor
+				if sshKey != "" {
+					executor = sshadapter.NewExecutorWithKey(t, sshKey)
+				} else {
+					executor = sshadapter.NewExecutor(t)
+				}
+				svc = svc.WithRemoteExecutor(executor)
+			}
+
 			label := configPath
 			if label == "" {
 				label = "vibewarden.yaml"
@@ -78,6 +110,7 @@ Examples:
 				ConfigPath: label,
 				WorkDir:    workDir,
 				JSON:       jsonOutput,
+				Target:     target,
 			}
 
 			allOK, err := svc.Run(cmd.Context(), cfg, opts, cmd.OutOrStdout())
@@ -94,6 +127,8 @@ Examples:
 
 	cmd.Flags().StringVar(&configPath, "config", "", "path to vibewarden.yaml (default: ./vibewarden.yaml)")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output results as JSON")
+	cmd.Flags().StringVar(&target, "target", "", "SSH target for production checks (e.g. ssh://user@host)")
+	cmd.Flags().StringVar(&sshKey, "ssh-key", "", "path to SSH private key (default: use SSH agent)")
 
 	return cmd
 }


### PR DESCRIPTION
Closes #913

## Summary

- Added two new check layers to `vibew doctor` beyond config/Docker:
  - **Local Runtime**: upstream reachability via HTTP health check, TLS certificate validity (expiry check for self-signed certs)
  - **Production** (requires `--target` flag): SSH connectivity, remote container health via `docker compose ps`, domain DNS resolution against target IP, remote TLS certificate expiry
- Added `--target` and `--ssh-key` flags to `vibew doctor` CLI command
- Added `WithRemoteExecutor()` method to `DoctorService` for optional SSH executor injection
- Output is grouped with section headers ("Config & Docker", "Local Runtime", "Production") in both human and JSON output
- Production checks only run when `--target` is provided; graceful handling when SSH fails

## Test plan

- [x] All 11 original doctor tests pass unchanged
- [x] 15 new tests added covering:
  - Upstream reachable / unreachable
  - TLS cert valid / expired / expiring soon / missing / non-self-signed skip
  - SSH connectivity success / failure
  - Remote container health (healthy / unhealthy)
  - Auto-detection: no target = no remote checks
  - Section headers in human and JSON output
- [x] `make check` passes (golangci-lint 0 issues, all tests with race detector)

🤖 Generated with [Claude Code](https://claude.com/claude-code)