### PR TITLE
fix(#953): prevent build context rsync from overwriting merged config

### DIFF
--- a/internal/adapters/ssh/executor.go
+++ b/internal/adapters/ssh/executor.go
@@ -152,6 +152,28 @@ func (e *Executor) Transfer(ctx context.Context, localDir, remoteDir string, del
 	return nil
 }
 
+// TransferExcluding syncs localDir to remoteDir on the remote host using rsync
+// over SSH, excluding files or directories matching the given patterns. Each
+// pattern is passed as an --exclude flag to rsync. When deleteExtra is true,
+// extraneous files in remoteDir are removed (but only those not matched by an
+// exclude pattern are considered).
+func (e *Executor) TransferExcluding(ctx context.Context, localDir, remoteDir string, deleteExtra bool, excludes []string) error {
+	args := e.rsyncExcludeArgs(localDir, remoteDir, deleteExtra, excludes)
+	//nolint:gosec // localDir is constructed internally from config paths; remoteDir
+	// is a fixed pattern (~/vibewarden/<project>/). Safe in this context.
+	c := exec.CommandContext(ctx, "rsync", args...)
+
+	var buf bytes.Buffer
+	c.Stdout = &buf
+	c.Stderr = &buf
+
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("rsync %s → %s:%s: %w\noutput: %s",
+			localDir, e.target.Destination(), remoteDir, err, strings.TrimSpace(buf.String()))
+	}
+	return nil
+}
+
 // TransferFile copies a single local file to remotePath on the remote host
 // using rsync over SSH. Unlike Transfer, the source path is used as-is (no
 // trailing slash) so rsync treats it as a file, not a directory.
@@ -256,6 +278,34 @@ func (e *Executor) rsyncArgs(localDir, remoteDir string, deleteExtra bool) []str
 	}
 	// Ensure localDir ends with "/" so rsync syncs the contents, not the
 	// directory name itself.
+	src := strings.TrimSuffix(localDir, "/") + "/"
+	dst := e.target.Destination() + ":" + remoteDir
+	args = append(args, src, dst)
+	return args
+}
+
+// rsyncExcludeArgs builds the rsync argument list for a directory transfer
+// with --exclude patterns.
+func (e *Executor) rsyncExcludeArgs(localDir, remoteDir string, deleteExtra bool, excludes []string) []string {
+	sshCmd := "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes"
+	if e.keyPath != "" {
+		sshCmd += " -i " + e.keyPath
+	}
+	if e.target.Port != 0 {
+		sshCmd += " -p " + strconv.Itoa(e.target.Port)
+	}
+
+	args := []string{
+		"-az",
+		"--progress",
+		"-e", sshCmd,
+	}
+	if deleteExtra {
+		args = append(args, "--delete")
+	}
+	for _, pattern := range excludes {
+		args = append(args, "--exclude", pattern)
+	}
 	src := strings.TrimSuffix(localDir, "/") + "/"
 	dst := e.target.Destination() + ":" + remoteDir
 	args = append(args, src, dst)

--- a/internal/app/deploy/artifact_test.go
+++ b/internal/app/deploy/artifact_test.go
@@ -247,6 +247,209 @@ func TestArtifact_SidecarCompose_ContainsDNS(t *testing.T) {
 	}
 }
 
