### PR TITLE
fix(#973,#977-979): absolute build context, Kratos public paths, image naming, auth flow fixes

### DIFF
--- a/examples/demo-app/static/login.html
+++ b/examples/demo-app/static/login.html
@@ -272,7 +272,7 @@
 
       // Submit button.
       if (attrs.type === 'submit') {
-        return '<button type="submit" class="btn-primary">' + escapeHtml((node.meta && node.meta.label && node.meta.label.text) || 'Submit') + '</button>';
+        return '<button type="submit" class="btn-primary" name="' + escapeHtml(attrs.name || '') + '" value="' + escapeHtml(attrs.value || '') + '">' + escapeHtml((node.meta && node.meta.label && node.meta.label.text) || 'Submit') + '</button>';
       }
 
       // Other inputs (email, password, text).

--- a/examples/demo-app/static/register.html
+++ b/examples/demo-app/static/register.html
@@ -257,7 +257,7 @@
       }
 
       if (attrs.type === 'submit') {
-        return '<button type="submit" class="btn-primary">' + escapeHtml((node.meta && node.meta.label && node.meta.label.text) || 'Submit') + '</button>';
+        return '<button type="submit" class="btn-primary" name="' + escapeHtml(attrs.name || '') + '" value="' + escapeHtml(attrs.value || '') + '">' + escapeHtml((node.meta && node.meta.label && node.meta.label.text) || 'Submit') + '</button>';
       }
 
       var labelText = (node.meta && node.meta.label && node.meta.label.text) || attrs.name;

--- a/internal/adapters/caddy/auth_handler.go
+++ b/internal/adapters/caddy/auth_handler.go
@@ -58,11 +58,52 @@ func (AuthHandler) CaddyModule() gocaddy.ModuleInfo {
 	}
 }
 
+// kratosDefaultPublicPaths contains the URL path patterns that must be
+// exempted from authentication when auth.mode is "kratos". These paths
+// cover the Kratos self-service browser flows, auth UI routes, the whoami
+// endpoint, and error pages. They are automatically appended in Provision()
+// so the user does not need to list them in auth.public_paths.
+var kratosDefaultPublicPaths = []string{
+	"/auth/*",
+	"/self-service/*",
+	"/login",
+	"/registration",
+	"/recovery",
+	"/verification",
+	"/error",
+	"/sessions/whoami",
+}
+
 // Provision sets up the handler.
 func (h *AuthHandler) Provision(_ gocaddy.Context) error {
 	h.logger = slog.Default()
 	h.client = &http.Client{Timeout: 5 * time.Second}
+
+	// When a KratosURL is configured, automatically append the default Kratos
+	// public paths so that auth flows and UI routes are never blocked by the
+	// authentication check.
+	if h.Config.KratosURL != "" {
+		h.Config.PublicPaths = appendKratosPublicPaths(h.Config.PublicPaths)
+	}
+
 	return nil
+}
+
+// appendKratosPublicPaths appends kratosDefaultPublicPaths to the given paths,
+// skipping any entries that are already present.
+func appendKratosPublicPaths(existing []string) []string {
+	set := make(map[string]bool, len(existing))
+	for _, p := range existing {
+		set[p] = true
+	}
+	result := make([]string, len(existing))
+	copy(result, existing)
+	for _, p := range kratosDefaultPublicPaths {
+		if !set[p] {
+			result = append(result, p)
+		}
+	}
+	return result
 }
 
 // UnmarshalJSON implements custom unmarshalling to support both nested

--- a/internal/adapters/caddy/auth_handler_test.go
+++ b/internal/adapters/caddy/auth_handler_test.go
@@ -542,6 +542,129 @@ func TestAuthHandler_ServeHTTP_ForwardsCookieToKratos(t *testing.T) {
 	}
 }
 
