### PR TITLE
fix(#953): generator overwrites merged config, health check uses wrong port

### DIFF
--- a/internal/app/deploy/artifact_test.go
+++ b/internal/app/deploy/artifact_test.go
@@ -527,9 +527,105 @@ security_headers:
 	}
 }
 
-// TestArtifact_FirstDeploy_NoDriftWarning verifies that on first deploy to an
-// empty remote, the dry-run output containing only new-file entries (all "+"
-// attributes) does NOT trigger a DriftError. Only actual modifications should
-// be treated as drift.
+// TestArtifact_Bundle_GeneratorWriteOverwrittenByMerge is a regression test
+// for #953. It verifies that the merged vibewarden.yaml is written AFTER the
+// generator runs, so a generator that copies the unmerged base config into the
+// output directory does not clobber the production overlay.
 //
-// Regression test for #962.
+// The test uses a fake generator that writes a sentinel value to
+// vibewarden.yaml, then verifies the final file has the merged (production)
+// content, not the sentinel.
+func TestArtifact_Bundle_GeneratorWriteOverwrittenByMerge(t *testing.T) {
+	projDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	baseYAML := `server:
+  port: 8443
+upstream:
+  host: "0.0.0.0"
+  port: 3000
+tls:
+  enabled: true
+  provider: self-signed
+app:
+  image: "myapp:latest"
+`
+	basePath := filepath.Join(projDir, "vibewarden.yaml")
+	if err := os.WriteFile(basePath, []byte(baseYAML), 0o600); err != nil {
+		t.Fatalf("writing base config: %v", err)
+	}
+
+	prodYAML := `server:
+  port: 443
+tls:
+  enabled: true
+  provider: letsencrypt
+  domain: app.example.com
+`
+	prodPath := filepath.Join(projDir, "vibewarden.production.yaml")
+	if err := os.WriteFile(prodPath, []byte(prodYAML), 0o600); err != nil {
+		t.Fatalf("writing prod config: %v", err)
+	}
+
+	cfg := &config.Config{
+		Server:   config.ServerConfig{Port: 443},
+		Upstream: config.UpstreamConfig{Host: "0.0.0.0", Port: 3000},
+		App:      config.AppConfig{Image: "myapp:latest"},
+		TLS:      config.TLSConfig{Enabled: true, Provider: "letsencrypt", Domain: "app.example.com"},
+	}
+
+	// sentinelGenerator writes a sentinel value to vibewarden.yaml in the output
+	// directory, simulating the real generator which copies the original config.
+	gen := &sentinelGenerator{sentinel: "provider: SENTINEL_NOT_MERGED"}
+	svc := deployapp.NewService(&fakeExecutor{}, gen)
+
+	err := svc.Bundle(context.Background(), deployapp.BundleOptions{
+		Config:         cfg,
+		ConfigPath:     basePath,
+		ProdConfigPath: prodPath,
+		ProjectName:    "myapp",
+		MultiSite:      false,
+		OutputDir:      outputDir,
+	})
+	if err != nil {
+		t.Fatalf("Bundle() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(outputDir, "vibewarden.yaml"))
+	if err != nil {
+		t.Fatalf("reading bundled config: %v", err)
+	}
+
+	s := string(data)
+
+	// The sentinel must NOT appear -- the merged write must overwrite it.
+	if strings.Contains(s, "SENTINEL_NOT_MERGED") {
+		t.Errorf("bundled vibewarden.yaml contains sentinel from generator; merged write did not overwrite it:\n%s", s)
+	}
+
+	// The production values must be present.
+	if !strings.Contains(s, "provider: letsencrypt") {
+		t.Errorf("expected 'provider: letsencrypt' in merged config, got:\n%s", s)
+	}
+	if !strings.Contains(s, "port: 443") {
+		t.Errorf("expected 'port: 443' in merged config, got:\n%s", s)
+	}
+	if !strings.Contains(s, "domain: app.example.com") {
+		t.Errorf("expected 'domain: app.example.com' in merged config, got:\n%s", s)
+	}
+}
+
+// sentinelGenerator is a test double for ports.ConfigGenerator that writes a
+// sentinel value to vibewarden.yaml in the output directory, simulating the
+// real generator's behaviour of copying the base config into the output.
+type sentinelGenerator struct {
+	sentinel string
+}
+
+func (g *sentinelGenerator) Generate(_ context.Context, _ ports.GeneratorInput, outputDir string) error {
+	dir := outputDir
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "vibewarden.yaml"), []byte(g.sentinel), 0o600)
+}