+// TestArtifact_BuildContextDoesNotOverwriteMergedConfig is a regression test
+// for #953. When app.build is "." the build context rsync was overwriting the
+// merged vibewarden.yaml (letsencrypt, port 443) with the original base config
+// (self-signed, port 8443) because both the bundle and the build context were
+// transferred to the same remote directory without excludes.
+//
+// The fix uses TransferExcluding for the build context transfer so that bundle
+// files (vibewarden.yaml, .vibewarden/, .credentials, etc.) are never
+// overwritten by the project source tree.
+func TestArtifact_BuildContextDoesNotOverwriteMergedConfig(t *testing.T) {
+	projDir := t.TempDir()
+
+	// Base config: self-signed TLS on port 8443 (local dev).
+	baseYAML := `server:
+  port: 8443
+upstream:
+  host: "0.0.0.0"
+  port: 3000
+tls:
+  enabled: true
+  provider: self-signed
+app:
+  build: "."
+`
+	basePath := filepath.Join(projDir, "vibewarden.yaml")
+	if err := os.WriteFile(basePath, []byte(baseYAML), 0o600); err != nil {
+		t.Fatalf("writing base config: %v", err)
+	}
+
+	// Production override: letsencrypt on port 443.
+	prodYAML := `server:
+  port: 443
+tls:
+  enabled: true
+  provider: letsencrypt
+  domain: app.example.com
+`
+	prodPath := filepath.Join(projDir, "vibewarden.production.yaml")
+	if err := os.WriteFile(prodPath, []byte(prodYAML), 0o600); err != nil {
+		t.Fatalf("writing prod config: %v", err)
+	}
+
+	// The merged config that config.Load would produce.
+	cfg := &config.Config{
+		Server:   config.ServerConfig{Port: 443},
+		Upstream: config.UpstreamConfig{Host: "0.0.0.0", Port: 3000},
+		App:      config.AppConfig{Build: "."},
+		TLS:      config.TLSConfig{Enabled: true, Provider: "letsencrypt", Domain: "app.example.com"},
+	}
+
+	executor := &fakeExecutor{}
+	generator := &fakeGenerator{}
+	svc := deployapp.NewService(executor, generator)
+
+	bundleDir := t.TempDir()
+
+	err := svc.Deploy(context.Background(), cfg, deployapp.RunOptions{
+		ConfigPath:     basePath,
+		ProdConfigPath: prodPath,
+		ProjectName:    "myapp",
+		GeneratedDir:   bundleDir,
+		Force:          true,
+	})
+	if err != nil {
+		t.Fatalf("Deploy() unexpected error: %v", err)
+	}
+
+	// 1. The bundled vibewarden.yaml must have the merged (production) values.
+	bundledConfig, err := os.ReadFile(filepath.Join(bundleDir, "vibewarden.yaml"))
+	if err != nil {
+		t.Fatalf("reading bundled config: %v", err)
+	}
+	s := string(bundledConfig)
+	if !strings.Contains(s, "provider: letsencrypt") {
+		t.Errorf("bundled config should contain 'provider: letsencrypt' (merged), got:\n%s", s)
+	}
+	if !strings.Contains(s, "port: 443") {
+		t.Errorf("bundled config should contain 'port: 443' (merged), got:\n%s", s)
+	}
+	if strings.Contains(s, "provider: self-signed") {
+		t.Errorf("bundled config must NOT contain 'provider: self-signed' (base), got:\n%s", s)
+	}
+
+	// 2. The build context must be transferred via TransferExcluding, not plain Transfer.
+	if len(executor.transferExcludingCalls) == 0 {
+		t.Fatal("expected TransferExcluding to be called for the build context, but it was not called")
+	}
+
+	// 3. The exclude list must contain vibewarden.yaml to prevent overwriting.
+	excludes := executor.transferExcludingCalls[0].excludes
+	foundVibewardenYAML := false
+	for _, pattern := range excludes {
+		if pattern == "vibewarden.yaml" {
+			foundVibewardenYAML = true
+		}
+	}
+	if !foundVibewardenYAML {
+		t.Errorf("TransferExcluding excludes should contain 'vibewarden.yaml', got: %v", excludes)
+	}
+
+	// 4. The exclude list should also protect other bundle artifacts.
+	requiredExcludes := []string{
+		"vibewarden.yaml",
+		"vibewarden.*.yaml",
+		".vibewarden",
+		".credentials",
+		".env",
+		"docker-compose.yml",
+	}
+	for _, required := range requiredExcludes {
+		found := false
+		for _, actual := range excludes {
+			if actual == required {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("TransferExcluding excludes should contain %q, got: %v", required, excludes)
+		}
+	}
+}
+
+// TestArtifact_BuildContextExcludes_MultiApp is a regression test for #953
+// in multi-app mode. Verifies that BootstrapSidecar and DeployMultiApp also
+// use TransferExcluding for the build context transfer.
+func TestArtifact_BuildContextExcludes_MultiApp(t *testing.T) {
+	projDir := t.TempDir()
+
+	baseYAML := `upstream:
+  host: "0.0.0.0"
+  port: 3000
+app:
+  build: "."
+`
+	basePath := filepath.Join(projDir, "vibewarden.yaml")
+	if err := os.WriteFile(basePath, []byte(baseYAML), 0o600); err != nil {
+		t.Fatalf("writing base config: %v", err)
+	}
+
+	cfg := &config.Config{
+		Server:   config.ServerConfig{Port: 443},
+		Upstream: config.UpstreamConfig{Host: "0.0.0.0", Port: 3000},
+		App:      config.AppConfig{Build: "."},
+	}
+
+	tests := []struct {
+		name   string
+		deploy func(svc *deployapp.Service, executor *fakeExecutor) error
+	}{
+		{
+			name: "BootstrapSidecar uses TransferExcluding for build context",
+			deploy: func(svc *deployapp.Service, _ *fakeExecutor) error {
+				return svc.BootstrapSidecar(context.Background(), cfg, deployapp.RunOptions{
+					ConfigPath:   basePath,
+					ProjectName:  "buildsite",
+					GeneratedDir: t.TempDir(),
+				})
+			},
+		},
+		{
+			name: "DeployMultiApp uses TransferExcluding for build context",
+			deploy: func(svc *deployapp.Service, _ *fakeExecutor) error {
+				return svc.DeployMultiApp(context.Background(), cfg, deployapp.RunOptions{
+					ConfigPath:   basePath,
+					ProjectName:  "buildsite",
+					GeneratedDir: t.TempDir(),
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &fakeExecutor{}
+			generator := &fakeGenerator{}
+			svc := deployapp.NewService(executor, generator)
+
+			if err := tt.deploy(svc, executor); err != nil {
+				t.Fatalf("deploy error: %v", err)
+			}
+
+			if len(executor.transferExcludingCalls) == 0 {
+				t.Fatal("expected TransferExcluding to be called for build context, but it was not")
+			}
+
+			excludes := executor.transferExcludingCalls[0].excludes
+			for _, required := range []string{"vibewarden.yaml", "docker-compose.yml"} {
+				found := false
+				for _, actual := range excludes {
+					if actual == required {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("TransferExcluding excludes should contain %q, got: %v", required, excludes)
+				}
+			}
+		})
+	}
+}
+
 // TestArtifact_MergeYAML_PreservesFieldNames verifies that deep-merging YAML
 // configs preserves underscore field names like rate_limit and security_headers
 // instead of mangling them (e.g. "ratelimit").

--- a/internal/app/deploy/multiapp.go
+++ b/internal/app/deploy/multiapp.go
@@ -133,13 +133,15 @@ func (s *Service) BootstrapSidecar(ctx context.Context, cfg *config.Config, opts
 		return fmt.Errorf("transferring site bundle: %w", err)
 	}
 
-	// Step 4b: if app.build is set, rsync the build context to the remote site dir.
+	// Step 4b: if app.build is set, rsync the build context to the remote site
+	// dir. Use TransferExcluding to prevent the project's original config files
+	// from overwriting the merged bundle files deployed in the previous step.
 	if cfg.App.Build != "" {
 		projectRoot := filepath.Dir(filepath.Clean(opts.ConfigPath))
 		buildContextLocal := filepath.Join(projectRoot, cfg.App.Build)
 		buildContextRemote := siteDir + strings.TrimPrefix(strings.TrimSuffix(cfg.App.Build, "/"), "./") + "/"
 		fmt.Fprintf(out, "Transferring app build context (%s)...\n", cfg.App.Build)
-		if err := s.executor.Transfer(ctx, buildContextLocal, buildContextRemote, false); err != nil {
+		if err := s.executor.TransferExcluding(ctx, buildContextLocal, buildContextRemote, false, buildContextExcludes); err != nil {
 			return fmt.Errorf("transferring app build context: %w", err)
 		}
 	}
@@ -233,13 +235,15 @@ func (s *Service) DeployMultiApp(ctx context.Context, cfg *config.Config, opts R
 		return fmt.Errorf("transferring site bundle: %w", err)
 	}
 
-	// Step 3b: if app.build is set, rsync the build context to the remote site dir.
+	// Step 3b: if app.build is set, rsync the build context to the remote site
+	// dir. Use TransferExcluding to prevent the project's original config files
+	// from overwriting the merged bundle files deployed in the previous step.
 	if cfg.App.Build != "" {
 		projectRoot := filepath.Dir(filepath.Clean(opts.ConfigPath))
 		buildContextLocal := filepath.Join(projectRoot, cfg.App.Build)
 		buildContextRemote := siteDir + strings.TrimPrefix(strings.TrimSuffix(cfg.App.Build, "/"), "./") + "/"
 		fmt.Fprintf(out, "Transferring app build context (%s)...\n", cfg.App.Build)
-		if err := s.executor.Transfer(ctx, buildContextLocal, buildContextRemote, false); err != nil {
+		if err := s.executor.TransferExcluding(ctx, buildContextLocal, buildContextRemote, false, buildContextExcludes); err != nil {
 			return fmt.Errorf("transferring app build context: %w", err)
 		}
 	}

--- a/internal/app/deploy/multiapp_test.go
+++ b/internal/app/deploy/multiapp_test.go
@@ -721,21 +721,26 @@ func TestDeploySite_BuildMode_RsyncsSource(t *testing.T) {
 		t.Fatalf("DeployMultiApp() unexpected error: %v", err)
 	}
 
-	// Transfer must be called for the build context (plus the site bundle).
-	if len(executor.transferCalls) < 2 {
-		t.Fatalf("expected at least 2 Transfer calls (site bundle + build context), got %d: %v",
+	// Transfer must be called for the site bundle; TransferExcluding for the
+	// build context.
+	if len(executor.transferCalls) < 1 {
+		t.Fatalf("expected at least 1 Transfer call (site bundle), got %d: %v",
 			len(executor.transferCalls), executor.transferCalls)
+	}
+	if len(executor.transferExcludingCalls) < 1 {
+		t.Fatalf("expected at least 1 TransferExcluding call (build context), got %d: %v",
+			len(executor.transferExcludingCalls), executor.transferExcludingCalls)
 	}
 
 	found := false
-	for _, call := range executor.transferCalls {
+	for _, call := range executor.transferExcludingCalls {
 		if strings.Contains(call.remoteDir, "sites/buildapp/") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected Transfer to site directory, got: %v", executor.transferCalls)
+		t.Errorf("expected TransferExcluding to site directory, got: %v", executor.transferExcludingCalls)
 	}
 }
 

--- a/internal/app/deploy/openbao_test.go
+++ b/internal/app/deploy/openbao_test.go
@@ -363,6 +363,10 @@ func (w *wildcardExecutor) Transfer(_ context.Context, _, _ string, _ bool) erro
 	return nil
 }
 
+func (w *wildcardExecutor) TransferExcluding(_ context.Context, _, _ string, _ bool, _ []string) error {
+	return nil
+}
+
 func (w *wildcardExecutor) TransferFile(_ context.Context, _, _ string) error {
 	return nil
 }

--- a/internal/app/deploy/service.go
+++ b/internal/app/deploy/service.go
@@ -59,6 +59,21 @@ const (
 	defaultHealthPort = 8443
 )
 
+// buildContextExcludes is the list of rsync --exclude patterns used when
+// transferring the app build context to the remote host. These patterns
+// prevent the project's original files from overwriting the deploy bundle's
+// merged versions (e.g. the merged vibewarden.yaml with production TLS
+// settings must not be clobbered by the base config from the source tree).
+var buildContextExcludes = []string{
+	"vibewarden.yaml",
+	"vibewarden.*.yaml",
+	".vibewarden",
+	".credentials",
+	".env",
+	".env.template",
+	"docker-compose.yml",
+}
+
 // Service orchestrates the "vibew deploy" use case.
 // It generates runtime config, transfers files to the remote, starts Docker
 // Compose, and verifies the sidecar health endpoint.
@@ -198,12 +213,18 @@ func (s *Service) Deploy(ctx context.Context, cfg *config.Config, opts RunOption
 	// When app.build is set the image must be built on the remote host.
 	// Transfer the app source (the build context directory) so that
 	// `docker compose up --build` can build the image remotely.
+	//
+	// Use TransferExcluding to prevent the project's original config files
+	// (vibewarden.yaml, docker-compose.yml, etc.) from overwriting the
+	// merged bundle files that were already deployed in the previous step.
+	// This is critical when app.build is "." because the build context
+	// directory overlaps with the deploy bundle directory on the remote.
 	if cfg.App.Build != "" {
 		projectRoot := filepath.Dir(filepath.Clean(opts.ConfigPath))
 		buildContextLocal := filepath.Join(projectRoot, cfg.App.Build)
 		buildContextRemote := remoteDir + strings.TrimPrefix(strings.TrimSuffix(cfg.App.Build, "/"), "./") + "/"
 		fmt.Fprintf(out, "Transferring app build context (%s) to remote...\n", cfg.App.Build)
-		if err := s.executor.Transfer(ctx, buildContextLocal, buildContextRemote, false); err != nil {
+		if err := s.executor.TransferExcluding(ctx, buildContextLocal, buildContextRemote, false, buildContextExcludes); err != nil {
 			return fmt.Errorf("transferring app build context: %w", err)
 		}
 	}

--- a/internal/app/deploy/service_test.go
+++ b/internal/app/deploy/service_test.go
@@ -20,6 +20,8 @@ type fakeExecutor struct {
 	runResponses map[string]runResponse
 	// transferErr is returned by every Transfer call if set.
 	transferErr error
+	// transferExcludingErr is returned by every TransferExcluding call if set.
+	transferExcludingErr error
 	// transferFileErr is returned by every TransferFile call if set.
 	transferFileErr error
 	// dryRunChanges is returned by DryRunTransfer when non-nil.
@@ -30,6 +32,8 @@ type fakeExecutor struct {
 	runCalls []string
 	// transferCalls records every Transfer invocation for assertions.
 	transferCalls []transferCall
+	// transferExcludingCalls records every TransferExcluding invocation for assertions.
+	transferExcludingCalls []transferExcludingCall
 	// transferFileCalls records every TransferFile invocation for assertions.
 	transferFileCalls []transferFileCall
 }
@@ -43,6 +47,13 @@ type transferCall struct {
 	localDir    string
 	remoteDir   string
 	deleteExtra bool
+}
+
+type transferExcludingCall struct {
+	localDir    string
+	remoteDir   string
+	deleteExtra bool
+	excludes    []string
 }
 
 type transferFileCall struct {
@@ -73,6 +84,13 @@ func (f *fakeExecutor) RunStream(_ context.Context, cmd string, stdout, _ io.Wri
 func (f *fakeExecutor) Transfer(_ context.Context, localDir, remoteDir string, deleteExtra bool) error {
 	f.transferCalls = append(f.transferCalls, transferCall{localDir: localDir, remoteDir: remoteDir, deleteExtra: deleteExtra})
 	return f.transferErr
+}
+
+func (f *fakeExecutor) TransferExcluding(_ context.Context, localDir, remoteDir string, deleteExtra bool, excludes []string) error {
+	f.transferExcludingCalls = append(f.transferExcludingCalls, transferExcludingCall{
+		localDir: localDir, remoteDir: remoteDir, deleteExtra: deleteExtra, excludes: excludes,
+	})
+	return f.transferExcludingErr
 }
 
 func (f *fakeExecutor) TransferFile(_ context.Context, localFile, remotePath string) error {
@@ -646,9 +664,10 @@ func TestService_Deploy_ComposeUpFails(t *testing.T) {
 
 // mockRunExecutor is a flexible test double with a custom Run function.
 type mockRunExecutor struct {
-	runFn             func(cmd string) (string, error)
-	transferCalls     []transferCall
-	transferFileCalls []transferFileCall
+	runFn                  func(cmd string) (string, error)
+	transferCalls          []transferCall
+	transferExcludingCalls []transferExcludingCall
+	transferFileCalls      []transferFileCall
 }
 
 func (m *mockRunExecutor) Run(_ context.Context, cmd string) (string, error) {
@@ -664,6 +683,13 @@ func (m *mockRunExecutor) RunStream(_ context.Context, _ string, _ io.Writer, _ 
 
 func (m *mockRunExecutor) Transfer(_ context.Context, localDir, remoteDir string, deleteExtra bool) error {
 	m.transferCalls = append(m.transferCalls, transferCall{localDir: localDir, remoteDir: remoteDir, deleteExtra: deleteExtra})
+	return nil
+}
+
+func (m *mockRunExecutor) TransferExcluding(_ context.Context, localDir, remoteDir string, deleteExtra bool, excludes []string) error {
+	m.transferExcludingCalls = append(m.transferExcludingCalls, transferExcludingCall{
+		localDir: localDir, remoteDir: remoteDir, deleteExtra: deleteExtra, excludes: excludes,
+	})
 	return nil
 }
 
@@ -748,10 +774,14 @@ func TestService_Deploy_BuildMode(t *testing.T) {
 		}
 	}
 
-	// Two Transfer calls expected: bundle + build context.
-	if len(executor.transferCalls) != 2 {
-		t.Errorf("expected 2 Transfer calls in build mode (bundle + build context), got %d: %v",
+	// One Transfer call (bundle) + one TransferExcluding call (build context).
+	if len(executor.transferCalls) != 1 {
+		t.Errorf("expected 1 Transfer call in build mode (bundle only), got %d: %v",
 			len(executor.transferCalls), executor.transferCalls)
+	}
+	if len(executor.transferExcludingCalls) != 1 {
+		t.Errorf("expected 1 TransferExcluding call in build mode (build context), got %d: %v",
+			len(executor.transferExcludingCalls), executor.transferExcludingCalls)
 	}
 }
 
@@ -803,6 +833,16 @@ func (b *buildContextFailExecutor) Transfer(_ context.Context, localDir, remoteD
 	}
 	b.transferCalls = append(b.transferCalls,
 		transferCall{localDir: localDir, remoteDir: remoteDir, deleteExtra: deleteExtra})
+	return nil
+}
+
+func (b *buildContextFailExecutor) TransferExcluding(_ context.Context, localDir, remoteDir string, deleteExtra bool, excludes []string) error {
+	*b.callCount++
+	if *b.callCount == b.failOnTransfer {
+		return b.transferErr
+	}
+	b.transferExcludingCalls = append(b.transferExcludingCalls,
+		transferExcludingCall{localDir: localDir, remoteDir: remoteDir, deleteExtra: deleteExtra, excludes: excludes})
 	return nil
 }
 

--- a/internal/app/ops/doctor_test.go
+++ b/internal/app/ops/doctor_test.go
@@ -69,6 +69,10 @@ func (f *fakeRemoteExecutor) Transfer(_ context.Context, _, _ string, _ bool) er
 	return nil
 }
 
+func (f *fakeRemoteExecutor) TransferExcluding(_ context.Context, _, _ string, _ bool, _ []string) error {
+	return nil
+}
+
 func (f *fakeRemoteExecutor) TransferFile(_ context.Context, _, _ string) error {
 	return nil
 }

--- a/internal/ports/remote.go
+++ b/internal/ports/remote.go
@@ -35,6 +35,14 @@ type RemoteExecutor interface {
 	// file rather than a directory.
 	TransferFile(ctx context.Context, localFile, remotePath string) error
 
+	// TransferExcluding syncs localDir to remoteDir on the remote host using
+	// rsync, excluding files or directories matching the given patterns. Each
+	// pattern is passed as an --exclude flag to rsync. This is used when the
+	// build context directory overlaps with the deploy bundle directory and
+	// certain files (e.g. vibewarden.yaml, .vibewarden/) must not be
+	// overwritten by the source project files.
+	TransferExcluding(ctx context.Context, localDir, remoteDir string, deleteExtra bool, excludes []string) error
+
 	// DryRunTransfer performs a dry-run rsync between localDir and remoteDir
 	// with --delete --itemize-changes to detect what would change without
 	// actually modifying any files. It returns a list of human-readable change

--- a/test/integration/deploy_multisite_test.go
+++ b/test/integration/deploy_multisite_test.go
@@ -435,6 +435,54 @@ func (e *sshExecutor) TransferFile(_ context.Context, localFile, remotePath stri
 	return e.writeRemoteFile(remotePath, content)
 }
 
+// TransferExcluding syncs a local directory to a remote path, excluding files
+// matching the given patterns. In integration tests this delegates to Transfer
+// with basic exclude filtering applied during the file walk.
+func (e *sshExecutor) TransferExcluding(_ context.Context, localDir, remoteDir string, _ bool, excludes []string) error {
+	if _, err := e.runCmd("mkdir -p " + remoteDir); err != nil {
+		return fmt.Errorf("creating remote dir %s: %w", remoteDir, err)
+	}
+
+	return filepath.Walk(localDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		relPath, relErr := filepath.Rel(localDir, path)
+		if relErr != nil {
+			return fmt.Errorf("computing relative path: %w", relErr)
+		}
+
+		// Check excludes against the relative path and its base name.
+		for _, pattern := range excludes {
+			matched, matchErr := filepath.Match(pattern, filepath.Base(relPath))
+			if matchErr == nil && matched {
+				return nil
+			}
+			matched, matchErr = filepath.Match(pattern, relPath)
+			if matchErr == nil && matched {
+				return nil
+			}
+		}
+
+		remotePath := remoteDir + relPath
+		remoteSubDir := filepath.Dir(remotePath)
+		if _, mkdirErr := e.runCmd("mkdir -p " + remoteSubDir); mkdirErr != nil {
+			return fmt.Errorf("creating remote subdir %s: %w", remoteSubDir, mkdirErr)
+		}
+
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return fmt.Errorf("reading local file %s: %w", path, readErr)
+		}
+
+		return e.writeRemoteFile(remotePath, content)
+	})
+}
+
 // DryRunTransfer performs a dry-run comparison of localDir against remoteDir.
 // In integration tests this always returns no changes, since the test controls
 // the exact file content and drift detection is tested at the unit level.


### PR DESCRIPTION
Closes #953

## Summary
- Added `TransferExcluding` method to `RemoteExecutor` interface (`internal/ports/remote.go`) that accepts `[]string` of rsync `--exclude` patterns
- Implemented `TransferExcluding` in the SSH adapter (`internal/adapters/ssh/executor.go`) with `--exclude` args passed to rsync
- Changed build context transfers in `Deploy()`, `BootstrapSidecar()`, and `DeployMultiApp()` to use `TransferExcluding` with exclude patterns for `vibewarden.yaml`, `vibewarden.*.yaml`, `.vibewarden`, `.credentials`, `.env`, `.env.template`, and `docker-compose.yml`
- Updated all test doubles implementing `RemoteExecutor` across 4 files
- Added regression tests that verify the merged config survives build context transfer

## Root cause
When `app.build: "."`, the build context rsync computed `buildContextRemote = remoteDir + "/"` -- the same directory as the deploy bundle. The plain `Transfer` call overwrote the bundle's merged `vibewarden.yaml` (letsencrypt, port 443) with the project's original base config (self-signed, port 8443).

## Test plan
- [x] `TestArtifact_BuildContextDoesNotOverwriteMergedConfig` -- regression test verifying merged config survives, TransferExcluding is called, and exclude list contains all required patterns
- [x] `TestArtifact_BuildContextExcludes_MultiApp` -- verifies fix applies in both BootstrapSidecar and DeployMultiApp paths
- [x] All existing deploy tests pass (Transfer call count assertions updated)
- [x] `make check` passes (lint, build, all tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)