+// TestAuthHandler_Provision_AppendKratosPublicPaths verifies that Provision
+// automatically appends kratosDefaultPublicPaths when KratosURL is set, and
+// does not duplicate paths that are already present.
+//
+// Regression test for #977 and #978.
+func TestAuthHandler_Provision_AppendKratosPublicPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		kratosURL  string
+		initial    []string
+		wantPaths  []string
+		wantAbsent []string
+	}{
+		{
+			name:      "appends all default paths when none present",
+			kratosURL: "http://kratos:4433",
+			initial:   []string{"/_vibewarden/*"},
+			wantPaths: []string{
+				"/_vibewarden/*",
+				"/auth/*",
+				"/self-service/*",
+				"/login",
+				"/registration",
+				"/recovery",
+				"/verification",
+				"/error",
+				"/sessions/whoami",
+			},
+		},
+		{
+			name:      "does not duplicate existing paths",
+			kratosURL: "http://kratos:4433",
+			initial:   []string{"/auth/*", "/self-service/*"},
+			wantPaths: []string{
+				"/auth/*",
+				"/self-service/*",
+				"/login",
+				"/registration",
+				"/recovery",
+				"/verification",
+				"/error",
+				"/sessions/whoami",
+			},
+		},
+		{
+			name:       "no append when KratosURL is empty",
+			kratosURL:  "",
+			initial:    []string{"/_vibewarden/*"},
+			wantPaths:  []string{"/_vibewarden/*"},
+			wantAbsent: []string{"/auth/*", "/self-service/*"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &AuthHandler{Config: AuthHandlerConfig{
+				CookieName:  "ory_kratos_session",
+				LoginURL:    "/login",
+				KratosURL:   tt.kratosURL,
+				PublicPaths: tt.initial,
+			}}
+
+			err := h.Provision(gocaddy.Context{})
+			if err != nil {
+				t.Fatalf("Provision() error = %v", err)
+			}
+
+			pathSet := make(map[string]bool)
+			for _, p := range h.Config.PublicPaths {
+				pathSet[p] = true
+			}
+
+			for _, want := range tt.wantPaths {
+				if !pathSet[want] {
+					t.Errorf("PublicPaths missing %q, got %v", want, h.Config.PublicPaths)
+				}
+			}
+
+			for _, absent := range tt.wantAbsent {
+				if pathSet[absent] {
+					t.Errorf("PublicPaths should not contain %q, got %v", absent, h.Config.PublicPaths)
+				}
+			}
+		})
+	}
+}
+
+// TestAuthHandler_Provision_KratosPathsBypass verifies that after Provision
+// the automatically-added Kratos paths bypass authentication.
+//
+// Regression test for #978.
+func TestAuthHandler_Provision_KratosPathsBypass(t *testing.T) {
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName: "ory_kratos_session",
+		LoginURL:   "/login",
+		KratosURL:  "http://kratos:4433",
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	bypassPaths := []string{
+		"/auth/login",
+		"/auth/registration",
+		"/self-service/login/browser",
+		"/self-service/registration/flows",
+		"/login",
+		"/registration",
+		"/recovery",
+		"/verification",
+		"/error",
+		"/sessions/whoami",
+	}
+
+	for _, p := range bypassPaths {
+		t.Run(p, func(t *testing.T) {
+			if !h.isPublicPath(p) {
+				t.Errorf("isPublicPath(%q) = false after Provision(), want true", p)
+			}
+		})
+	}
+}
+
 // TestAuthHandler_ServeHTTP_KratosServerError verifies redirect when Kratos
 // returns a 5xx error.
 func TestAuthHandler_ServeHTTP_KratosServerError(t *testing.T) {

--- a/internal/adapters/caddy/config_routes.go
+++ b/internal/adapters/caddy/config_routes.go
@@ -9,13 +9,20 @@ import (
 // the Kratos public API instead of the upstream application.
 // These paths are the Kratos self-service browser flows and the Ory canonical prefix.
 var kratosFlowPaths = []string{
+	"/self-service/login",
 	"/self-service/login/*",
+	"/self-service/registration",
 	"/self-service/registration/*",
+	"/self-service/logout",
 	"/self-service/logout/*",
+	"/self-service/settings",
 	"/self-service/settings/*",
+	"/self-service/recovery",
 	"/self-service/recovery/*",
+	"/self-service/verification",
 	"/self-service/verification/*",
 	"/.ory/kratos/public/*",
+	"/sessions/whoami",
 }
 
 // buildKratosFlowRoute constructs a Caddy route that transparently proxies all

--- a/internal/app/deploy/bundle.go
+++ b/internal/app/deploy/bundle.go
@@ -104,8 +104,8 @@ func (s *Service) bundleSingleSite(ctx context.Context, cfg *config.Config, conf
 	// Resolve upstream.host on the merged Config for template rendering.
 	resolved := ResolveProdConfig(mergedCfg, projectName, false)
 
-	// Set deploy mode so the template uses build context paths relative to
-	// the deploy bundle directory (e.g. "." instead of "../../.").
+	// Set deploy mode so the template uses the original App.Build value as
+	// the build context (e.g. ".") instead of the resolved ProjectRoot.
 	resolved.DeployMode = true
 
 	// When app.build is set, the image is built locally by `vibew build` and

--- a/internal/app/generate/service.go
+++ b/internal/app/generate/service.go
@@ -16,6 +16,24 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
+// resolveProjectRoot returns the absolute path to the project root directory.
+// When configSourcePath is set, the project root is the directory containing
+// the config file. Otherwise, the current working directory is used.
+func resolveProjectRoot(configSourcePath string) (string, error) {
+	if configSourcePath != "" {
+		abs, err := filepath.Abs(configSourcePath)
+		if err != nil {
+			return "", fmt.Errorf("resolving config source path: %w", err)
+		}
+		return filepath.Dir(abs), nil
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolving working directory: %w", err)
+	}
+	return wd, nil
+}
+
 const defaultOutputDir = ".vibewarden/generated"
 
 // File permission constants used throughout this package.
@@ -96,6 +114,16 @@ func (s *Service) Generate(ctx context.Context, input ports.GeneratorInput, outp
 
 	// Sanitise the caller-supplied output directory to prevent path traversal.
 	outputDir = filepath.Clean(outputDir)
+
+	// Resolve the project root so that the docker-compose.yml template can use
+	// an absolute build context path instead of fragile relative paths.
+	if cfg.ProjectRoot == "" {
+		root, err := resolveProjectRoot(s.configSourcePath)
+		if err != nil {
+			return fmt.Errorf("resolving project root: %w", err)
+		}
+		cfg.ProjectRoot = root
+	}
 
 	// Warn when prod profile is used without secrets enabled.
 	// OpenBao is strongly recommended for production but is no longer mandatory

--- a/internal/app/generate/service_integration_test.go
+++ b/internal/app/generate/service_integration_test.go
@@ -290,3 +290,150 @@ func TestGenerate_Integration_KratosOIDCRendering(t *testing.T) {
 		})
 	}
 }
+
+// TestGenerate_Integration_KratosBaseURL verifies that the generated
+// kratos.yml uses the sidecar's public URL (http[s]://localhost:<port>) as
+// serve.public.base_url instead of the internal Docker hostname, because
+// browsers need to reach the sidecar, not the internal Kratos container.
+//
+// Regression test for #977.
+func TestGenerate_Integration_KratosBaseURL(t *testing.T) {
+	renderer := template.NewRenderer(templates.FS)
+	svc := generate.NewService(renderer)
+
+	tests := []struct {
+		name        string
+		tlsEnabled  bool
+		serverPort  int
+		wantBaseURL string
+		wantAbsent  string
+	}{
+		{
+			name:        "HTTP mode uses http://localhost:<port>",
+			tlsEnabled:  false,
+			serverPort:  8080,
+			wantBaseURL: "base_url: http://localhost:8080",
+			wantAbsent:  "base_url: http://127.0.0.1:4433",
+		},
+		{
+			name:        "TLS mode uses https://localhost:<port>",
+			tlsEnabled:  true,
+			serverPort:  8443,
+			wantBaseURL: "base_url: https://localhost:8443",
+			wantAbsent:  "base_url: http://127.0.0.1:4433",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputDir := t.TempDir()
+			cfg := minimalConfig()
+			cfg.TLS.Enabled = tt.tlsEnabled
+			cfg.Server.Port = tt.serverPort
+
+			if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
+				t.Fatalf("Generate() unexpected error: %v", err)
+			}
+
+			kratosYML := filepath.Join(outputDir, "kratos", "kratos.yml")
+			data, err := os.ReadFile(kratosYML)
+			if err != nil {
+				t.Fatalf("reading kratos.yml: %v", err)
+			}
+
+			if !bytes.Contains(data, []byte(tt.wantBaseURL)) {
+				t.Errorf("kratos.yml missing expected base_url %q\n--- content ---\n%s", tt.wantBaseURL, data)
+			}
+			if bytes.Contains(data, []byte(tt.wantAbsent)) {
+				t.Errorf("kratos.yml contains unexpected base_url %q\n--- content ---\n%s", tt.wantAbsent, data)
+			}
+		})
+	}
+}
+
+// TestGenerate_Integration_KratosUIUrlsUseAuthPrefix verifies that the
+// generated kratos.yml uses /auth/ prefix for all ui_url entries so that
+// Kratos redirects to the sidecar's auth UI routes.
+//
+// Regression test for #977.
+func TestGenerate_Integration_KratosUIUrlsUseAuthPrefix(t *testing.T) {
+	renderer := template.NewRenderer(templates.FS)
+	svc := generate.NewService(renderer)
+
+	outputDir := t.TempDir()
+	cfg := minimalConfig()
+	cfg.Server.Port = 8080
+
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
+		t.Fatalf("Generate() unexpected error: %v", err)
+	}
+
+	kratosYML := filepath.Join(outputDir, "kratos", "kratos.yml")
+	data, err := os.ReadFile(kratosYML)
+	if err != nil {
+		t.Fatalf("reading kratos.yml: %v", err)
+	}
+
+	wantPaths := []string{
+		"ui_url: http://localhost:8080/auth/error",
+		"ui_url: http://localhost:8080/auth/settings",
+		"ui_url: http://localhost:8080/auth/recovery",
+		"ui_url: http://localhost:8080/auth/verification",
+		"ui_url: http://localhost:8080/auth/login",
+		"ui_url: http://localhost:8080/auth/registration",
+		"default_browser_return_url: http://localhost:8080/auth/login",
+	}
+
+	for _, want := range wantPaths {
+		if !bytes.Contains(data, []byte(want)) {
+			t.Errorf("kratos.yml missing expected path %q\n--- content ---\n%s", want, data)
+		}
+	}
+
+	// Ensure old paths without /auth/ prefix are NOT present.
+	unwantedPaths := []string{
+		"ui_url: http://localhost:8080/login",
+		"ui_url: http://localhost:8080/registration",
+		"ui_url: http://localhost:8080/recovery",
+		"ui_url: http://localhost:8080/verification",
+		"ui_url: http://localhost:8080/error\n",
+		"ui_url: http://localhost:8080/settings",
+	}
+
+	for _, unwanted := range unwantedPaths {
+		if bytes.Contains(data, []byte(unwanted)) {
+			t.Errorf("kratos.yml contains old path without /auth/ prefix: %q\n--- content ---\n%s", unwanted, data)
+		}
+	}
+}
+
+// TestGenerate_Integration_ComposeBuildContextIsAbsolutePath verifies that the
+// generated docker-compose.yml uses an absolute path for the build context
+// instead of fragile relative paths like "../../.".
+//
+// Regression test for #979.
+func TestGenerate_Integration_ComposeBuildContextIsAbsolutePath(t *testing.T) {
+	renderer := template.NewRenderer(templates.FS)
+	svc := generate.NewService(renderer)
+
+	outputDir := t.TempDir()
+	cfg := minimalConfig()
+	cfg.App.Build = "."
+
+	if err := svc.Generate(context.Background(), cfg.ToGeneratorInput(), outputDir); err != nil {
+		t.Fatalf("Generate() unexpected error: %v", err)
+	}
+
+	composePath := filepath.Join(outputDir, "docker-compose.yml")
+	data, err := os.ReadFile(composePath)
+	if err != nil {
+		t.Fatalf("reading docker-compose.yml: %v", err)
+	}
+
+	if bytes.Contains(data, []byte("context: ../../")) {
+		t.Error("docker-compose.yml must not use relative '../../' build context")
+	}
+	if !bytes.Contains(data, []byte("context: /")) {
+		t.Error("docker-compose.yml build context should be an absolute path starting with '/'")
+	}
+}

