### PR TITLE
fix(#940-943): healthcheck shell detection, restart rebuild, status diagnosis, dev letsencrypt warning

### DIFF
--- a/internal/adapters/ops/compose.go
+++ b/internal/adapters/ops/compose.go
@@ -50,10 +50,12 @@ func (c *ComposeAdapter) Up(ctx context.Context, composeFile string, profiles []
 	return nil
 }
 
-// Restart runs "docker compose [-f <composeFile>] restart [<service>...]".
+// Restart runs "docker compose [-f <composeFile>] up -d --force-recreate --build [<service>...]".
+// This rebuilds images if the Dockerfile has changed and recreates containers,
+// making it safe to call after any project file change.
 // When composeFile is non-empty it is passed as the -f flag.
 // When services is non-empty each service name is appended so that only those
-// services are restarted; when empty all services are restarted.
+// services are rebuilt and recreated; when empty all services are affected.
 // On failure, stderr output from the command is included in the returned error
 // to give the caller actionable context for diagnosis.
 func (c *ComposeAdapter) Restart(ctx context.Context, composeFile string, services []string) error {
@@ -61,7 +63,7 @@ func (c *ComposeAdapter) Restart(ctx context.Context, composeFile string, servic
 	if composeFile != "" {
 		args = append(args, "-f", composeFile)
 	}
-	args = append(args, "restart")
+	args = append(args, "up", "-d", "--force-recreate", "--build")
 	args = append(args, services...)
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
@@ -70,9 +72,9 @@ func (c *ComposeAdapter) Restart(ctx context.Context, composeFile string, servic
 	if err := cmd.Run(); err != nil {
 		msg := strings.TrimSpace(stderr.String())
 		if msg != "" {
-			return fmt.Errorf("docker compose restart: %w\nstderr: %s", err, msg)
+			return fmt.Errorf("docker compose up --force-recreate --build: %w\nstderr: %s", err, msg)
 		}
-		return fmt.Errorf("docker compose restart: %w", err)
+		return fmt.Errorf("docker compose up --force-recreate --build: %w", err)
 	}
 	return nil
 }
@@ -162,4 +164,47 @@ func (c *ComposeAdapter) PS(ctx context.Context, composeFile string) ([]ports.Co
 		})
 	}
 	return results, nil
+}
+
+// Tail returns the last n lines of logs from the specified service.
+// It runs "docker compose [-f <composeFile>] logs --tail <n> <service>".
+func (c *ComposeAdapter) Tail(ctx context.Context, composeFile string, service string, n int) (string, error) {
+	args := []string{"compose"}
+	if composeFile != "" {
+		args = append(args, "-f", composeFile)
+	}
+	args = append(args, "logs", "--tail", fmt.Sprintf("%d", n), service)
+
+	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("docker compose logs: %w", err)
+	}
+	return string(out), nil
+}
+
+// ShellProberAdapter implements ports.DockerShellProber by shelling out to
+// the docker CLI.
+type ShellProberAdapter struct{}
+
+// NewShellProberAdapter creates a new ShellProberAdapter.
+func NewShellProberAdapter() *ShellProberAdapter {
+	return &ShellProberAdapter{}
+}
+
+// HasShell probes whether the given Docker image contains a working /bin/sh by
+// running "docker run --rm --entrypoint="" <image> /bin/sh -c "echo ok"".
+// Returns (true, nil) if the command succeeds, (false, nil) if the command
+// exits with a non-zero status (indicating no shell), or (false, err) for
+// unexpected failures.
+func (a *ShellProberAdapter) HasShell(ctx context.Context, image string) (bool, error) {
+	args := []string{"run", "--rm", "--entrypoint=", image, "/bin/sh", "-c", "echo ok"}
+	cmd := exec.CommandContext(ctx, "docker", args...) //nolint:gosec // args are constructed from caller-supplied image name
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return false, nil
+		}
+		return false, fmt.Errorf("docker run shell probe: %w", err)
+	}
+	return true, nil
 }

--- a/internal/adapters/ops/compose_test.go
+++ b/internal/adapters/ops/compose_test.go
@@ -115,13 +115,14 @@ func TestComposeAdapter_Restart_CancelledContextWithService(t *testing.T) {
 }
 
 // restartArgs mirrors the argument-construction logic of ComposeAdapter.Restart
-// for use in table-driven tests.
+// for use in table-driven tests. The adapter now uses "up -d --force-recreate
+// --build" instead of "restart" so that Dockerfile changes are picked up.
 func restartArgs(composeFile string, services []string) []string {
 	args := []string{"compose"}
 	if composeFile != "" {
 		args = append(args, "-f", composeFile)
 	}
-	args = append(args, "restart")
+	args = append(args, "up", "-d", "--force-recreate", "--build")
 	args = append(args, services...)
 	return args
 }
