### PR TITLE
fix: file permissions 644/755, deploy logs project name resolution

### DIFF
--- a/internal/adapters/template/renderer.go
+++ b/internal/adapters/template/renderer.go
@@ -22,9 +22,9 @@ import (
 // File permission constants.
 const (
 	// permDir is the permission mode for directories created during rendering.
-	permDir = os.FileMode(0o750)
+	permDir = os.FileMode(0o755)
 	// permConfig is the permission mode for rendered config/template output files.
-	permConfig = os.FileMode(0o600)
+	permConfig = os.FileMode(0o644)
 )
 
 // Renderer implements ports.TemplateRenderer using an embed.FS.

--- a/internal/app/generate/service.go
+++ b/internal/app/generate/service.go
@@ -40,7 +40,7 @@ const defaultOutputDir = ".vibewarden/generated"
 const (
 	// permDir is the permission mode for generated directories.
 	// Group and world execute bits are omitted to prevent unintended access.
-	permDir = os.FileMode(0o750)
+	permDir = os.FileMode(0o755)
 	// permConfig is the permission mode for generated config/data files.
 	// Readable only by the owner to protect credentials embedded in kratos.yml.
 	permConfig = os.FileMode(0o644)

--- a/internal/cli/cmd/deploy.go
+++ b/internal/cli/cmd/deploy.go
@@ -404,11 +404,19 @@ Examples:
 				absConfig = configPath
 			}
 
+			// Load config to get the project name (cfg.Name).
+			logsCfg, loadErr := config.Load(absConfig)
+			var projectName string
+			if loadErr == nil && logsCfg.Name != "" {
+				projectName = logsCfg.Name
+			}
+
 			return svc.Logs(cmd.Context(), deployapp.LogsOptions{
-				ConfigPath: absConfig,
-				Lines:      lines,
-				Follow:     follow,
-				Out:        cmd.OutOrStdout(),
+				ConfigPath:  absConfig,
+				ProjectName: projectName,
+				Lines:       lines,
+				Follow:      follow,
+				Out:         cmd.OutOrStdout(),
 			})
 		},
 	}


### PR DESCRIPTION
Containers can read config files, deploy logs finds correct remote directory.