### PR TITLE
fix(#925): wire plugin handlers into multi-site Caddy config

### DIFF
--- a/cmd/vibewarden/wiring_serve_multisite.go
+++ b/cmd/vibewarden/wiring_serve_multisite.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"syscall"
 
 	caddyadapter "github.com/vibewarden/vibewarden/internal/adapters/caddy"
@@ -16,6 +17,7 @@ import (
 	reloadsvc "github.com/vibewarden/vibewarden/internal/app/reload"
 	"github.com/vibewarden/vibewarden/internal/config/sites"
 	"github.com/vibewarden/vibewarden/internal/domain/site"
+	"github.com/vibewarden/vibewarden/internal/plugins"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
@@ -95,15 +97,27 @@ func runServeMultiSite(ctx context.Context, baseDir string, ver string) error {
 	// Step 5: Create the event logger.
 	eventLogger := logadapter.NewSlogEventLogger(os.Stdout)
 
-	// Step 6: Create the multi-site Caddy adapter.
+	// Step 6: Build per-site plugin registries and collect Caddy handlers.
+	//
+	// Each healthy site gets its own plugin registry so that plugins like WAF,
+	// rate limiting, auth, CORS, and IP filter contribute their handlers to the
+	// correct site's middleware chain. Only Init is called (no Start) because
+	// handler contribution requires initialised state but not running background
+	// work. See wiring_serve_helpers.go for the single-site equivalent.
+	perSiteHandlers, err := buildPerSitePluginHandlers(ctx, registry, eventLogger, logger)
+	if err != nil {
+		return fmt.Errorf("building per-site plugin handlers: %w", err)
+	}
+
+	// Step 7: Create the multi-site Caddy adapter.
 	// A minimal ProxyConfig is needed for backward-compatible fields (version).
 	minimalProxyCfg := &ports.ProxyConfig{
 		ListenAddr: fmt.Sprintf("%s:%d", globalCfg.ListenHost, globalCfg.ListenPort),
 		Version:    ver,
 	}
-	adapter := caddyadapter.NewMultiSiteAdapter(minimalProxyCfg, registry, logger, eventLogger)
+	adapter := caddyadapter.NewMultiSiteAdapter(minimalProxyCfg, registry, perSiteHandlers, logger, eventLogger)
 
-	// Step 7: Set up signal handling.
+	// Step 8: Set up signal handling.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -120,7 +134,7 @@ func runServeMultiSite(ctx context.Context, baseDir string, ver string) error {
 		}
 	}()
 
-	// Step 8: Start the site watcher for hot-reload.
+	// Step 9: Start the site watcher for hot-reload.
 	siteWatcher := fsnotifyadapter.NewSiteWatcher(logger)
 	watchCh, watchErr := siteWatcher.Watch(ctx, sitesDir)
 	if watchErr != nil {
@@ -129,7 +143,7 @@ func runServeMultiSite(ctx context.Context, baseDir string, ver string) error {
 			slog.String("error", watchErr.Error()),
 		)
 	} else {
-		// Step 9: Create the MultiSiteService event loop.
+		// Step 10: Create the MultiSiteService event loop.
 		reloadFn := func(reloadCtx context.Context) error {
 			return adapter.Reload(reloadCtx)
 		}
@@ -137,13 +151,83 @@ func runServeMultiSite(ctx context.Context, baseDir string, ver string) error {
 		go multiSiteSvc.Run(ctx, watchCh)
 	}
 
-	// Step 10: Run the proxy until shutdown.
+	// Step 11: Run the proxy until shutdown.
 	svc := proxy.NewService(adapter, logger)
 	if err := svc.Run(ctx); err != nil {
 		return fmt.Errorf("proxy service: %w", err)
 	}
 
 	return nil
+}
+
+// buildPerSitePluginHandlers creates a per-site plugin registry for each
+// healthy site, registers builtin plugins, calls InitAll, and collects the
+// CaddyContributor handlers. The returned map is keyed by site name.
+//
+// Only Init is called — Start is not needed because CaddyContributors are
+// queried after Init (matching the single-site lifecycle in wiring_serve.go
+// and wiring_serve_helpers.go).
+//
+// Non-critical plugin init failures are logged and the plugin is marked
+// degraded (it will not contribute handlers). Critical plugin init failures
+// for a site cause that site's handlers to be skipped entirely — the site
+// still serves with its config-driven handlers (security headers, rate
+// limiting, compression) but without plugin-contributed handlers.
+func buildPerSitePluginHandlers(
+	ctx context.Context,
+	siteRegistry *site.Registry,
+	eventLogger ports.EventLogger,
+	logger *slog.Logger,
+) (map[string][]ports.CaddyHandler, error) {
+	healthySites := siteRegistry.HealthySites()
+	if len(healthySites) == 0 {
+		return nil, nil
+	}
+
+	perSiteHandlers := make(map[string][]ports.CaddyHandler, len(healthySites))
+
+	for _, s := range healthySites {
+		cfg := s.Config()
+		if cfg == nil {
+			continue
+		}
+
+		siteLogger := logger.With(slog.String("site", s.Name()))
+
+		// Create a per-site plugin registry with a site-scoped logger so that
+		// plugin lifecycle log lines include the site name.
+		reg := plugins.NewRegistry(siteLogger)
+		plugins.RegisterBuiltinPlugins(reg, cfg, eventLogger, siteLogger)
+
+		if err := reg.InitAll(ctx); err != nil {
+			// Critical plugin failed — log the error but continue. The site
+			// will serve without plugin-contributed handlers.
+			siteLogger.Error("per-site plugin init failed — site will serve without plugin handlers",
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+
+		// Collect handlers from CaddyContributor plugins.
+		var handlers []ports.CaddyHandler
+		for _, contrib := range reg.CaddyContributors() {
+			handlers = append(handlers, contrib.ContributeCaddyHandlers()...)
+		}
+
+		if len(handlers) > 0 {
+			// Sort by ascending priority for deterministic ordering.
+			sort.Slice(handlers, func(i, j int) bool {
+				return handlers[i].Priority < handlers[j].Priority
+			})
+			perSiteHandlers[s.Name()] = handlers
+
+			siteLogger.Info("plugin handlers collected",
+				slog.Int("count", len(handlers)),
+			)
+		}
+	}
+
+	return perSiteHandlers, nil
 }
 
 // buildMultiSiteLogger creates an slog.Logger from the global log level string.

--- a/cmd/vibewarden/wiring_serve_multisite.go
+++ b/cmd/vibewarden/wiring_serve_multisite.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"sort"
 	"syscall"
 
 	caddyadapter "github.com/vibewarden/vibewarden/internal/adapters/caddy"
@@ -144,7 +143,16 @@ func runServeMultiSite(ctx context.Context, baseDir string, ver string) error {
 		)
 	} else {
 		// Step 10: Create the MultiSiteService event loop.
+		// The reload function rebuilds per-site plugin handlers from the
+		// current registry state before reloading Caddy, ensuring that
+		// modified site configs get fresh handlers instead of stale ones
+		// computed at startup.
 		reloadFn := func(reloadCtx context.Context) error {
+			freshHandlers, buildErr := buildPerSitePluginHandlers(reloadCtx, registry, eventLogger, logger)
+			if buildErr != nil {
+				return fmt.Errorf("rebuilding per-site plugin handlers: %w", buildErr)
+			}
+			adapter.UpdatePerSiteHandlers(freshHandlers)
 			return adapter.Reload(reloadCtx)
 		}
 		multiSiteSvc := reloadsvc.NewMultiSiteService(registry, eventLogger, logger, reloadFn)
@@ -214,11 +222,18 @@ func buildPerSitePluginHandlers(
 			handlers = append(handlers, contrib.ContributeCaddyHandlers()...)
 		}
 
+		// Clean up the per-site registry: handlers have been serialized to
+		// JSON-compatible structures, so plugin instances (including any
+		// OTel MeterProvider allocated by the metrics plugin) are no longer
+		// needed. Without this call, resources are leaked.
+		if stopErr := reg.StopAll(ctx); stopErr != nil {
+			siteLogger.Warn("per-site plugin registry stop error",
+				slog.String("error", stopErr.Error()),
+			)
+		}
+
 		if len(handlers) > 0 {
-			// Sort by ascending priority for deterministic ordering.
-			sort.Slice(handlers, func(i, j int) bool {
-				return handlers[i].Priority < handlers[j].Priority
-			})
+			// Sorting is deferred to buildSiteRoutes to avoid duplicate sorts.
 			perSiteHandlers[s.Name()] = handlers
 
 			siteLogger.Info("plugin handlers collected",

--- a/internal/adapters/caddy/adapter.go
+++ b/internal/adapters/caddy/adapter.go
@@ -24,10 +24,11 @@ import (
 // routes from the registry's healthy sites. When registry is nil, the
 // adapter falls back to single-site mode using BuildCaddyConfig.
 type Adapter struct {
-	config      *ports.ProxyConfig
-	registry    *site.Registry
-	logger      *slog.Logger
-	eventLogger ports.EventLogger
+	config          *ports.ProxyConfig
+	registry        *site.Registry
+	perSiteHandlers map[string][]ports.CaddyHandler
+	logger          *slog.Logger
+	eventLogger     ports.EventLogger
 }
 
 // NewAdapter creates a new Caddy adapter in single-site mode.
@@ -46,14 +47,19 @@ func NewAdapter(cfg *ports.ProxyConfig, logger *slog.Logger, eventLogger ports.E
 // When buildConfigJSON is called, it reads the registry's healthy sites
 // and global config to produce per-host Caddy routes.
 //
+// perSiteHandlers maps each site name to the Caddy handlers contributed by
+// that site's plugin registry (e.g. WAF, auth, CORS). Pass nil to omit
+// plugin-contributed handlers.
+//
 // The cfg parameter is still required for backward-compatible fields
 // (version, event logging params) that are sidecar-global, not per-site.
-func NewMultiSiteAdapter(cfg *ports.ProxyConfig, registry *site.Registry, logger *slog.Logger, eventLogger ports.EventLogger) *Adapter {
+func NewMultiSiteAdapter(cfg *ports.ProxyConfig, registry *site.Registry, perSiteHandlers map[string][]ports.CaddyHandler, logger *slog.Logger, eventLogger ports.EventLogger) *Adapter {
 	return &Adapter{
-		config:      cfg,
-		registry:    registry,
-		logger:      logger,
-		eventLogger: eventLogger,
+		config:          cfg,
+		registry:        registry,
+		perSiteHandlers: perSiteHandlers,
+		logger:          logger,
+		eventLogger:     eventLogger,
 	}
 }
 
@@ -127,7 +133,7 @@ func (a *Adapter) buildConfigJSON() ([]byte, error) {
 			g := site.DefaultGlobalConfig()
 			global = &g
 		}
-		cfg, err = BuildMultiSiteConfig(a.registry.HealthySites(), *global, a.logger)
+		cfg, err = BuildMultiSiteConfig(a.registry.HealthySites(), *global, a.perSiteHandlers, a.logger)
 	} else {
 		cfg, err = BuildCaddyConfig(a.config)
 	}

--- a/internal/adapters/caddy/adapter.go
+++ b/internal/adapters/caddy/adapter.go
@@ -118,6 +118,14 @@ func (a *Adapter) UpdateConfig(cfg *ports.ProxyConfig) {
 	a.config = cfg
 }
 
+// UpdatePerSiteHandlers replaces the per-site plugin handlers map with the
+// supplied value. This must be called before Reload when site configurations
+// change so that the rebuilt Caddy config includes the current plugin handlers
+// rather than stale ones computed at startup.
+func (a *Adapter) UpdatePerSiteHandlers(handlers map[string][]ports.CaddyHandler) {
+	a.perSiteHandlers = handlers
+}
+
 // buildConfigJSON constructs and marshals the Caddy JSON configuration.
 // When a registry is present, multi-site mode is used. Otherwise, the
 // adapter falls back to single-site mode for backward compatibility.

--- a/internal/adapters/caddy/adapter_test.go
+++ b/internal/adapters/caddy/adapter_test.go
@@ -120,7 +120,7 @@ func TestNewMultiSiteAdapter(t *testing.T) {
 	registry := site.NewRegistry()
 	logger := slog.Default()
 
-	adapter := NewMultiSiteAdapter(cfg, registry, logger, nil)
+	adapter := NewMultiSiteAdapter(cfg, registry, nil, logger, nil)
 
 	if adapter == nil {
 		t.Fatal("NewMultiSiteAdapter() returned nil")
@@ -144,7 +144,7 @@ func TestNewMultiSiteAdapter_WithEventLogger(t *testing.T) {
 	registry := site.NewRegistry()
 	spy := &fakeEventLogger{}
 
-	adapter := NewMultiSiteAdapter(cfg, registry, slog.Default(), spy)
+	adapter := NewMultiSiteAdapter(cfg, registry, nil, slog.Default(), spy)
 
 	if adapter == nil {
 		t.Fatal("NewMultiSiteAdapter() returned nil")
@@ -180,7 +180,7 @@ func TestAdapter_BuildConfigJSON_MultiSiteMode(t *testing.T) {
 		ListenAddr:   "0.0.0.0:443",
 		UpstreamAddr: "127.0.0.1:3000",
 	}
-	adapter := NewMultiSiteAdapter(proxyCfg, registry, slog.Default(), nil)
+	adapter := NewMultiSiteAdapter(proxyCfg, registry, nil, slog.Default(), nil)
 
 	data, err := adapter.buildConfigJSON()
 	if err != nil {
@@ -239,7 +239,7 @@ func TestAdapter_BuildConfigJSON_MultiSite_DefaultGlobal(t *testing.T) {
 		ListenAddr:   "0.0.0.0:443",
 		UpstreamAddr: "127.0.0.1:3000",
 	}
-	adapter := NewMultiSiteAdapter(proxyCfg, registry, slog.Default(), nil)
+	adapter := NewMultiSiteAdapter(proxyCfg, registry, nil, slog.Default(), nil)
 
 	data, err := adapter.buildConfigJSON()
 	if err != nil {
@@ -331,7 +331,7 @@ func TestAdapter_EmitStartEvents_MultiSite(t *testing.T) {
 		ListenAddr: "0.0.0.0:443",
 		Version:    "v2.0.0",
 	}
-	adapter := NewMultiSiteAdapter(proxyCfg, registry, slog.Default(), spy)
+	adapter := NewMultiSiteAdapter(proxyCfg, registry, nil, slog.Default(), spy)
 
 	adapter.emitStartEvents(context.Background())
 
@@ -429,7 +429,7 @@ func TestAdapter_EmitStartEvents_MultiSite_SkipStartEvent(t *testing.T) {
 		ListenAddr:     "0.0.0.0:443",
 		SkipStartEvent: true,
 	}
-	adapter := NewMultiSiteAdapter(proxyCfg, registry, slog.Default(), spy)
+	adapter := NewMultiSiteAdapter(proxyCfg, registry, nil, slog.Default(), spy)
 
 	adapter.emitStartEvents(context.Background())
 
@@ -466,7 +466,7 @@ func TestAdapter_EmitStartEvents_MultiSite_SkipsErrorSites(t *testing.T) {
 		ListenAddr: "0.0.0.0:443",
 		Version:    "v1.0.0",
 	}
-	adapter := NewMultiSiteAdapter(proxyCfg, registry, slog.Default(), spy)
+	adapter := NewMultiSiteAdapter(proxyCfg, registry, nil, slog.Default(), spy)
 
 	adapter.emitStartEvents(context.Background())
 

--- a/internal/adapters/caddy/adapter_test.go
+++ b/internal/adapters/caddy/adapter_test.go
@@ -499,6 +499,70 @@ func TestAdapter_EmitStartEvents_NilEventLogger(t *testing.T) {
 	}
 }
 
+func TestAdapter_UpdatePerSiteHandlers(t *testing.T) {
+	registry := site.NewRegistry()
+	global := site.DefaultGlobalConfig()
+	registry.SetGlobal(global)
+
+	proxyCfg := &ports.ProxyConfig{
+		ListenAddr: "0.0.0.0:443",
+		Version:    "v1.0.0",
+	}
+	adapter := NewMultiSiteAdapter(proxyCfg, registry, nil, slog.Default(), nil)
+
+	if adapter.perSiteHandlers != nil {
+		t.Fatal("expected nil perSiteHandlers before update")
+	}
+
+	newHandlers := map[string][]ports.CaddyHandler{
+		"app1": {
+			{Priority: 10, Handler: map[string]any{"handler": "test"}},
+		},
+	}
+	adapter.UpdatePerSiteHandlers(newHandlers)
+
+	if adapter.perSiteHandlers == nil {
+		t.Fatal("expected non-nil perSiteHandlers after update")
+	}
+	if len(adapter.perSiteHandlers["app1"]) != 1 {
+		t.Errorf("expected 1 handler for app1, got %d", len(adapter.perSiteHandlers["app1"]))
+	}
+}
+
+func TestAdapter_UpdatePerSiteHandlers_OverwritesExisting(t *testing.T) {
+	registry := site.NewRegistry()
+
+	initialHandlers := map[string][]ports.CaddyHandler{
+		"app1": {
+			{Priority: 10, Handler: map[string]any{"handler": "old"}},
+		},
+	}
+	proxyCfg := &ports.ProxyConfig{
+		ListenAddr: "0.0.0.0:443",
+		Version:    "v1.0.0",
+	}
+	adapter := NewMultiSiteAdapter(proxyCfg, registry, initialHandlers, slog.Default(), nil)
+
+	if len(adapter.perSiteHandlers["app1"]) != 1 {
+		t.Fatalf("expected 1 initial handler for app1, got %d", len(adapter.perSiteHandlers["app1"]))
+	}
+
+	newHandlers := map[string][]ports.CaddyHandler{
+		"app2": {
+			{Priority: 20, Handler: map[string]any{"handler": "new1"}},
+			{Priority: 30, Handler: map[string]any{"handler": "new2"}},
+		},
+	}
+	adapter.UpdatePerSiteHandlers(newHandlers)
+
+	if _, hasApp1 := adapter.perSiteHandlers["app1"]; hasApp1 {
+		t.Error("expected app1 to be absent after overwrite")
+	}
+	if len(adapter.perSiteHandlers["app2"]) != 2 {
+		t.Errorf("expected 2 handlers for app2, got %d", len(adapter.perSiteHandlers["app2"]))
+	}
+}
+
 func TestAdapter_StopWithoutStart(t *testing.T) {
 	cfg := &ports.ProxyConfig{
 		ListenAddr:   "127.0.0.1:8080",

--- a/internal/adapters/caddy/multisite_config.go
+++ b/internal/adapters/caddy/multisite_config.go
@@ -3,6 +3,7 @@ package caddy
 import (
 	"fmt"
 	"log/slog"
+	"sort"
 
 	"github.com/vibewarden/vibewarden/internal/domain/site"
 	"github.com/vibewarden/vibewarden/internal/ports"
@@ -17,10 +18,16 @@ import (
 // Each site's config.Config is converted to a per-site ProxyConfig and then
 // to a Caddy route with a host matcher restricting it to that site's domain.
 //
+// perSiteHandlers maps each site name to the Caddy handlers contributed by
+// that site's plugin registry (e.g. WAF, auth, CORS). When non-nil, these
+// handlers are inserted into the site's handler chain before the reverse
+// proxy, sorted by ascending priority. Pass nil to omit plugin handlers
+// (backward-compatible with the previous signature).
+//
 // TLS automation policies are generated per domain so that each site gets
 // its own ACME certificate. A single Caddy server instance handles all
 // sites on the same listen address.
-func BuildMultiSiteConfig(sites []*site.Site, globalCfg site.GlobalConfig, logger *slog.Logger) (map[string]any, error) {
+func BuildMultiSiteConfig(sites []*site.Site, globalCfg site.GlobalConfig, perSiteHandlers map[string][]ports.CaddyHandler, logger *slog.Logger) (map[string]any, error) {
 	if len(sites) == 0 {
 		return nil, fmt.Errorf("no sites provided")
 	}
@@ -61,7 +68,12 @@ func BuildMultiSiteConfig(sites []*site.Site, globalCfg site.GlobalConfig, logge
 			continue
 		}
 
-		siteRoutes, err := buildSiteRoutes(s, domain)
+		var extraHandlers []ports.CaddyHandler
+		if perSiteHandlers != nil {
+			extraHandlers = perSiteHandlers[s.Name()]
+		}
+
+		siteRoutes, err := buildSiteRoutes(s, domain, extraHandlers)
 		if err != nil {
 			logger.Error("skipping site due to route build error",
 				slog.String("site", s.Name()),
@@ -117,9 +129,14 @@ func BuildMultiSiteConfig(sites []*site.Site, globalCfg site.GlobalConfig, logge
 // host-matched to the site's domain so that requests to different domains
 // are routed to different upstreams with independent middleware chains.
 //
+// extraHandlers contains plugin-contributed handlers (e.g. WAF, auth, CORS)
+// that are inserted into the handler chain before the reverse proxy, sorted
+// by ascending priority. This mirrors the single-site ExtraHandlers mechanism
+// in BuildCaddyConfig.
+//
 // The returned slice contains the site's health check route and catch-all
 // proxy route, both scoped to the site's domain via host matchers.
-func buildSiteRoutes(s *site.Site, domain string) ([]map[string]any, error) {
+func buildSiteRoutes(s *site.Site, domain string, extraHandlers []ports.CaddyHandler) ([]map[string]any, error) {
 	cfg := s.Config()
 
 	upstreamAddr := fmt.Sprintf("%s:%d", cfg.Upstream.Host, cfg.Upstream.Port)
@@ -155,6 +172,22 @@ func buildSiteRoutes(s *site.Site, domain string) ([]map[string]any, error) {
 			PermittedCrossDomainPolicies: cfg.SecurityHeaders.PermittedCrossDomainPolicies,
 			SuppressViaHeader:            cfg.SecurityHeaders.SuppressViaHeader,
 		}, true))
+	}
+
+	// Insert extra handlers contributed by per-site plugins (e.g. WAF, auth,
+	// CORS, IP filter). These run after security headers but before rate
+	// limiting, matching the single-site handler chain order in BuildCaddyConfig.
+	// Handlers are sorted by ascending priority so that lower-priority plugins
+	// (e.g. WAF at 25) run before higher-priority ones (e.g. rate limiting at 50).
+	if len(extraHandlers) > 0 {
+		sorted := make([]ports.CaddyHandler, len(extraHandlers))
+		copy(sorted, extraHandlers)
+		sort.Slice(sorted, func(i, j int) bool {
+			return sorted[i].Priority < sorted[j].Priority
+		})
+		for _, eh := range sorted {
+			handlers = append(handlers, eh.Handler)
+		}
 	}
 
 	if cfg.RateLimit.Enabled {

--- a/internal/adapters/caddy/multisite_config_test.go
+++ b/internal/adapters/caddy/multisite_config_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/vibewarden/vibewarden/internal/config"
 	"github.com/vibewarden/vibewarden/internal/domain/site"
+	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
 // helperNewSite creates a healthy Site for testing. It panics on error
@@ -52,7 +53,7 @@ func TestBuildMultiSiteConfig_SingleSite(t *testing.T) {
 	s := helperNewSite(t, "app1", cfg)
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{s}, global, slog.Default())
+	result, err := BuildMultiSiteConfig([]*site.Site{s}, global, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -107,7 +108,7 @@ func TestBuildMultiSiteConfig_TwoSitesDifferentDomains(t *testing.T) {
 	s2 := helperNewSite(t, "app2", cfg2)
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global, slog.Default())
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -162,7 +163,7 @@ func TestBuildMultiSiteConfig_SiteWithNoDomainSkipped(t *testing.T) {
 	s2 := helperNewSite(t, "app2", cfg2)
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global, slog.Default())
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -190,7 +191,7 @@ func TestBuildMultiSiteConfig_ErrorSiteSkipped(t *testing.T) {
 	s2 := helperNewErrorSite(t, "app2")
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global, slog.Default())
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -213,7 +214,7 @@ func TestBuildMultiSiteConfig_ErrorSiteSkipped(t *testing.T) {
 
 func TestBuildMultiSiteConfig_EmptySitesList(t *testing.T) {
 	global := site.DefaultGlobalConfig()
-	_, err := BuildMultiSiteConfig([]*site.Site{}, global, slog.Default())
+	_, err := BuildMultiSiteConfig([]*site.Site{}, global, nil, slog.Default())
 	if err == nil {
 		t.Fatal("expected error for empty sites list, got nil")
 	}
@@ -221,7 +222,7 @@ func TestBuildMultiSiteConfig_EmptySitesList(t *testing.T) {
 
 func TestBuildMultiSiteConfig_NilSitesList(t *testing.T) {
 	global := site.DefaultGlobalConfig()
-	_, err := BuildMultiSiteConfig(nil, global, slog.Default())
+	_, err := BuildMultiSiteConfig(nil, global, nil, slog.Default())
 	if err == nil {
 		t.Fatal("expected error for nil sites list, got nil")
 	}
@@ -232,7 +233,7 @@ func TestBuildMultiSiteConfig_AllSitesUnhealthy(t *testing.T) {
 	s2 := helperNewErrorSite(t, "app2")
 
 	global := site.DefaultGlobalConfig()
-	_, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global, slog.Default())
+	_, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global, nil, slog.Default())
 	if err == nil {
 		t.Fatal("expected error when all sites are unhealthy, got nil")
 	}
@@ -257,7 +258,7 @@ func TestBuildMultiSiteConfig_PerSiteMiddlewareIndependence(t *testing.T) {
 	sB := helperNewSite(t, "site-b", cfgB)
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{sA, sB}, global, slog.Default())
+	result, err := BuildMultiSiteConfig([]*site.Site{sA, sB}, global, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -314,7 +315,7 @@ func TestBuildMultiSiteConfig_TLSPolicyPerDomain(t *testing.T) {
 
 	global := site.DefaultGlobalConfig()
 	global.ACMEEmail = "admin@example.com"
-	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2, s3}, global, slog.Default())
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2, s3}, global, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -378,7 +379,7 @@ func TestBuildMultiSiteConfig_ListenAddress(t *testing.T) {
 		ListenPort: 8443,
 		LogLevel:   "info",
 	}
-	result, err := BuildMultiSiteConfig([]*site.Site{s}, global, slog.Default())
+	result, err := BuildMultiSiteConfig([]*site.Site{s}, global, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -406,7 +407,7 @@ func TestBuildMultiSiteConfig_HealthRoutePerSite(t *testing.T) {
 	s2 := helperNewSite(t, "app2", cfg2)
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global, slog.Default())
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2}, global, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -461,7 +462,7 @@ func TestBuildMultiSiteConfig_ErrorIsolation(t *testing.T) {
 	s3 := helperNewErrorSite(t, "broken")
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2, s3}, global, slog.Default())
+	result, err := BuildMultiSiteConfig([]*site.Site{s1, s2, s3}, global, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -495,7 +496,7 @@ func TestBuildMultiSiteConfig_ValidJSON(t *testing.T) {
 	s := helperNewSite(t, "valid", cfg)
 
 	global := site.DefaultGlobalConfig()
-	result, err := BuildMultiSiteConfig([]*site.Site{s}, global, slog.Default())
+	result, err := BuildMultiSiteConfig([]*site.Site{s}, global, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
 	}
@@ -668,9 +669,216 @@ func TestBuildSiteRoutes_InvalidUpstream(t *testing.T) {
 	}
 	s := helperNewSite(t, "broken-upstream", cfg)
 
-	_, err := buildSiteRoutes(s, "test.example.com")
+	_, err := buildSiteRoutes(s, "test.example.com", nil)
 	if err == nil {
 		t.Fatal("expected error for invalid upstream, got nil")
+	}
+}
+
+func TestBuildMultiSiteConfig_PerSitePluginHandlers(t *testing.T) {
+	// Site A: has plugin handlers (e.g. WAF).
+	cfgA := helperMinimalConfig("a.example.com", 3001)
+	sA := helperNewSite(t, "site-a", cfgA)
+
+	// Site B: no plugin handlers.
+	cfgB := helperMinimalConfig("b.example.com", 3002)
+	sB := helperNewSite(t, "site-b", cfgB)
+
+	global := site.DefaultGlobalConfig()
+
+	// Provide handlers only for site-a.
+	perSiteHandlers := map[string][]ports.CaddyHandler{
+		"site-a": {
+			{
+				Handler:  map[string]any{"handler": "vibewarden_waf_engine", "mode": "block"},
+				Priority: 25,
+			},
+			{
+				Handler:  map[string]any{"handler": "vibewarden_cors", "allow_all": true},
+				Priority: 10,
+			},
+		},
+	}
+
+	result, err := BuildMultiSiteConfig([]*site.Site{sA, sB}, global, perSiteHandlers, slog.Default())
+	if err != nil {
+		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
+	}
+
+	data, _ := json.Marshal(result)
+	var parsed map[string]any
+	_ = json.Unmarshal(data, &parsed)
+
+	apps := parsed["apps"].(map[string]any)
+	httpApp := apps["http"].(map[string]any)
+	servers := httpApp["servers"].(map[string]any)
+	vw := servers["vibewarden"].(map[string]any)
+	routes := vw["routes"].([]any)
+
+	// 4 routes total: 2 per site (health + catch-all).
+	if len(routes) != 4 {
+		t.Fatalf("expected 4 routes, got %d", len(routes))
+	}
+
+	// Catch-all routes are at indices 1 (site-a) and 3 (site-b).
+	catchAllA := routes[1].(map[string]any)
+	handlersA := catchAllA["handle"].([]any)
+
+	catchAllB := routes[3].(map[string]any)
+	handlersB := catchAllB["handle"].([]any)
+
+	// Site A should have 2 more handlers than site B (WAF + CORS from plugins).
+	if len(handlersA) != len(handlersB)+2 {
+		t.Errorf("site A should have %d handlers (site B %d + 2 plugin handlers), got %d",
+			len(handlersB)+2, len(handlersB), len(handlersA))
+	}
+
+	// Verify that plugin handlers are sorted by priority (CORS at 10 before WAF at 25).
+	// The handler chain for site A should be:
+	//   [0] user header strip
+	//   [1] vibewarden_cors (priority 10)
+	//   [2] vibewarden_waf_engine (priority 25)
+	//   [3] reverse_proxy
+	corsHandler := handlersA[1].(map[string]any)
+	if corsHandler["handler"] != "vibewarden_cors" {
+		t.Errorf("expected handler[1] to be vibewarden_cors, got %v", corsHandler["handler"])
+	}
+	wafHandler := handlersA[2].(map[string]any)
+	if wafHandler["handler"] != "vibewarden_waf_engine" {
+		t.Errorf("expected handler[2] to be vibewarden_waf_engine, got %v", wafHandler["handler"])
+	}
+
+	// Verify that site B has no plugin handlers (just user header strip + reverse proxy).
+	for _, h := range handlersB {
+		handler := h.(map[string]any)
+		handlerName := handler["handler"].(string)
+		if handlerName == "vibewarden_waf_engine" || handlerName == "vibewarden_cors" {
+			t.Errorf("site B should not have handler %q", handlerName)
+		}
+	}
+}
+
+func TestBuildMultiSiteConfig_PerSitePluginHandlers_NilMap(t *testing.T) {
+	// When perSiteHandlers is nil, no plugin handlers are inserted.
+	cfg := helperMinimalConfig("app.example.com", 3000)
+	s := helperNewSite(t, "app", cfg)
+
+	global := site.DefaultGlobalConfig()
+	result, err := BuildMultiSiteConfig([]*site.Site{s}, global, nil, slog.Default())
+	if err != nil {
+		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
+	}
+
+	data, _ := json.Marshal(result)
+	var parsed map[string]any
+	_ = json.Unmarshal(data, &parsed)
+
+	apps := parsed["apps"].(map[string]any)
+	httpApp := apps["http"].(map[string]any)
+	servers := httpApp["servers"].(map[string]any)
+	vw := servers["vibewarden"].(map[string]any)
+	routes := vw["routes"].([]any)
+
+	catchAll := routes[1].(map[string]any)
+	handlers := catchAll["handle"].([]any)
+
+	// Should only have user header strip + reverse proxy (no plugin handlers).
+	if len(handlers) != 2 {
+		t.Errorf("expected 2 handlers (strip + proxy), got %d", len(handlers))
+	}
+}
+
+func TestBuildSiteRoutes_WithExtraHandlers(t *testing.T) {
+	cfg := helperMinimalConfig("test.example.com", 3000)
+	s := helperNewSite(t, "test", cfg)
+
+	extraHandlers := []ports.CaddyHandler{
+		{
+			Handler:  map[string]any{"handler": "vibewarden_waf_engine"},
+			Priority: 25,
+		},
+		{
+			Handler:  map[string]any{"handler": "vibewarden_ip_filter"},
+			Priority: 15,
+		},
+	}
+
+	routes, err := buildSiteRoutes(s, "test.example.com", extraHandlers)
+	if err != nil {
+		t.Fatalf("buildSiteRoutes() error = %v", err)
+	}
+
+	// 2 routes: health + catch-all.
+	if len(routes) != 2 {
+		t.Fatalf("expected 2 routes, got %d", len(routes))
+	}
+
+	catchAll := routes[1]
+	handlers := catchAll["handle"].([]map[string]any)
+
+	// Expected: user header strip, ip_filter (15), waf_engine (25), reverse_proxy.
+	if len(handlers) != 4 {
+		t.Fatalf("expected 4 handlers, got %d", len(handlers))
+	}
+
+	// Verify ordering: ip_filter before waf_engine (lower priority runs first).
+	if handlers[1]["handler"] != "vibewarden_ip_filter" {
+		t.Errorf("expected handler[1] = vibewarden_ip_filter, got %v", handlers[1]["handler"])
+	}
+	if handlers[2]["handler"] != "vibewarden_waf_engine" {
+		t.Errorf("expected handler[2] = vibewarden_waf_engine, got %v", handlers[2]["handler"])
+	}
+	if handlers[3]["handler"] != "reverse_proxy" {
+		t.Errorf("expected handler[3] = reverse_proxy, got %v", handlers[3]["handler"])
+	}
+}
+
+func TestBuildSiteRoutes_ExtraHandlersBeforeRateLimit(t *testing.T) {
+	// When both plugin handlers and config-driven rate limiting are active,
+	// plugin handlers should appear before rate limiting in the chain.
+	cfg := helperMinimalConfig("test.example.com", 3000)
+	cfg.RateLimit = config.RateLimitConfig{
+		Enabled: true,
+		PerIP:   config.RateLimitRuleConfig{RequestsPerSecond: 10, Burst: 20},
+	}
+	s := helperNewSite(t, "test", cfg)
+
+	extraHandlers := []ports.CaddyHandler{
+		{
+			Handler:  map[string]any{"handler": "vibewarden_waf_engine"},
+			Priority: 25,
+		},
+	}
+
+	routes, err := buildSiteRoutes(s, "test.example.com", extraHandlers)
+	if err != nil {
+		t.Fatalf("buildSiteRoutes() error = %v", err)
+	}
+
+	catchAll := routes[1]
+	handlers := catchAll["handle"].([]map[string]any)
+
+	// Expected: user header strip, waf_engine, rate_limit, reverse_proxy.
+	// Find indices of waf and rate_limit.
+	wafIdx := -1
+	rlIdx := -1
+	for i, h := range handlers {
+		switch h["handler"] {
+		case "vibewarden_waf_engine":
+			wafIdx = i
+		case "vibewarden_rate_limit":
+			rlIdx = i
+		}
+	}
+
+	if wafIdx < 0 {
+		t.Fatal("WAF handler not found in chain")
+	}
+	if rlIdx < 0 {
+		t.Fatal("rate limit handler not found in chain")
+	}
+	if wafIdx >= rlIdx {
+		t.Errorf("WAF handler (index %d) should appear before rate limit handler (index %d)", wafIdx, rlIdx)
 	}
 }
 


### PR DESCRIPTION
Closes #925

## Summary

- Multi-site mode was not running the plugin lifecycle, so plugins like WAF, auth, CORS, IP filter, input validation, maintenance mode, body size, and webhook signature verification never contributed their Caddy handlers to the per-site middleware chain. Only config-driven handlers (security headers, rate limiting, compression) were active.
- Added `buildPerSitePluginHandlers` in `cmd/vibewarden/wiring_serve_multisite.go` that creates a per-site `plugins.Registry` for each healthy site, calls `RegisterBuiltinPlugins` and `InitAll`, then collects `CaddyContributor` handlers into a `map[string][]ports.CaddyHandler`.
- Updated `NewMultiSiteAdapter` and `BuildMultiSiteConfig` to accept and propagate per-site handlers to the Caddy config builder.
- Updated `buildSiteRoutes` to insert plugin-contributed handlers after security headers but before rate limiting, sorted by ascending priority, matching the single-site handler chain order.

## Test plan

- [x] Existing tests updated to pass the new `perSiteHandlers` parameter (nil for backward compat)
- [x] `TestBuildMultiSiteConfig_PerSitePluginHandlers` — verifies plugin handlers are inserted only for the correct site and sorted by priority
- [x] `TestBuildMultiSiteConfig_PerSitePluginHandlers_NilMap` — verifies nil map produces no plugin handlers (backward compat)
- [x] `TestBuildSiteRoutes_WithExtraHandlers` — verifies extra handlers are inserted and sorted by priority
- [x] `TestBuildSiteRoutes_ExtraHandlersBeforeRateLimit` — verifies plugin handlers appear before config-driven rate limiting
- [x] `make check` passes (gofmt, golangci-lint, build, all tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)