### PR TITLE
fix(#972,#974,#976): build --platform, persist certs, TLS alternatives + cert trust

### DIFF
--- a/cmd/vibewarden/wiring_serve_helpers.go
+++ b/cmd/vibewarden/wiring_serve_helpers.go
@@ -73,6 +73,7 @@ func buildProxyConfig(cfg *config.Config, registry *plugins.Registry, version st
 			CertPath:    cfg.TLS.CertPath,
 			KeyPath:     cfg.TLS.KeyPath,
 			StoragePath: cfg.TLS.StoragePath,
+			ACMECA:      cfg.TLS.ACMECA,
 		},
 		SecurityHeaders: ports.SecurityHeadersConfig{
 			Enabled:               cfg.SecurityHeaders.Enabled,

--- a/internal/adapters/caddy/config.go
+++ b/internal/adapters/caddy/config.go
@@ -447,13 +447,19 @@ func buildTLSApp(cfg ports.TLSConfig) (map[string]any, error) {
 // to reject the config with "unknown field: storage". Storage is set at the
 // top-level in BuildCaddyConfig when cfg.StoragePath is non-empty.
 func buildLetsEncryptTLSApp(cfg ports.TLSConfig) map[string]any {
+	acmeIssuer := map[string]any{
+		"module": "acme",
+	}
+	// When ACMECA is set, override the default ACME directory URL.
+	// This allows using Let's Encrypt staging, ZeroSSL, or any other
+	// ACME-compliant CA.
+	if cfg.ACMECA != "" {
+		acmeIssuer["ca"] = cfg.ACMECA
+	}
+
 	policy := map[string]any{
 		"subjects": []string{cfg.Domain},
-		"issuers": []map[string]any{
-			{
-				"module": "acme",
-			},
-		},
+		"issuers":  []map[string]any{acmeIssuer},
 	}
 
 	return map[string]any{

--- a/internal/adapters/caddy/config_test.go
+++ b/internal/adapters/caddy/config_test.go
@@ -487,6 +487,81 @@ func TestBuildCaddyConfig_LetsEncryptACMEIssuer(t *testing.T) {
 	}
 }
 
+// TestBuildCaddyConfig_LetsEncryptACMECA verifies that when ACMECA is set, the
+// ACME issuer includes a "ca" field pointing to the custom directory URL.
+func TestBuildCaddyConfig_LetsEncryptACMECA(t *testing.T) {
+	tests := []struct {
+		name   string
+		acmeCA string
+		wantCA bool
+	}{
+		{
+			name:   "default CA (empty)",
+			acmeCA: "",
+			wantCA: false,
+		},
+		{
+			name:   "staging CA",
+			acmeCA: "https://acme-staging-v02.api.letsencrypt.org/directory",
+			wantCA: true,
+		},
+		{
+			name:   "custom CA",
+			acmeCA: "https://acme.zerossl.com/v2/DV90",
+			wantCA: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &ports.ProxyConfig{
+				ListenAddr:   "0.0.0.0:443",
+				UpstreamAddr: "127.0.0.1:3000",
+				TLS: ports.TLSConfig{
+					Enabled:  true,
+					Provider: ports.TLSProviderLetsEncrypt,
+					Domain:   "example.com",
+					ACMECA:   tt.acmeCA,
+				},
+			}
+
+			result, err := BuildCaddyConfig(cfg)
+			if err != nil {
+				t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+			}
+
+			apps := result["apps"].(map[string]any)
+			tlsApp := apps["tls"].(map[string]any)
+			automation := tlsApp["automation"].(map[string]any)
+			policies := automation["policies"].([]map[string]any)
+
+			if len(policies) == 0 {
+				t.Fatal("expected at least one automation policy")
+			}
+
+			issuers, ok := policies[0]["issuers"].([]map[string]any)
+			if !ok || len(issuers) == 0 {
+				t.Fatal("issuers not found in automation policy")
+			}
+
+			acmeIssuer := issuers[0]
+			caVal, hasCA := acmeIssuer["ca"]
+
+			if tt.wantCA {
+				if !hasCA {
+					t.Errorf("expected 'ca' field in ACME issuer for acme_ca=%q", tt.acmeCA)
+				} else if caVal != tt.acmeCA {
+					t.Errorf("ca = %q, want %q", caVal, tt.acmeCA)
+				}
+			} else {
+				if hasCA {
+					t.Errorf("unexpected 'ca' field in ACME issuer when acme_ca is empty: %v", caVal)
+				}
+			}
+		})
+	}
+}
+
 // TestBuildCaddyConfig_StorageAtTopLevel verifies that when StoragePath is set,
 // the storage module appears at the top level of the Caddy config (not inside
 // apps.tls). Placing storage inside apps.tls causes Caddy to reject the config

--- a/internal/adapters/ops/build.go
+++ b/internal/adapters/ops/build.go
@@ -14,11 +14,15 @@ func NewBuildAdapter() *BuildAdapter {
 	return &BuildAdapter{}
 }
 
-// Build runs "docker build -t <tag> [--no-cache] <contextDir>".
+// Build runs "docker build -t <tag> [--platform <platform>] [--no-cache] <contextDir>".
 // Output from the command is streamed directly to stdout/stderr so the user
 // sees progress in real time.
-func (b *BuildAdapter) Build(ctx context.Context, tag string, contextDir string, noCache bool) error {
-	args := []string{"build", "-t", tag}
+func (b *BuildAdapter) Build(ctx context.Context, tag string, contextDir string, noCache bool, platform string) error {
+	args := []string{"build"}
+	if platform != "" {
+		args = append(args, "--platform", platform)
+	}
+	args = append(args, "-t", tag)
 	if noCache {
 		args = append(args, "--no-cache")
 	}

--- a/internal/adapters/ops/build_test.go
+++ b/internal/adapters/ops/build_test.go
@@ -19,7 +19,7 @@ func TestBuildAdapter_CancelledContextReturnsError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately so docker exits fast
 
-	err := adapter.Build(ctx, "test-image:latest", ".", false)
+	err := adapter.Build(ctx, "test-image:latest", ".", false, "")
 	if err == nil {
 		t.Fatal("expected an error because context was cancelled before run")
 	}
@@ -36,7 +36,7 @@ func TestBuildAdapter_CancelledContextNoCacheReturnsError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := adapter.Build(ctx, "test-image:latest", ".", true)
+	err := adapter.Build(ctx, "test-image:latest", ".", true, "")
 	if err == nil {
 		t.Fatal("expected an error because context was cancelled before run")
 	}
@@ -50,7 +50,7 @@ func TestBuildAdapter_ReturnsErrorWhenDockerMissing(t *testing.T) {
 	}
 
 	adapter := opsadapter.NewBuildAdapter()
-	err := adapter.Build(context.Background(), "test-image:latest", ".", false)
+	err := adapter.Build(context.Background(), "test-image:latest", ".", false, "")
 	if err == nil {
 		t.Fatal("expected an error when docker is not available")
 	}
@@ -64,6 +64,7 @@ func TestBuildArgsConstruction(t *testing.T) {
 		tag        string
 		contextDir string
 		noCache    bool
+		platform   string
 		wantArgs   []string
 	}{
 		{
@@ -87,11 +88,27 @@ func TestBuildArgsConstruction(t *testing.T) {
 			noCache:    false,
 			wantArgs:   []string{"build", "-t", "webapp:v2", "/home/user/project"},
 		},
+		{
+			name:       "build with platform",
+			tag:        "myapp:latest",
+			contextDir: ".",
+			noCache:    false,
+			platform:   "linux/amd64",
+			wantArgs:   []string{"build", "--platform", "linux/amd64", "-t", "myapp:latest", "."},
+		},
+		{
+			name:       "build with platform and no-cache",
+			tag:        "myapp:latest",
+			contextDir: ".",
+			noCache:    true,
+			platform:   "linux/arm64",
+			wantArgs:   []string{"build", "--platform", "linux/arm64", "-t", "myapp:latest", "--no-cache", "."},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildArgs(tt.tag, tt.contextDir, tt.noCache)
+			got := buildArgs(tt.tag, tt.contextDir, tt.noCache, tt.platform)
 			if len(got) != len(tt.wantArgs) {
 				t.Fatalf("len(args) = %d, want %d\ngot:  %v\nwant: %v",
 					len(got), len(tt.wantArgs), got, tt.wantArgs)
@@ -107,8 +124,12 @@ func TestBuildArgsConstruction(t *testing.T) {
 
 // buildArgs mirrors the logic in BuildAdapter.Build to allow table-driven
 // testing of the argument construction without executing docker.
-func buildArgs(tag, contextDir string, noCache bool) []string {
-	args := []string{"build", "-t", tag}
+func buildArgs(tag, contextDir string, noCache bool, platform string) []string {
+	args := []string{"build"}
+	if platform != "" {
+		args = append(args, "--platform", platform)
+	}
+	args = append(args, "-t", tag)
 	if noCache {
 		args = append(args, "--no-cache")
 	}

--- a/internal/app/ops/build.go
+++ b/internal/app/ops/build.go
@@ -39,6 +39,10 @@ type BuildOptions struct {
 	// NoCache passes --no-cache to docker build when true.
 	NoCache bool
 
+	// Platform specifies the target platform for the Docker build (e.g.
+	// "linux/amd64"). When empty, docker uses the local platform.
+	Platform string
+
 	// ConfigPath is the path to vibewarden.yaml. Empty means the default
 	// discovery logic (current directory) applies.
 	ConfigPath string
@@ -65,11 +69,14 @@ func (s *BuildService) Run(ctx context.Context, cfg *config.Config, opts BuildOp
 
 	fmt.Fprintf(out, "Building Docker image: %s\n", tag)
 	fmt.Fprintf(out, "Context: %s\n", workDir)
+	if opts.Platform != "" {
+		fmt.Fprintf(out, "Platform: %s\n", opts.Platform)
+	}
 	if opts.NoCache {
 		fmt.Fprintln(out, "Flags: --no-cache")
 	}
 
-	if err := s.builder.Build(ctx, tag, workDir, opts.NoCache); err != nil {
+	if err := s.builder.Build(ctx, tag, workDir, opts.NoCache, opts.Platform); err != nil {
 		return err
 	}
 

--- a/internal/app/ops/build_test.go
+++ b/internal/app/ops/build_test.go
@@ -13,16 +13,18 @@ import (
 
 // fakeBuilder is a test double for ports.DockerBuilder.
 type fakeBuilder struct {
-	err             error
-	capturedTag     string
-	capturedDir     string
-	capturedNoCache bool
+	err              error
+	capturedTag      string
+	capturedDir      string
+	capturedNoCache  bool
+	capturedPlatform string
 }
 
-func (f *fakeBuilder) Build(_ context.Context, tag string, contextDir string, noCache bool) error {
+func (f *fakeBuilder) Build(_ context.Context, tag string, contextDir string, noCache bool, platform string) error {
 	f.capturedTag = tag
 	f.capturedDir = contextDir
 	f.capturedNoCache = noCache
+	f.capturedPlatform = platform
 	return f.err
 }
 
@@ -193,6 +195,61 @@ func TestBuildService_Run_PassesWorkDirToBuilder(t *testing.T) {
 
 	if fb.capturedDir != dir {
 		t.Errorf("contextDir = %q, want %q", fb.capturedDir, dir)
+	}
+}
+
+func TestBuildService_Run_PassesPlatformToBuilder(t *testing.T) {
+	tests := []struct {
+		name     string
+		platform string
+	}{
+		{"empty platform", ""},
+		{"linux/amd64", "linux/amd64"},
+		{"linux/arm64", "linux/arm64"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fb := &fakeBuilder{}
+			svc := ops.NewBuildService(fb)
+
+			cfg := &config.Config{}
+			cfg.App.Image = "img:latest"
+
+			var out bytes.Buffer
+			err := svc.Run(context.Background(), cfg, ops.BuildOptions{
+				Platform: tt.platform,
+				WorkDir:  ".",
+			}, &out)
+			if err != nil {
+				t.Fatalf("Run() unexpected error: %v", err)
+			}
+
+			if fb.capturedPlatform != tt.platform {
+				t.Errorf("platform = %q, want %q", fb.capturedPlatform, tt.platform)
+			}
+		})
+	}
+}
+
+func TestBuildService_Run_PlatformPrintedInOutput(t *testing.T) {
+	fb := &fakeBuilder{}
+	svc := ops.NewBuildService(fb)
+
+	cfg := &config.Config{}
+	cfg.App.Image = "myapp:latest"
+
+	var out bytes.Buffer
+	err := svc.Run(context.Background(), cfg, ops.BuildOptions{
+		Platform: "linux/amd64",
+		WorkDir:  ".",
+	}, &out)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "linux/amd64") {
+		t.Errorf("output missing platform indication: %s", out.String())
 	}
 }
 

--- a/internal/cli/cmd/build.go
+++ b/internal/cli/cmd/build.go
@@ -18,6 +18,7 @@ import (
 func NewBuildCmd() *cobra.Command {
 	var (
 		noCache    bool
+		platform   string
 		configPath string
 	)
 
@@ -30,9 +31,13 @@ The image tag is resolved from vibewarden.yaml (app.image field). When
 vibewarden.yaml is absent or app.image is not set, the current directory
 name is used with the ":latest" suffix.
 
+Use --platform to cross-compile for a different target architecture (e.g.
+building on Apple Silicon for an amd64 server).
+
 Examples:
   vibew build
   vibew build --no-cache
+  vibew build --platform linux/amd64
   vibew build --config ./my-vibewarden.yaml`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg, err := config.Load(configPath)
@@ -47,6 +52,7 @@ Examples:
 
 			opts := opsapp.BuildOptions{
 				NoCache:    noCache,
+				Platform:   platform,
 				ConfigPath: configPath,
 			}
 
@@ -58,6 +64,7 @@ Examples:
 	}
 
 	cmd.Flags().BoolVar(&noCache, "no-cache", false, "do not use Docker layer cache (passes --no-cache to docker build)")
+	cmd.Flags().StringVar(&platform, "platform", "", "target platform for the build (e.g. linux/amd64)")
 	cmd.Flags().StringVar(&configPath, "config", "", "path to vibewarden.yaml (default: ./vibewarden.yaml)")
 
 	return cmd

--- a/internal/cli/cmd/build_test.go
+++ b/internal/cli/cmd/build_test.go
@@ -23,6 +23,9 @@ func TestNewBuildCmd_RegisteredOnRoot(t *testing.T) {
 	if buildCmd.Flags().Lookup("no-cache") == nil {
 		t.Error("expected --no-cache flag to be registered on 'build' command")
 	}
+	if buildCmd.Flags().Lookup("platform") == nil {
+		t.Error("expected --platform flag to be registered on 'build' command")
+	}
 	if buildCmd.Flags().Lookup("config") == nil {
 		t.Error("expected --config flag to be registered on 'build' command")
 	}
@@ -49,7 +52,7 @@ func TestNewBuildCmd_Help(t *testing.T) {
 	}
 
 	out := outBuf.String()
-	for _, want := range []string{"build", "no-cache", "config", "app.image"} {
+	for _, want := range []string{"build", "no-cache", "platform", "config", "app.image"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("help output missing %q\ngot:\n%s", want, out)
 		}
@@ -68,6 +71,20 @@ func TestNewBuildCmd_NoCacheFlag(t *testing.T) {
 	}
 	if f.DefValue != "false" {
 		t.Errorf("--no-cache default = %q, want %q", f.DefValue, "false")
+	}
+}
+
+// TestNewBuildCmd_PlatformFlagDefault verifies that --platform defaults to empty string.
+func TestNewBuildCmd_PlatformFlagDefault(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	buildCmd, _, _ := root.Find([]string{"build"})
+
+	f := buildCmd.Flags().Lookup("platform")
+	if f == nil {
+		t.Fatal("--platform flag not found")
+	}
+	if f.DefValue != "" {
+		t.Errorf("--platform default = %q, want empty string", f.DefValue)
 	}
 }
 

--- a/internal/cli/cmd/cert.go
+++ b/internal/cli/cmd/cert.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 
@@ -25,7 +26,8 @@ func NewCertCmd() *cobra.Command {
 Examples:
   vibew cert export
   vibew cert export > vibewarden-ca.pem
-  vibew cert export --path`,
+  vibew cert export --path
+  vibew cert trust`,
 		// Default: print help when no subcommand is given.
 		Run: func(cmd *cobra.Command, _ []string) {
 			cmd.Help() //nolint:errcheck
@@ -33,6 +35,7 @@ Examples:
 	}
 
 	cmd.AddCommand(newCertExportCmd())
+	cmd.AddCommand(newCertTrustCmd())
 
 	return cmd
 }
@@ -169,4 +172,121 @@ func caddyUserDataDir() string {
 		}
 		return filepath.Join(home, ".local", "share", "caddy")
 	}
+}
+
+// newCertTrustCmd creates the "vibew cert trust" subcommand.
+//
+// It locates Caddy's local CA root certificate, copies it to the OS trust
+// store, and runs the platform-specific command to make the OS trust it.
+//
+// macOS: security add-trusted-cert
+// Linux: copy to /usr/local/share/ca-certificates/ + update-ca-certificates
+func newCertTrustCmd() *cobra.Command {
+	var certPathFlag string
+
+	cmd := &cobra.Command{
+		Use:   "trust",
+		Short: "Install the local CA certificate into the OS trust store",
+		Long: `Export Caddy's local CA root certificate and install it into the
+operating system trust store so that browsers and other tools trust
+VibeWarden's self-signed certificates without warnings.
+
+This command requires elevated privileges (sudo on Linux).
+
+Supported platforms:
+  macOS:  Adds the certificate to the System keychain via "security add-trusted-cert".
+  Linux:  Copies the certificate to /usr/local/share/ca-certificates/ and
+          runs "update-ca-certificates".
+
+Examples:
+  vibew cert trust
+  vibew cert trust --cert-path /path/to/root.crt`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var certPath string
+			if certPathFlag != "" {
+				if _, err := os.Stat(certPathFlag); err != nil {
+					return fmt.Errorf(
+						"certificate not found at %s: start the VibeWarden sidecar first",
+						certPathFlag,
+					)
+				}
+				certPath = certPathFlag
+			} else {
+				var err error
+				certPath, err = findCaddyLocalCACert()
+				if err != nil {
+					return err
+				}
+			}
+
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "Installing certificate: %s\n", certPath)
+
+			if err := installCertToTrustStore(cmd, certPath); err != nil {
+				return fmt.Errorf("installing certificate: %w", err)
+			}
+
+			fmt.Fprintln(out, "Certificate installed successfully.")
+			fmt.Fprintln(out, "You may need to restart your browser for changes to take effect.")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&certPathFlag, "cert-path", "", "override the automatic certificate path discovery")
+
+	return cmd
+}
+
+// installCertToTrustStore installs the given PEM certificate file into the
+// operating system trust store. The implementation is platform-specific.
+func installCertToTrustStore(cmd *cobra.Command, certPath string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return installCertDarwin(cmd, certPath)
+	case "linux":
+		return installCertLinux(cmd, certPath)
+	default:
+		return fmt.Errorf("unsupported platform %q; manually import %s into your trust store", runtime.GOOS, certPath)
+	}
+}
+
+// installCertDarwin installs a certificate into the macOS System keychain.
+func installCertDarwin(cmd *cobra.Command, certPath string) error {
+	fmt.Fprintln(cmd.OutOrStdout(), "Adding certificate to macOS System keychain...")
+	//nolint:gosec // certPath is validated above; "security" is a macOS system binary
+	c := exec.CommandContext(cmd.Context(), "sudo", "security", "add-trusted-cert",
+		"-d", "-r", "trustRoot",
+		"-k", "/Library/Keychains/System.keychain",
+		certPath,
+	)
+	c.Stdout = cmd.OutOrStdout()
+	c.Stderr = cmd.ErrOrStderr()
+	c.Stdin = os.Stdin // allow sudo password prompt
+	return c.Run()
+}
+
+// installCertLinux copies the certificate to the system CA directory and runs
+// update-ca-certificates.
+func installCertLinux(cmd *cobra.Command, certPath string) error {
+	const destDir = "/usr/local/share/ca-certificates"
+	destPath := filepath.Join(destDir, "vibewarden-local-ca.crt")
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Copying certificate to %s...\n", destPath)
+
+	//nolint:gosec // certPath is validated above; "sudo" + "cp" are standard system binaries
+	cpCmd := exec.CommandContext(cmd.Context(), "sudo", "cp", certPath, destPath)
+	cpCmd.Stdout = cmd.OutOrStdout()
+	cpCmd.Stderr = cmd.ErrOrStderr()
+	cpCmd.Stdin = os.Stdin
+	if err := cpCmd.Run(); err != nil {
+		return fmt.Errorf("copying certificate to %s: %w", destPath, err)
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), "Updating CA certificates...")
+	//nolint:gosec // "sudo" + "update-ca-certificates" are standard system binaries
+	updateCmd := exec.CommandContext(cmd.Context(), "sudo", "update-ca-certificates")
+	updateCmd.Stdout = cmd.OutOrStdout()
+	updateCmd.Stderr = cmd.ErrOrStderr()
+	updateCmd.Stdin = os.Stdin
+	return updateCmd.Run()
 }

--- a/internal/cli/cmd/cert_test.go
+++ b/internal/cli/cmd/cert_test.go
@@ -100,4 +100,56 @@ func TestCertCmd_HelpWhenNoSubcommand(t *testing.T) {
 	if !strings.Contains(out, "export") {
 		t.Errorf("help output does not mention 'export', got: %q", out)
 	}
+	if !strings.Contains(out, "trust") {
+		t.Errorf("help output does not mention 'trust', got: %q", out)
+	}
+}
+
+func TestCertTrust_Registered(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	trustCmd, _, err := root.Find([]string{"cert", "trust"})
+	if err != nil {
+		t.Fatalf("Find(cert trust) error: %v", err)
+	}
+	if trustCmd == nil || trustCmd.Use != "trust" {
+		t.Fatal("expected 'trust' subcommand to be registered on 'cert'")
+	}
+}
+
+func TestCertTrust_CertPathFlag(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	trustCmd, _, _ := root.Find([]string{"cert", "trust"})
+	if trustCmd.Flags().Lookup("cert-path") == nil {
+		t.Error("expected --cert-path flag on 'cert trust' command")
+	}
+}
+
+func TestCertTrust_NotFound(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var errBuf bytes.Buffer
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"cert", "trust", "--cert-path", "/nonexistent/path/root.crt"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute() expected error for missing cert, got nil")
+	}
+}
+
+func TestCertTrust_HelpContainsExpectedContent(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var outBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetArgs([]string{"cert", "trust", "--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	out := outBuf.String()
+	for _, want := range []string{"trust", "macOS", "Linux", "update-ca-certificates"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("help output missing %q, got: %q", want, out)
+		}
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -455,6 +455,10 @@ type TLSConfig struct {
 	// StoragePath is the directory where Caddy stores ACME certificates.
 	// Only applies when Provider is "letsencrypt".
 	StoragePath string `mapstructure:"storage_path"`
+	// ACMECA is the ACME directory URL to use instead of Let's Encrypt production.
+	// Only applies when Provider is "letsencrypt".
+	// Example: "https://acme-staging-v02.api.letsencrypt.org/directory"
+	ACMECA string `mapstructure:"acme_ca"`
 	// CertMonitoring holds configuration for the background certificate expiry monitor.
 	CertMonitoring TLSCertMonitoringConfig `mapstructure:"cert_monitoring"`
 }

--- a/internal/config/templates/docker-compose.yml.tmpl
+++ b/internal/config/templates/docker-compose.yml.tmpl
@@ -450,6 +450,9 @@ volumes:
 {{- end }}
 {{- if .TLS.Enabled }}
   vibewarden-data:
+    # Named volume persists TLS certificates across deploys.
+    # Never use "docker compose down -v" in production — it deletes certs
+    # and may trigger ACME rate limits on re-issuance.
 {{- end }}
 {{- if and (eq .RateLimit.Store "redis") (not (.RateLimit.Redis.HasExternalURL)) }}
   redis-data:

--- a/internal/config/templates/sidecar-compose.yml.tmpl
+++ b/internal/config/templates/sidecar-compose.yml.tmpl
@@ -30,3 +30,6 @@ networks:
 
 volumes:
   vibewarden-data:
+    # Named volume persists Let's Encrypt certificates across deploys.
+    # Never use "docker compose down -v" in production — it deletes certs
+    # and may trigger ACME rate limits on re-issuance.

--- a/internal/ports/ops.go
+++ b/internal/ports/ops.go
@@ -56,9 +56,10 @@ type ComposeRunner interface {
 type DockerBuilder interface {
 	// Build runs "docker build -t <tag> <contextDir>".
 	// When noCache is true the --no-cache flag is passed to docker build.
+	// When platform is non-empty it is passed as --platform (e.g. "linux/amd64").
 	// Output from the command is streamed to stdout/stderr so the user sees
 	// progress in real time.
-	Build(ctx context.Context, tag string, contextDir string, noCache bool) error
+	Build(ctx context.Context, tag string, contextDir string, noCache bool, platform string) error
 }
 
 // HealthChecker performs HTTP health checks against VibeWarden endpoints.

--- a/internal/ports/proxy.go
+++ b/internal/ports/proxy.go
@@ -331,6 +331,12 @@ type TLSConfig struct {
 	// Uses the Caddy default when empty (applicable to TLSProviderLetsEncrypt only).
 	StoragePath string
 
+	// ACMECA is the ACME directory URL to use instead of the default
+	// (Let's Encrypt production). Only applicable when Provider is
+	// TLSProviderLetsEncrypt.
+	// Example: "https://acme-staging-v02.api.letsencrypt.org/directory"
+	ACMECA string
+
 	// CertMonitoring holds configuration for the background certificate
 	// expiry monitor. The monitor is only active when TLS is enabled.
 	CertMonitoring TLSCertMonitoringConfig

--- a/vibewarden.reference.yaml
+++ b/vibewarden.reference.yaml
@@ -152,6 +152,13 @@ tls:
   # Only applies when provider is "letsencrypt".
   storage_path: ""
 
+  # ACME directory URL to use instead of Let's Encrypt production.
+  # Only applies when provider is "letsencrypt".
+  # Use the staging URL for testing to avoid rate limits:
+  #   acme_ca: "https://acme-staging-v02.api.letsencrypt.org/directory"
+  # Other ACME CAs (ZeroSSL, Buypass, etc.) are also supported.
+  acme_ca: ""
+
 # Ory Kratos (identity/auth) settings
 kratos:
   # Kratos public API (user-facing flows). When set, VibeWarden automatically:


### PR DESCRIPTION
Closes #972, #974, #976

## Summary

- **#972 -- build --platform**: Added `--platform` flag to `vibew build` (e.g. `vibew build --platform linux/amd64`) for cross-platform Docker builds. The flag propagates through the `DockerBuilder` port, adapter, and application service.
- **#974 -- persist certs**: Confirmed the deploy code already preserves volumes (uses `docker compose up -d --force-recreate`, never `docker compose down -v`). Added explicit warning comments to the named `vibewarden-data` volume in both compose templates to prevent accidental cert deletion.
- **#976 -- TLS alternatives + cert trust**: Added `tls.acme_ca` config field to override the ACME directory URL (enables Let's Encrypt staging, ZeroSSL, Buypass, etc.). Added `vibew cert trust` command that installs Caddy's local CA root certificate into the OS trust store (macOS System keychain / Linux update-ca-certificates).

## Test plan

- [ ] `vibew build --platform linux/amd64` passes `--platform` to `docker build`
- [ ] `vibew build` without `--platform` omits the flag (backward compatible)
- [ ] `vibew cert trust --cert-path <path>` attempts OS trust store installation
- [ ] `vibew cert trust --help` shows macOS and Linux instructions
- [ ] `tls.acme_ca` set in config produces `"ca"` field in Caddy ACME issuer JSON
- [ ] `tls.acme_ca` empty produces no `"ca"` field (default Let's Encrypt production)
- [ ] `make check` passes (golangci-lint, build, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)