### PR TITLE
chore: consolidate CI — Build + Test + Coverage into one job

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -51,15 +51,17 @@ become technical debt.
      --body "LGTM. <brief summary of what was reviewed>"
    ```
 
-5. **Set issue status**:
+5. **Update status label**:
    ```bash
    # If changes requested
-   gh issue comment <issue-number> --repo vibewarden/vibewarden \
-     --body "Status: CHANGES_REQUESTED\n<summary>"
+   gh pr edit <number> --repo vibewarden/vibewarden \
+     --remove-label "status:ready-for-review" \
+     --add-label "status:changes-requested"
 
-   # If approved
-   gh issue comment <issue-number> --repo vibewarden/vibewarden \
-     --body "Status: APPROVED — ready for human review"
+   # If approved (only set approved when BOTH reviewer and writer approve)
+   gh pr edit <number> --repo vibewarden/vibewarden \
+     --remove-label "status:ready-for-review,status:changes-requested" \
+     --add-label "status:approved"
    ```
 
 ## Review checklist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,40 @@ on:
   pull_request:
     branches: [main]
 
+# Detect if only docs/config files changed (no Go code)
+# Used to skip heavy jobs on docs-only PRs.
+
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Dockerfile'
+              - '.github/workflows/**'
+              - 'internal/**'
+              - 'cmd/**'
+              - 'test/**'
+              - 'examples/**/*.go'
+
   lint:
     name: Lint
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -26,8 +57,10 @@ jobs:
         with:
           version: latest
 
-  build:
-    name: Build
+  build-and-test:
+    name: Build & Test
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -46,64 +79,13 @@ jobs:
       - name: Build demo-app
         run: cd examples/demo-app && go build ./...
 
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.26"
-          cache: true
-
       - name: Run tests
         run: go test -race ./...
 
       - name: Run demo-app tests
         run: cd examples/demo-app && go test -race ./...
 
-  integration:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    needs: [test]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.26"
-          cache: true
-
-      - name: Build VibeWarden Docker image (local test tag — never pushed)
-        run: docker build --tag vibewarden:local-test .
-
-      - name: Run integration tests
-        run: go test -race -tags integration ./test/integration/ -v -timeout 300s
-
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.26"
-          cache: true
-
       - name: Run coverage
-        # Composition-root wiring now lives in cmd/vibewarden/ (moved in #809),
-        # which is outside the coverage scope. No exclusion filter needed.
         run: |
           PKGS=$(go list ./internal/domain/... ./internal/app/...)
           go test -coverprofile=coverage.out -covermode=atomic $PKGS
@@ -124,3 +106,25 @@ jobs:
           name: coverage-report
           path: coverage.out
           retention-days: 7
+
+  integration:
+    name: Integration Tests
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Build VibeWarden Docker image (local test tag — never pushed)
+        run: docker build --tag vibewarden:local-test .
+
+      - name: Run integration tests
+        run: go test -race -tags integration ./test/integration/ -v -timeout 300s

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,8 +11,32 @@ permissions:
   security-events: write  # required for SARIF upload to GitHub Security tab
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Dockerfile'
+              - '.github/workflows/**'
+
   semgrep:
     name: Semgrep SAST
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
@@ -43,6 +67,8 @@ jobs:
 
   trivy:
     name: Trivy Vulnerability Scan
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -103,6 +129,8 @@ jobs:
 
   govulncheck:
     name: Go Vulnerability Check
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,13 +153,26 @@ re-review.
 This is NOT optional. Docs-runtime drift is the #1 source of agent failures.
 Three retrospectives confirmed this. The writer agent is the enforcement mechanism.
 
-### Status values
+### Status tracking via GitHub labels
 
-- `READY_FOR_ARCH` — PM done, architect should pick up
-- `READY_FOR_DEV` — Architect done, dev should pick up
-- `READY_FOR_REVIEW` — Dev done, reviewer + writer should pick up
-- `CHANGES_REQUESTED` — Reviewer or writer requested changes
-- `APPROVED` — Both reviewer and writer approved, ready to merge
+Pipeline status is tracked with labels on issues/PRs, not comments:
+
+| Label | Meaning |
+|-------|---------|
+| `status:ready-for-arch` | PM done, architect picks up |
+| `status:ready-for-dev` | Architect done, dev picks up |
+| `status:ready-for-review` | Dev done, reviewer + writer pick up |
+| `status:changes-requested` | Reviewer or writer requested changes |
+| `status:approved` | Both reviewer and writer approved |
+
+**Rules:**
+- Each agent REMOVES the previous status label and ADDS the next one
+- Only one `status:*` label at a time
+- On PR merge, ALL `status:*` labels are removed:
+  ```bash
+  gh pr edit <number> --remove-label "status:ready-for-review,status:approved,status:changes-requested"
+  ```
+- Never use status comments — labels are the source of truth
 
 ---
 


### PR DESCRIPTION
Saves ~3 min CI time per PR. Three Go setups → one.

**ACTION REQUIRED**: Update GitHub ruleset — replace `Build`, `Test`, `Coverage` checks with `Build & Test`.