### PR TITLE
feat(#984): optional auth on public paths — set session headers without requiring login

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,7 +121,7 @@ tls:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `auth.mode` | string | `none` | Auth strategy and single source of truth for whether auth is on. Set to `none` to disable, or `kratos`, `jwt`, or `api-key` to enable. See ADR-065 |
-| `auth.public_paths` | list | `[]` | Glob patterns that bypass auth. `/_vibewarden/*` is always public |
+| `auth.public_paths` | list | `[]` | Paths that do not require authentication. If a valid session cookie is present, identity headers are still set (optional auth). `/_vibewarden/*` is always public |
 | `auth.session_cookie_name` | string | `ory_kratos_session` | Kratos session cookie name |
 | `auth.login_url` | string | `/self-service/login/browser` | Redirect for unauthenticated users |
 | `auth.on_kratos_unavailable` | string | `503` | Behavior when Kratos is unreachable: `503` or `allow_public` |

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -31,6 +31,10 @@ When auth is enabled, read user identity from these headers:
 - `X-User-Email` — user email
 - `X-User-Verified` — email verification status ("true"/"false")
 
+On public paths (`auth.public_paths`), these headers are set when a valid session
+cookie is present but are absent for anonymous visitors. Your app code should
+treat them as optional on public paths and required on protected paths.
+
 ## Architecture
 
 This project follows hexagonal architecture (ports and adapters):

--- a/docs/examples/express.md
+++ b/docs/examples/express.md
@@ -356,8 +356,7 @@ app.use("/api", apiRouter);
 ### Health check route
 
 Add a `/health` endpoint that does not require authentication. Register it in
-`auth.public_paths` in `vibewarden.yaml` so VibeWarden passes it through without a
-session check:
+`auth.public_paths` in `vibewarden.yaml` so VibeWarden does not require authentication:
 
 ```javascript
 app.get("/health", (req, res) => {

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,6 +113,8 @@ Your app receives authenticated user info via headers:
 | `X-User-Email` | `email` | Primary email address |
 | `X-User-Verified` | `email_verified` | Email verification status (`true`/`false`) |
 
+On public paths, these headers are present when the visitor has a valid session (optional auth).
+
 ---
 
 ## Comparison with Alternatives

--- a/internal/adapters/caddy/auth_handler.go
+++ b/internal/adapters/caddy/auth_handler.go
@@ -230,10 +230,33 @@ func extractVerified(whoami *kratosWhoamiResponse) bool {
 	return false
 }
 
+// setIdentityHeaders injects X-User-Id, X-User-Email, and X-User-Verified
+// headers into the request based on the Kratos whoami response.
+func setIdentityHeaders(r *http.Request, whoami *kratosWhoamiResponse) {
+	if whoami.Identity.ID != "" {
+		r.Header.Set("X-User-Id", whoami.Identity.ID)
+	}
+	if email := extractEmail(whoami); email != "" {
+		r.Header.Set("X-User-Email", email)
+	}
+	if extractVerified(whoami) {
+		r.Header.Set("X-User-Verified", "true")
+	} else {
+		r.Header.Set("X-User-Verified", "false")
+	}
+}
+
 // ServeHTTP implements caddyhttp.MiddlewareHandler.
 func (h *AuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
-	// Skip public paths.
+	// Public paths: optional auth — check session if cookie present, set
+	// headers if valid, but never redirect or block the request.
 	if h.isPublicPath(r.URL.Path) {
+		if cookie, err := r.Cookie(h.Config.CookieName); err == nil {
+			if whoami, err := h.callWhoami(r.Context(), cookie.Value); err == nil {
+				setIdentityHeaders(r, whoami)
+			}
+			// If whoami fails, proceed without headers (don't redirect, don't error).
+		}
 		return next.ServeHTTP(w, r)
 	}
 
@@ -257,17 +280,7 @@ func (h *AuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	}
 
 	// Set identity headers for the upstream app.
-	if whoami.Identity.ID != "" {
-		r.Header.Set("X-User-Id", whoami.Identity.ID)
-	}
-	if email := extractEmail(whoami); email != "" {
-		r.Header.Set("X-User-Email", email)
-	}
-	if extractVerified(whoami) {
-		r.Header.Set("X-User-Verified", "true")
-	} else {
-		r.Header.Set("X-User-Verified", "false")
-	}
+	setIdentityHeaders(r, whoami)
 
 	return next.ServeHTTP(w, r)
 }

--- a/internal/adapters/caddy/auth_handler_test.go
+++ b/internal/adapters/caddy/auth_handler_test.go
@@ -665,6 +665,175 @@ func TestAuthHandler_Provision_KratosPathsBypass(t *testing.T) {
 	}
 }
 
+// TestAuthHandler_PublicPath_WithValidSession_SetsHeaders verifies that a
+// public path with a valid Kratos session cookie sets identity headers on
+// the request without blocking or redirecting.
+func TestAuthHandler_PublicPath_WithValidSession_SetsHeaders(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/sessions/whoami" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"identity": {
+				"id": "user-pub-123",
+				"traits": {"email": "pub@example.com"},
+				"verifiable_addresses": [
+					{"value": "pub@example.com", "via": "email", "verified": true}
+				]
+			}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName:  "ory_kratos_session",
+		LoginURL:    "/login",
+		PublicPaths: []string{"/public", "/home"},
+		KratosURL:   kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	var capturedHeaders http.Header
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		capturedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/public", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "valid-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	if capturedHeaders == nil {
+		t.Fatal("next handler was not called")
+	}
+	if w.Code == http.StatusFound {
+		t.Error("public path should not redirect even with session check")
+	}
+	if got := capturedHeaders.Get("X-User-Id"); got != "user-pub-123" {
+		t.Errorf("X-User-Id = %q, want %q", got, "user-pub-123")
+	}
+	if got := capturedHeaders.Get("X-User-Email"); got != "pub@example.com" {
+		t.Errorf("X-User-Email = %q, want %q", got, "pub@example.com")
+	}
+	if got := capturedHeaders.Get("X-User-Verified"); got != "true" {
+		t.Errorf("X-User-Verified = %q, want %q", got, "true")
+	}
+}
+
+// TestAuthHandler_PublicPath_WithInvalidSession_NoHeaders verifies that a
+// public path with an expired/invalid session cookie still passes through
+// without setting identity headers and without redirecting.
+func TestAuthHandler_PublicPath_WithInvalidSession_NoHeaders(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer kratosServer.Close()
+
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName:  "ory_kratos_session",
+		LoginURL:    "/login",
+		PublicPaths: []string{"/public"},
+		KratosURL:   kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	var capturedHeaders http.Header
+	nextCalled := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		capturedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/public", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "expired-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	if !nextCalled {
+		t.Error("next handler should be called for public path even with invalid session")
+	}
+	if w.Code == http.StatusFound {
+		t.Error("public path should not redirect even with invalid session")
+	}
+	if got := capturedHeaders.Get("X-User-Id"); got != "" {
+		t.Errorf("X-User-Id = %q, want empty", got)
+	}
+	if got := capturedHeaders.Get("X-User-Email"); got != "" {
+		t.Errorf("X-User-Email = %q, want empty", got)
+	}
+	if got := capturedHeaders.Get("X-User-Verified"); got != "" {
+		t.Errorf("X-User-Verified = %q, want empty", got)
+	}
+}
+
+// TestAuthHandler_PublicPath_NoCookie_NoHeaders verifies that a public path
+// without any session cookie passes through without identity headers and
+// without redirecting.
+func TestAuthHandler_PublicPath_NoCookie_NoHeaders(t *testing.T) {
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName:  "ory_kratos_session",
+		LoginURL:    "/login",
+		PublicPaths: []string{"/public"},
+		KratosURL:   "http://unreachable:4433", // should not be called
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	var capturedHeaders http.Header
+	nextCalled := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		capturedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/public", nil)
+	// No cookie added.
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	if !nextCalled {
+		t.Error("next handler should be called for public path without cookie")
+	}
+	if w.Code == http.StatusFound {
+		t.Error("public path should not redirect without cookie")
+	}
+	if got := capturedHeaders.Get("X-User-Id"); got != "" {
+		t.Errorf("X-User-Id = %q, want empty", got)
+	}
+	if got := capturedHeaders.Get("X-User-Email"); got != "" {
+		t.Errorf("X-User-Email = %q, want empty", got)
+	}
+	if got := capturedHeaders.Get("X-User-Verified"); got != "" {
+		t.Errorf("X-User-Verified = %q, want empty", got)
+	}
+}
+
 // TestAuthHandler_ServeHTTP_KratosServerError verifies redirect when Kratos
 // returns a 5xx error.
 func TestAuthHandler_ServeHTTP_KratosServerError(t *testing.T) {

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -35,6 +35,10 @@ When auth is enabled, read user identity from these headers:
 - `X-User-Email` — user email
 - `X-User-Verified` — email verification status ("true"/"false")
 
+On public paths (`auth.public_paths`), these headers are set when a valid session
+cookie is present but are absent for anonymous visitors. Your app code should
+treat them as optional on public paths and required on protected paths.
+
 ## Architecture
 
 This project follows hexagonal architecture (ports and adapters):


### PR DESCRIPTION
Closes #984

## Summary
- Extract duplicated identity header-setting logic into a `setIdentityHeaders` helper function
- On public paths, perform optional session checking: if a Kratos session cookie is present and valid, set `X-User-Id`, `X-User-Email`, and `X-User-Verified` headers — but never redirect or block the request
- If the session cookie is absent or invalid on a public path, the request passes through without identity headers (no error, no redirect)

## Test plan
- [x] `TestAuthHandler_PublicPath_WithValidSession_SetsHeaders` — public path + valid cookie: identity headers set, request passes through
- [x] `TestAuthHandler_PublicPath_WithInvalidSession_NoHeaders` — public path + expired cookie: no identity headers, request still passes through (no redirect)
- [x] `TestAuthHandler_PublicPath_NoCookie_NoHeaders` — public path + no cookie: no identity headers, request passes through (no redirect)
- [x] All existing auth handler tests continue to pass
- [x] `make check` passes (lint, build, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)