@@ -135,28 +136,28 @@ func TestRestartArgsConstruction(t *testing.T) {
 	}{
 		{
 			name: "no file, no services",
-			want: []string{"compose", "restart"},
+			want: []string{"compose", "up", "-d", "--force-recreate", "--build"},
 		},
 		{
 			name:     "no file, single service",
 			services: []string{"app"},
-			want:     []string{"compose", "restart", "app"},
+			want:     []string{"compose", "up", "-d", "--force-recreate", "--build", "app"},
 		},
 		{
 			name:     "no file, multiple services",
 			services: []string{"app", "kratos"},
-			want:     []string{"compose", "restart", "app", "kratos"},
+			want:     []string{"compose", "up", "-d", "--force-recreate", "--build", "app", "kratos"},
 		},
 		{
 			name:        "with file, no services",
 			composeFile: ".vibewarden/generated/docker-compose.yml",
-			want:        []string{"compose", "-f", ".vibewarden/generated/docker-compose.yml", "restart"},
+			want:        []string{"compose", "-f", ".vibewarden/generated/docker-compose.yml", "up", "-d", "--force-recreate", "--build"},
 		},
 		{
 			name:        "with file and service",
 			composeFile: ".vibewarden/generated/docker-compose.yml",
 			services:    []string{"app"},
-			want:        []string{"compose", "-f", ".vibewarden/generated/docker-compose.yml", "restart", "app"},
+			want:        []string{"compose", "-f", ".vibewarden/generated/docker-compose.yml", "up", "-d", "--force-recreate", "--build", "app"},
 		},
 	}
 
@@ -257,6 +258,36 @@ func TestImageCheckerAdapter_ImageExists_CancelledContext(t *testing.T) {
 	_, err := adapter.ImageExists(ctx, "alpine:latest")
 	if err == nil {
 		t.Fatal("ImageExists() expected error with cancelled context, got nil")
+	}
+}
+
+func TestShellProberAdapter_CancelledContext(t *testing.T) {
+	if !dockerAvailable() {
+		t.Skip("docker binary not available")
+	}
+
+	adapter := opsadapter.NewShellProberAdapter()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := adapter.HasShell(ctx, "alpine:latest")
+	if err == nil {
+		t.Fatal("HasShell() expected error with cancelled context, got nil")
+	}
+}
+
+func TestComposeAdapter_Tail_CancelledContext(t *testing.T) {
+	if !dockerAvailable() {
+		t.Skip("docker binary not available")
+	}
+
+	adapter := opsadapter.NewComposeAdapter()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := adapter.Tail(ctx, "", "vibewarden", 10)
+	if err == nil {
+		t.Fatal("Tail() expected error with cancelled context, got nil")
 	}
 }
 

--- a/internal/app/ops/build.go
+++ b/internal/app/ops/build.go
@@ -14,13 +14,24 @@ import (
 // BuildService orchestrates the "vibew build" use case.
 // It resolves the Docker image tag from vibewarden.yaml (app.image) or falls
 // back to the current directory name, then delegates to a DockerBuilder.
+// When a shell prober is wired, it probes the built image for /bin/sh and
+// prints a warning when the image has no shell (distroless/scratch images).
 type BuildService struct {
-	builder ports.DockerBuilder
+	builder     ports.DockerBuilder
+	shellProber ports.DockerShellProber // optional; nil disables shell probe
 }
 
 // NewBuildService creates a new BuildService.
 func NewBuildService(builder ports.DockerBuilder) *BuildService {
 	return &BuildService{builder: builder}
+}
+
+// WithShellProber attaches a DockerShellProber to the BuildService.
+// When set, Run probes the built image for /bin/sh after a successful build
+// and prints a warning when no shell is found.
+func (s *BuildService) WithShellProber(prober ports.DockerShellProber) *BuildService {
+	s.shellProber = prober
+	return s
 }
 
 // BuildOptions holds options for the build command.
@@ -63,7 +74,34 @@ func (s *BuildService) Run(ctx context.Context, cfg *config.Config, opts BuildOp
 	}
 
 	fmt.Fprintf(out, "Successfully built: %s\n", tag)
+
+	// Post-build: probe the image for /bin/sh so we can warn about healthcheck
+	// compatibility. Distroless and scratch images have no shell, which means
+	// the generated docker-compose healthcheck (CMD-SHELL) will fail at runtime.
+	s.probeShell(ctx, tag, out)
+
 	return nil
+}
+
+// probeShell checks whether the built image contains /bin/sh and prints a
+// warning when it does not. The probe is best-effort: errors from the prober
+// are silently ignored so they never fail the build.
+func (s *BuildService) probeShell(ctx context.Context, image string, out io.Writer) {
+	if s.shellProber == nil {
+		return
+	}
+
+	hasShell, err := s.shellProber.HasShell(ctx, image)
+	if err != nil {
+		// Probe failure is not fatal — just skip.
+		return
+	}
+	if !hasShell {
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "Warning: your app image has no shell (/bin/sh). The generated healthcheck")
+		fmt.Fprintln(out, "requires a shell. Switch to an Alpine-based image or add a custom healthcheck")
+		fmt.Fprintln(out, "in your Dockerfile.")
+	}
 }
 
 // resolveImageTag returns the Docker image tag for the build.

