### PR TITLE
fix: Kratos URLs use tls.domain instead of localhost in production

### DIFF
--- a/internal/adapters/template/renderer.go
+++ b/internal/adapters/template/renderer.go
@@ -22,9 +22,9 @@ import (
 // File permission constants.
 const (
 	// permDir is the permission mode for directories created during rendering.
-	permDir = os.FileMode(0o750)
+	permDir = os.FileMode(0o755)
 	// permConfig is the permission mode for rendered config/template output files.
-	permConfig = os.FileMode(0o600)
+	permConfig = os.FileMode(0o644)
 )
 
 // Renderer implements ports.TemplateRenderer using an embed.FS.

--- a/internal/app/generate/service.go
+++ b/internal/app/generate/service.go
@@ -40,7 +40,7 @@ const defaultOutputDir = ".vibewarden/generated"
 const (
 	// permDir is the permission mode for generated directories.
 	// Group and world execute bits are omitted to prevent unintended access.
-	permDir = os.FileMode(0o750)
+	permDir = os.FileMode(0o755)
 	// permConfig is the permission mode for generated config/data files.
 	// Readable only by the owner to protect credentials embedded in kratos.yml.
 	permConfig = os.FileMode(0o644)

--- a/internal/cli/cmd/deploy.go
+++ b/internal/cli/cmd/deploy.go
@@ -404,11 +404,19 @@ Examples:
 				absConfig = configPath
 			}
 
+			// Load config to get the project name (cfg.Name).
+			logsCfg, loadErr := config.Load(absConfig)
+			var projectName string
+			if loadErr == nil && logsCfg.Name != "" {
+				projectName = logsCfg.Name
+			}
+
 			return svc.Logs(cmd.Context(), deployapp.LogsOptions{
-				ConfigPath: absConfig,
-				Lines:      lines,
-				Follow:     follow,
-				Out:        cmd.OutOrStdout(),
+				ConfigPath:  absConfig,
+				ProjectName: projectName,
+				Lines:       lines,
+				Follow:      follow,
+				Out:         cmd.OutOrStdout(),
 			})
 		},
 	}

--- a/internal/config/templates/kratos.yml.tmpl
+++ b/internal/config/templates/kratos.yml.tmpl
@@ -9,16 +9,16 @@ version: v1.3.0
 
 serve:
   public:
-    base_url: {{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}
+    base_url: {{ if .TLS.Domain }}https://{{ .TLS.Domain }}{{ else }}{{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}{{ end }}
     cors:
       enabled: false
   admin:
     base_url: {{ .Kratos.AdminURL }}
 
 selfservice:
-  default_browser_return_url: {{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}/
+  default_browser_return_url: {{ if .TLS.Domain }}https://{{ .TLS.Domain }}{{ else }}{{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}{{ end }}/
   allowed_return_urls:
-    - {{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}
+    - {{ if .TLS.Domain }}https://{{ .TLS.Domain }}{{ else }}{{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}{{ end }}
 
   methods:
 {{- if eq .Auth.IdentitySchema "email_password" }}
@@ -98,34 +98,34 @@ selfservice:
 
   flows:
     error:
-      ui_url: {{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}/auth/error
+      ui_url: {{ if .TLS.Domain }}https://{{ .TLS.Domain }}{{ else }}{{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}{{ end }}/auth/error
 
     settings:
-      ui_url: {{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}/auth/settings
+      ui_url: {{ if .TLS.Domain }}https://{{ .TLS.Domain }}{{ else }}{{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}{{ end }}/auth/settings
       privileged_session_max_age: 15m
       required_aal: highest_available
 
     recovery:
       enabled: true
-      ui_url: {{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}/auth/recovery
+      ui_url: {{ if .TLS.Domain }}https://{{ .TLS.Domain }}{{ else }}{{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}{{ end }}/auth/recovery
 
     verification:
       enabled: true
-      ui_url: {{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}/auth/verification
+      ui_url: {{ if .TLS.Domain }}https://{{ .TLS.Domain }}{{ else }}{{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}{{ end }}/auth/verification
       after:
-        default_browser_return_url: {{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}/
+        default_browser_return_url: {{ if .TLS.Domain }}https://{{ .TLS.Domain }}{{ else }}{{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}{{ end }}/
 
     logout:
       after:
-        default_browser_return_url: {{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}/auth/login
+        default_browser_return_url: {{ if .TLS.Domain }}https://{{ .TLS.Domain }}{{ else }}{{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}{{ end }}/auth/login
 
     login:
-      ui_url: {{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}/auth/login
+      ui_url: {{ if .TLS.Domain }}https://{{ .TLS.Domain }}{{ else }}{{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}{{ end }}/auth/login
       lifespan: 10m
 
     registration:
       lifespan: 10m
-      ui_url: {{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}/auth/registration
+      ui_url: {{ if .TLS.Domain }}https://{{ .TLS.Domain }}{{ else }}{{ if .TLS.Enabled }}https{{ else }}http{{ end }}://localhost:{{ .Server.Port }}{{ end }}/auth/registration
       after:
         password:
           hooks:


### PR DESCRIPTION
Fixes redirect to localhost when deployed with a domain.