--- a/internal/app/generate/service_test.go
+++ b/internal/app/generate/service_test.go
@@ -599,13 +599,17 @@ func TestGenerate_AppService_BothSet_BuildTakesPrecedence(t *testing.T) {
 	if !bytes.Contains(compose, []byte("build:")) {
 		t.Error("expected 'build:' directive when both build and image are set")
 	}
-	// The build context should be an absolute path (ProjectRoot), not a
+	// The build context should be an absolute path (ProjectRoot/src), not a
 	// relative "../.././src" prefix.
 	if bytes.Contains(compose, []byte("context: ../../")) {
 		t.Error("build context must be an absolute path, not relative '../../'")
 	}
 	if !bytes.Contains(compose, []byte("context: /")) {
 		t.Error("expected build context to be an absolute path starting with '/'")
+	}
+	// The subdirectory "src" must be preserved in the build context path.
+	if !bytes.Contains(compose, []byte("/src")) {
+		t.Error("build context must include the 'src' subdirectory from App.Build")
 	}
 	// image: for the app service must not appear when build takes precedence.
 	// Note: "image:" still appears in vibewarden service itself so we check

--- a/internal/app/generate/service_test.go
+++ b/internal/app/generate/service_test.go
@@ -563,8 +563,14 @@ func TestGenerate_AppService_BuildMode(t *testing.T) {
 	if !bytes.Contains(compose, []byte("build:")) {
 		t.Error("expected 'build:' directive")
 	}
-	if !bytes.Contains(compose, []byte("context: ../../.")) {
-		t.Error("expected 'context: ../../.' (build path prefixed with ../../ for compose-file-relative resolution)")
+	// The build context should be an absolute path (ProjectRoot), not a
+	// relative "../../." prefix. The absolute path is resolved from cwd at
+	// generation time.
+	if bytes.Contains(compose, []byte("context: ../../.")) {
+		t.Error("build context must be an absolute path, not relative '../../.'")
+	}
+	if !bytes.Contains(compose, []byte("context: /")) {
+		t.Error("expected build context to be an absolute path starting with '/'")
 	}
 	if bytes.Contains(compose, []byte("image: ${VIBEWARDEN_APP_IMAGE")) {
 		t.Error("image: directive must not appear in build mode")
@@ -593,8 +599,13 @@ func TestGenerate_AppService_BothSet_BuildTakesPrecedence(t *testing.T) {
 	if !bytes.Contains(compose, []byte("build:")) {
 		t.Error("expected 'build:' directive when both build and image are set")
 	}
-	if !bytes.Contains(compose, []byte("context: ../.././src")) {
-		t.Error("expected 'context: ../.././src' (build path prefixed with ../../ for compose-file-relative resolution)")
+	// The build context should be an absolute path (ProjectRoot), not a
+	// relative "../.././src" prefix.
+	if bytes.Contains(compose, []byte("context: ../../")) {
+		t.Error("build context must be an absolute path, not relative '../../'")
+	}
+	if !bytes.Contains(compose, []byte("context: /")) {
+		t.Error("expected build context to be an absolute path starting with '/'")
 	}
 	// image: for the app service must not appear when build takes precedence.
 	// Note: "image:" still appears in vibewarden service itself so we check

--- a/internal/app/ops/build.go
+++ b/internal/app/ops/build.go
@@ -105,13 +105,28 @@ func (s *BuildService) probeShell(ctx context.Context, image string, out io.Writ
 }
 
 // resolveImageTag returns the Docker image tag for the build.
+// The tag must match what docker-compose expects for the app service so that
+// `vibew build` followed by `vibew dev` or `vibew deploy` finds the image.
+//
+// Docker Compose names built images as "<project>-<service>:latest". Since the
+// app service is always called "app", the expected image name is
+// "<ComposeProjectName>-app:latest". This function uses the same derivation
+// logic as the deploy bundle to ensure consistency.
+//
 // Priority:
-//  1. cfg.App.Image when cfg is non-nil and non-empty.
+//  1. cfg.ComposeProjectName() + "-app:latest" when cfg is non-nil and has a
+//     project name or image. This matches Docker Compose's naming convention.
 //  2. Base name of workDir (directory name), normalised to lower-case with
-//     ":latest" appended.
+//     "-app:latest" appended.
 func resolveImageTag(cfg *config.Config, workDir string) (string, error) {
-	if cfg != nil && cfg.App.Image != "" {
-		return cfg.App.Image, nil
+	if cfg != nil {
+		name := cfg.ComposeProjectName()
+		if name != "" && name != "vibewarden" {
+			return name + "-app:latest", nil
+		}
+		// When ComposeProjectName() returns "vibewarden" (the fallback), it means
+		// neither name nor image is set. Fall through to directory-based derivation
+		// so the tag is project-specific rather than the generic fallback.
 	}
 
 	abs, err := filepath.Abs(workDir)
@@ -124,5 +139,5 @@ func resolveImageTag(cfg *config.Config, workDir string) (string, error) {
 		return "", fmt.Errorf("cannot derive image name from directory %q", workDir)
 	}
 
-	return name + ":latest", nil
+	return name + "-app:latest", nil
 }

--- a/internal/app/ops/build_test.go
+++ b/internal/app/ops/build_test.go
@@ -26,7 +26,7 @@ func (f *fakeBuilder) Build(_ context.Context, tag string, contextDir string, no
 	return f.err
 }
 
-func TestBuildService_Run_UsesAppImageFromConfig(t *testing.T) {
+func TestBuildService_Run_UsesComposeProjectNameFromConfig(t *testing.T) {
 	fb := &fakeBuilder{}
 	svc := ops.NewBuildService(fb)
 
@@ -39,11 +39,15 @@ func TestBuildService_Run_UsesAppImageFromConfig(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 
-	if fb.capturedTag != "myapp:v1.2.3" {
-		t.Errorf("tag = %q, want %q", fb.capturedTag, "myapp:v1.2.3")
+	// ComposeProjectName() strips the tag from App.Image, giving "myapp".
+	// resolveImageTag uses that to produce "myapp-app:latest" which matches
+	// what docker-compose expects for the app service.
+	wantTag := "myapp-app:latest"
+	if fb.capturedTag != wantTag {
+		t.Errorf("tag = %q, want %q", fb.capturedTag, wantTag)
 	}
 
-	if !strings.Contains(out.String(), "myapp:v1.2.3") {
+	if !strings.Contains(out.String(), wantTag) {
 		t.Errorf("output missing image tag: %s", out.String())
 	}
 }
@@ -61,8 +65,8 @@ func TestBuildService_Run_FallsBackToDirectoryName(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 
-	if !strings.HasSuffix(fb.capturedTag, ":latest") {
-		t.Errorf("tag %q should end with :latest when falling back to dir name", fb.capturedTag)
+	if !strings.HasSuffix(fb.capturedTag, "-app:latest") {
+		t.Errorf("tag %q should end with -app:latest when falling back to dir name", fb.capturedTag)
 	}
 }
 
@@ -96,8 +100,7 @@ func TestBuildService_Run_PassesNoCache(t *testing.T) {
 			fb := &fakeBuilder{}
 			svc := ops.NewBuildService(fb)
 
-			cfg := &config.Config{}
-			cfg.App.Image = "img:latest"
+			cfg := &config.Config{Name: "img"}
 
 			var out bytes.Buffer
 			err := svc.Run(context.Background(), cfg, ops.BuildOptions{
@@ -119,8 +122,7 @@ func TestBuildService_Run_NoCachePrintedInOutput(t *testing.T) {
 	fb := &fakeBuilder{}
 	svc := ops.NewBuildService(fb)
 
-	cfg := &config.Config{}
-	cfg.App.Image = "myapp:latest"
+	cfg := &config.Config{Name: "myapp"}
 
 	var out bytes.Buffer
 	err := svc.Run(context.Background(), cfg, ops.BuildOptions{
@@ -141,8 +143,7 @@ func TestBuildService_Run_ReturnsBuilderError(t *testing.T) {
 	fb := &fakeBuilder{err: want}
 	svc := ops.NewBuildService(fb)
 
-	cfg := &config.Config{}
-	cfg.App.Image = "myapp:latest"
+	cfg := &config.Config{Name: "myapp"}
 
 	var out bytes.Buffer
 	err := svc.Run(context.Background(), cfg, ops.BuildOptions{WorkDir: "."}, &out)
@@ -158,8 +159,7 @@ func TestBuildService_Run_SuccessOutputContainsTag(t *testing.T) {
 	fb := &fakeBuilder{}
 	svc := ops.NewBuildService(fb)
 
-	cfg := &config.Config{}
-	cfg.App.Image = "webapp:1.0"
+	cfg := &config.Config{Name: "webapp"}
 
 	var out bytes.Buffer
 	err := svc.Run(context.Background(), cfg, ops.BuildOptions{WorkDir: "."}, &out)
@@ -168,7 +168,7 @@ func TestBuildService_Run_SuccessOutputContainsTag(t *testing.T) {
 	}
 
 	output := out.String()
-	if !strings.Contains(output, "webapp:1.0") {
+	if !strings.Contains(output, "webapp-app:latest") {
 		t.Errorf("success output missing tag: %s", output)
 	}
 	if !strings.Contains(output, "Successfully built") {
@@ -180,8 +180,7 @@ func TestBuildService_Run_PassesWorkDirToBuilder(t *testing.T) {
 	fb := &fakeBuilder{}
 	svc := ops.NewBuildService(fb)
 
-	cfg := &config.Config{}
-	cfg.App.Image = "myapp:latest"
+	cfg := &config.Config{Name: "myapp"}
 
 	dir := t.TempDir()
 
@@ -211,8 +210,7 @@ func TestBuildService_ShellProber_NoShellWarning(t *testing.T) {
 	fp := &fakeShellProber{hasShell: false}
 	svc := ops.NewBuildService(fb).WithShellProber(fp)
 
-	cfg := &config.Config{}
-	cfg.App.Image = "myapp:latest"
+	cfg := &config.Config{Name: "myapp"}
 
 	var out bytes.Buffer
 	err := svc.Run(context.Background(), cfg, ops.BuildOptions{WorkDir: "."}, &out)
@@ -234,8 +232,7 @@ func TestBuildService_ShellProber_HasShell_NoWarning(t *testing.T) {
 	fp := &fakeShellProber{hasShell: true}
 	svc := ops.NewBuildService(fb).WithShellProber(fp)
 
-	cfg := &config.Config{}
-	cfg.App.Image = "myapp:latest"
+	cfg := &config.Config{Name: "myapp"}
 
 	var out bytes.Buffer
 	err := svc.Run(context.Background(), cfg, ops.BuildOptions{WorkDir: "."}, &out)
@@ -254,8 +251,7 @@ func TestBuildService_ShellProber_Error_NoWarning(t *testing.T) {
 	fp := &fakeShellProber{err: errors.New("docker daemon unreachable")}
 	svc := ops.NewBuildService(fb).WithShellProber(fp)
 
-	cfg := &config.Config{}
-	cfg.App.Image = "myapp:latest"
+	cfg := &config.Config{Name: "myapp"}
 
 	var out bytes.Buffer
 	err := svc.Run(context.Background(), cfg, ops.BuildOptions{WorkDir: "."}, &out)
@@ -273,8 +269,7 @@ func TestBuildService_ShellProber_NilProber_NoWarning(t *testing.T) {
 	fb := &fakeBuilder{}
 	svc := ops.NewBuildService(fb) // no prober wired
 
-	cfg := &config.Config{}
-	cfg.App.Image = "myapp:latest"
+	cfg := &config.Config{Name: "myapp"}
 
 	var out bytes.Buffer
 	err := svc.Run(context.Background(), cfg, ops.BuildOptions{WorkDir: "."}, &out)
@@ -285,5 +280,51 @@ func TestBuildService_ShellProber_NilProber_NoWarning(t *testing.T) {
 	output := out.String()
 	if strings.Contains(output, "Warning: your app image has no shell") {
 		t.Errorf("unexpected shell warning when no prober wired:\n%s", output)
+	}
+}
+
+// TestBuildService_Run_ImageNameMatchesComposeProjectName verifies that the
+// image tag produced by `vibew build` matches what docker-compose expects:
+// <ComposeProjectName>-app:latest.
+//
+// Regression test for #973.
+func TestBuildService_Run_ImageNameMatchesComposeProjectName(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *config.Config
+		wantTag string
+	}{
+		{
+			name:    "explicit name in config",
+			cfg:     &config.Config{Name: "myapp"},
+			wantTag: "myapp-app:latest",
+		},
+		{
+			name:    "image-derived name (tag stripped)",
+			cfg:     &config.Config{App: config.AppConfig{Image: "webapp:v2.0"}},
+			wantTag: "webapp-app:latest",
+		},
+		{
+			name:    "image with registry prefix",
+			cfg:     &config.Config{App: config.AppConfig{Image: "ghcr.io/org/service:latest"}},
+			wantTag: "service-app:latest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fb := &fakeBuilder{}
+			svc := ops.NewBuildService(fb)
+
+			var out bytes.Buffer
+			err := svc.Run(context.Background(), tt.cfg, ops.BuildOptions{WorkDir: "."}, &out)
+			if err != nil {
+				t.Fatalf("Run() unexpected error: %v", err)
+			}
+
+			if fb.capturedTag != tt.wantTag {
+				t.Errorf("tag = %q, want %q", fb.capturedTag, tt.wantTag)
+			}
+		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,9 +130,17 @@ type Config struct {
 
 	// DeployMode is set to true by the deploy service when generating files for
 	// a deploy bundle. Templates use this to adjust paths (e.g. build context
-	// is "." in deploy mode instead of "../../." in dev mode). This field is
-	// not loaded from YAML — it is set programmatically.
+	// is the original App.Build value in deploy mode instead of the resolved
+	// ProjectRoot in dev mode). This field is not loaded from YAML — it is set
+	// programmatically.
 	DeployMode bool `mapstructure:"-"`
+
+	// ProjectRoot is the absolute path to the project directory (i.e. the
+	// directory containing vibewarden.yaml). It is set programmatically at
+	// generation time so that the docker-compose.yml template can reference an
+	// absolute build context instead of fragile relative paths like "../../.".
+	// This field is not loaded from YAML.
+	ProjectRoot string `mapstructure:"-"`
 }
 
 // WatchConfig holds settings for the config file watcher.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -232,6 +232,23 @@ func (c *Config) EgressNoProxy() string {
 	return strings.Join(parts, ",")
 }
 
+// ResolvedBuildContext returns the Docker build context path for the app
+// service. In deploy mode it returns App.Build verbatim (a relative path
+// that Docker Compose resolves from the compose file directory). In
+// generate mode it returns the absolute build context by joining ProjectRoot
+// with the App.Build subdirectory (stripping a leading "./" prefix first).
+// When App.Build is "." (project root), ProjectRoot alone is returned.
+func (c *Config) ResolvedBuildContext() string {
+	if c.DeployMode {
+		return c.App.Build
+	}
+	if c.App.Build == "" || c.App.Build == "." {
+		return c.ProjectRoot
+	}
+	sub := strings.TrimPrefix(c.App.Build, "./")
+	return c.ProjectRoot + "/" + sub
+}
+
 // DatabasePoolConfig holds connection pool settings for PostgreSQL.
 type DatabasePoolConfig struct {
 	// MaxConns is the maximum number of open connections in the pool.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3172,3 +3172,35 @@ func TestComposeProjectName(t *testing.T) {
 		})
 	}
 }
+
+func TestResolvedBuildContext(t *testing.T) {
+	tests := []struct {
+		name        string
+		projectRoot string
+		appBuild    string
+		deployMode  bool
+		want        string
+	}{
+		{"dot build uses project root", "/home/user/myapp", ".", false, "/home/user/myapp"},
+		{"empty build uses project root", "/home/user/myapp", "", false, "/home/user/myapp"},
+		{"subdirectory is appended", "/home/user/myapp", "./src", false, "/home/user/myapp/src"},
+		{"subdirectory without dot-slash", "/home/user/myapp", "src", false, "/home/user/myapp/src"},
+		{"nested subdirectory", "/home/user/myapp", "./apps/web", false, "/home/user/myapp/apps/web"},
+		{"deploy mode returns build verbatim", "/home/user/myapp", "./src", true, "./src"},
+		{"deploy mode dot build", "/home/user/myapp", ".", true, "."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				ProjectRoot: tt.projectRoot,
+				DeployMode:  tt.deployMode,
+			}
+			cfg.App.Build = tt.appBuild
+			got := cfg.ResolvedBuildContext()
+			if got != tt.want {
+				t.Errorf("ResolvedBuildContext() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/templates/docker-compose.yml.tmpl
+++ b/internal/config/templates/docker-compose.yml.tmpl
@@ -41,7 +41,7 @@ services:
     restart: unless-stopped
 {{- if .App.Build }}
     build:
-      context: {{ if .DeployMode }}{{ .App.Build }}{{ else }}{{ .ProjectRoot }}{{ end }}
+      context: {{ .ResolvedBuildContext }}
 {{- else if .App.Image }}
     image: ${VIBEWARDEN_APP_IMAGE:-{{ .App.Image }}}
 {{- end }}

--- a/internal/config/templates/docker-compose.yml.tmpl
+++ b/internal/config/templates/docker-compose.yml.tmpl
@@ -41,7 +41,7 @@ services:
     restart: unless-stopped
 {{- if .App.Build }}
     build:
-      context: {{ if .DeployMode }}{{ .App.Build }}{{ else }}../../{{ .App.Build }}{{ end }}
+      context: {{ if .DeployMode }}{{ .App.Build }}{{ else }}{{ .ProjectRoot }}{{ end }}
 {{- else if .App.Image }}
     image: ${VIBEWARDEN_APP_IMAGE:-{{ .App.Image }}}
 {{- end }}
@@ -275,7 +275,7 @@ services:
     environment:
       KRATOS_ADMIN_URL: http://kratos:4434
     volumes:
-      - ../../scripts/seed-users.sh:/seed-users.sh:ro
+      - {{ .ProjectRoot }}/scripts/seed-users.sh:/seed-users.sh:ro
     command: sh /seed-users.sh
     depends_on:
       kratos:

--- a/internal/config/templates/kratos.yml.tmpl
+++ b/internal/config/templates/kratos.yml.tmpl
@@ -9,7 +9,7 @@ version: v1.3.0
 
 serve:
   public:
-    base_url: {{ .Kratos.PublicURL }}
+    base_url: {{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}
     cors:
       enabled: false
   admin:
@@ -98,34 +98,34 @@ selfservice:
 
   flows:
     error:
-      ui_url: http://localhost:{{ .Server.Port }}/error
+      ui_url: http://localhost:{{ .Server.Port }}/auth/error
 
     settings:
-      ui_url: http://localhost:{{ .Server.Port }}/settings
+      ui_url: http://localhost:{{ .Server.Port }}/auth/settings
       privileged_session_max_age: 15m
       required_aal: highest_available
 
     recovery:
       enabled: true
-      ui_url: http://localhost:{{ .Server.Port }}/recovery
+      ui_url: http://localhost:{{ .Server.Port }}/auth/recovery
 
     verification:
       enabled: true
-      ui_url: http://localhost:{{ .Server.Port }}/verification
+      ui_url: http://localhost:{{ .Server.Port }}/auth/verification
       after:
         default_browser_return_url: http://localhost:{{ .Server.Port }}/
 
     logout:
       after:
-        default_browser_return_url: http://localhost:{{ .Server.Port }}/login
+        default_browser_return_url: http://localhost:{{ .Server.Port }}/auth/login
 
     login:
-      ui_url: http://localhost:{{ .Server.Port }}/login
+      ui_url: http://localhost:{{ .Server.Port }}/auth/login
       lifespan: 10m
 
     registration:
       lifespan: 10m
-      ui_url: http://localhost:{{ .Server.Port }}/registration
+      ui_url: http://localhost:{{ .Server.Port }}/auth/registration
       after:
         password:
           hooks:

--- a/internal/plugins/auth/plugin.go
+++ b/internal/plugins/auth/plugin.go
@@ -23,13 +23,20 @@ var _ ports.DependencyChecker = (*Plugin)(nil)
 // These paths are the Kratos self-service browser flows and the Ory canonical
 // prefix (used by the Ory UI SDK).
 var kratosFlowPaths = []string{
+	"/self-service/login",
 	"/self-service/login/*",
+	"/self-service/registration",
 	"/self-service/registration/*",
+	"/self-service/logout",
 	"/self-service/logout/*",
+	"/self-service/settings",
 	"/self-service/settings/*",
+	"/self-service/recovery",
 	"/self-service/recovery/*",
+	"/self-service/verification",
 	"/self-service/verification/*",
 	"/.ory/kratos/public/*",
+	"/sessions/whoami",
 }
 
 // whoamiPath is the Kratos endpoint used for health-checking connectivity.

--- a/internal/plugins/auth/plugin_test.go
+++ b/internal/plugins/auth/plugin_test.go
@@ -382,13 +382,20 @@ func TestPlugin_ContributeCaddyRoutes_HasKratosFlowPaths(t *testing.T) {
 	}
 
 	wantPaths := []string{
+		"/self-service/login",
 		"/self-service/login/*",
+		"/self-service/registration",
 		"/self-service/registration/*",
+		"/self-service/logout",
 		"/self-service/logout/*",
+		"/self-service/settings",
 		"/self-service/settings/*",
+		"/self-service/recovery",
 		"/self-service/recovery/*",
+		"/self-service/verification",
 		"/self-service/verification/*",
 		"/.ory/kratos/public/*",
+		"/sessions/whoami",
 	}
 
 	if len(paths) != len(wantPaths) {


### PR DESCRIPTION
Closes #973, #977, #978, #979

## Summary

- **#979 compose build context**: Replaced fragile relative `../../` path in docker-compose.yml.tmpl with absolute `ProjectRoot` resolved at generation time. Also fixed seed-users volume mount.
- **#978 + #977 Kratos auth public paths**: Auth handler now auto-appends default Kratos public paths (`/auth/*`, `/self-service/*`, `/login`, `/registration`, `/recovery`, `/verification`, `/error`, `/sessions/whoami`) in `Provision()` to prevent redirect loops.
- **#973 vibew build image name**: `vibew build` now names images as `<ComposeProjectName>-app:latest` to match Docker Compose's naming convention, ensuring the built image is found by `vibew dev` and `vibew deploy`.
- **Kratos base_url**: `serve.public.base_url` in kratos.yml now uses the sidecar's public URL (`http[s]://localhost:<port>`) instead of the internal Docker hostname.
- **Kratos ui_url paths**: All flow `ui_url` entries now use `/auth/` prefix to match the app's route convention.
- **Kratos flow proxy paths**: Added exact paths (without wildcard) for POST support and `/sessions/whoami` endpoint.
- **Demo-app login/register forms**: Submit buttons now include `name` and `value` attributes required by Kratos for method selection.

## Test plan

- [x] `TestGenerate_Integration_ComposeBuildContextIsAbsolutePath` -- verifies compose build context is absolute, not relative `../../`
- [x] `TestAuthHandler_Provision_AppendKratosPublicPaths` -- verifies auto-append of Kratos default public paths, no duplicates
- [x] `TestAuthHandler_Provision_KratosPathsBypass` -- verifies auth/self-service/login paths bypass authentication
- [x] `TestBuildService_Run_ImageNameMatchesComposeProjectName` -- verifies `vibew build` produces `<name>-app:latest` matching compose
- [x] `TestGenerate_Integration_KratosBaseURL` -- verifies base_url uses sidecar public URL for both HTTP and TLS modes
- [x] `TestGenerate_Integration_KratosUIUrlsUseAuthPrefix` -- verifies all ui_url entries use `/auth/` prefix
- [x] `make check` passes (golangci-lint, go build, go test -race, demo-app checks)

Generated with Claude Code