### PR TITLE
fix: merge production config before OpenBao check in deploy

### DIFF
--- a/internal/app/deploy/bundle.go
+++ b/internal/app/deploy/bundle.go
@@ -96,7 +96,7 @@ func (s *Service) bundleSingleSite(ctx context.Context, cfg *config.Config, conf
 	// Load and overlay the production override into the Config struct so that
 	// the compose template uses production values (port 443, letsencrypt, etc.)
 	// for port bindings, TLS config, and other template-driven settings.
-	mergedCfg, err := loadMergedConfig(cfg, prodConfigPath)
+	mergedCfg, err := LoadMergedConfig(cfg, prodConfigPath)
 	if err != nil {
 		return err
 	}

--- a/internal/app/deploy/resolve.go
+++ b/internal/app/deploy/resolve.go
@@ -161,12 +161,12 @@ func deepMerge(dst, src map[string]any) {
 	}
 }
 
-// loadMergedConfig loads the production override file (if prodConfigPath is
+// LoadMergedConfig loads the production override file (if prodConfigPath is
 // non-empty) and overlays its values on top of base. When prodConfigPath is
 // empty the base config is returned unchanged. Errors from config.Load are
 // propagated so that syntax errors in the production YAML are never silently
 // ignored.
-func loadMergedConfig(base *config.Config, prodConfigPath string) (*config.Config, error) {
+func LoadMergedConfig(base *config.Config, prodConfigPath string) (*config.Config, error) {
 	if prodConfigPath == "" {
 		return base, nil
 	}

--- a/internal/app/deploy/service.go
+++ b/internal/app/deploy/service.go
@@ -243,7 +243,7 @@ func (s *Service) Deploy(ctx context.Context, cfg *config.Config, opts RunOption
 	// Step 6: health check -- run curl on the remote so the probe is independent
 	// of DNS propagation, external port availability, and TLS certificate issuance.
 	// Use the merged config (base + prod overlay) for the correct port and TLS state.
-	healthCfg, err := loadMergedConfig(cfg, opts.ProdConfigPath)
+	healthCfg, err := LoadMergedConfig(cfg, opts.ProdConfigPath)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cmd/deploy.go
+++ b/internal/cli/cmd/deploy.go
@@ -150,8 +150,18 @@ Examples:
 				Out:            cmd.OutOrStdout(),
 			}
 
+			// Merge production overrides before checking feature flags
+			// so that e.g. secrets.enabled: false in production yaml
+			// correctly disables OpenBao bootstrap.
+			deployCfg := cfg
+			if prodConfigPath != "" {
+				if merged, mergeErr := deployapp.LoadMergedConfig(cfg, prodConfigPath); mergeErr == nil {
+					deployCfg = merged
+				}
+			}
+
 			// Bootstrap OpenBao when the secrets plugin is enabled.
-			if cfg.Secrets.Enabled {
+			if deployCfg.Secrets.Enabled {
 				bootstrapper := deployapp.NewOpenBaoBootstrapper(executor)
 				result, err := bootstrapper.Bootstrap(cmd.Context(), deployapp.BootstrapOptions{
 					SecretsFile:   secretsFrom,


### PR DESCRIPTION
Fixes deploy failing with bao not found when secrets.enabled: false in production yaml.