### PR TITLE
feat: deploy transfers local image instead of remote build, add app.environment support

### DIFF
--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -104,6 +104,31 @@ EXPOSE 3000
 CMD ["/app/server"]
 ```
 
+## Deploy model
+
+`vibew build` builds the Docker image locally from your Dockerfile. `vibew deploy`
+transfers the pre-built image to the server via `docker save | rsync | docker load`.
+No source code is ever copied to the production server -- the image must be
+production-ready (all dependencies installed, assets compiled, etc.).
+
+Use `app.environment` in vibewarden.yaml for runtime configuration:
+```yaml
+app:
+  build: "."
+  environment:
+    DATABASE_URL: "postgres://user:pass@db:5432/myapp"
+    REDIS_URL: "redis://redis:6379"
+```
+
+Do NOT bake secrets into the Docker image. Use environment variables or
+the secrets plugin (OpenBao) for sensitive values.
+
+## Extra services (database, cache, etc.)
+
+Create `docker-compose.override.yml` next to your `vibewarden.yaml` for additional
+services like PostgreSQL or Redis. Docker Compose auto-merges it with the
+generated compose. VibeWarden never overwrites this file.
+
 ## Known limitations
 
 - WAF is in `detect` mode by default (logs but does not block). Set `waf.mode: block` in vibewarden.yaml to enforce blocking.

--- a/internal/app/deploy/artifact_test.go
+++ b/internal/app/deploy/artifact_test.go
@@ -25,13 +25,13 @@ func (g *captureGenerator) Generate(_ context.Context, input ports.GeneratorInpu
 	return g.err
 }
 
-// TestArtifact_DeployCompose_ContextIsLocal verifies that the generated
-// docker-compose.yml in a single-site deploy bundle uses build context "."
-// (relative to the bundle directory) instead of "../../." which only works
-// for the local dev layout (.vibewarden/generated/ is two levels deep).
+// TestArtifact_DeployCompose_UsesImageNotBuild verifies that the generated
+// docker-compose.yml in a single-site deploy bundle uses image: instead of
+// build: when app.build is set. The image is built locally by `vibew build`
+// and transferred via docker save/load -- no source code on the server.
 //
 // Regression test for #952.
-func TestArtifact_DeployCompose_ContextIsLocal(t *testing.T) {
+func TestArtifact_DeployCompose_UsesImageNotBuild(t *testing.T) {
 	projDir := t.TempDir()
 	outputDir := t.TempDir()
 
@@ -69,8 +69,7 @@ app:
 		t.Fatalf("Bundle() error = %v", err)
 	}
 
-	// The generator input's TemplateData must have DeployMode = true so the
-	// template renders build context as "." instead of "../../.".
+	// The generator input's TemplateData must have DeployMode = true.
 	if gen.lastInput.TemplateData == nil {
 		t.Fatal("generator was not called")
 	}
@@ -79,10 +78,14 @@ app:
 		t.Fatalf("TemplateData is %T, want *config.Config", gen.lastInput.TemplateData)
 	}
 	if !inputCfg.DeployMode {
-		t.Error("deploy bundle must set DeployMode = true so the template renders 'context: .' instead of 'context: ../../.'")
+		t.Error("deploy bundle must set DeployMode = true")
 	}
-	if inputCfg.App.Build != "." {
-		t.Errorf("deploy bundle App.Build = %q, want %q", inputCfg.App.Build, ".")
+	// App.Build must be cleared and App.Image set for deploy compose.
+	if inputCfg.App.Build != "" {
+		t.Errorf("deploy bundle App.Build = %q, want empty (image mode)", inputCfg.App.Build)
+	}
+	if inputCfg.App.Image != "vibewarden-app:latest" {
+		t.Errorf("deploy bundle App.Image = %q, want %q", inputCfg.App.Image, "vibewarden-app:latest")
 	}
 }
 
@@ -248,16 +251,13 @@ func TestArtifact_SidecarCompose_ContainsDNS(t *testing.T) {
 	}
 }
 
-// TestArtifact_BuildContextDoesNotOverwriteMergedConfig is a regression test
-// for #953. When app.build is "." the build context rsync was overwriting the
-// merged vibewarden.yaml (letsencrypt, port 443) with the original base config
-// (self-signed, port 8443) because both the bundle and the build context were
-// transferred to the same remote directory without excludes.
+// TestArtifact_BuildMode_TransfersImageNotSource verifies that when app.build
+// is set, Deploy transfers the locally-built image via docker save/load instead
+// of rsyncing source code. No TransferExcluding is used because no source code
+// is sent to the server.
 //
-// The fix uses TransferExcluding for the build context transfer so that bundle
-// files (vibewarden.yaml, .vibewarden/, .credentials, etc.) are never
-// overwritten by the project source tree.
-func TestArtifact_BuildContextDoesNotOverwriteMergedConfig(t *testing.T) {
+// Replaces #953 regression test (build context rsync is no longer used).
+func TestArtifact_BuildMode_TransfersImageNotSource(t *testing.T) {
 	projDir := t.TempDir()
 
 	// Base config: self-signed TLS on port 8443 (local dev).
@@ -331,63 +331,26 @@ tls:
 		t.Errorf("bundled config must NOT contain 'provider: self-signed' (base), got:\n%s", s)
 	}
 
-	// 2. The build context must be transferred via TransferExcluding, not plain Transfer.
-	if len(executor.transferExcludingCalls) == 0 {
-		t.Fatal("expected TransferExcluding to be called for the build context, but it was not called")
+	// 2. No TransferExcluding must be called -- no source code is transferred.
+	if len(executor.transferExcludingCalls) != 0 {
+		t.Errorf("expected no TransferExcluding calls (no source code transfer), got %d: %v",
+			len(executor.transferExcludingCalls), executor.transferExcludingCalls)
 	}
 
-	// 3. The exclude list must contain vibewarden.yaml to prevent overwriting.
-	excludes := executor.transferExcludingCalls[0].excludes
-	foundVibewardenYAML := false
-	for _, pattern := range excludes {
-		if pattern == "vibewarden.yaml" {
-			foundVibewardenYAML = true
-		}
-	}
-	if !foundVibewardenYAML {
-		t.Errorf("TransferExcluding excludes should contain 'vibewarden.yaml', got: %v", excludes)
-	}
-
-	// 4. The exclude list should also protect other bundle artifacts.
-	requiredExcludes := []string{
-		"vibewarden.yaml",
-		"vibewarden.*.yaml",
-		".vibewarden",
-		".credentials",
-		".env",
-		"docker-compose.yml",
-	}
-	for _, required := range requiredExcludes {
-		found := false
-		for _, actual := range excludes {
-			if actual == required {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("TransferExcluding excludes should contain %q, got: %v", required, excludes)
+	// 3. No --build flag must be present in docker compose up.
+	for _, c := range executor.runCalls {
+		if strings.Contains(c, "--build") {
+			t.Errorf("did not expect --build flag (image transfer mode), got: %q", c)
 		}
 	}
 }
 
-// TestArtifact_BuildContextExcludes_MultiApp is a regression test for #953
-// in multi-app mode. Verifies that BootstrapSidecar and DeployMultiApp also
-// use TransferExcluding for the build context transfer.
-func TestArtifact_BuildContextExcludes_MultiApp(t *testing.T) {
-	projDir := t.TempDir()
-
-	baseYAML := `upstream:
-  host: "0.0.0.0"
-  port: 3000
-app:
-  build: "."
-`
-	basePath := filepath.Join(projDir, "vibewarden.yaml")
-	if err := os.WriteFile(basePath, []byte(baseYAML), 0o600); err != nil {
-		t.Fatalf("writing base config: %v", err)
-	}
-
+// TestArtifact_BuildMode_MultiApp_NoSourceTransfer verifies that in multi-app
+// mode, when app.build is set, no source code is transferred to the server.
+// The image is transferred via docker save/load instead.
+//
+// Replaces #953 multi-app regression test.
+func TestArtifact_BuildMode_MultiApp_NoSourceTransfer(t *testing.T) {
 	cfg := &config.Config{
 		Server:   config.ServerConfig{Port: 443},
 		Upstream: config.UpstreamConfig{Host: "0.0.0.0", Port: 3000},
@@ -399,20 +362,20 @@ app:
 		deploy func(svc *deployapp.Service, executor *fakeExecutor) error
 	}{
 		{
-			name: "BootstrapSidecar uses TransferExcluding for build context",
+			name: "BootstrapSidecar does not transfer source code",
 			deploy: func(svc *deployapp.Service, _ *fakeExecutor) error {
 				return svc.BootstrapSidecar(context.Background(), cfg, deployapp.RunOptions{
-					ConfigPath:   basePath,
+					ConfigPath:   "/tmp/buildsite/vibewarden.yaml",
 					ProjectName:  "buildsite",
 					GeneratedDir: t.TempDir(),
 				})
 			},
 		},
 		{
-			name: "DeployMultiApp uses TransferExcluding for build context",
+			name: "DeployMultiApp does not transfer source code",
 			deploy: func(svc *deployapp.Service, _ *fakeExecutor) error {
 				return svc.DeployMultiApp(context.Background(), cfg, deployapp.RunOptions{
-					ConfigPath:   basePath,
+					ConfigPath:   "/tmp/buildsite/vibewarden.yaml",
 					ProjectName:  "buildsite",
 					GeneratedDir: t.TempDir(),
 				})
@@ -430,21 +393,16 @@ app:
 				t.Fatalf("deploy error: %v", err)
 			}
 
-			if len(executor.transferExcludingCalls) == 0 {
-				t.Fatal("expected TransferExcluding to be called for build context, but it was not")
+			// No TransferExcluding must be called -- no source code transfer.
+			if len(executor.transferExcludingCalls) != 0 {
+				t.Errorf("expected no TransferExcluding calls (no source transfer), got %d: %v",
+					len(executor.transferExcludingCalls), executor.transferExcludingCalls)
 			}
 
-			excludes := executor.transferExcludingCalls[0].excludes
-			for _, required := range []string{"vibewarden.yaml", "docker-compose.yml"} {
-				found := false
-				for _, actual := range excludes {
-					if actual == required {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("TransferExcluding excludes should contain %q, got: %v", required, excludes)
+			// No --build flag in docker compose up.
+			for _, c := range executor.runCalls {
+				if strings.Contains(c, "--build") {
+					t.Errorf("did not expect --build flag, got: %q", c)
 				}
 			}
 		})
@@ -612,6 +570,144 @@ tls:
 	}
 	if !strings.Contains(s, "domain: app.example.com") {
 		t.Errorf("expected 'domain: app.example.com' in merged config, got:\n%s", s)
+	}
+}
+
+// TestArtifact_AppEnvironment_RendersInCompose verifies that app.environment
+// variables are rendered in the generated docker-compose.yml for single-site mode.
+func TestArtifact_AppEnvironment_RendersInCompose(t *testing.T) {
+	gen := &captureGenerator{}
+	svc := deployapp.NewService(&fakeExecutor{}, gen)
+
+	outputDir := t.TempDir()
+
+	cfg := &config.Config{
+		Server:   config.ServerConfig{Port: 8443},
+		Upstream: config.UpstreamConfig{Host: "localhost", Port: 3000},
+		App: config.AppConfig{
+			Image: "myapp:latest",
+			Environment: map[string]string{
+				"DATABASE_URL": "postgres://user:pass@db:5432/myapp",
+				"LOG_LEVEL":    "info",
+			},
+		},
+	}
+
+	err := svc.Bundle(context.Background(), deployapp.BundleOptions{
+		Config:      cfg,
+		ConfigPath:  "/tmp/proj/vibewarden.yaml",
+		ProjectName: "myproject",
+		MultiSite:   false,
+		OutputDir:   outputDir,
+	})
+	if err != nil {
+		t.Fatalf("Bundle() error = %v", err)
+	}
+
+	// Verify the captured generator input has environment variables.
+	if gen.lastInput.TemplateData == nil {
+		t.Fatal("generator was not called")
+	}
+	inputCfg, ok := gen.lastInput.TemplateData.(*config.Config)
+	if !ok {
+		t.Fatalf("TemplateData is %T, want *config.Config", gen.lastInput.TemplateData)
+	}
+	if len(inputCfg.App.Environment) != 2 {
+		t.Errorf("expected 2 environment variables, got %d", len(inputCfg.App.Environment))
+	}
+	if inputCfg.App.Environment["DATABASE_URL"] != "postgres://user:pass@db:5432/myapp" {
+		t.Errorf("expected DATABASE_URL, got: %v", inputCfg.App.Environment)
+	}
+}
+
+// TestArtifact_AppEnvironment_RendersInAppCompose verifies that app.environment
+// variables are rendered in the per-app compose file for multi-site mode.
+func TestArtifact_AppEnvironment_RendersInAppCompose(t *testing.T) {
+	svc := deployapp.NewService(&fakeExecutor{}, &fakeGenerator{})
+
+	outputDir := t.TempDir()
+
+	cfg := &config.Config{
+		Server:   config.ServerConfig{Port: 443},
+		Upstream: config.UpstreamConfig{Host: "localhost", Port: 3000},
+		App: config.AppConfig{
+			Image: "myapp:latest",
+			Environment: map[string]string{
+				"DATABASE_URL": "postgres://user:pass@db:5432/myapp",
+				"REDIS_URL":    "redis://redis:6379",
+			},
+		},
+	}
+
+	err := svc.Bundle(context.Background(), deployapp.BundleOptions{
+		Config:      cfg,
+		ConfigPath:  "/tmp/proj/vibewarden.yaml",
+		ProjectName: "envsite",
+		MultiSite:   true,
+		OutputDir:   outputDir,
+	})
+	if err != nil {
+		t.Fatalf("Bundle() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(outputDir, "sites", "envsite", "docker-compose.yml"))
+	if err != nil {
+		t.Fatalf("reading bundled compose: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "environment:") {
+		t.Errorf("expected 'environment:' in compose, got:\n%s", content)
+	}
+	if !strings.Contains(content, "DATABASE_URL=postgres://user:pass@db:5432/myapp") {
+		t.Errorf("expected DATABASE_URL in compose, got:\n%s", content)
+	}
+	if !strings.Contains(content, "REDIS_URL=redis://redis:6379") {
+		t.Errorf("expected REDIS_URL in compose, got:\n%s", content)
+	}
+}
+
+// TestArtifact_DeployCompose_HasImageNotBuild verifies that when app.build is
+// set, the deploy compose file uses image: instead of build:. This ensures no
+// source code needs to exist on the production server.
+func TestArtifact_DeployCompose_HasImageNotBuild(t *testing.T) {
+	gen := &captureGenerator{}
+	svc := deployapp.NewService(&fakeExecutor{}, gen)
+
+	outputDir := t.TempDir()
+
+	cfg := &config.Config{
+		Name:     "myapp",
+		Server:   config.ServerConfig{Port: 8443},
+		Upstream: config.UpstreamConfig{Host: "localhost", Port: 3000},
+		App:      config.AppConfig{Build: "."},
+	}
+
+	err := svc.Bundle(context.Background(), deployapp.BundleOptions{
+		Config:      cfg,
+		ConfigPath:  "/tmp/proj/vibewarden.yaml",
+		ProjectName: "myapp",
+		MultiSite:   false,
+		OutputDir:   outputDir,
+	})
+	if err != nil {
+		t.Fatalf("Bundle() error = %v", err)
+	}
+
+	if gen.lastInput.TemplateData == nil {
+		t.Fatal("generator was not called")
+	}
+	inputCfg, ok := gen.lastInput.TemplateData.(*config.Config)
+	if !ok {
+		t.Fatalf("TemplateData is %T, want *config.Config", gen.lastInput.TemplateData)
+	}
+
+	// App.Build must be cleared for deploy.
+	if inputCfg.App.Build != "" {
+		t.Errorf("deploy bundle App.Build = %q, want empty", inputCfg.App.Build)
+	}
+	// App.Image must be set to the derived name.
+	if inputCfg.App.Image != "myapp-app:latest" {
+		t.Errorf("deploy bundle App.Image = %q, want %q", inputCfg.App.Image, "myapp-app:latest")
 	}
 }
 

--- a/internal/app/deploy/bundle.go
+++ b/internal/app/deploy/bundle.go
@@ -108,6 +108,14 @@ func (s *Service) bundleSingleSite(ctx context.Context, cfg *config.Config, conf
 	// the deploy bundle directory (e.g. "." instead of "../../.").
 	resolved.DeployMode = true
 
+	// When app.build is set, the image is built locally by `vibew build` and
+	// transferred via docker save/load. The deploy compose must use `image:`
+	// (not `build:`) because no source code is present on the server.
+	if resolved.App.Build != "" {
+		resolved.App.Image = mergedCfg.ComposeProjectName() + "-app:latest"
+		resolved.App.Build = ""
+	}
+
 	// Use the generator to produce docker-compose.yml, kratos/, credentials,
 	// etc. The generator writes directly into outputDir. This must run BEFORE
 	// the merged config write because the generator copies the original
@@ -144,8 +152,18 @@ func (s *Service) bundleMultiSiteSite(_ context.Context, cfg *config.Config, con
 		return fmt.Errorf("writing vibewarden.yaml to bundle: %w", err)
 	}
 
+	// When app.build is set, the image is built locally and transferred via
+	// docker save/load. The per-app compose must use image: instead of build:.
+	composeCfg := cfg
+	if cfg.App.Build != "" {
+		cfgCopy := *cfg
+		cfgCopy.App.Image = cfg.ComposeProjectName() + "-app:latest"
+		cfgCopy.App.Build = ""
+		composeCfg = &cfgCopy
+	}
+
 	// Render and write the per-app compose file.
-	appCompose, err := renderAppCompose(cfg, projectName)
+	appCompose, err := renderAppCompose(composeCfg, projectName)
 	if err != nil {
 		return fmt.Errorf("rendering app compose: %w", err)
 	}
@@ -238,6 +256,7 @@ func renderAppCompose(cfg *config.Config, projectName string) (string, error) {
 		AppHealthcheck: healthcheck,
 		UpstreamPort:   cfg.Upstream.Port,
 		AppLanguage:    cfg.App.Language,
+		AppEnvironment: cfg.App.Environment,
 	}
 
 	var buf bytes.Buffer

--- a/internal/app/deploy/bundle_test.go
+++ b/internal/app/deploy/bundle_test.go
@@ -229,7 +229,7 @@ func TestBundleSidecar_DefaultPort(t *testing.T) {
 	}
 }
 
-func TestBundle_MultiSite_AppBuildInCompose(t *testing.T) {
+func TestBundle_MultiSite_AppBuildUsesImage(t *testing.T) {
 	generator := &fakeGenerator{}
 	svc := deployapp.NewService(&fakeExecutor{}, generator)
 
@@ -257,11 +257,16 @@ func TestBundle_MultiSite_AppBuildInCompose(t *testing.T) {
 		t.Fatalf("reading compose: %v", err)
 	}
 	content := string(data)
-	if !strings.Contains(content, "build:") {
-		t.Errorf("expected 'build:' in compose for build mode, got:\n%s", content)
+	// Deploy compose must use image: instead of build: because the image
+	// is built locally and transferred via docker save/load.
+	if strings.Contains(content, "build:") {
+		t.Errorf("expected no 'build:' in deploy compose (image transfer mode), got:\n%s", content)
 	}
-	if !strings.Contains(content, "context: .") {
-		t.Errorf("expected 'context: .' in compose for build mode, got:\n%s", content)
+	if !strings.Contains(content, "image:") {
+		t.Errorf("expected 'image:' in deploy compose, got:\n%s", content)
+	}
+	if !strings.Contains(content, "vibewarden-app:latest") {
+		t.Errorf("expected 'vibewarden-app:latest' in deploy compose, got:\n%s", content)
 	}
 }
 

--- a/internal/app/deploy/multiapp.go
+++ b/internal/app/deploy/multiapp.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"strings"
 
 	"github.com/vibewarden/vibewarden/internal/config"
 )
@@ -52,6 +51,10 @@ type AppComposeData struct {
 
 	// AppLanguage is the app's language/runtime for health check probe selection.
 	AppLanguage string
+
+	// AppEnvironment is a map of custom environment variables to inject into
+	// the app container.
+	AppEnvironment map[string]string
 }
 
 // BootstrapSidecar creates the full multi-app directory layout on the remote
@@ -133,23 +136,15 @@ func (s *Service) BootstrapSidecar(ctx context.Context, cfg *config.Config, opts
 		return fmt.Errorf("transferring site bundle: %w", err)
 	}
 
-	// Step 4b: if app.build is set, rsync the build context to the remote site
-	// dir. Use TransferExcluding to prevent the project's original config files
-	// from overwriting the merged bundle files deployed in the previous step.
+	// Step 4b: transfer local image if applicable.
+	// When app.build is set, the image was built locally by `vibew build`.
+	// Derive the image name and transfer via docker save/load.
+	imageName := cfg.App.Image
 	if cfg.App.Build != "" {
-		projectRoot := filepath.Dir(filepath.Clean(opts.ConfigPath))
-		buildContextLocal := filepath.Join(projectRoot, cfg.App.Build)
-		buildContextRemote := siteDir + strings.TrimPrefix(strings.TrimSuffix(cfg.App.Build, "/"), "./") + "/"
-		fmt.Fprintf(out, "Transferring app build context (%s)...\n", cfg.App.Build)
-		if err := s.executor.TransferExcluding(ctx, buildContextLocal, buildContextRemote, false, buildContextExcludes); err != nil {
-			return fmt.Errorf("transferring app build context: %w", err)
-		}
+		imageName = cfg.ComposeProjectName() + "-app:latest"
 	}
-
-	// Step 4c: transfer local image if using a bare image name (no registry prefix)
-	// and an image exporter is configured.
-	if cfg.App.Image != "" && isLocalImage(cfg.App.Image) && s.imageExporter != nil {
-		if err := s.transferLocalImage(ctx, cfg.App.Image, siteDir, out); err != nil {
+	if imageName != "" && isLocalImage(imageName) && s.imageExporter != nil {
+		if err := s.transferLocalImage(ctx, imageName, siteDir, out); err != nil {
 			return fmt.Errorf("transferring local image: %w", err)
 		}
 	}
@@ -157,9 +152,6 @@ func (s *Service) BootstrapSidecar(ctx context.Context, cfg *config.Config, opts
 	// Step 5: start the app container.
 	fmt.Fprintf(out, "Starting site %q...\n", projectName)
 	startCmd := fmt.Sprintf("cd %s && docker compose up -d", siteDir)
-	if cfg.App.Build != "" {
-		startCmd = fmt.Sprintf("cd %s && docker compose up -d --build", siteDir)
-	}
 	if _, err := s.executor.Run(ctx, startCmd); err != nil {
 		return fmt.Errorf("starting app container: %w", err)
 	}
@@ -235,23 +227,15 @@ func (s *Service) DeployMultiApp(ctx context.Context, cfg *config.Config, opts R
 		return fmt.Errorf("transferring site bundle: %w", err)
 	}
 
-	// Step 3b: if app.build is set, rsync the build context to the remote site
-	// dir. Use TransferExcluding to prevent the project's original config files
-	// from overwriting the merged bundle files deployed in the previous step.
+	// Step 3b: transfer local image if applicable.
+	// When app.build is set, the image was built locally by `vibew build`.
+	// Derive the image name and transfer via docker save/load.
+	imageName := cfg.App.Image
 	if cfg.App.Build != "" {
-		projectRoot := filepath.Dir(filepath.Clean(opts.ConfigPath))
-		buildContextLocal := filepath.Join(projectRoot, cfg.App.Build)
-		buildContextRemote := siteDir + strings.TrimPrefix(strings.TrimSuffix(cfg.App.Build, "/"), "./") + "/"
-		fmt.Fprintf(out, "Transferring app build context (%s)...\n", cfg.App.Build)
-		if err := s.executor.TransferExcluding(ctx, buildContextLocal, buildContextRemote, false, buildContextExcludes); err != nil {
-			return fmt.Errorf("transferring app build context: %w", err)
-		}
+		imageName = cfg.ComposeProjectName() + "-app:latest"
 	}
-
-	// Step 3c: transfer local image if using a bare image name (no registry prefix)
-	// and an image exporter is configured.
-	if cfg.App.Image != "" && isLocalImage(cfg.App.Image) && s.imageExporter != nil {
-		if err := s.transferLocalImage(ctx, cfg.App.Image, siteDir, out); err != nil {
+	if imageName != "" && isLocalImage(imageName) && s.imageExporter != nil {
+		if err := s.transferLocalImage(ctx, imageName, siteDir, out); err != nil {
 			return fmt.Errorf("transferring local image: %w", err)
 		}
 	}
@@ -259,9 +243,6 @@ func (s *Service) DeployMultiApp(ctx context.Context, cfg *config.Config, opts R
 	// Step 4: start the app container.
 	fmt.Fprintf(out, "Starting site %q...\n", projectName)
 	startCmd := fmt.Sprintf("cd %s && docker compose up -d", siteDir)
-	if cfg.App.Build != "" {
-		startCmd = fmt.Sprintf("cd %s && docker compose up -d --build", siteDir)
-	}
 	if _, err := s.executor.Run(ctx, startCmd); err != nil {
 		return fmt.Errorf("starting app container: %w", err)
 	}

--- a/internal/app/deploy/multiapp_test.go
+++ b/internal/app/deploy/multiapp_test.go
@@ -428,7 +428,7 @@ func TestRenderAppCompose_ImageMode(t *testing.T) {
 	}
 }
 
-func TestRenderAppCompose_BuildMode(t *testing.T) {
+func TestRenderAppCompose_BuildMode_UsesImage(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{}
 
@@ -448,15 +448,19 @@ func TestRenderAppCompose_BuildMode(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Verify the app compose was written with build context.
+	// Verify the app compose was written with image (not build context).
+	// The image is built locally and transferred via docker save/load.
 	composePath := filepath.Join(bundleDir, "sites", "buildsite", "docker-compose.yml")
 	data, err := os.ReadFile(composePath)
 	if err != nil {
 		t.Fatalf("reading bundled compose: %v", err)
 	}
 	content := string(data)
-	if !strings.Contains(content, "build:") {
-		t.Errorf("expected compose to contain 'build:', got:\n%s", content)
+	if strings.Contains(content, "build:") {
+		t.Errorf("expected no 'build:' in deploy compose (image transfer mode), got:\n%s", content)
+	}
+	if !strings.Contains(content, "image:") {
+		t.Errorf("expected compose to contain 'image:', got:\n%s", content)
 	}
 	if !strings.Contains(content, "vibewarden-buildsite-app") {
 		t.Errorf("expected compose to contain 'vibewarden-buildsite-app', got:\n%s", content)
@@ -700,9 +704,9 @@ func TestDeployMultiApp_TLSHealthCheck(t *testing.T) {
 	}
 }
 
-// TestDeploySite_BuildMode_RsyncsSource verifies that when cfg.App.Build is set,
-// the app source directory is transferred to the remote site directory.
-func TestDeploySite_BuildMode_RsyncsSource(t *testing.T) {
+// TestDeploySite_BuildMode_NoSourceTransfer verifies that when cfg.App.Build is set,
+// no source code is transferred -- only the site bundle is transferred.
+func TestDeploySite_BuildMode_NoSourceTransfer(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{}
 
@@ -721,32 +725,22 @@ func TestDeploySite_BuildMode_RsyncsSource(t *testing.T) {
 		t.Fatalf("DeployMultiApp() unexpected error: %v", err)
 	}
 
-	// Transfer must be called for the site bundle; TransferExcluding for the
-	// build context.
+	// Transfer must be called for the site bundle.
 	if len(executor.transferCalls) < 1 {
 		t.Fatalf("expected at least 1 Transfer call (site bundle), got %d: %v",
 			len(executor.transferCalls), executor.transferCalls)
 	}
-	if len(executor.transferExcludingCalls) < 1 {
-		t.Fatalf("expected at least 1 TransferExcluding call (build context), got %d: %v",
-			len(executor.transferExcludingCalls), executor.transferExcludingCalls)
-	}
 
-	found := false
-	for _, call := range executor.transferExcludingCalls {
-		if strings.Contains(call.remoteDir, "sites/buildapp/") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("expected TransferExcluding to site directory, got: %v", executor.transferExcludingCalls)
+	// No TransferExcluding -- no source code transfer.
+	if len(executor.transferExcludingCalls) != 0 {
+		t.Errorf("expected no TransferExcluding calls (no source transfer), got %d: %v",
+			len(executor.transferExcludingCalls), executor.transferExcludingCalls)
 	}
 }
 
-// TestDeploySite_BuildMode_UsesComposeUpBuild verifies that when cfg.App.Build
-// is set, docker compose up is called with --build.
-func TestDeploySite_BuildMode_UsesComposeUpBuild(t *testing.T) {
+// TestDeploySite_BuildMode_NoBuildFlag verifies that when cfg.App.Build is set,
+// docker compose up is called WITHOUT --build (image is pre-built and transferred).
+func TestDeploySite_BuildMode_NoBuildFlag(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{}
 
@@ -765,7 +759,15 @@ func TestDeploySite_BuildMode_UsesComposeUpBuild(t *testing.T) {
 		t.Fatalf("DeployMultiApp() unexpected error: %v", err)
 	}
 
-	assertRunCalledContains(t, executor.runCalls, "docker compose up -d --build")
+	// docker compose up -d must be called (without --build).
+	assertRunCalledContains(t, executor.runCalls, "docker compose up -d")
+
+	// --build must NOT appear.
+	for _, c := range executor.runCalls {
+		if strings.Contains(c, "--build") {
+			t.Errorf("did not expect --build flag in image transfer mode, got: %q", c)
+		}
+	}
 }
 
 // TestDeploySite_ImageMode_NoBuildContext verifies that in image mode (no build),
@@ -804,23 +806,16 @@ func TestDeploySite_ImageMode_NoBuildContext(t *testing.T) {
 	}
 }
 
-// TestDeploySite_BuildMode_TransferFails verifies that a failure to rsync the
-// app build context is propagated as an error.
-func TestDeploySite_BuildMode_TransferFails(t *testing.T) {
-	callCount := 0
-	mockExec := &mockRunExecutor{
-		runFn: func(_ string) (string, error) { return "", nil },
+// TestDeploySite_BuildMode_ImageTransferFails verifies that a failure to
+// transfer the locally-built image is propagated as an error.
+func TestDeploySite_BuildMode_ImageTransferFails(t *testing.T) {
+	executor := &fakeExecutor{
+		transferFileErr: errors.New("rsync failed"),
 	}
-	// Fail on the second Transfer call (build context).
-	failingExec := &buildContextFailExecutor{
-		mockRunExecutor: mockExec,
-		failOnTransfer:  2,
-		transferErr:     errors.New("rsync failed"),
-		callCount:       &callCount,
-	}
-
 	generator := &fakeGenerator{}
-	svc := deployapp.NewService(failingExec, generator)
+
+	exporter := &fakeImageExporter{}
+	svc := deployapp.NewService(executor, generator).WithImageExporter(exporter)
 
 	cfg := multiappConfig()
 	cfg.App.Image = ""
@@ -832,10 +827,10 @@ func TestDeploySite_BuildMode_TransferFails(t *testing.T) {
 		GeneratedDir: t.TempDir(),
 	})
 	if err == nil {
-		t.Fatal("expected error when build context transfer fails")
+		t.Fatal("expected error when image transfer fails")
 	}
-	if !strings.Contains(err.Error(), "transferring app build context") {
-		t.Errorf("error should mention 'transferring app build context', got: %v", err)
+	if !strings.Contains(err.Error(), "transferring") {
+		t.Errorf("error should mention 'transferring', got: %v", err)
 	}
 }
 

--- a/internal/app/deploy/service.go
+++ b/internal/app/deploy/service.go
@@ -59,21 +59,6 @@ const (
 	defaultHealthPort = 8443
 )
 
-// buildContextExcludes is the list of rsync --exclude patterns used when
-// transferring the app build context to the remote host. These patterns
-// prevent the project's original files from overwriting the deploy bundle's
-// merged versions (e.g. the merged vibewarden.yaml with production TLS
-// settings must not be clobbered by the base config from the source tree).
-var buildContextExcludes = []string{
-	"vibewarden.yaml",
-	"vibewarden.*.yaml",
-	".vibewarden",
-	".credentials",
-	".env",
-	".env.template",
-	"docker-compose.yml",
-}
-
 // Service orchestrates the "vibew deploy" use case.
 // It generates runtime config, transfers files to the remote, starts Docker
 // Compose, and verifies the sidecar health endpoint.
@@ -210,32 +195,17 @@ func (s *Service) Deploy(ctx context.Context, cfg *config.Config, opts RunOption
 		return fmt.Errorf("transferring deploy bundle: %w", err)
 	}
 
-	// When app.build is set the image must be built on the remote host.
-	// Transfer the app source (the build context directory) so that
-	// `docker compose up --build` can build the image remotely.
-	//
-	// Use TransferExcluding to prevent the project's original config files
-	// (vibewarden.yaml, docker-compose.yml, etc.) from overwriting the
-	// merged bundle files that were already deployed in the previous step.
-	// This is critical when app.build is "." because the build context
-	// directory overlaps with the deploy bundle directory on the remote.
-	if cfg.App.Build != "" {
-		projectRoot := filepath.Dir(filepath.Clean(opts.ConfigPath))
-		buildContextLocal := filepath.Join(projectRoot, cfg.App.Build)
-		buildContextRemote := remoteDir + strings.TrimPrefix(strings.TrimSuffix(cfg.App.Build, "/"), "./") + "/"
-		fmt.Fprintf(out, "Transferring app build context (%s) to remote...\n", cfg.App.Build)
-		if err := s.executor.TransferExcluding(ctx, buildContextLocal, buildContextRemote, false, buildContextExcludes); err != nil {
-			return fmt.Errorf("transferring app build context: %w", err)
-		}
-	}
-
-	// Step 4: transfer local image if using a bare image name (no registry prefix)
-	// and an image exporter is configured.
-	// This must happen before docker compose up so the image is available on the
-	// remote daemon.
+	// Step 4: transfer local image.
+	// When app.build is set the image was built locally by `vibew build`.
+	// Derive the image name (projectName-app:latest) and transfer it via
+	// docker save/load. No source code is transferred to the server.
 	localImageTransferred := false
-	if cfg.App.Image != "" && isLocalImage(cfg.App.Image) && s.imageExporter != nil {
-		if err := s.transferLocalImage(ctx, cfg.App.Image, remoteDir, out); err != nil {
+	imageName := cfg.App.Image
+	if cfg.App.Build != "" {
+		imageName = cfg.ComposeProjectName() + "-app:latest"
+	}
+	if imageName != "" && isLocalImage(imageName) && s.imageExporter != nil {
+		if err := s.transferLocalImage(ctx, imageName, remoteDir, out); err != nil {
 			return fmt.Errorf("transferring local image: %w", err)
 		}
 		localImageTransferred = true
@@ -243,22 +213,13 @@ func (s *Service) Deploy(ctx context.Context, cfg *config.Config, opts RunOption
 
 	// Step 5: start Docker Compose on the remote.
 	// Always pull the latest sidecar image before starting, regardless of mode.
-	// In build mode the app image is built locally, but the sidecar image may be
-	// cached from an older version, so we explicitly pull it first.
 	fmt.Fprintln(out, "Pulling latest sidecar image on remote...")
 	pullSidecarCmd := fmt.Sprintf("cd %s && docker compose pull vibewarden", remoteDir)
 	if _, err := s.executor.Run(ctx, pullSidecarCmd); err != nil {
 		return fmt.Errorf("docker compose pull vibewarden: %w", err)
 	}
 
-	// When app.build is set, build the image remotely instead of pulling the app image.
-	if cfg.App.Build != "" {
-		fmt.Fprintln(out, "Building and starting services on remote...")
-		upCmd := fmt.Sprintf("cd %s && docker compose up -d --build --force-recreate", remoteDir)
-		if _, err := s.executor.Run(ctx, upCmd); err != nil {
-			return fmt.Errorf("docker compose up: %w", err)
-		}
-	} else if localImageTransferred {
+	if localImageTransferred {
 		// Local image was already transferred -- skip pulling and just start.
 		fmt.Fprintln(out, "Starting services on remote...")
 		upCmd := fmt.Sprintf("cd %s && docker compose up -d --force-recreate", remoteDir)

--- a/internal/app/deploy/service_test.go
+++ b/internal/app/deploy/service_test.go
@@ -114,6 +114,15 @@ func (f *fakeGenerator) Generate(_ context.Context, _ ports.GeneratorInput, _ st
 	return f.err
 }
 
+// fakeImageExporter is a test double for ports.ImageExporter.
+type fakeImageExporter struct {
+	err error
+}
+
+func (f *fakeImageExporter) Save(_ context.Context, _, _ string) error {
+	return f.err
+}
+
 // defaultConfig returns a minimal Config for testing.
 func defaultConfig() *config.Config {
 	return &config.Config{
@@ -740,8 +749,8 @@ func TestService_Deploy_ImageMode(t *testing.T) {
 }
 
 // TestService_Deploy_BuildMode verifies that when cfg.App.Build is set the
-// deploy flow transfers the build context and runs docker compose up -d --build
-// instead of docker compose pull && docker compose up -d.
+// deploy flow transfers the image (not source code) and runs docker compose
+// up -d without --build.
 func TestService_Deploy_BuildMode(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{}
@@ -759,49 +768,42 @@ func TestService_Deploy_BuildMode(t *testing.T) {
 		t.Fatalf("Deploy() unexpected error: %v", err)
 	}
 
-	// docker compose up -d --build must be called.
-	assertRunCalledContains(t, executor.runCalls, "docker compose up -d --build")
+	// docker compose up -d must be called (without --build).
+	assertRunCalledContains(t, executor.runCalls, "docker compose up -d")
 
-	// docker compose pull vibewarden (sidecar image refresh) must be called even
-	// in build mode, to ensure the sidecar is not running a stale cached image.
-	assertRunCalledContains(t, executor.runCalls, "docker compose pull vibewarden")
-
-	// But a full docker compose pull (all services) must NOT be called --
-	// only the targeted vibewarden pull should occur.
+	// --build must NOT appear -- image is pre-built and transferred.
 	for _, c := range executor.runCalls {
-		if c != "" && strings.Contains(c, "docker compose pull") && !strings.Contains(c, "pull vibewarden") {
-			t.Errorf("unexpected broad 'docker compose pull' in build mode, got run call: %q", c)
+		if strings.Contains(c, "--build") {
+			t.Errorf("did not expect --build flag in image transfer mode, got: %q", c)
 		}
 	}
 
-	// One Transfer call (bundle) + one TransferExcluding call (build context).
+	// docker compose pull vibewarden (sidecar image refresh) must be called.
+	assertRunCalledContains(t, executor.runCalls, "docker compose pull vibewarden")
+
+	// Only the bundle transfer is expected (one Transfer call).
 	if len(executor.transferCalls) != 1 {
 		t.Errorf("expected 1 Transfer call in build mode (bundle only), got %d: %v",
 			len(executor.transferCalls), executor.transferCalls)
 	}
-	if len(executor.transferExcludingCalls) != 1 {
-		t.Errorf("expected 1 TransferExcluding call in build mode (build context), got %d: %v",
+
+	// No TransferExcluding -- no source code transfer.
+	if len(executor.transferExcludingCalls) != 0 {
+		t.Errorf("expected 0 TransferExcluding calls in build mode, got %d: %v",
 			len(executor.transferExcludingCalls), executor.transferExcludingCalls)
 	}
 }
 
-// TestService_Deploy_BuildMode_TransferContextFails verifies that a failure to
-// transfer the app build context is propagated correctly.
-func TestService_Deploy_BuildMode_TransferContextFails(t *testing.T) {
-	callCount := 0
-	executor := &mockRunExecutor{
-		runFn: func(_ string) (string, error) { return "", nil },
+// TestService_Deploy_BuildMode_ImageTransferFails verifies that a failure to
+// transfer the locally-built image is propagated correctly.
+func TestService_Deploy_BuildMode_ImageTransferFails(t *testing.T) {
+	executor := &fakeExecutor{
+		transferFileErr: fmt.Errorf("rsync failed"),
 	}
-	// Wrap in a custom executor that fails on the second Transfer call (build context).
-	failingTransfer := &buildContextFailExecutor{
-		mockRunExecutor: executor,
-		failOnTransfer:  2,
-		transferErr:     fmt.Errorf("rsync failed"),
-		callCount:       &callCount,
-	}
-
 	generator := &fakeGenerator{}
-	svc := deployapp.NewService(failingTransfer, generator)
+
+	exporter := &fakeImageExporter{}
+	svc := deployapp.NewService(executor, generator).WithImageExporter(exporter)
 
 	cfg := defaultConfig()
 	cfg.App.Build = "."
@@ -811,45 +813,11 @@ func TestService_Deploy_BuildMode_TransferContextFails(t *testing.T) {
 		GeneratedDir: t.TempDir(),
 	})
 	if err == nil {
-		t.Fatal("expected error when build context transfer fails")
+		t.Fatal("expected error when image transfer fails")
 	}
-	if !strings.Contains(err.Error(), "transferring app build context") {
-		t.Errorf("error should mention 'transferring app build context', got: %v", err)
+	if !strings.Contains(err.Error(), "transferring") {
+		t.Errorf("error should mention 'transferring', got: %v", err)
 	}
-}
-
-// buildContextFailExecutor wraps mockRunExecutor and fails on the nth Transfer call.
-type buildContextFailExecutor struct {
-	*mockRunExecutor
-	failOnTransfer int
-	transferErr    error
-	callCount      *int
-}
-
-func (b *buildContextFailExecutor) Transfer(_ context.Context, localDir, remoteDir string, deleteExtra bool) error {
-	*b.callCount++
-	if *b.callCount == b.failOnTransfer {
-		return b.transferErr
-	}
-	b.transferCalls = append(b.transferCalls,
-		transferCall{localDir: localDir, remoteDir: remoteDir, deleteExtra: deleteExtra})
-	return nil
-}
-
-func (b *buildContextFailExecutor) TransferExcluding(_ context.Context, localDir, remoteDir string, deleteExtra bool, excludes []string) error {
-	*b.callCount++
-	if *b.callCount == b.failOnTransfer {
-		return b.transferErr
-	}
-	b.transferExcludingCalls = append(b.transferExcludingCalls,
-		transferExcludingCall{localDir: localDir, remoteDir: remoteDir, deleteExtra: deleteExtra, excludes: excludes})
-	return nil
-}
-
-func (b *buildContextFailExecutor) TransferFile(_ context.Context, localFile, remotePath string) error {
-	b.transferFileCalls = append(b.transferFileCalls,
-		transferFileCall{localFile: localFile, remotePath: remotePath})
-	return nil
 }
 
 // TestProjectNameFromConfig_Unit directly exercises ProjectNameFromConfig with
@@ -1139,10 +1107,10 @@ func TestService_LogsMultiApp_Error(t *testing.T) {
 // Ensure fmt is used (used in assertRunCalledContains via Errorf).
 var _ = fmt.Sprintf
 
-// TestService_Deploy_PullsSidecarBeforeBuild verifies that "docker compose pull
-// vibewarden" is always executed before starting services in build mode, so that
+// TestService_Deploy_PullsSidecarBeforeUp verifies that "docker compose pull
+// vibewarden" is always executed before starting services, so that
 // the sidecar image is never served from a stale Docker layer cache.
-func TestService_Deploy_PullsSidecarBeforeBuild(t *testing.T) {
+func TestService_Deploy_PullsSidecarBeforeUp(t *testing.T) {
 	executor := &fakeExecutor{}
 	generator := &fakeGenerator{}
 
@@ -1162,13 +1130,13 @@ func TestService_Deploy_PullsSidecarBeforeBuild(t *testing.T) {
 	// "docker compose pull vibewarden" must appear in run calls.
 	assertRunCalledContains(t, executor.runCalls, "docker compose pull vibewarden")
 
-	// Verify ordering: pull vibewarden must come before compose up --build.
+	// Verify ordering: pull vibewarden must come before compose up.
 	pullIdx, upIdx := -1, -1
 	for i, c := range executor.runCalls {
 		if strings.Contains(c, "docker compose pull vibewarden") && pullIdx == -1 {
 			pullIdx = i
 		}
-		if strings.Contains(c, "docker compose up -d --build") && upIdx == -1 {
+		if strings.Contains(c, "docker compose up -d") && upIdx == -1 {
 			upIdx = i
 		}
 	}
@@ -1176,10 +1144,10 @@ func TestService_Deploy_PullsSidecarBeforeBuild(t *testing.T) {
 		t.Error("'docker compose pull vibewarden' was not found in run calls")
 	}
 	if upIdx == -1 {
-		t.Error("'docker compose up -d --build' was not found in run calls")
+		t.Error("'docker compose up -d' was not found in run calls")
 	}
 	if pullIdx != -1 && upIdx != -1 && pullIdx >= upIdx {
-		t.Errorf("expected 'docker compose pull vibewarden' (call %d) before 'docker compose up -d --build' (call %d)", pullIdx, upIdx)
+		t.Errorf("expected 'docker compose pull vibewarden' (call %d) before 'docker compose up -d' (call %d)", pullIdx, upIdx)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -418,6 +418,12 @@ type AppConfig struct {
 	// Values: "go", "python", "typescript", "kotlin", or empty (auto-detect
 	// at init/wrap time; falls back to wget).
 	Language string `mapstructure:"language"`
+
+	// Environment is a map of custom environment variables injected into the
+	// app container in the generated Docker Compose file. Use this for runtime
+	// configuration (e.g. DATABASE_URL, API keys). Values are rendered as
+	// KEY=VALUE entries in the environment list of the app service.
+	Environment map[string]string `mapstructure:"environment"`
 }
 
 // TLSCertMonitoringConfig holds configuration for the certificate expiry monitor.

--- a/internal/config/templates/app-compose.yml.tmpl
+++ b/internal/config/templates/app-compose.yml.tmpl
@@ -15,6 +15,12 @@ services:
 {{- else if .AppImage }}
     image: {{ .AppImage }}
 {{- end }}
+{{- if len .AppEnvironment }}
+    environment:
+{{- range $key, $value := .AppEnvironment }}
+      - {{ $key }}={{ $value }}
+{{- end }}
+{{- end }}
 {{- if ne .AppHealthcheck "none" }}
     healthcheck:
       test:

--- a/internal/config/templates/docker-compose.yml.tmpl
+++ b/internal/config/templates/docker-compose.yml.tmpl
@@ -47,11 +47,16 @@ services:
 {{- end }}
     networks:
       - {{ .InternalNetworkName }}
-{{- if .Egress.Enabled }}
+{{- if or .Egress.Enabled (len .App.Environment) }}
     environment:
+{{- if .Egress.Enabled }}
       - HTTP_PROXY=http://vibewarden:{{ .Egress.ListenPort }}
       - HTTPS_PROXY=http://vibewarden:{{ .Egress.ListenPort }}
       - NO_PROXY={{ .EgressNoProxy }}
+{{- end }}
+{{- range $key, $value := .App.Environment }}
+      - {{ $key }}={{ $value }}
+{{- end }}
 {{- end }}
 {{- if ne .App.Healthcheck "none" }}
     healthcheck:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -178,6 +178,15 @@ Key commands:
 
 Full guide: https://vibewarden.dev/docs/multi-app/
 
+### Deploy model
+
+`vibew build` builds the Docker image locally from the app's Dockerfile.
+`vibew deploy` transfers the pre-built image to the server via
+`docker save | rsync | docker load`. No source code is ever sent to the
+production server -- the image must be production-ready.
+
+Use `app.environment` for runtime config (database URLs, API keys, etc.).
+
 ### deploy flags
 
 `vibew deploy` uses SSH to deploy the stack remotely. It reads both
@@ -229,6 +238,9 @@ Key sections:
 
 - `server.port` — port the sidecar listens on (default 8443)
 - `upstream.port` — port the upstream application listens on
+- `app.build` — Docker build context; `vibew build` builds locally, `vibew deploy` transfers the image (no source on server)
+- `app.image` — Docker image reference (used when `app.build` is empty)
+- `app.environment` — custom env vars injected into the app container (e.g. DATABASE_URL, REDIS_URL)
 - `tls.enabled`, `tls.provider` — TLS termination (letsencrypt, self-signed, external)
 - `auth.mode` — authentication strategy: `none`, `kratos`, `jwt`, or `api-key` (single source of truth; see ADR-065)
 - `rate_limit.enabled`, `rate_limit.per_ip` — per-IP rate limiting

--- a/vibewarden.reference.yaml
+++ b/vibewarden.reference.yaml
@@ -82,6 +82,39 @@ upstream:
   # Port of your application
   port: 3000
 
+# Application container configuration
+#
+# Controls how the app runs inside Docker Compose. `vibew build` builds
+# the image locally; `vibew deploy` transfers it via docker save/load
+# (no source code on the server). Use `environment` for runtime config
+# (database URLs, API keys, etc.) -- never bake secrets into the image.
+#
+# app:
+#   # Docker build context path (e.g., "." for the current directory).
+#   # When set, `vibew build` builds the image locally. `vibew deploy`
+#   # transfers the built image to the server, not the source code.
+#   build: "."
+#
+#   # Docker image reference. Default: derived from the project name.
+#   # For registry images, set to e.g. "ghcr.io/org/myapp:latest".
+#   image: "myapp:latest"
+#
+#   # Language/runtime for health check probe selection.
+#   # Values: "go", "python", "typescript", "kotlin", or empty (auto-detect).
+#   language: ""
+#
+#   # Custom Docker healthcheck command. Set to "none" to disable.
+#   healthcheck: ""
+#
+#   # Custom environment variables injected into the app container.
+#   # Use for runtime configuration (database URLs, feature flags, etc.).
+#   # Example:
+#   #   environment:
+#   #     DATABASE_URL: "postgres://user:pass@db:5432/myapp"
+#   #     REDIS_URL: "redis://redis:6379"
+#   #     LOG_LEVEL: "info"
+#   environment: {}
+
 # TLS configuration
 tls:
   # Enable TLS termination. Enabled by default — VibeWarden is secure by default.


### PR DESCRIPTION
## Summary

- **Image transfer instead of remote build**: When `app.build` is set, `vibew deploy` now transfers the locally-built image via `docker save | rsync | docker load` instead of rsyncing source code and building remotely. The deploy compose file uses `image:` instead of `build:`, and `--build` is never passed to `docker compose up` in deploy mode.
- **`app.environment` support**: New config field `app.environment` (map of key-value pairs) injects custom environment variables into the app container in both single-site and multi-site compose templates.
- **Documentation**: Updated AGENTS-VIBEWARDEN.md with deploy model and `docker-compose.override.yml` guidance. Updated `llms-full.txt` and `vibewarden.reference.yaml` with new config fields.

## Test plan

- [ ] `TestArtifact_DeployCompose_UsesImageNotBuild` -- verifies deploy compose uses `image:` not `build:` when `app.build` is set
- [ ] `TestArtifact_DeployCompose_HasImageNotBuild` -- verifies the derived image name `<project>-app:latest`
- [ ] `TestArtifact_BuildMode_TransfersImageNotSource` -- verifies no `TransferExcluding` for source code, no `--build` flag
- [ ] `TestArtifact_BuildMode_MultiApp_NoSourceTransfer` -- same for multi-app (BootstrapSidecar and DeployMultiApp)
- [ ] `TestArtifact_AppEnvironment_RendersInCompose` -- verifies environment vars reach the generator input
- [ ] `TestArtifact_AppEnvironment_RendersInAppCompose` -- verifies environment vars render in multi-site compose
- [ ] `TestService_Deploy_BuildMode` -- verifies no `--build` flag and no `TransferExcluding`
- [ ] `TestService_Deploy_BuildMode_ImageTransferFails` -- verifies image transfer error propagation
- [ ] `TestBundle_MultiSite_AppBuildUsesImage` -- verifies multi-site compose uses `image:` for build mode
- [ ] `TestDeploySite_BuildMode_NoBuildFlag` -- verifies no `--build` in multi-app deploy
- [ ] All existing tests updated to match new behavior; `make check` passes (golangci-lint, go test -race, go vet)

Generated with [Claude Code](https://claude.com/claude-code)