### PR TITLE
docs(#1004): migrate ASCII diagrams to Mermaid

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,22 @@ make observability-down   # Tear down
 
 See [`docs/observability.md`](docs/observability.md) for details.
 
+## Diagram Conventions
+
+Use **Mermaid** fenced code blocks (` ```mermaid `) for branching or
+multi-component diagrams (architecture overviews, fan-out routing, data flows
+with multiple paths).
+
+Keep **ASCII** for:
+
+- Linear flows (single vertical or horizontal pipe)
+- Directory trees
+- CLI output samples and terminal snippets
+
+When adding a Mermaid diagram, use default styling (no custom colors or themes)
+unless the context explicitly requires it. Verify the diagram renders correctly
+with `mkdocs serve` or a Mermaid preview tool before submitting.
+
 ## Makefile Targets
 
 | Target | Description |

--- a/README.md
+++ b/README.md
@@ -131,31 +131,37 @@ Do not edit generated files — re-run `vibew generate` after changing `vibeward
 
 ## How It Works
 
+**Ingress (inbound traffic):**
+
+```mermaid
+flowchart LR
+    Internet --> VW
+    subgraph VW["VibeWarden :8443"]
+        TLS["TLS termination"]
+        Auth["Auth (JWT / Kratos)"]
+        RL["Rate limiting"]
+        WAF["WAF"]
+        SH["Security headers"]
+        Audit["Audit trail"]
+    end
+    VW --> App["Your App :3000"]
 ```
-                          INGRESS (inbound traffic)
 
-  Internet ──────►  VibeWarden  :8443 (HTTPS)  ──────►  Your App  :3000
-                    │                         │
-                    │  TLS termination        │
-                    │  Auth (JWT / Kratos)    │
-                    │  Rate limiting          │
-                    │  WAF                    │
-                    │  Security headers       │
-                    │  Audit trail            │
-                    └─────────────────────────┘
+**Egress (outbound traffic):**
 
-                          EGRESS (outbound traffic)
-
-  Your App  :3000  ──────►  VibeWarden  :8081  ──────►  External APIs
-                            │                         │
-                            │  Route allowlist        │
-                            │  SSRF protection        │
-                            │  Secret injection       │
-                            │  TLS enforcement        │
-                            │  Circuit breaker        │
-                            │  Rate limiting          │
-                            │  PII redaction          │
-                            └─────────────────────────┘
+```mermaid
+flowchart LR
+    App["Your App :3000"] --> VW
+    subgraph VW["VibeWarden :8081"]
+        Allow["Route allowlist"]
+        SSRF["SSRF protection"]
+        Secret["Secret injection"]
+        TLS["TLS enforcement"]
+        CB["Circuit breaker"]
+        RL["Rate limiting"]
+        PII["PII redaction"]
+    end
+    VW --> APIs["External APIs"]
 ```
 
 VibeWarden is a local sidecar — it always runs on the same machine as your app.

--- a/docs/multi-app.md
+++ b/docs/multi-app.md
@@ -28,12 +28,17 @@ There is no config merging. Each app's `vibewarden.yaml` is copied as-is to a
 per-site directory on the server. The sidecar reads all site configs and
 generates one Caddy route block per app, with host-based routing.
 
-```
-                    +----------------------------------+
-  app1.example.com -->|                                  |--> app1 container :3000
-  app2.example.com -->|  Single VibeWarden sidecar       |--> app2 container :8080
-  app3.example.com -->|  TLS + routing + per-app config  |--> app3 container :3000
-                    +----------------------------------+
+```mermaid
+flowchart LR
+    A1["app1.example.com"] --> VW
+    A2["app2.example.com"] --> VW
+    A3["app3.example.com"] --> VW
+    subgraph VW["VibeWarden sidecar"]
+        TLS["TLS + routing + per-app config"]
+    end
+    VW --> C1["app1 container :3000"]
+    VW --> C2["app2 container :8080"]
+    VW --> C3["app3 container :3000"]
 ```
 
 ---

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -444,7 +444,7 @@ Prometheus collectors:
 ```mermaid
 flowchart LR
     App["Your App"] <--> VW["VibeWarden :8080"]
-    VW -. "scrape /_vibewarden/metrics" .-> Prom["Prometheus :9090"]
+    Prom["Prometheus :9090"] -. "scrape /_vibewarden/metrics" .-> VW
     Prom --> Grafana["Grafana :3000"]
     Logs["Docker container logs"] --> Promtail
     Promtail --> Loki["Loki :3100"]

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -441,13 +441,14 @@ Prometheus collectors:
 
 ## Architecture
 
-```
-[Your App]  <---->  [VibeWarden :8080]  <--(scrape)--  [Prometheus :9090]
-                          |                                     |
-                          +---> /_vibewarden/metrics            v
-                                                         [Grafana :3000]
-                                                               ^
-[Docker container logs]  -->  [Promtail]  -->  [Loki :3100] --+
+```mermaid
+flowchart LR
+    App["Your App"] <--> VW["VibeWarden :8080"]
+    VW -. "scrape /_vibewarden/metrics" .-> Prom["Prometheus :9090"]
+    Prom --> Grafana["Grafana :3000"]
+    Logs["Docker container logs"] --> Promtail
+    Promtail --> Loki["Loki :3100"]
+    Loki --> Grafana
 ```
 
 Prometheus scrapes VibeWarden every 15 seconds. Promtail discovers all running Docker

--- a/docs/secret-management.md
+++ b/docs/secret-management.md
@@ -34,22 +34,15 @@ If you already deployed with `secrets.store: openbao` (or the deprecated `secret
 
 ## Architecture
 
-```
-vibewarden.yaml
-       |
-       v
-  VibeWarden (sidecar)
-       |
-       |--- Built-in store (AES-256-GCM encrypted file)
-       |        .vibewarden/secrets.enc
-       |
-       |--- OR: OpenBao (KV v2 + database engine)
-       |        |
-       |        v
-       |     Postgres (dynamic credentials, OpenBao only)
-       |
-       v
-  upstream app (receives secrets via headers or .env file)
+```mermaid
+flowchart TD
+    Config["vibewarden.yaml"] --> VW["VibeWarden (sidecar)"]
+    VW --> Builtin["Built-in store (AES-256-GCM)"]
+    Builtin --> Enc[".vibewarden/secrets.enc"]
+    VW --> OpenBao["OpenBao (KV v2 + database engine)"]
+    OpenBao --> PG["Postgres (dynamic credentials)"]
+    Builtin --> App["Upstream app (headers or .env file)"]
+    OpenBao --> App
 ```
 
 ---
@@ -145,21 +138,12 @@ Use OpenBao when you need dynamic credentials, lease rotation, or metadata-based
 
 The OpenBao path looks like this:
 
-```
-vibewarden.yaml
-       |
-       v
-  VibeWarden (sidecar)
-       |
-       | HTTP API (no SDK)
-       v
-    OpenBao (KV v2 + database engine)
-       |
-       v
-  Postgres (dynamic credentials)
-       |
-       v
-  upstream app (receives secrets via headers or .env file)
+```mermaid
+flowchart TD
+    Config["vibewarden.yaml"] --> VW["VibeWarden (sidecar)"]
+    VW -- "HTTP API (no SDK)" --> OpenBao["OpenBao (KV v2 + database engine)"]
+    OpenBao --> PG["Postgres (dynamic credentials)"]
+    PG --> App["Upstream app (headers or .env file)"]
 ```
 
 ### 1. Start the stack


### PR DESCRIPTION
Closes #1004

## Summary

- **README.md**: replaced ingress and egress ASCII diagrams with two `flowchart LR` Mermaid diagrams showing middleware features in subgraphs
- **docs/secret-management.md**: replaced architecture overview ASCII with `flowchart TD` showing branching to built-in store vs OpenBao converging on upstream app; replaced OpenBao-specific linear flow with `flowchart TD` with "HTTP API (no SDK)" edge label
- **docs/observability.md**: replaced architecture ASCII with `flowchart LR` showing Prometheus scrape (dotted arrow), Promtail/Loki pipeline, and Grafana as sink
- **docs/multi-app.md**: replaced fan-out ASCII with `flowchart LR` showing three subdomains through a VibeWarden subgraph to three app containers
- **CONTRIBUTING.md**: added "Diagram Conventions" section documenting when to use Mermaid vs ASCII

## Deliberately kept as ASCII

- `docs/getting-started.md` middleware chain (linear vertical pipe)
- `docs/examples/{rails,nextjs,express,django}.md` (linear 3-tier diagrams)
- `docs/troubleshooting.md` (CLI output samples)
- `schema/README.md` (directory tree)
- `README.md` architecture directory tree
- `CONTRIBUTING.md` architecture directory tree and dependency arrows
- `CLAUDE.md` directory layout
- `llms.txt` / `llms-full.txt` (AI-agent-consumable, must stay ASCII)

## Test plan

- [ ] Verify all 6 Mermaid blocks render on GitHub PR diff preview
- [ ] Verify `mkdocs serve` renders diagrams (mkdocs.yml already configured at lines 47-51)
- [ ] Confirm keep-ASCII files are unchanged