--- a/internal/app/ops/build_test.go
+++ b/internal/app/ops/build_test.go
@@ -195,3 +195,95 @@ func TestBuildService_Run_PassesWorkDirToBuilder(t *testing.T) {
 		t.Errorf("contextDir = %q, want %q", fb.capturedDir, dir)
 	}
 }
+
+// fakeShellProber is a test double for ports.DockerShellProber.
+type fakeShellProber struct {
+	hasShell bool
+	err      error
+}
+
+func (f *fakeShellProber) HasShell(_ context.Context, _ string) (bool, error) {
+	return f.hasShell, f.err
+}
+
+func TestBuildService_ShellProber_NoShellWarning(t *testing.T) {
+	fb := &fakeBuilder{}
+	fp := &fakeShellProber{hasShell: false}
+	svc := ops.NewBuildService(fb).WithShellProber(fp)
+
+	cfg := &config.Config{}
+	cfg.App.Image = "myapp:latest"
+
+	var out bytes.Buffer
+	err := svc.Run(context.Background(), cfg, ops.BuildOptions{WorkDir: "."}, &out)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "Warning: your app image has no shell") {
+		t.Errorf("expected shell warning in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Alpine-based") {
+		t.Errorf("expected Alpine suggestion in output, got:\n%s", output)
+	}
+}
+
+func TestBuildService_ShellProber_HasShell_NoWarning(t *testing.T) {
+	fb := &fakeBuilder{}
+	fp := &fakeShellProber{hasShell: true}
+	svc := ops.NewBuildService(fb).WithShellProber(fp)
+
+	cfg := &config.Config{}
+	cfg.App.Image = "myapp:latest"
+
+	var out bytes.Buffer
+	err := svc.Run(context.Background(), cfg, ops.BuildOptions{WorkDir: "."}, &out)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if strings.Contains(output, "Warning: your app image has no shell") {
+		t.Errorf("unexpected shell warning in output:\n%s", output)
+	}
+}
+
+func TestBuildService_ShellProber_Error_NoWarning(t *testing.T) {
+	fb := &fakeBuilder{}
+	fp := &fakeShellProber{err: errors.New("docker daemon unreachable")}
+	svc := ops.NewBuildService(fb).WithShellProber(fp)
+
+	cfg := &config.Config{}
+	cfg.App.Image = "myapp:latest"
+
+	var out bytes.Buffer
+	err := svc.Run(context.Background(), cfg, ops.BuildOptions{WorkDir: "."}, &out)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if strings.Contains(output, "Warning: your app image has no shell") {
+		t.Errorf("unexpected shell warning when prober errors:\n%s", output)
+	}
+}
+
+func TestBuildService_ShellProber_NilProber_NoWarning(t *testing.T) {
+	fb := &fakeBuilder{}
+	svc := ops.NewBuildService(fb) // no prober wired
+
+	cfg := &config.Config{}
+	cfg.App.Image = "myapp:latest"
+
+	var out bytes.Buffer
+	err := svc.Run(context.Background(), cfg, ops.BuildOptions{WorkDir: "."}, &out)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if strings.Contains(output, "Warning: your app image has no shell") {
+		t.Errorf("unexpected shell warning when no prober wired:\n%s", output)
+	}
+}

--- a/internal/app/ops/dev.go
+++ b/internal/app/ops/dev.go
@@ -102,6 +102,16 @@ func (s *DevService) Run(ctx context.Context, cfg *config.Config, opts DevOption
 		fmt.Fprintln(out, "Observability profile enabled (Prometheus + Grafana).")
 	}
 
