### PR TITLE
feat(#937): transfer local Docker image to remote via docker save/load

### DIFF
--- a/internal/adapters/ops/image_export.go
+++ b/internal/adapters/ops/image_export.go
@@ -1,0 +1,28 @@
+package ops
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// ImageExportAdapter implements ports.ImageExporter by shelling out to the
+// docker CLI.
+type ImageExportAdapter struct{}
+
+// NewImageExportAdapter creates a new ImageExportAdapter.
+func NewImageExportAdapter() *ImageExportAdapter {
+	return &ImageExportAdapter{}
+}
+
+// Save exports the named Docker image to destPath using "docker save -o".
+func (a *ImageExportAdapter) Save(ctx context.Context, imageName, destPath string) error {
+	//nolint:gosec // "docker" is a hardcoded binary; args are operator-controlled
+	cmd := exec.CommandContext(ctx, "docker", "save", "-o", destPath, imageName)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker save %s: %w\noutput: %s", imageName, err, string(output))
+	}
+	return nil
+}

--- a/internal/adapters/ops/image_export_test.go
+++ b/internal/adapters/ops/image_export_test.go
@@ -1,0 +1,40 @@
+package ops_test
+
+import (
+	"context"
+	"testing"
+
+	opsadapter "github.com/vibewarden/vibewarden/internal/adapters/ops"
+)
+
+// TestImageExportAdapter_CancelledContextReturnsError verifies that Save
+// returns an error when the context is already cancelled. This confirms the
+// adapter respects context cancellation without requiring a real Docker daemon.
+func TestImageExportAdapter_CancelledContextReturnsError(t *testing.T) {
+	if !dockerAvailable() {
+		t.Skip("docker binary not available")
+	}
+
+	adapter := opsadapter.NewImageExportAdapter()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately so docker exits fast
+
+	err := adapter.Save(ctx, "nonexistent:latest", "/tmp/vibewarden-test-export.tar")
+	if err == nil {
+		t.Fatal("expected an error because context was cancelled before run")
+	}
+}
+
+// TestImageExportAdapter_ReturnsErrorWhenDockerMissing verifies that Save
+// returns an error when docker is not installed.
+func TestImageExportAdapter_ReturnsErrorWhenDockerMissing(t *testing.T) {
+	if dockerAvailable() {
+		t.Skip("docker is available; skipping missing-docker test")
+	}
+
+	adapter := opsadapter.NewImageExportAdapter()
+	err := adapter.Save(context.Background(), "myapp:latest", "/tmp/vibewarden-test-export.tar")
+	if err == nil {
+		t.Fatal("expected an error when docker is not available")
+	}
+}

