### PR TITLE
fix(#927): deploy exits non-zero when health check times out

### DIFF
--- a/internal/app/deploy/multiapp.go
+++ b/internal/app/deploy/multiapp.go
@@ -138,7 +138,10 @@ func (s *Service) BootstrapSidecar(ctx context.Context, cfg *config.Config, opts
 	}
 	healthURL := healthCheckURL(port, cfg.TLS.Enabled)
 	fmt.Fprintf(out, "Waiting for sidecar health check at %s (via SSH)...\n", healthURL)
-	s.waitHealthy(ctx, port, cfg.TLS.Enabled, out)
+	if !s.waitHealthy(ctx, port, cfg.TLS.Enabled, out) {
+		fmt.Fprintln(out, "Bootstrap completed but health check failed — verify with: vibew deploy status")
+		return ErrHealthCheck
+	}
 
 	fmt.Fprintln(out, "Bootstrap complete.")
 	return nil
@@ -181,7 +184,10 @@ func (s *Service) DeployMultiApp(ctx context.Context, cfg *config.Config, opts R
 	}
 	healthURL := healthCheckURL(port, cfg.TLS.Enabled)
 	fmt.Fprintf(out, "Waiting for sidecar health check at %s (via SSH)...\n", healthURL)
-	s.waitHealthy(ctx, port, cfg.TLS.Enabled, out)
+	if !s.waitHealthy(ctx, port, cfg.TLS.Enabled, out) {
+		fmt.Fprintln(out, "Site deployed but health check failed — verify with: vibew deploy status")
+		return ErrHealthCheck
+	}
 
 	fmt.Fprintln(out, "Site deployed.")
 	return nil

--- a/internal/app/deploy/multiapp_test.go
+++ b/internal/app/deploy/multiapp_test.go
@@ -912,3 +912,79 @@ func TestDeploySite_BuildMode_TransferBeforeConfig(t *testing.T) {
 	// in deploySite, the fact that Transfer has entries confirms it was called.
 	// The code structure ensures Transfer happens before TransferFile.
 }
+
+// TestBootstrapSidecar_HealthCheckFails verifies that BootstrapSidecar returns
+// ErrHealthCheck when the sidecar health check times out.
+func TestBootstrapSidecar_HealthCheckFails(t *testing.T) {
+	executor := &fakeExecutor{
+		runResponses: map[string]runResponse{
+			"curl -sf http://localhost:443/_vibewarden/health": {err: errors.New("exit status 7")},
+		},
+	}
+	generator := &fakeGenerator{}
+
+	svc := deployapp.NewService(executor, generator)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { cancel() }()
+
+	var buf bytes.Buffer
+	err := svc.BootstrapSidecar(ctx, multiappConfig(), deployapp.RunOptions{
+		ConfigPath:  "/tmp/proj/vibewarden.yaml",
+		ProjectName: "myproject",
+		Out:         &buf,
+	})
+	if !errors.Is(err, deployapp.ErrHealthCheck) {
+		t.Fatalf("BootstrapSidecar() should return ErrHealthCheck, got: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "health check failed") {
+		t.Errorf("expected 'health check failed' in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "vibew doctor") {
+		t.Errorf("expected 'vibew doctor' suggestion in output, got:\n%s", out)
+	}
+	// "Bootstrap complete" should NOT appear when health check fails.
+	if strings.Contains(out, "Bootstrap complete.") {
+		t.Errorf("'Bootstrap complete.' should NOT appear when health check fails, got:\n%s", out)
+	}
+}
+
+// TestDeployMultiApp_HealthCheckFails verifies that DeployMultiApp returns
+// ErrHealthCheck when the sidecar health check times out.
+func TestDeployMultiApp_HealthCheckFails(t *testing.T) {
+	executor := &fakeExecutor{
+		runResponses: map[string]runResponse{
+			"curl -sf http://localhost:443/_vibewarden/health": {err: errors.New("exit status 7")},
+		},
+	}
+	generator := &fakeGenerator{}
+
+	svc := deployapp.NewService(executor, generator)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { cancel() }()
+
+	var buf bytes.Buffer
+	err := svc.DeployMultiApp(ctx, multiappConfig(), deployapp.RunOptions{
+		ConfigPath:  "/tmp/site/vibewarden.yaml",
+		ProjectName: "mysite",
+		Out:         &buf,
+	})
+	if !errors.Is(err, deployapp.ErrHealthCheck) {
+		t.Fatalf("DeployMultiApp() should return ErrHealthCheck, got: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "health check failed") {
+		t.Errorf("expected 'health check failed' in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "vibew doctor") {
+		t.Errorf("expected 'vibew doctor' suggestion in output, got:\n%s", out)
+	}
+	// "Site deployed." should NOT appear when health check fails.
+	if strings.Contains(out, "Site deployed.") {
+		t.Errorf("'Site deployed.' should NOT appear when health check fails, got:\n%s", out)
+	}
+}

--- a/internal/app/deploy/service.go
+++ b/internal/app/deploy/service.go
@@ -4,6 +4,7 @@ package deploy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,6 +15,11 @@ import (
 	"github.com/vibewarden/vibewarden/internal/config"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
+
+// ErrHealthCheck is returned when the sidecar health check fails after
+// deployment. Files have been deployed and services started, but the
+// sidecar did not become healthy within the timeout.
+var ErrHealthCheck = errors.New("health check failed")
 
 // DriftError is returned when remote files have diverged from local files
 // and --force was not specified. It carries the list of changes that would
@@ -230,7 +236,10 @@ func (s *Service) Deploy(ctx context.Context, cfg *config.Config, opts RunOption
 	}
 	healthURL := healthCheckURL(port, cfg.TLS.Enabled)
 	fmt.Fprintf(out, "Waiting for sidecar health check at %s (via SSH)...\n", healthURL)
-	s.waitHealthy(ctx, port, cfg.TLS.Enabled, out)
+	if !s.waitHealthy(ctx, port, cfg.TLS.Enabled, out) {
+		fmt.Fprintln(out, "Deploy completed but health check failed — verify with: vibew deploy status")
+		return ErrHealthCheck
+	}
 
 	fmt.Fprintln(out, "Deploy complete.")
 	return nil
@@ -451,10 +460,10 @@ func (s *Service) checkRemotePrerequisites(ctx context.Context) error {
 // certificate issuance dependencies — the request is made from inside the
 // server to its own localhost interface.
 //
-// On timeout or context cancellation the function prints a warning and returns
-// without error — the deploy is considered successful because services may still
-// be starting up. The operator can run "vibew deploy status" to check manually.
-func (s *Service) waitHealthy(ctx context.Context, port int, tlsEnabled bool, out io.Writer) {
+// Returns true when the sidecar becomes healthy, false on timeout or context
+// cancellation. When false, a warning is printed suggesting diagnostic
+// commands the operator can run.
+func (s *Service) waitHealthy(ctx context.Context, port int, tlsEnabled bool, out io.Writer) bool {
 	cmd := healthCheckCmd(port, tlsEnabled)
 	deadline := time.Now().Add(healthCheckTimeout)
 	attempt := 0
@@ -465,20 +474,20 @@ func (s *Service) waitHealthy(ctx context.Context, port int, tlsEnabled bool, ou
 		_, err := s.executor.Run(ctx, cmd)
 		if err == nil {
 			fmt.Fprintln(out, "Sidecar is healthy.")
-			return
+			return true
 		}
 		lastErr = err
 		fmt.Fprintf(out, "  attempt %d: %v\n", attempt, err)
 
 		if time.Now().After(deadline) {
-			fmt.Fprintf(out, "Warning: health check timed out (last error: %v). Services may still be starting. Run: vibew deploy status --target ... to check.\n", lastErr)
-			return
+			fmt.Fprintf(out, "Warning: health check timed out (last error: %v). Services may still be starting.\n  Run: vibew deploy status --target <host> to check.\n  Run: vibew doctor --target <host> to diagnose.\n", lastErr)
+			return false
 		}
 
 		select {
 		case <-ctx.Done():
-			fmt.Fprintf(out, "Warning: health check cancelled (%v). Services may still be starting. Run: vibew deploy status --target ... to check.\n", ctx.Err())
-			return
+			fmt.Fprintf(out, "Warning: health check cancelled (%v). Services may still be starting.\n  Run: vibew deploy status --target <host> to check.\n  Run: vibew doctor --target <host> to diagnose.\n", ctx.Err())
+			return false
 		case <-time.After(healthCheckInterval):
 		}
 	}

--- a/internal/app/deploy/service_test.go
+++ b/internal/app/deploy/service_test.go
@@ -196,8 +196,9 @@ func TestService_Deploy_TransferFails(t *testing.T) {
 }
 
 // TestService_Deploy_HealthCheckTimeout verifies that a health-check timeout
-// does NOT fail the deploy — it prints a warning and returns nil so that
-// "Deploy complete." is still printed. The operator can check status manually.
+// DOES fail the deploy — it returns ErrHealthCheck and prints an actionable
+// message. The operator can run "vibew deploy status" or "vibew doctor" to
+// diagnose.
 func TestService_Deploy_HealthCheckTimeout(t *testing.T) {
 	executor := &fakeExecutor{
 		runResponses: map[string]runResponse{
@@ -222,17 +223,20 @@ func TestService_Deploy_HealthCheckTimeout(t *testing.T) {
 		ConfigPath: "/tmp/proj/vibewarden.yaml",
 		Out:        &buf,
 	})
-	// Health check timeout must NOT fail the deploy.
-	if err != nil {
-		t.Fatalf("Deploy() should succeed even when health check times out, got error: %v", err)
+	// Health check timeout must now fail the deploy.
+	if !errors.Is(err, deployapp.ErrHealthCheck) {
+		t.Fatalf("Deploy() should return ErrHealthCheck when health check times out, got: %v", err)
 	}
 
 	out := buf.String()
-	if !strings.Contains(out, "Deploy complete") {
-		t.Errorf("expected 'Deploy complete' in output even after health-check timeout, got:\n%s", out)
+	if !strings.Contains(out, "health check failed") {
+		t.Errorf("expected 'health check failed' in output, got:\n%s", out)
 	}
 	if !strings.Contains(out, "Warning") {
 		t.Errorf("expected a warning message in output after health-check timeout, got:\n%s", out)
+	}
+	if !strings.Contains(out, "vibew doctor") {
+		t.Errorf("expected 'vibew doctor' suggestion in output, got:\n%s", out)
 	}
 }
 
@@ -1410,7 +1414,7 @@ func TestDriftError_ErrorMessage(t *testing.T) {
 }
 
 // TestService_Deploy_HealthCheckWarnOnTimeout verifies the exact warning message
-// format when the health check times out.
+// format when the health check times out, including the doctor suggestion.
 func TestService_Deploy_HealthCheckWarnOnTimeout(t *testing.T) {
 	executor := &fakeExecutor{
 		runResponses: map[string]runResponse{
@@ -1431,16 +1435,23 @@ func TestService_Deploy_HealthCheckWarnOnTimeout(t *testing.T) {
 		Out:        &buf,
 	})
 
-	if err != nil {
-		t.Fatalf("Deploy() should return nil on health-check timeout, got: %v", err)
+	if !errors.Is(err, deployapp.ErrHealthCheck) {
+		t.Fatalf("Deploy() should return ErrHealthCheck on health-check timeout, got: %v", err)
 	}
 
 	out := buf.String()
 	if !strings.Contains(out, "Warning") {
 		t.Errorf("expected warning in output, got:\n%s", out)
 	}
-	if !strings.Contains(out, "Deploy complete") {
-		t.Errorf("expected 'Deploy complete' in output, got:\n%s", out)
+	if !strings.Contains(out, "vibew deploy status") {
+		t.Errorf("expected 'vibew deploy status' suggestion in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "vibew doctor") {
+		t.Errorf("expected 'vibew doctor' suggestion in output, got:\n%s", out)
+	}
+	// "Deploy complete" should NOT appear when health check fails.
+	if strings.Contains(out, "Deploy complete.") {
+		t.Errorf("'Deploy complete.' should NOT appear when health check fails, got:\n%s", out)
 	}
 }
 

--- a/test/integration/deploy_multisite_test.go
+++ b/test/integration/deploy_multisite_test.go
@@ -18,6 +18,7 @@ package integration
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -167,9 +168,15 @@ func TestDeployMultiSite(t *testing.T) {
 		})
 		t.Logf("bootstrap output:\n%s", buf.String())
 
-		if bootstrapErr != nil {
+		// In CI (DinD), the health check may time out due to slow container startup.
+		// ErrHealthCheck is acceptable — the deploy itself succeeded, only the
+		// post-deploy health probe timed out.
+		if bootstrapErr != nil && !errors.Is(bootstrapErr, deployapp.ErrHealthCheck) {
 			dumpDockerState(ctx, t, executor)
 			t.Fatalf("BootstrapSidecar failed: %v", bootstrapErr)
+		}
+		if bootstrapErr != nil {
+			t.Logf("health check timed out (expected in slow CI): %v", bootstrapErr)
 		}
 
 		// Wait for the app container to stabilize.
@@ -200,9 +207,13 @@ func TestDeployMultiSite(t *testing.T) {
 		})
 		t.Logf("add-site output:\n%s", buf.String())
 
-		if deployErr != nil {
+		// In CI (DinD), the health check may time out due to slow container startup.
+		if deployErr != nil && !errors.Is(deployErr, deployapp.ErrHealthCheck) {
 			dumpDockerState(ctx, t, executor)
 			t.Fatalf("DeployMultiApp failed: %v", deployErr)
+		}
+		if deployErr != nil {
+			t.Logf("health check timed out (expected in slow CI): %v", deployErr)
 		}
 
 		// Wait for the app2 container.


### PR DESCRIPTION
Closes #927
Closes #932

## Summary
- Changed `waitHealthy()` to return `bool` (true = healthy, false = timed out/cancelled) instead of silently returning on failure
- `Deploy()`, `BootstrapSidecar()`, and `DeployMultiApp()` now check the return value and return `ErrHealthCheck` when the sidecar is not healthy
- On health check failure, callers print an actionable message: "Deploy completed but health check failed -- verify with: vibew deploy status"
- Warning messages now include `vibew doctor --target <host>` suggestion (also closes #932)
- Added `ErrHealthCheck` sentinel error so CLI callers can match on `errors.Is(err, deploy.ErrHealthCheck)`

## Test plan
- [x] `TestService_Deploy_HealthCheckTimeout` -- updated: now verifies `ErrHealthCheck` is returned and "vibew doctor" is suggested
- [x] `TestService_Deploy_HealthCheckWarnOnTimeout` -- updated: verifies warning format, doctor suggestion, and no false "Deploy complete."
- [x] `TestBootstrapSidecar_HealthCheckFails` -- new: verifies `ErrHealthCheck` from `BootstrapSidecar`
- [x] `TestDeployMultiApp_HealthCheckFails` -- new: verifies `ErrHealthCheck` from `DeployMultiApp`
- [x] All happy-path tests still pass (fake executor returns nil for unrecognised curl commands)
- [x] `make check` passes (lint, build, all tests)


🤖 Generated with [Claude Code](https://claude.com/claude-code)