+	// Warn when letsencrypt is configured in dev mode — ACME challenges will
+	// fail on localhost since the server is not publicly reachable.
+	if cfg.TLS.Enabled && cfg.TLS.Provider == "letsencrypt" {
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "Warning: tls.provider is 'letsencrypt' -- ACME HTTP-01 challenges require a")
+		fmt.Fprintln(out, "publicly reachable server. Local dev will use self-signed certificates instead.")
+		fmt.Fprintln(out, "Set tls.provider: self-signed to suppress this warning.")
+		fmt.Fprintln(out, "")
+	}
+
 	// Determine the compose file path to use.
 	composeFile, err := s.resolveComposeFile(ctx, cfg, out)
 	if err != nil {

--- a/internal/app/ops/dev_test.go
+++ b/internal/app/ops/dev_test.go
@@ -527,3 +527,66 @@ func TestDevService_ImageCheck_CheckerError_ReturnsError(t *testing.T) {
 		t.Errorf("error should wrap checker error, got: %v", err)
 	}
 }
+
+func TestDevService_LetsencryptWarning(t *testing.T) {
+	fc := &fakeCompose{}
+	svc := ops.NewDevService(fc)
+	cfg := defaultConfig()
+	cfg.TLS.Enabled = true
+	cfg.TLS.Provider = "letsencrypt"
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{}, &buf)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "tls.provider is 'letsencrypt'") {
+		t.Errorf("expected letsencrypt warning in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ACME HTTP-01") {
+		t.Errorf("expected ACME HTTP-01 mention in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "self-signed") {
+		t.Errorf("expected self-signed suggestion in output, got:\n%s", out)
+	}
+}
+
+func TestDevService_SelfSigned_NoLetsencryptWarning(t *testing.T) {
+	fc := &fakeCompose{}
+	svc := ops.NewDevService(fc)
+	cfg := defaultConfig()
+	cfg.TLS.Enabled = true
+	cfg.TLS.Provider = "self-signed"
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{}, &buf)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "tls.provider is 'letsencrypt'") {
+		t.Errorf("unexpected letsencrypt warning when provider is self-signed:\n%s", out)
+	}
+}
+
+func TestDevService_TLSDisabled_NoLetsencryptWarning(t *testing.T) {
+	fc := &fakeCompose{}
+	svc := ops.NewDevService(fc)
+	cfg := defaultConfig()
+	cfg.TLS.Enabled = false
+	cfg.TLS.Provider = "letsencrypt"
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{}, &buf)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "tls.provider is 'letsencrypt'") {
+		t.Errorf("unexpected letsencrypt warning when TLS is disabled:\n%s", out)
+	}
+}

--- a/internal/app/ops/restart.go
+++ b/internal/app/ops/restart.go
@@ -10,8 +10,8 @@ import (
 )
 
 // RestartService orchestrates the "vibew restart" use case.
-// It restarts one or more services in the Docker Compose stack without
-// rebuilding or recreating containers.
+// It rebuilds and recreates containers using "docker compose up -d
+// --force-recreate --build" so that Dockerfile changes are picked up.
 type RestartService struct {
 	compose ports.ComposeRunner
 }
@@ -21,17 +21,17 @@ func NewRestartService(compose ports.ComposeRunner) *RestartService {
 	return &RestartService{compose: compose}
 }
 
