### PR TITLE
fix(#939,#944,#945): init non-TTY fallback, fix stale AGENTS note, dev startup verification

### DIFF
--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -77,8 +77,7 @@ vibew logs         # pretty-print structured logs
 ## Known limitations
 
 - WAF is in `detect` mode by default (logs but does not block). Set `waf.mode: block` in vibewarden.yaml to enforce blocking.
-- `vibew add waf` does not exist — configure WAF directly in vibewarden.yaml under `plugins.waf`.
-- `vibew doctor` checks config, Docker, ports, and container health, but does not verify production reachability or external HTTP health.
+- `vibew doctor` checks config, Docker, ports, container health, and production reachability (when `--target` is provided).
 - Multi-site deployment is new and may have edge cases — report issues if routes or certs behave unexpectedly.
 - `vibew init` does not accept `--tls` or `--domain` flags — run `vibew add tls --domain <your-domain>` after init.
 

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/crypto v0.49.0
+	golang.org/x/term v0.41.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -214,7 +215,6 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 	google.golang.org/api v0.271.0 // indirect

--- a/internal/adapters/ops/compose.go
+++ b/internal/adapters/ops/compose.go
@@ -132,6 +132,22 @@ func (a *ImageCheckerAdapter) ImageExists(ctx context.Context, name string) (boo
 	return true, nil
 }
 
+// Logs runs "docker compose [-f <composeFile>] logs --tail <tailLines> <service>"
+// and returns the combined stdout/stderr output as a string.
+func (c *ComposeAdapter) Logs(ctx context.Context, composeFile string, service string, tailLines int) (string, error) {
+	args := []string{"compose"}
+	if composeFile != "" {
+		args = append(args, "-f", composeFile)
+	}
+	args = append(args, "logs", "--tail", fmt.Sprintf("%d", tailLines), service)
+
+	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("docker compose logs: %w", err)
+	}
+	return string(out), nil
+}
+
 // PS runs "docker compose [-f <composeFile>] ps --format json" and returns one
 // ContainerInfo per container.  An empty slice is returned when no containers
 // are running (not an error).

--- a/internal/app/ops/dev.go
+++ b/internal/app/ops/dev.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/vibewarden/vibewarden/internal/config"
 	"github.com/vibewarden/vibewarden/internal/ports"
@@ -24,6 +26,15 @@ var buildInstructionsByLang = map[string]string{
 }
 
 const generatedOutputDir = ".vibewarden/generated"
+
+// sidecarServiceName is the Compose service name for the VibeWarden sidecar
+// as defined in the generated docker-compose.yml template.
+const sidecarServiceName = "vibewarden"
+
+// SidecarSettleDuration is the time to wait after compose up before checking
+// whether the sidecar container is still running. It is a package-level
+// variable so that tests can override it to avoid real delays.
+var SidecarSettleDuration = 5 * time.Second
 
 // DevService orchestrates the "vibew dev" use case.
 // It optionally generates runtime configuration files from vibewarden.yaml
@@ -125,6 +136,11 @@ func (s *DevService) Run(ctx context.Context, cfg *config.Config, opts DevOption
 
 	if err := s.compose.Up(ctx, composeFile, profiles); err != nil {
 		return fmt.Errorf("starting dev environment: %w", err)
+	}
+
+	// Post-start: verify the sidecar container is still running.
+	if err := s.verifySidecar(ctx, composeFile, out); err != nil {
+		return err
 	}
 
 	printServiceURLs(cfg, opts, out)
@@ -239,6 +255,58 @@ func (s *DevService) checkAppImage(ctx context.Context, cfg *config.Config, opts
 	}
 
 	return buildMissingImageError(image, opts.DetectedLang)
+}
+
+// verifySidecar waits briefly after compose up, then checks whether the
+// sidecar container is still running. If it exited or is restarting, the
+// last few lines of its logs are printed and an error is returned so that
+// the command exits non-zero instead of printing a misleading success message.
+func (s *DevService) verifySidecar(ctx context.Context, composeFile string, out io.Writer) error {
+	fmt.Fprintln(out, "Waiting for sidecar to settle...")
+
+	select {
+	case <-time.After(SidecarSettleDuration):
+	case <-ctx.Done():
+		return nil
+	}
+
+	containers, err := s.compose.PS(ctx, composeFile)
+	if err != nil {
+		// PS failure is not fatal — the containers might still be starting.
+		slog.Warn("could not check sidecar status", "error", err)
+		return nil
+	}
+
+	for _, c := range containers {
+		if c.Service != sidecarServiceName {
+			continue
+		}
+
+		state := strings.ToLower(c.State)
+		if state == "running" {
+			return nil
+		}
+
+		// Sidecar is not running — fetch logs for diagnosis.
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "Sidecar container is not running (state: "+c.State+").")
+
+		logs, logsErr := s.compose.Logs(ctx, composeFile, sidecarServiceName, 20)
+		if logsErr != nil {
+			slog.Warn("could not fetch sidecar logs", "error", logsErr)
+		} else if logs != "" {
+			fmt.Fprintln(out, "")
+			fmt.Fprintln(out, "Last sidecar logs:")
+			fmt.Fprintln(out, logs)
+		}
+
+		fmt.Fprintln(out, "Sidecar failed to start — run vibew logs or vibew doctor for details.")
+		return fmt.Errorf("sidecar failed to start (state: %s)", c.State) //nolint:err113 // dynamic user-facing error
+	}
+
+	// Sidecar container not found in PS output — might not be part of the
+	// compose project (e.g. user-managed compose file). Not an error.
+	return nil
 }
 
 // buildMissingImageError constructs a descriptive error for a missing Docker

