### PR TITLE
fix: unblock main — gosec G304 suppression + TLS health-check test expectations

### DIFF
--- a/internal/app/deploy/multiapp_test.go
+++ b/internal/app/deploy/multiapp_test.go
@@ -596,7 +596,7 @@ func TestBootstrapSidecar_TLSHealthCheck(t *testing.T) {
 		{
 			name:        "TLS enabled uses HTTPS with -sfk",
 			cfg:         multiappTLSConfig(),
-			wantCurlCmd: "curl -sfk https://localhost:443/_vibewarden/health",
+			wantCurlCmd: "curl -sfk https://localhost:443/_vibewarden/health 2>/dev/null || curl -sf http://localhost:443/_vibewarden/health",
 			wantScheme:  "https://",
 		},
 		{
@@ -607,7 +607,7 @@ func TestBootstrapSidecar_TLSHealthCheck(t *testing.T) {
 				App:      config.AppConfig{Image: "myapp:latest"},
 				TLS:      config.TLSConfig{Enabled: true},
 			},
-			wantCurlCmd: "curl -sfk https://localhost:8443/_vibewarden/health",
+			wantCurlCmd: "curl -sfk https://localhost:8443/_vibewarden/health 2>/dev/null || curl -sf http://localhost:8443/_vibewarden/health",
 			wantScheme:  "https://",
 		},
 	}
@@ -658,7 +658,7 @@ func TestDeployMultiApp_TLSHealthCheck(t *testing.T) {
 		{
 			name:        "TLS enabled uses HTTPS with -sfk",
 			cfg:         multiappTLSConfig(),
-			wantCurlCmd: "curl -sfk https://localhost:443/_vibewarden/health",
+			wantCurlCmd: "curl -sfk https://localhost:443/_vibewarden/health 2>/dev/null || curl -sf http://localhost:443/_vibewarden/health",
 			wantScheme:  "https://",
 		},
 		{
@@ -669,7 +669,7 @@ func TestDeployMultiApp_TLSHealthCheck(t *testing.T) {
 				App:      config.AppConfig{Image: "myapp:latest"},
 				TLS:      config.TLSConfig{Enabled: true},
 			},
-			wantCurlCmd: "curl -sfk https://localhost:8443/_vibewarden/health",
+			wantCurlCmd: "curl -sfk https://localhost:8443/_vibewarden/health 2>/dev/null || curl -sf http://localhost:8443/_vibewarden/health",
 			wantScheme:  "https://",
 		},
 	}

--- a/internal/app/deploy/service_test.go
+++ b/internal/app/deploy/service_test.go
@@ -1384,7 +1384,7 @@ func TestService_Deploy_HealthCheckAlwaysUsesLocalhost(t *testing.T) {
 				Server: config.ServerConfig{Port: 8443},
 				TLS:    config.TLSConfig{Enabled: true},
 			},
-			wantCurlCmd: "curl -sfk https://localhost:8443/_vibewarden/health",
+			wantCurlCmd: "curl -sfk https://localhost:8443/_vibewarden/health 2>/dev/null || curl -sf http://localhost:8443/_vibewarden/health",
 		},
 		{
 			name: "TLS enabled with domain uses HTTPS with -k on localhost",
@@ -1396,7 +1396,7 @@ func TestService_Deploy_HealthCheckAlwaysUsesLocalhost(t *testing.T) {
 					Domain:   "app.example.com",
 				},
 			},
-			wantCurlCmd: "curl -sfk https://localhost:443/_vibewarden/health",
+			wantCurlCmd: "curl -sfk https://localhost:443/_vibewarden/health 2>/dev/null || curl -sf http://localhost:443/_vibewarden/health",
 		},
 	}
 

--- a/internal/cli/cmd/deploy.go
+++ b/internal/cli/cmd/deploy.go
@@ -156,7 +156,7 @@ Examples:
 			// to false" for booleans, so we read the raw YAML map.
 			secretsEnabled := cfg.Secrets.Enabled
 			if prodConfigPath != "" {
-				if data, readErr := os.ReadFile(prodConfigPath); readErr == nil {
+				if data, readErr := os.ReadFile(prodConfigPath); readErr == nil { //nolint:gosec // CLI-user-provided prod-config path
 					var m map[string]any
 					if yaml.Unmarshal(data, &m) == nil {
 						if secrets, ok := m["secrets"].(map[string]any); ok {


### PR DESCRIPTION
## Problem

`main` has been failing CI across multiple checks for every PR:

1. **Lint** — `internal/cli/cmd/deploy.go:159` trips gosec G304 (potential file inclusion via variable) on `os.ReadFile(prodConfigPath)`. `prodConfigPath` comes from the `--prod-config` CLI flag — the user provides their own path.
2. **Test / Coverage** — 6 subtests across `TestBootstrapSidecar_TLSHealthCheck`, `TestDeployMultiApp_TLSHealthCheck`, `TestService_Deploy_HealthCheckAlwaysUsesLocalhost` fail because PR #1007 updated `healthCheckCmd` to try HTTPS then fall back to HTTP, but didn't update test expectations. `assertRunCalled` does exact-match.

## Fix

Two commits:

- `fix(lint): suppress gosec G304 on deploy prod-config read` — adds `//nolint:gosec // CLI-user-provided prod-config path`, mirroring the pattern already used in `init_test.go` and `init_interactive_test.go`.
- `fix(test): update TLS health-check expectations to match fallback form` — updates 6 `wantCurlCmd` strings to include the new `2>/dev/null || curl -sf http://...` fallback. No production code changed.

## Context

The lint rule surfaced after `golangci/golangci-lint-action@v8 → v9` (#851). The test drift is a test-update miss from #1007.

Every open PR is blocked until this lands.