### PR TITLE
fix: CSP inline styles + health check HTTP fallback during cert acquisition

### DIFF
--- a/examples/demo-app/vibewarden.yaml
+++ b/examples/demo-app/vibewarden.yaml
@@ -108,7 +108,7 @@ security_headers:
   hsts_preload: false
   content_type_nosniff: true
   frame_option: "DENY"
-  content_security_policy: "default-src 'self'; style-src 'self'; script-src 'self' 'unsafe-inline'"
+  content_security_policy: "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'"
   referrer_policy: "strict-origin-when-cross-origin"
 
 observability:

--- a/internal/app/deploy/service.go
+++ b/internal/app/deploy/service.go
@@ -537,11 +537,13 @@ func healthCheckURL(port int, tlsEnabled bool) string {
 }
 
 // healthCheckCmd returns the curl command used to probe the health endpoint.
-// When TLS is enabled it adds the -k flag to skip certificate verification,
-// since the probe targets localhost rather than the public domain.
+// When TLS is enabled it tries HTTPS first (with -k to skip cert verification),
+// falling back to HTTP if the TLS handshake fails (e.g., during ACME cert
+// acquisition). This prevents false health check failures during the first
+// minute of a deploy when the cert hasn't been issued yet.
 func healthCheckCmd(port int, tlsEnabled bool) string {
 	if tlsEnabled {
-		return fmt.Sprintf("curl -sfk https://localhost:%d/_vibewarden/health", port)
+		return fmt.Sprintf("curl -sfk https://localhost:%d/_vibewarden/health 2>/dev/null || curl -sf http://localhost:%d/_vibewarden/health", port, port)
 	}
 	return fmt.Sprintf("curl -sf http://localhost:%d/_vibewarden/health", port)
 }


### PR DESCRIPTION
- Demo-app CSP allows `'unsafe-inline'` for style-src (login page inline styles)
- Health check tries HTTPS first, falls back to HTTP during ACME cert provisioning