--- a/internal/app/deploy/bundle.go
+++ b/internal/app/deploy/bundle.go
@@ -93,27 +93,40 @@ func (s *Service) BundleSidecar(_ context.Context, cfg *config.Config, outputDir
 
 // bundleSingleSite generates the complete single-site deploy bundle.
 func (s *Service) bundleSingleSite(ctx context.Context, cfg *config.Config, configPath, prodConfigPath, projectName string, outputDir string) error {
-	// Resolve upstream.host on the typed Config for template rendering.
-	resolved := ResolveProdConfig(cfg, projectName, false)
+	// Load and overlay the production override into the Config struct so that
+	// the compose template uses production values (port 443, letsencrypt, etc.)
+	// for port bindings, TLS config, and other template-driven settings.
+	mergedCfg := cfg
+	if prodConfigPath != "" {
+		if prodCfg, err := config.Load(prodConfigPath); err == nil {
+			mergedCfg = overlayProdConfig(cfg, prodCfg)
+		}
+	}
+
+	// Resolve upstream.host on the merged Config for template rendering.
+	resolved := ResolveProdConfig(mergedCfg, projectName, false)
 
 	// Set deploy mode so the template uses build context paths relative to
 	// the deploy bundle directory (e.g. "." instead of "../../.").
 	resolved.DeployMode = true
 
+	// Use the generator to produce docker-compose.yml, kratos/, credentials,
+	// etc. The generator writes directly into outputDir. This must run BEFORE
+	// the merged config write because the generator copies the original
+	// vibewarden.yaml into outputDir — the merged write overwrites it.
+	if err := s.generator.Generate(ctx, resolved.ToGeneratorInput(), outputDir); err != nil {
+		return fmt.Errorf("generating config files: %w", err)
+	}
+
 	// Build the merged YAML map for writing vibewarden.yaml.
 	// This preserves original field names (rate_limit, security_headers, etc.).
+	// Written AFTER generator.Generate() to overwrite the unmerged copy.
 	configData, err := buildMergedConfigYAML(configPath, prodConfigPath, projectName, false, cfg)
 	if err != nil {
 		return fmt.Errorf("building merged config YAML: %w", err)
 	}
 	if err := writeFile(filepath.Join(outputDir, "vibewarden.yaml"), configData); err != nil {
 		return fmt.Errorf("writing vibewarden.yaml to bundle: %w", err)
-	}
-
-	// Use the generator to produce docker-compose.yml, kratos/, credentials,
-	// etc. The generator writes directly into outputDir.
-	if err := s.generator.Generate(ctx, resolved.ToGeneratorInput(), outputDir); err != nil {
-		return fmt.Errorf("generating config files: %w", err)
 	}
 
 	return nil

--- a/internal/app/deploy/bundle.go
+++ b/internal/app/deploy/bundle.go
@@ -96,11 +96,9 @@ func (s *Service) bundleSingleSite(ctx context.Context, cfg *config.Config, conf
 	// Load and overlay the production override into the Config struct so that
 	// the compose template uses production values (port 443, letsencrypt, etc.)
 	// for port bindings, TLS config, and other template-driven settings.
-	mergedCfg := cfg
-	if prodConfigPath != "" {
-		if prodCfg, err := config.Load(prodConfigPath); err == nil {
-			mergedCfg = overlayProdConfig(cfg, prodCfg)
-		}
+	mergedCfg, err := loadMergedConfig(cfg, prodConfigPath)
+	if err != nil {
+		return err
 	}
 
 	// Resolve upstream.host on the merged Config for template rendering.

--- a/internal/app/deploy/resolve.go
+++ b/internal/app/deploy/resolve.go
@@ -160,3 +160,29 @@ func deepMerge(dst, src map[string]any) {
 		}
 	}
 }
+
+// overlayProdConfig creates a copy of base with non-zero values from prod
+// overlaid on top. Only fields relevant to deploy are checked: Server.Port,
+// TLS (Enabled, Provider, Domain), and Log.Level.
+func overlayProdConfig(base, prod *config.Config) *config.Config {
+	merged := *base
+	if prod.Server.Port != 0 {
+		merged.Server.Port = prod.Server.Port
+	}
+	if prod.TLS.Enabled {
+		merged.TLS.Enabled = prod.TLS.Enabled
+	}
+	if prod.TLS.Provider != "" {
+		merged.TLS.Provider = prod.TLS.Provider
+	}
+	if prod.TLS.Domain != "" {
+		merged.TLS.Domain = prod.TLS.Domain
+	}
+	if prod.Log.Level != "" {
+		merged.Log.Level = prod.Log.Level
+	}
+	if prod.WAF.Mode != "" {
+		merged.WAF.Mode = prod.WAF.Mode
+	}
+	return &merged
+}

--- a/internal/app/deploy/resolve.go
+++ b/internal/app/deploy/resolve.go
@@ -161,6 +161,22 @@ func deepMerge(dst, src map[string]any) {
 	}
 }
 
+// loadMergedConfig loads the production override file (if prodConfigPath is
+// non-empty) and overlays its values on top of base. When prodConfigPath is
+// empty the base config is returned unchanged. Errors from config.Load are
+// propagated so that syntax errors in the production YAML are never silently
+// ignored.
+func loadMergedConfig(base *config.Config, prodConfigPath string) (*config.Config, error) {
+	if prodConfigPath == "" {
+		return base, nil
+	}
+	prodCfg, err := config.Load(prodConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading production config %s: %w", prodConfigPath, err)
+	}
+	return overlayProdConfig(base, prodCfg), nil
+}
+
 // overlayProdConfig creates a copy of base with non-zero values from prod
 // overlaid on top. Only fields relevant to deploy are checked: Server.Port,
 // TLS (Enabled, Provider, Domain), and Log.Level.

--- a/internal/app/deploy/resolve_test.go
+++ b/internal/app/deploy/resolve_test.go
@@ -389,3 +389,132 @@ security_headers:
 		t.Errorf("rate_limit.enabled = %v, want true", rl["enabled"])
 	}
 }