-// Run restarts the compose stack (or a subset of services) using the generated
-// compose file under .vibewarden/generated/.
-// When services is empty all services are restarted.
-// When services is non-empty only those named services are restarted.
+// Run rebuilds and recreates the compose stack (or a subset of services) using
+// the generated compose file under .vibewarden/generated/.
+// When services is empty all services are rebuilt and recreated.
+// When services is non-empty only those named services are affected.
 func (s *RestartService) Run(ctx context.Context, services []string, out io.Writer) error {
 	composeFile := filepath.Join(generatedOutputDir, "docker-compose.yml")
 
 	if len(services) == 0 {
-		fmt.Fprintln(out, "Restarting all services...")
+		fmt.Fprintln(out, "Rebuilding and restarting all services...")
 	} else {
-		fmt.Fprintf(out, "Restarting service(s): %v...\n", services)
+		fmt.Fprintf(out, "Rebuilding and restarting service(s): %v...\n", services)
 	}
 
 	if err := s.compose.Restart(ctx, composeFile, services); err != nil {

--- a/internal/app/ops/restart_test.go
+++ b/internal/app/ops/restart_test.go
@@ -56,7 +56,7 @@ func TestRestartService_Run(t *testing.T) {
 		{
 			name:       "restart all services",
 			services:   nil,
-			wantOutput: "Restarting all services",
+			wantOutput: "Rebuilding and restarting all services",
 		},
 		{
 			name:       "restart single service",

--- a/internal/app/ops/status.go
+++ b/internal/app/ops/status.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/fatih/color"
@@ -24,13 +26,29 @@ type ComponentStatus struct {
 
 // StatusService orchestrates the "vibew status" use case.
 // It queries each component and returns a structured summary.
+// When a ComposeRunner is wired, it provides additional diagnostic details
+// when the proxy is unreachable (container state, log snippets).
 type StatusService struct {
-	health ports.HealthChecker
+	health  ports.HealthChecker
+	compose ports.ComposeRunner // optional; nil disables container diagnostics
+	logs    ports.ComposeLogs   // optional; nil disables log-based diagnostics
 }
 
 // NewStatusService creates a new StatusService.
 func NewStatusService(health ports.HealthChecker) *StatusService {
 	return &StatusService{health: health}
+}
+
+// WithCompose attaches a ComposeRunner for diagnostic container status checks.
+func (s *StatusService) WithCompose(compose ports.ComposeRunner) *StatusService {
+	s.compose = compose
+	return s
+}
+
+// WithLogs attaches a ComposeLogs for diagnostic log tail checks.
+func (s *StatusService) WithLogs(logs ports.ComposeLogs) *StatusService {
+	s.logs = logs
+	return s
 }
 
 // Run queries all components and writes the status dashboard to out.
@@ -51,6 +69,15 @@ func (s *StatusService) Run(ctx context.Context, cfg *config.Config, out io.Writ
 	statuses := s.gatherStatuses(checkCtx, cfg, proxyBase)
 	pluginStatuses := gatherPluginStatuses(cfg)
 	printStatusTable(statuses, pluginStatuses, out)
+
+	// When the proxy is unreachable, print additional diagnostic details.
+	for _, st := range statuses {
+		if st.Name == "Proxy" && !st.Healthy {
+			s.diagnoseProxy(checkCtx, cfg, out)
+			break
+		}
+	}
+
 	return nil
 }
 
@@ -180,6 +207,54 @@ func (s *StatusService) checkHTTP(ctx context.Context, name, url, base string) C
 		Healthy: true,
 		Detail:  base,
 	}
+}
+
+// diagnoseProxy prints additional diagnostic details when the proxy is
+// unreachable. It checks whether the sidecar container is running and
+// inspects recent log lines for common error patterns.
+func (s *StatusService) diagnoseProxy(ctx context.Context, cfg *config.Config, out io.Writer) {
+	composeFile := filepath.Join(generatedOutputDir, "docker-compose.yml")
+
+	// Step 1: check container state via docker compose ps.
+	if s.compose != nil {
+		containers, err := s.compose.PS(ctx, composeFile)
+		if err == nil {
+			sidecarRunning := false
+			for _, c := range containers {
+				if c.Service == "vibewarden" || c.Service == "sidecar" || c.Service == "proxy" {
+					if c.State == "running" {
+						sidecarRunning = true
+					}
+					break
+				}
+			}
+
+			if len(containers) == 0 || !sidecarRunning {
+				fmt.Fprintln(out, "  Diagnosis: Sidecar container is not running -- run 'vibew dev' to start")
+				fmt.Fprintln(out, "  Suggestion: Run 'vibew doctor' for detailed diagnostics")
+				return
+			}
+		}
+	}
+
+	// Step 2: check sidecar logs for ACME/TLS errors.
+	if s.logs != nil {
+		logOutput, err := s.logs.Tail(ctx, composeFile, "vibewarden", 20)
+		if err == nil && logOutput != "" {
+			lower := strings.ToLower(logOutput)
+			if strings.Contains(lower, "acme") || strings.Contains(lower, "challenge") || strings.Contains(lower, "tls") {
+				fmt.Fprintln(out, "  Diagnosis: Recent sidecar logs contain TLS/ACME errors")
+			}
+		}
+	}
+
+	// Step 3: letsencrypt + localhost is a known misconfiguration.
+	if cfg.TLS.Enabled && cfg.TLS.Provider == "letsencrypt" {
+		fmt.Fprintln(out, "  Diagnosis: tls.provider is 'letsencrypt' -- ACME HTTP-01 challenges require a")
+		fmt.Fprintln(out, "  publicly reachable server. Use tls.provider: self-signed for local dev.")
+	}
+
+	fmt.Fprintln(out, "  Suggestion: Run 'vibew doctor' for detailed diagnostics")
 }
 
 // printStatusTable renders the component and plugin statuses as a table.

--- a/internal/app/ops/status_test.go
+++ b/internal/app/ops/status_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
 // fakeHealthChecker is a test double for ports.HealthChecker.
@@ -213,5 +215,166 @@ func TestStatusService_TLSEnabled(t *testing.T) {
 	}
 	if !strings.Contains(out, "example.com") {
 		t.Errorf("expected domain in output, got:\n%s", out)
+	}
+}
+
+// fakeStatusCompose is a test double for ports.ComposeRunner used by status tests.
+type fakeStatusCompose struct {
+	psResult []ports.ContainerInfo
+	psErr    error
+}
+
+func (f *fakeStatusCompose) Up(_ context.Context, _ string, _ []string) error { return nil }
+func (f *fakeStatusCompose) Restart(_ context.Context, _ string, _ []string) error {
+	return nil
+}
+func (f *fakeStatusCompose) Version(_ context.Context) (string, error) { return "", nil }
+func (f *fakeStatusCompose) Info(_ context.Context) error              { return nil }
+func (f *fakeStatusCompose) PS(_ context.Context, _ string) ([]ports.ContainerInfo, error) {
+	return f.psResult, f.psErr
+}
+
+// fakeStatusLogs is a test double for ports.ComposeLogs used by status tests.
+type fakeStatusLogs struct {
+	output string
+	err    error
+}
+
+func (f *fakeStatusLogs) Tail(_ context.Context, _ string, _ string, _ int) (string, error) {
+	return f.output, f.err
+}
+
+func TestStatusService_ProxyUnreachable_NoContainers_ShowsDiagnosis(t *testing.T) {
+	cfg := defaultConfig()
+
+	proxyBase := "https://localhost:8443"
+	checker := &fakeHealthChecker{responses: map[string]healthResponse{
+		proxyBase + "/_vibewarden/health":          {ok: false, err: errors.New("connection refused")},
+		proxyBase + "/_vibewarden/metrics":         {ok: true, statusCode: 200},
+		"http://127.0.0.1:4434/admin/health/ready": {ok: true, statusCode: 200},
+	}}
+
+	compose := &fakeStatusCompose{psResult: nil} // no containers
+	svc := ops.NewStatusService(checker).WithCompose(compose)
+
+	var buf bytes.Buffer
+	if err := svc.Run(context.Background(), cfg, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Sidecar container is not running") {
+		t.Errorf("expected 'Sidecar container is not running' in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "vibew doctor") {
+		t.Errorf("expected 'vibew doctor' suggestion in output, got:\n%s", out)
+	}
+}
+
+func TestStatusService_ProxyUnreachable_SidecarRunning_ShowsLogDiagnosis(t *testing.T) {
+	cfg := defaultConfig()
+
+	proxyBase := "https://localhost:8443"
+	checker := &fakeHealthChecker{responses: map[string]healthResponse{
+		proxyBase + "/_vibewarden/health":          {ok: false, err: errors.New("connection refused")},
+		proxyBase + "/_vibewarden/metrics":         {ok: true, statusCode: 200},
+		"http://127.0.0.1:4434/admin/health/ready": {ok: true, statusCode: 200},
+	}}
+
+	compose := &fakeStatusCompose{psResult: []ports.ContainerInfo{
+		{Service: "vibewarden", State: "running"},
+	}}
+	logs := &fakeStatusLogs{output: "error: ACME challenge failed for domain"}
+	svc := ops.NewStatusService(checker).WithCompose(compose).WithLogs(logs)
+
+	var buf bytes.Buffer
+	if err := svc.Run(context.Background(), cfg, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "TLS/ACME errors") {
+		t.Errorf("expected TLS/ACME diagnosis in output, got:\n%s", out)
+	}
+}
+
+func TestStatusService_ProxyUnreachable_LetsencryptLocal_ShowsHint(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.TLS.Enabled = true
+	cfg.TLS.Provider = "letsencrypt"
+
+	proxyBase := "https://localhost:8443"
+	checker := &fakeHealthChecker{responses: map[string]healthResponse{
+		proxyBase + "/_vibewarden/health":          {ok: false, err: errors.New("connection refused")},
+		proxyBase + "/_vibewarden/metrics":         {ok: true, statusCode: 200},
+		"http://127.0.0.1:4434/admin/health/ready": {ok: true, statusCode: 200},
+	}}
+
+	compose := &fakeStatusCompose{psResult: []ports.ContainerInfo{
+		{Service: "vibewarden", State: "running"},
+	}}
+	svc := ops.NewStatusService(checker).WithCompose(compose)
+
+	var buf bytes.Buffer
+	if err := svc.Run(context.Background(), cfg, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "letsencrypt") {
+		t.Errorf("expected letsencrypt hint in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "self-signed") {
+		t.Errorf("expected self-signed suggestion in output, got:\n%s", out)
+	}
+}
+
+func TestStatusService_ProxyHealthy_NoDiagnostics(t *testing.T) {
+	cfg := defaultConfig()
+
+	proxyBase := "https://localhost:8443"
+	checker := &fakeHealthChecker{responses: map[string]healthResponse{
+		proxyBase + "/_vibewarden/health":          {ok: true, statusCode: 200},
+		proxyBase + "/_vibewarden/metrics":         {ok: true, statusCode: 200},
+		"http://127.0.0.1:4434/admin/health/ready": {ok: true, statusCode: 200},
+	}}
+
+	compose := &fakeStatusCompose{psResult: nil}
+	svc := ops.NewStatusService(checker).WithCompose(compose)
+
+	var buf bytes.Buffer
+	if err := svc.Run(context.Background(), cfg, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "Diagnosis") {
+		t.Errorf("expected no diagnosis when proxy is healthy, got:\n%s", out)
+	}
+}
+
+func TestStatusService_ProxyUnreachable_DoctorSuggestion(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{Host: "127.0.0.1", Port: 8443},
+		TLS:    config.TLSConfig{Enabled: true, Provider: "self-signed"},
+	}
+
+	proxyBase := "https://localhost:8443"
+	checker := &fakeHealthChecker{responses: map[string]healthResponse{
+		proxyBase + "/_vibewarden/health":          {ok: false, err: errors.New("connection refused")},
+		"http://127.0.0.1:4434/admin/health/ready": {ok: true, statusCode: 200},
+	}}
+
+	// No compose wired, so diagnosis falls through to the suggestion.
+	svc := ops.NewStatusService(checker)
+
+	var buf bytes.Buffer
+	if err := svc.Run(context.Background(), cfg, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "vibew doctor") {
+		t.Errorf("expected 'vibew doctor' suggestion in output, got:\n%s", out)
 	}
 }

--- a/internal/cli/cmd/build.go
+++ b/internal/cli/cmd/build.go
@@ -42,7 +42,8 @@ Examples:
 			}
 
 			builder := opsadapter.NewBuildAdapter()
-			svc := opsapp.NewBuildService(builder)
+			svc := opsapp.NewBuildService(builder).
+				WithShellProber(opsadapter.NewShellProberAdapter())
 
 			opts := opsapp.BuildOptions{
 				NoCache:    noCache,

--- a/internal/cli/cmd/restart.go
+++ b/internal/cli/cmd/restart.go
@@ -9,24 +9,27 @@ import (
 
 // NewRestartCmd creates the "vibew restart [service...]" subcommand.
 //
-// The command restarts the Docker Compose stack (or a subset of named services)
-// without rebuilding or recreating containers.  It always uses the generated
-// compose file at .vibewarden/generated/docker-compose.yml.
+// The command rebuilds and recreates containers in the Docker Compose stack
+// (or a subset of named services), picking up any Dockerfile or config changes.
+// It always uses the generated compose file at .vibewarden/generated/docker-compose.yml.
 //
 // Examples:
 //
-//	vibew restart              # restart all services
-//	vibew restart app          # restart only the app service
-//	vibew restart app kratos   # restart multiple services
+//	vibew restart              # rebuild and restart all services
+//	vibew restart app          # rebuild and restart only the app service
+//	vibew restart app kratos   # rebuild and restart multiple services
 func NewRestartCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "restart [service...]",
-		Short: "Restart the stack without rebuilding",
-		Long: `Restart the VibeWarden Docker Compose stack without rebuilding or recreating
-containers.  This is faster than 'vibew dev' after a config-only change.
+		Short: "Rebuild and restart the stack",
+		Long: `Rebuild and restart the VibeWarden Docker Compose stack, picking up
+any Dockerfile or configuration changes.
 
-When called without arguments all services are restarted.  Pass one or more
-service names to restart only those services.
+Internally runs 'docker compose up -d --force-recreate --build' so that
+images are rebuilt and containers are recreated.
+
+When called without arguments all services are rebuilt and restarted.  Pass
+one or more service names to rebuild and restart only those services.
 
 The generated compose file at .vibewarden/generated/docker-compose.yml is used.
 Run 'vibew generate' first if that file does not yet exist.

--- a/internal/cli/cmd/status.go
+++ b/internal/cli/cmd/status.go
@@ -43,7 +43,10 @@ Examples:
 
 			httpClient := newStatusHTTPClient(cfg)
 			checker := opsadapter.NewHTTPHealthChecker(httpClient)
-			svc := opsapp.NewStatusService(checker)
+			compose := opsadapter.NewComposeAdapter()
+			svc := opsapp.NewStatusService(checker).
+				WithCompose(compose).
+				WithLogs(compose)
 
 			return svc.Run(cmd.Context(), cfg, cmd.OutOrStdout())
 		},

--- a/internal/ports/ops.go
+++ b/internal/ports/ops.go
@@ -25,11 +25,11 @@ type ComposeRunner interface {
 	// The output of the command is streamed to the caller via the returned channel.
 	Up(ctx context.Context, composeFile string, profiles []string) error
 
-	// Restart restarts services in the compose project.
-	// composeFile is the path to the docker-compose.yml; when empty the default
-	// discovery logic applies.
-	// services is the optional list of service names to restart; when empty all
-	// services are restarted.
+	// Restart rebuilds and recreates services in the compose project using
+	// docker compose up -d --force-recreate --build. This ensures Dockerfile
+	// changes are picked up. composeFile is the path to the docker-compose.yml;
+	// when empty the default discovery logic applies. services is the optional
+	// list of service names to restart; when empty all services are restarted.
 	Restart(ctx context.Context, composeFile string, services []string) error
 
 	// Version returns the docker compose version string.

--- a/internal/ports/ops.go
+++ b/internal/ports/ops.go
@@ -79,3 +79,21 @@ type DockerImageChecker interface {
 	// unreachable); a missing image is not an error — it returns (false, nil).
 	ImageExists(ctx context.Context, name string) (bool, error)
 }
+
+// DockerShellProber checks whether a Docker image contains /bin/sh.
+// Implementations shell out to the docker CLI.
+type DockerShellProber interface {
+	// HasShell returns true when the image contains a working /bin/sh.
+	// Returns an error only for unexpected failures (e.g. docker daemon
+	// unreachable); an image without a shell is not an error — it returns
+	// (false, nil).
+	HasShell(ctx context.Context, image string) (bool, error)
+}
+
+// ComposeLogs fetches recent log lines from a Docker Compose service.
+// Implementations shell out to the docker compose CLI.
+type ComposeLogs interface {
+	// Tail returns the last n lines of logs from the specified service in the
+	// given compose file. Returns an empty string when no logs are available.
+	Tail(ctx context.Context, composeFile string, service string, n int) (string, error)
+}


### PR DESCRIPTION
Closes #940, #941, #942, #943

## Summary

- **#940 Healthcheck shell detection**: After `vibew build`, probe the built image for `/bin/sh` via `docker run --rm --entrypoint="" <image> /bin/sh -c "echo ok"`. When the probe fails (distroless/scratch images), print a clear warning that the generated CMD-SHELL healthcheck will not work. The build itself does not fail -- only warns. Added `DockerShellProber` port and `ShellProberAdapter` adapter.

- **#941 Restart rebuilds on Dockerfile change**: Changed `vibew restart` from `docker compose restart` (which only restarts existing containers) to `docker compose up -d --force-recreate --build` so that Dockerfile and config changes are picked up automatically.

- **#942 Status shows diagnosis when proxy unreachable**: When `vibew status` reports the proxy as unreachable, it now provides actionable diagnosis:
  1. Checks if the sidecar container is running via `docker compose ps` -- if not: "Sidecar container is not running -- run vibew dev to start"
  2. If running but unreachable: checks last 20 log lines for ACME/TLS error patterns
  3. If `tls.provider: letsencrypt` is configured: hints that ACME requires a public server
  4. Always suggests: "Run vibew doctor for detailed diagnostics"
  Added `ComposeLogs` port and `Tail` method on `ComposeAdapter`.

- **#943 Dev letsencrypt warning**: When `vibew dev` starts with `tls.provider: letsencrypt`, prints a warning explaining that ACME HTTP-01 challenges require a publicly reachable server and suggesting `tls.provider: self-signed` for local dev.

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./...` passes (all tests green)
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] `make check` passes (via pre-push hook)
- [x] New table-driven tests for shell prober (warning shown, no warning when has shell, no warning on prober error, no warning when nil prober)
- [x] New tests for status diagnosis (no containers, sidecar running with ACME logs, letsencrypt hint, no diagnosis when healthy)
- [x] New tests for dev letsencrypt warning (warning shown, no warning for self-signed, no warning when TLS disabled)
- [x] Updated restart tests for new output messages
- [x] Updated compose adapter arg tests for new `up -d --force-recreate --build` command

Generated with [Claude Code](https://claude.com/claude-code)