--- a/internal/app/deploy/image_transfer.go
+++ b/internal/app/deploy/image_transfer.go
@@ -1,0 +1,85 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// isLocalImage returns true when imageName is a bare Docker image name without
+// a registry prefix. A registry prefix is identified by the presence of a "/"
+// before the optional ":" tag separator.
+//
+// Examples:
+//
+//	"myapp:latest"                  -> true  (local)
+//	"myapp"                         -> true  (local, no tag)
+//	"ghcr.io/org/myapp:latest"     -> false (registry)
+//	"docker.io/library/nginx:latest" -> false (registry)
+//	"localhost:5000/myapp:latest"   -> false (registry -- contains "/")
+func isLocalImage(imageName string) bool {
+	if imageName == "" {
+		return false
+	}
+
+	// Strip the tag (":latest", ":v1.0", etc.) to isolate the repository part.
+	repo := imageName
+	if idx := strings.LastIndex(imageName, ":"); idx != -1 {
+		repo = imageName[:idx]
+	}
+
+	// A registry prefix always introduces at least one "/" in the repo part
+	// (e.g. "ghcr.io/org/app", "docker.io/library/nginx", "localhost:5000/app").
+	// A bare name like "myapp" has no "/".
+	return !strings.Contains(repo, "/")
+}
+
+// transferLocalImage saves the Docker image from the local daemon, rsyncs the
+// tar archive to the remote host, loads it into the remote Docker daemon, and
+// cleans up the temporary files on both sides.
+func (s *Service) transferLocalImage(ctx context.Context, imageName, remoteDir string, out io.Writer) error {
+	if s.imageExporter == nil {
+		return fmt.Errorf("local image %q requires an image exporter; this is a bug -- please report it", imageName)
+	}
+
+	fmt.Fprintf(out, "Transferring local image %s to remote...\n", imageName)
+
+	// Step 1: save the image to a local temp file.
+	tmpFile, err := os.CreateTemp("", "vibewarden-image-*.tar")
+	if err != nil {
+		return fmt.Errorf("creating temp file for image export: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close() //nolint:errcheck // we only need the path; docker save writes to it
+
+	// Ensure local cleanup.
+	defer os.Remove(tmpPath) //nolint:errcheck
+
+	fmt.Fprintf(out, "  Saving image %s to local temp file...\n", imageName)
+	if err := s.imageExporter.Save(ctx, imageName, tmpPath); err != nil {
+		return fmt.Errorf("saving image %s locally: %w", imageName, err)
+	}
+
+	// Step 2: rsync the tar to the remote host.
+	remoteTmpPath := remoteDir + "image-transfer.tar"
+	fmt.Fprintln(out, "  Uploading image archive to remote...")
+	if err := s.executor.TransferFile(ctx, tmpPath, remoteTmpPath); err != nil {
+		return fmt.Errorf("transferring image archive to remote: %w", err)
+	}
+
+	// Step 3: load the image on the remote and clean up the remote file.
+	// The load and cleanup are split into separate calls so that the temp file
+	// is always removed even when docker load fails.
+	fmt.Fprintln(out, "  Loading image on remote...")
+	_, loadErr := s.executor.Run(ctx, fmt.Sprintf("docker load < %s", remoteTmpPath))
+	// Always clean up, even if load fails.
+	s.executor.Run(ctx, fmt.Sprintf("rm -f %s", remoteTmpPath)) //nolint:errcheck // best-effort cleanup
+	if loadErr != nil {
+		return fmt.Errorf("loading image on remote: %w", loadErr)
+	}
+
+	fmt.Fprintf(out, "  Image %s transferred successfully.\n", imageName)
+	return nil
+}

--- a/internal/app/deploy/image_transfer_test.go
+++ b/internal/app/deploy/image_transfer_test.go
@@ -1,0 +1,76 @@
+package deploy
+
+import "testing"
+
+func TestIsLocalImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		imageName string
+		want      bool
+	}{
+		{
+			name:      "bare name with tag is local",
+			imageName: "myapp:latest",
+			want:      true,
+		},
+		{
+			name:      "bare name without tag is local",
+			imageName: "myapp",
+			want:      true,
+		},
+		{
+			name:      "bare name with version tag is local",
+			imageName: "myapp:v1.2.3",
+			want:      true,
+		},
+		{
+			name:      "ghcr.io registry is not local",
+			imageName: "ghcr.io/org/myapp:latest",
+			want:      false,
+		},
+		{
+			name:      "docker.io official image is not local",
+			imageName: "docker.io/library/nginx:latest",
+			want:      false,
+		},
+		{
+			name:      "quay.io registry is not local",
+			imageName: "quay.io/org/myapp:v1",
+			want:      false,
+		},
+		{
+			name:      "localhost registry is not local",
+			imageName: "localhost:5000/myapp:latest",
+			want:      false,
+		},
+		{
+			name:      "org slash repo is not local",
+			imageName: "myorg/myapp:latest",
+			want:      false,
+		},
+		{
+			name:      "empty string is not local",
+			imageName: "",
+			want:      false,
+		},
+		{
+			name:      "single word no tag",
+			imageName: "nginx",
+			want:      true,
+		},
+		{
+			name:      "name with port-like tag but no slash",
+			imageName: "myapp:8080",
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isLocalImage(tt.imageName)
+			if got != tt.want {
+				t.Errorf("isLocalImage(%q) = %v, want %v", tt.imageName, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/app/deploy/multiapp.go
+++ b/internal/app/deploy/multiapp.go
@@ -144,6 +144,14 @@ func (s *Service) BootstrapSidecar(ctx context.Context, cfg *config.Config, opts
 		}
 	}
 
+	// Step 4c: transfer local image if using a bare image name (no registry prefix)
+	// and an image exporter is configured.
+	if cfg.App.Image != "" && isLocalImage(cfg.App.Image) && s.imageExporter != nil {
+		if err := s.transferLocalImage(ctx, cfg.App.Image, siteDir, out); err != nil {
+			return fmt.Errorf("transferring local image: %w", err)
+		}
+	}
+
 	// Step 5: start the app container.
 	fmt.Fprintf(out, "Starting site %q...\n", projectName)
 	startCmd := fmt.Sprintf("cd %s && docker compose up -d", siteDir)
@@ -233,6 +241,14 @@ func (s *Service) DeployMultiApp(ctx context.Context, cfg *config.Config, opts R
 		fmt.Fprintf(out, "Transferring app build context (%s)...\n", cfg.App.Build)
 		if err := s.executor.Transfer(ctx, buildContextLocal, buildContextRemote, false); err != nil {
 			return fmt.Errorf("transferring app build context: %w", err)
+		}
+	}
+
+	// Step 3c: transfer local image if using a bare image name (no registry prefix)
+	// and an image exporter is configured.
+	if cfg.App.Image != "" && isLocalImage(cfg.App.Image) && s.imageExporter != nil {
+		if err := s.transferLocalImage(ctx, cfg.App.Image, siteDir, out); err != nil {
+			return fmt.Errorf("transferring local image: %w", err)
 		}
 	}
 

--- a/internal/app/deploy/service.go
+++ b/internal/app/deploy/service.go
@@ -63,8 +63,9 @@ const (
 // It generates runtime config, transfers files to the remote, starts Docker
 // Compose, and verifies the sidecar health endpoint.
 type Service struct {
-	executor  ports.RemoteExecutor
-	generator ports.ConfigGenerator
+	executor      ports.RemoteExecutor
+	generator     ports.ConfigGenerator
+	imageExporter ports.ImageExporter
 }
 
 // NewService creates a Service.
@@ -78,6 +79,15 @@ func NewService(
 		executor:  executor,
 		generator: generator,
 	}
+}
+
+// WithImageExporter sets the ImageExporter on the Service and returns it for
+// chaining. The exporter is used to save Docker images from the local daemon so
+// they can be transferred to the remote host when the image name has no registry
+// prefix (bare name like "myapp:latest").
+func (s *Service) WithImageExporter(exporter ports.ImageExporter) *Service {
+	s.imageExporter = exporter
+	return s
 }
 
 // RunOptions holds parameters for a deploy run.
@@ -198,7 +208,19 @@ func (s *Service) Deploy(ctx context.Context, cfg *config.Config, opts RunOption
 		}
 	}
 
-	// Step 4: start Docker Compose on the remote.
+	// Step 4: transfer local image if using a bare image name (no registry prefix)
+	// and an image exporter is configured.
+	// This must happen before docker compose up so the image is available on the
+	// remote daemon.
+	localImageTransferred := false
+	if cfg.App.Image != "" && isLocalImage(cfg.App.Image) && s.imageExporter != nil {
+		if err := s.transferLocalImage(ctx, cfg.App.Image, remoteDir, out); err != nil {
+			return fmt.Errorf("transferring local image: %w", err)
+		}
+		localImageTransferred = true
+	}
+
+	// Step 5: start Docker Compose on the remote.
 	// Always pull the latest sidecar image before starting, regardless of mode.
 	// In build mode the app image is built locally, but the sidecar image may be
 	// cached from an older version, so we explicitly pull it first.
@@ -212,6 +234,13 @@ func (s *Service) Deploy(ctx context.Context, cfg *config.Config, opts RunOption
 	if cfg.App.Build != "" {
 		fmt.Fprintln(out, "Building and starting services on remote...")
 		upCmd := fmt.Sprintf("cd %s && docker compose up -d --build --force-recreate", remoteDir)
+		if _, err := s.executor.Run(ctx, upCmd); err != nil {
+			return fmt.Errorf("docker compose up: %w", err)
+		}
+	} else if localImageTransferred {
+		// Local image was already transferred -- skip pulling and just start.
+		fmt.Fprintln(out, "Starting services on remote...")
+		upCmd := fmt.Sprintf("cd %s && docker compose up -d --force-recreate", remoteDir)
 		if _, err := s.executor.Run(ctx, upCmd); err != nil {
 			return fmt.Errorf("docker compose up: %w", err)
 		}
@@ -229,7 +258,7 @@ func (s *Service) Deploy(ctx context.Context, cfg *config.Config, opts RunOption
 		}
 	}
 
-	// Step 5: health check -- run curl on the remote so the probe is independent
+	// Step 6: health check -- run curl on the remote so the probe is independent
 	// of DNS propagation, external port availability, and TLS certificate issuance.
 	port := cfg.Server.Port
 	if port == 0 {

--- a/internal/cli/cmd/deploy.go
+++ b/internal/cli/cmd/deploy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	credentialsadapter "github.com/vibewarden/vibewarden/internal/adapters/credentials"
+	opsadapter "github.com/vibewarden/vibewarden/internal/adapters/ops"
 	sshadapter "github.com/vibewarden/vibewarden/internal/adapters/ssh"
 	templateadapter "github.com/vibewarden/vibewarden/internal/adapters/template"
 	deployapp "github.com/vibewarden/vibewarden/internal/app/deploy"
@@ -101,7 +102,8 @@ Examples:
 				credentialsadapter.NewGenerator(),
 				credentialsadapter.NewStore(),
 			).WithConfigSourcePath(configPath)
-			svc := deployapp.NewService(executor, generator)
+			svc := deployapp.NewService(executor, generator).
+				WithImageExporter(opsadapter.NewImageExportAdapter())
 
 			absConfig, err := filepath.Abs(configPath)
 			if err != nil {

--- a/internal/ports/ops.go
+++ b/internal/ports/ops.go
@@ -102,3 +102,13 @@ type ComposeLogs interface {
 	// given compose file. Returns an empty string when no logs are available.
 	Tail(ctx context.Context, composeFile string, service string, n int) (string, error)
 }
+
+// ImageExporter saves a Docker image from the local daemon to a tar archive.
+// Implementations shell out to the docker CLI ("docker save").
+type ImageExporter interface {
+	// Save exports the named Docker image to the file at destPath using
+	// "docker save -o <destPath> <imageName>". The image must exist in the
+	// local Docker daemon. Returns an error when the image is not found or
+	// the docker CLI fails.
+	Save(ctx context.Context, imageName, destPath string) error
+}


### PR DESCRIPTION
Closes #937

## Summary

- Add `ImageExporter` port interface (`internal/ports/ops.go`) with `Save(ctx, imageName, destPath) error`
- Add `ImageExportAdapter` adapter (`internal/adapters/ops/image_export.go`) using `docker save -o`
- Add `isLocalImage()` detection logic and `transferLocalImage()` orchestration (`internal/app/deploy/image_transfer.go`)
- Wire into `Service.Deploy()`, `Service.BootstrapSidecar()`, and `Service.DeployMultiApp()` -- image transfer runs after bundle rsync but before docker compose up
- When a local image is transferred, `docker compose pull` is skipped for the app (only sidecar pull runs)
- Backward compatible: when `imageExporter` is nil, behavior is unchanged (falls back to pull)
- 11-case table-driven test for `isLocalImage()` covering bare names, registry prefixes, edge cases
- Adapter tests for cancelled context and missing docker

This is a reapplication of PR #949 on top of the redesigned deploy code from PR #948. The original PR had merge conflicts after the deploy redesign merged.

## Test plan

- [x] `make check` passes (golangci-lint, build, all tests with race detector)
- [x] `isLocalImage()` correctly identifies bare names vs registry-prefixed images
- [x] Deploy flow skips pull when local image is transferred
- [x] Multi-app flows (bootstrap + add-site) integrate image transfer before compose up
- [x] Nil exporter gracefully falls back to standard pull behavior
- [x] Remote temp file cleanup runs unconditionally (even on docker load failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)