+
+func TestOverlayProdConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		base         *config.Config
+		prod         *config.Config
+		wantPort     int
+		wantProvider string
+		wantDomain   string
+		wantTLS      bool
+		wantLogLevel string
+		wantWAFMode  string
+	}{
+		{
+			name: "prod overrides all fields",
+			base: &config.Config{
+				Server: config.ServerConfig{Port: 8443},
+				TLS:    config.TLSConfig{Enabled: true, Provider: "self-signed"},
+			},
+			prod: &config.Config{
+				Server: config.ServerConfig{Port: 443},
+				TLS:    config.TLSConfig{Enabled: true, Provider: "letsencrypt", Domain: "example.com"},
+				Log:    config.LogConfig{Level: "warn"},
+				WAF:    config.WAFConfig{Mode: "block"},
+			},
+			wantPort:     443,
+			wantProvider: "letsencrypt",
+			wantDomain:   "example.com",
+			wantTLS:      true,
+			wantLogLevel: "warn",
+			wantWAFMode:  "block",
+		},
+		{
+			name: "prod zero port keeps base port",
+			base: &config.Config{
+				Server: config.ServerConfig{Port: 8443},
+				TLS:    config.TLSConfig{Provider: "self-signed"},
+			},
+			prod: &config.Config{
+				Server: config.ServerConfig{Port: 0},
+			},
+			wantPort:     8443,
+			wantProvider: "self-signed",
+		},
+		{
+			name: "prod empty provider keeps base provider",
+			base: &config.Config{
+				TLS: config.TLSConfig{Provider: "self-signed"},
+			},
+			prod: &config.Config{
+				TLS: config.TLSConfig{Provider: ""},
+			},
+			wantProvider: "self-signed",
+		},
+		{
+			name: "prod WAF mode block overrides base",
+			base: &config.Config{
+				WAF: config.WAFConfig{Mode: "detect"},
+			},
+			prod: &config.Config{
+				WAF: config.WAFConfig{Mode: "block"},
+			},
+			wantWAFMode: "block",
+		},
+		{
+			name: "all zero prod returns base unchanged",
+			base: &config.Config{
+				Server: config.ServerConfig{Port: 8443},
+				TLS:    config.TLSConfig{Enabled: true, Provider: "self-signed", Domain: "dev.local"},
+				Log:    config.LogConfig{Level: "debug"},
+				WAF:    config.WAFConfig{Mode: "detect"},
+			},
+			prod:         &config.Config{},
+			wantPort:     8443,
+			wantProvider: "self-signed",
+			wantDomain:   "dev.local",
+			wantTLS:      true,
+			wantLogLevel: "debug",
+			wantWAFMode:  "detect",
+		},
+		{
+			name: "does not mutate base",
+			base: &config.Config{
+				Server: config.ServerConfig{Port: 8443},
+			},
+			prod: &config.Config{
+				Server: config.ServerConfig{Port: 443},
+			},
+			wantPort: 443,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalPort := tt.base.Server.Port
+
+			got := overlayProdConfig(tt.base, tt.prod)
+
+			if tt.wantPort != 0 && got.Server.Port != tt.wantPort {
+				t.Errorf("Server.Port = %d, want %d", got.Server.Port, tt.wantPort)
+			}
+			if tt.wantProvider != "" && got.TLS.Provider != tt.wantProvider {
+				t.Errorf("TLS.Provider = %q, want %q", got.TLS.Provider, tt.wantProvider)
+			}
+			if tt.wantDomain != "" && got.TLS.Domain != tt.wantDomain {
+				t.Errorf("TLS.Domain = %q, want %q", got.TLS.Domain, tt.wantDomain)
+			}
+			if tt.wantTLS && !got.TLS.Enabled {
+				t.Error("TLS.Enabled = false, want true")
+			}
+			if tt.wantLogLevel != "" && got.Log.Level != tt.wantLogLevel {
+				t.Errorf("Log.Level = %q, want %q", got.Log.Level, tt.wantLogLevel)
+			}
+			if tt.wantWAFMode != "" && got.WAF.Mode != tt.wantWAFMode {
+				t.Errorf("WAF.Mode = %q, want %q", got.WAF.Mode, tt.wantWAFMode)
+			}
+
+			// Verify the original base is not mutated.
+			if tt.name == "does not mutate base" && tt.base.Server.Port != originalPort {
+				t.Errorf("base.Server.Port was mutated: got %d, want %d", tt.base.Server.Port, originalPort)
+			}
+
+			// Verify the result is a distinct pointer from the input.
+			if got == tt.base {
+				t.Error("overlayProdConfig returned the same pointer as base, want a copy")
+			}
+		})
+	}
+}