--- a/internal/app/ops/dev_test.go
+++ b/internal/app/ops/dev_test.go
@@ -21,6 +21,8 @@ type fakeCompose struct {
 	infoErr    error
 	psResult   []ports.ContainerInfo
 	psErr      error
+	logsResult string
+	logsErr    error
 
 	capturedComposeFile string
 	capturedProfiles    []string
@@ -48,6 +50,13 @@ func (f *fakeCompose) Info(_ context.Context) error {
 
 func (f *fakeCompose) PS(_ context.Context, _ string) ([]ports.ContainerInfo, error) {
 	return f.psResult, f.psErr
+}
+
+func (f *fakeCompose) Logs(_ context.Context, _ string, service string, _ int) (string, error) {
+	if f.logsResult != "" {
+		return f.logsResult, f.logsErr
+	}
+	return "fake log output for " + service, f.logsErr
 }
 
 // fakeGenerator is a test double for ports.ConfigGenerator.
@@ -588,5 +597,143 @@ func TestDevService_TLSDisabled_NoLetsencryptWarning(t *testing.T) {
 	out := buf.String()
 	if strings.Contains(out, "tls.provider is 'letsencrypt'") {
 		t.Errorf("unexpected letsencrypt warning when TLS is disabled:\n%s", out)
+	}
+}
+
+func TestDevService_VerifySidecar_Running_PrintsSuccess(t *testing.T) {
+
+	fc := &fakeCompose{
+		psResult: []ports.ContainerInfo{
+			{Name: "proj-vibewarden-1", Service: "vibewarden", State: "running", Health: "healthy"},
+		},
+	}
+	svc := ops.NewDevService(fc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{}, &buf)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Dev environment started") {
+		t.Errorf("expected success message when sidecar is running, got:\n%s", out)
+	}
+}
+
+func TestDevService_VerifySidecar_Exited_ReturnsError(t *testing.T) {
+
+	fc := &fakeCompose{
+		psResult: []ports.ContainerInfo{
+			{Name: "proj-vibewarden-1", Service: "vibewarden", State: "exited", Health: ""},
+		},
+		logsResult: "Error: config validation failed: upstream.host is required",
+	}
+	svc := ops.NewDevService(fc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{}, &buf)
+	if err == nil {
+		t.Fatal("Run() expected error when sidecar exited, got nil")
+	}
+	if !strings.Contains(err.Error(), "sidecar failed to start") {
+		t.Errorf("error should mention sidecar failure, got: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "not running") {
+		t.Errorf("expected 'not running' in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "config validation failed") {
+		t.Errorf("expected sidecar logs in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "vibew logs or vibew doctor") {
+		t.Errorf("expected diagnostic hint in output, got:\n%s", out)
+	}
+	// Success message should NOT have been printed.
+	if strings.Contains(out, "Dev environment started") {
+		t.Errorf("success message should not appear when sidecar failed:\n%s", out)
+	}
+}
+
+func TestDevService_VerifySidecar_Restarting_ReturnsError(t *testing.T) {
+
+	fc := &fakeCompose{
+		psResult: []ports.ContainerInfo{
+			{Name: "proj-vibewarden-1", Service: "vibewarden", State: "restarting", Health: ""},
+		},
+		logsResult: "panic: runtime error",
+	}
+	svc := ops.NewDevService(fc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{}, &buf)
+	if err == nil {
+		t.Fatal("Run() expected error when sidecar is restarting, got nil")
+	}
+	if !strings.Contains(err.Error(), "restarting") {
+		t.Errorf("error should mention state, got: %v", err)
+	}
+}
+
+func TestDevService_VerifySidecar_NoSidecarContainer_Succeeds(t *testing.T) {
+	// When the sidecar service is not in the compose project (e.g. user-managed
+	// compose file), the check should not fail.
+
+	fc := &fakeCompose{
+		psResult: []ports.ContainerInfo{
+			{Name: "proj-app-1", Service: "app", State: "running", Health: "healthy"},
+		},
+	}
+	svc := ops.NewDevService(fc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{}, &buf)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+}
+
+func TestDevService_VerifySidecar_PSError_DoesNotFail(t *testing.T) {
+	// When PS fails (e.g. docker daemon issue), the verification is skipped
+	// gracefully — the command should not fail.
+
+	fc := &fakeCompose{
+		psErr: errors.New("docker daemon not responding"),
+	}
+	svc := ops.NewDevService(fc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{}, &buf)
+	if err != nil {
+		t.Fatalf("Run() unexpected error when PS fails: %v", err)
+	}
+}
+
+func TestDevService_VerifySidecar_LogsError_StillReturnsError(t *testing.T) {
+	// When the sidecar exited but Logs() also fails, the command should still
+	// return an error about the sidecar failure (just without log output).
+
+	fc := &fakeCompose{
+		psResult: []ports.ContainerInfo{
+			{Name: "proj-vibewarden-1", Service: "vibewarden", State: "exited", Health: ""},
+		},
+		logsErr: errors.New("no such service"),
+	}
+	svc := ops.NewDevService(fc)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	err := svc.Run(context.Background(), cfg, ops.DevOptions{}, &buf)
+	if err == nil {
+		t.Fatal("Run() expected error when sidecar exited, got nil")
+	}
+	if !strings.Contains(err.Error(), "sidecar failed to start") {
+		t.Errorf("error should mention sidecar failure, got: %v", err)
 	}
 }

--- a/internal/app/ops/main_test.go
+++ b/internal/app/ops/main_test.go
@@ -1,0 +1,17 @@
+package ops_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/app/ops"
+)
+
+// TestMain overrides the sidecar settle duration for all tests in this
+// package so that tests exercising DevService.Run do not incur a real
+// 5-second wait.
+func TestMain(m *testing.M) {
+	ops.SidecarSettleDuration = time.Millisecond
+	os.Exit(m.Run())
+}

--- a/internal/app/ops/restart_test.go
+++ b/internal/app/ops/restart_test.go
@@ -43,6 +43,10 @@ func (f *fakeComposeRunner) PS(_ context.Context, _ string) ([]ports.ContainerIn
 	return nil, nil
 }
 
+func (f *fakeComposeRunner) Logs(_ context.Context, _ string, _ string, _ int) (string, error) {
+	return "", nil
+}
+
 func TestRestartService_Run(t *testing.T) {
 	wantComposeFile := filepath.Join(".vibewarden", "generated", "docker-compose.yml")
 

--- a/internal/app/ops/status_test.go
+++ b/internal/app/ops/status_test.go
@@ -229,7 +229,7 @@ func (f *fakeStatusCompose) Restart(_ context.Context, _ string, _ []string) err
 	return nil
 }
 func (f *fakeStatusCompose) Version(_ context.Context) (string, error) { return "", nil }
-func (f *fakeStatusCompose) Info(_ context.Context) error { return nil }
+func (f *fakeStatusCompose) Info(_ context.Context) error              { return nil }
 func (f *fakeStatusCompose) PS(_ context.Context, _ string) ([]ports.ContainerInfo, error) {
 	return f.psResult, f.psErr
 }

--- a/internal/app/ops/status_test.go
+++ b/internal/app/ops/status_test.go
@@ -229,9 +229,12 @@ func (f *fakeStatusCompose) Restart(_ context.Context, _ string, _ []string) err
 	return nil
 }
 func (f *fakeStatusCompose) Version(_ context.Context) (string, error) { return "", nil }
-func (f *fakeStatusCompose) Info(_ context.Context) error              { return nil }
+func (f *fakeStatusCompose) Info(_ context.Context) error { return nil }
 func (f *fakeStatusCompose) PS(_ context.Context, _ string) ([]ports.ContainerInfo, error) {
 	return f.psResult, f.psErr
+}
+func (f *fakeStatusCompose) Logs(_ context.Context, _ string, _ string, _ int) (string, error) {
+	return "", nil
 }
 
 // fakeStatusLogs is a test double for ports.ComposeLogs used by status tests.

--- a/internal/cli/cmd/init.go
+++ b/internal/cli/cmd/init.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	templateadapter "github.com/vibewarden/vibewarden/internal/adapters/template"
 	scaffoldapp "github.com/vibewarden/vibewarden/internal/app/scaffold"
@@ -18,15 +19,12 @@ import (
 )
 
 // IsTTY reports whether fd is connected to a terminal.
-// It calls the os.File.Stat method and checks for ModeCharDevice, which is set
-// on UNIX ttys and on Windows console handles. The function is a package-level
-// variable so that tests can replace it without build-tag gymnastics.
+// It uses term.IsTerminal (ioctl-based) which is more reliable than os.File.Stat
+// for detecting non-TTY contexts such as CI, piped stdin, or AI agent sessions.
+// The function is a package-level variable so that tests can replace it without
+// build-tag gymnastics.
 var IsTTY = func(fd *os.File) bool {
-	info, err := fd.Stat()
-	if err != nil {
-		return false
-	}
-	return (info.Mode() & os.ModeCharDevice) != 0
+	return term.IsTerminal(int(fd.Fd()))
 }
 
 // promptString writes prompt to w and reads a single line of input from r.

--- a/internal/cli/templates/agent_context_templates_test.go
+++ b/internal/cli/templates/agent_context_templates_test.go
@@ -42,11 +42,13 @@ func TestAgentContextTemplates_AgentsVibewardenMD(t *testing.T) {
 			wantContains: []string{
 				"Known limitations",
 				"detect",
-				"vibew add waf",
 				"vibew doctor",
 				"Multi-site",
 				"vibew init",
 				"vibew add tls --domain",
+			},
+			wantAbsent: []string{
+				"vibew add waf` does not exist",
 			},
 		},
 		{

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -107,8 +107,7 @@ sites/
 ## Known limitations
 
 - WAF is in `detect` mode by default (logs but does not block). Set `waf.mode: block` in vibewarden.yaml to enforce blocking.
-- `vibew add waf` does not exist — configure WAF directly in vibewarden.yaml under `plugins.waf`.
-- `vibew doctor` checks config, Docker, ports, and container health, but does not verify production reachability or external HTTP health.
+- `vibew doctor` checks config, Docker, ports, container health, and production reachability (when `--target` is provided).
 - Multi-site deployment is new and may have edge cases — report issues if routes or certs behave unexpectedly.
 - `vibew init` does not accept `--tls` or `--domain` flags — run `vibew add tls --domain <your-domain>` after init.
 

--- a/internal/ports/ops.go
+++ b/internal/ports/ops.go
@@ -44,6 +44,11 @@ type ComposeRunner interface {
 	// composeFile is the path to the docker-compose.yml; when empty the default
 	// discovery logic applies.  Returns an empty slice when no containers exist.
 	PS(ctx context.Context, composeFile string) ([]ContainerInfo, error)
+
+	// Logs returns the last tailLines lines of logs for the given service.
+	// composeFile is the path to the docker-compose.yml; when empty the default
+	// discovery logic applies.
+	Logs(ctx context.Context, composeFile string, service string, tailLines int) (string, error)
 }
 
 // DockerBuilder runs "docker build" commands.


### PR DESCRIPTION
Closes #939, #944, #945

## Summary

- **#939 — vibew init EOF on non-TTY**: Switched `IsTTY` from `os.File.Stat`/`ModeCharDevice` to `term.IsTerminal` (ioctl-based) for reliable non-TTY detection in CI, piped stdin, and AI agent sessions. `golang.org/x/term` was already an indirect dependency.
- **#944 — stale AGENTS-VIBEWARDEN.md limitations**: Removed the incorrect "`vibew add waf` does not exist" bullet (added in v0.12.0). Updated the `vibew doctor` limitation to reflect that `--target` now enables production reachability checks. Fixed in both the Go template and docs/examples.
- **#945 — vibew dev silent sidecar failure**: After `docker compose up -d`, the dev command now waits 5 seconds, checks sidecar container state via `docker compose ps`, and if the sidecar exited or is restarting: prints the last 20 lines of sidecar logs, a diagnostic hint, and exits non-zero. Added `Logs` method to `ComposeRunner` port and adapter.

## Test plan

- [x] `make check` passes (lint, build, test with `-race`, demo-app)
- [x] New table-driven tests for sidecar verification: running, exited, restarting, no sidecar container, PS error, Logs error
- [x] Updated agent template test to assert "vibew add waf does not exist" is absent
- [x] Existing init tests continue to pass (non-interactive mode via `TestMain`)
- [x] `TestMain` in `ops_test` sets `SidecarSettleDuration` to 1ms so tests do not incur real 5s delays

🤖 Generated with [Claude Code](https://claude.com/claude-code)