--- a/internal/app/deploy/service.go
+++ b/internal/app/deploy/service.go
@@ -281,13 +281,20 @@ func (s *Service) Deploy(ctx context.Context, cfg *config.Config, opts RunOption
 
 	// Step 6: health check -- run curl on the remote so the probe is independent
 	// of DNS propagation, external port availability, and TLS certificate issuance.
-	port := cfg.Server.Port
+	// Use the merged config (base + prod overlay) for the correct port and TLS state.
+	healthCfg := cfg
+	if opts.ProdConfigPath != "" {
+		if prodCfg, loadErr := config.Load(opts.ProdConfigPath); loadErr == nil {
+			healthCfg = overlayProdConfig(cfg, prodCfg)
+		}
+	}
+	port := healthCfg.Server.Port
 	if port == 0 {
 		port = defaultHealthPort
 	}
-	healthURL := healthCheckURL(port, cfg.TLS.Enabled)
+	healthURL := healthCheckURL(port, healthCfg.TLS.Enabled)
 	fmt.Fprintf(out, "Waiting for sidecar health check at %s (via SSH)...\n", healthURL)
-	if !s.waitHealthy(ctx, port, cfg.TLS.Enabled, out) {
+	if !s.waitHealthy(ctx, port, healthCfg.TLS.Enabled, out) {
 		fmt.Fprintln(out, "Deploy completed but health check failed — verify with: vibew deploy status")
 		return ErrHealthCheck
 	}

--- a/internal/app/deploy/service.go
+++ b/internal/app/deploy/service.go
@@ -282,11 +282,9 @@ func (s *Service) Deploy(ctx context.Context, cfg *config.Config, opts RunOption
 	// Step 6: health check -- run curl on the remote so the probe is independent
 	// of DNS propagation, external port availability, and TLS certificate issuance.
 	// Use the merged config (base + prod overlay) for the correct port and TLS state.
-	healthCfg := cfg
-	if opts.ProdConfigPath != "" {
-		if prodCfg, loadErr := config.Load(opts.ProdConfigPath); loadErr == nil {
-			healthCfg = overlayProdConfig(cfg, prodCfg)
-		}
+	healthCfg, err := loadMergedConfig(cfg, opts.ProdConfigPath)
+	if err != nil {
+		return err
 	}
 	port := healthCfg.Server.Port
 	if port == 0 {


### PR DESCRIPTION
## Summary
- Generator.Generate() was copying the unmerged vibewarden.yaml on top of the merged version. Swapped execution order.
- overlayProdConfig merges production overrides into the Config struct for compose template rendering.
- Health check now uses merged config's port/TLS instead of base config.

## Verified
- Deployed to demo.vibewarden.dev — Let's Encrypt cert, WAF 403 on SQLi, HSTS headers, port 443

Closes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)