### PR TITLE
feat(#985): role-based access control via Kratos identity traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Your app receives authenticated user info via headers:
 | `X-User-Id` | `sub` | Subject identifier |
 | `X-User-Email` | `email` | Primary email address |
 | `X-User-Verified` | `email_verified` | Email verification status (`true`/`false`) |
+| `X-User-Role` | `traits.role` | User role (Kratos only; defaults to `user`) |
 
 See [docs/identity-providers.md](docs/identity-providers.md) for Auth0, Keycloak,
 Firebase, Cognito, Okta, Supabase, and Kratos step-by-step guides.

--- a/dev/kratos/identity.schema.json
+++ b/dev/kratos/identity.schema.json
@@ -24,6 +24,12 @@
               "via": "email"
             }
           }
+        },
+        "role": {
+          "type": "string",
+          "title": "Role",
+          "default": "user",
+          "enum": ["user", "admin", "moderator"]
         }
       },
       "required": ["email"],

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,6 +126,7 @@ tls:
 | `auth.login_url` | string | `/self-service/login/browser` | Redirect for unauthenticated users |
 | `auth.on_kratos_unavailable` | string | `503` | Behavior when Kratos is unreachable: `503` or `allow_public` |
 | `auth.identity_schema` | string | `email_password` | Identity schema: `email_password`, `email_only`, `username_password`, `social`, or a file path |
+| `auth.role_paths` | map | `{}` | Maps role names (`user`, `admin`, `moderator`) to URL path patterns requiring that role. Users whose Kratos `role` trait does not match receive HTTP 403. Only valid when `auth.mode` is `kratos`. When empty, no role enforcement is performed but `X-User-Role` is still set |
 
 ### `auth.jwt`
 

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -30,6 +30,11 @@ When auth is enabled, read user identity from these headers:
 - `X-User-Id` — user identifier
 - `X-User-Email` — user email
 - `X-User-Verified` — email verification status ("true"/"false")
+- `X-User-Role` — user role from Kratos identity traits ("user", "admin", or "moderator"; defaults to "user")
+
+Role-based path restrictions can be configured in vibewarden.yaml via
+`auth.role_paths` (only when `auth.mode: kratos`). Requests to restricted
+paths by users without the required role receive HTTP 403.
 
 On public paths (`auth.public_paths`), these headers are set when a valid session
 cookie is present but are absent for anonymous visitors. Your app code should

--- a/docs/examples/express.md
+++ b/docs/examples/express.md
@@ -252,6 +252,7 @@ function vibewardenAuth(req, res, next) {
   const userId    = req.headers["x-user-id"];
   const userEmail = req.headers["x-user-email"];
   const verified  = req.headers["x-user-verified"] === "true";
+  const userRole  = req.headers["x-user-role"] || "user";
   const sessionId = req.headers["x-session-id"];
 
   if (!userId) {
@@ -260,7 +261,7 @@ function vibewardenAuth(req, res, next) {
     return res.status(401).json({ error: "unauthorized" });
   }
 
-  req.user = { id: userId, email: userEmail, verified, sessionId };
+  req.user = { id: userId, email: userEmail, verified, role: userRole, sessionId };
   next();
 }
 
@@ -296,6 +297,7 @@ export function vibewardenAuth(
   const id        = req.headers["x-user-id"] as string | undefined;
   const email     = (req.headers["x-user-email"] as string) ?? "";
   const verified  = req.headers["x-user-verified"] === "true";
+  const role      = (req.headers["x-user-role"] as string) ?? "user";
   const sessionId = (req.headers["x-session-id"] as string) ?? "";
 
   if (!id) {
@@ -303,7 +305,7 @@ export function vibewardenAuth(
     return;
   }
 
-  req.user = { id, email, verified, sessionId };
+  req.user = { id, email, verified, role, sessionId };
   next();
 }
 ```

--- a/docs/examples/express.md
+++ b/docs/examples/express.md
@@ -231,6 +231,7 @@ without making any additional auth calls.
 | `X-User-ID` | Kratos identity UUID |
 | `X-User-Email` | Primary email address from the identity traits |
 | `X-User-Verified` | `"true"` if the email address has been verified |
+| `X-User-Role` | User role from the identity traits (`user`, `admin`, or `moderator`). Defaults to `user` when the trait is absent |
 | `X-Session-ID` | Kratos session UUID |
 
 ### Middleware to extract user identity

--- a/docs/examples/nextjs.md
+++ b/docs/examples/nextjs.md
@@ -254,6 +254,7 @@ export default async function DashboardPage() {
   const userId    = headersList.get("x-user-id");
   const userEmail = headersList.get("x-user-email");
   const verified  = headersList.get("x-user-verified") === "true";
+  const userRole  = headersList.get("x-user-role") ?? "user";
 
   if (!userId) {
     // VibeWarden should have redirected unauthenticated requests to /login.
@@ -265,6 +266,7 @@ export default async function DashboardPage() {
     <main>
       <h1>Welcome, {userEmail}</h1>
       {!verified && <p>Please verify your email address.</p>}
+      {userRole === "admin" && <a href="/admin">Admin Dashboard</a>}
     </main>
   );
 }

--- a/docs/examples/nextjs.md
+++ b/docs/examples/nextjs.md
@@ -238,6 +238,7 @@ without making any additional auth calls.
 | `X-User-ID` | Kratos identity UUID |
 | `X-User-Email` | Primary email address from the identity traits |
 | `X-User-Verified` | `"true"` if the email address has been verified |
+| `X-User-Role` | User role from the identity traits (`user`, `admin`, or `moderator`). Defaults to `user` when the trait is absent |
 | `X-Session-ID` | Kratos session UUID |
 
 ### App Router (Next.js 13+)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -46,8 +46,9 @@ internet required), and `auth.mode: jwt` in production to validate tokens from
 your cloud IAM (Cognito, Auth0, Azure AD, etc.).
 
 Your application code does not change between environments. VibeWarden injects
-the same `X-User-Id`, `X-User-Email`, and `X-User-Verified` headers in both
-modes. Only the VibeWarden config differs.
+`X-User-Id`, `X-User-Email`, and `X-User-Verified` headers in both modes.
+Kratos mode additionally sets `X-User-Role` from the identity traits.
+Only the VibeWarden config differs.
 
 Switch between them with `vibewarden start --config vibewarden.dev.yaml` or
 via environment variable interpolation in a single shared config file.

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,6 +112,7 @@ Your app receives authenticated user info via headers:
 | `X-User-Id` | `sub` | Subject identifier |
 | `X-User-Email` | `email` | Primary email address |
 | `X-User-Verified` | `email_verified` | Email verification status (`true`/`false`) |
+| `X-User-Role` | `traits.role` | User role (Kratos only; defaults to `user`) |
 
 On public paths, these headers are present when the visitor has a valid session (optional auth).
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -290,6 +290,12 @@ Create `config/kratos/identity.schema.json`:
             "recovery": { "via": "email" },
             "verification": { "via": "email" }
           }
+        },
+        "role": {
+          "type": "string",
+          "title": "Role",
+          "enum": ["user", "admin", "moderator"],
+          "default": "user"
         }
       },
       "required": ["email"],

--- a/examples/demo-app/kratos/identity.schema.json
+++ b/examples/demo-app/kratos/identity.schema.json
@@ -24,6 +24,12 @@
               "via": "email"
             }
           }
+        },
+        "role": {
+          "type": "string",
+          "title": "Role",
+          "default": "user",
+          "enum": ["user", "admin", "moderator"]
         }
       },
       "required": ["email"],

--- a/internal/adapters/caddy/auth_handler.go
+++ b/internal/adapters/caddy/auth_handler.go
@@ -33,12 +33,17 @@ type AuthHandlerConfig struct {
 
 	// KratosURL is the base URL of the Kratos public API (e.g. "http://kratos:4433").
 	KratosURL string `json:"kratos_url"`
+
+	// RolePaths maps role names (e.g. "admin") to URL path patterns that
+	// require that role. When set, authenticated users whose role does not
+	// match receive HTTP 403. When empty, no role enforcement is performed.
+	RolePaths map[string][]string `json:"role_paths,omitempty"`
 }
 
 // AuthHandler is a Caddy HTTP handler module that validates Kratos session
 // cookies and enforces authentication. Unauthenticated requests are redirected
 // to the configured login URL. Authenticated requests have identity headers
-// (X-User-Id, X-User-Email, X-User-Verified) injected for the upstream app.
+// (X-User-Id, X-User-Email, X-User-Verified, X-User-Role) injected for the upstream app.
 //
 // The module is registered under the name "vibewarden_authentication" and referenced from
 // the Caddy JSON configuration as:
@@ -246,6 +251,45 @@ func setIdentityHeaders(r *http.Request, whoami *kratosWhoamiResponse) {
 	}
 }
 
+// extractRole extracts the role string from the Kratos whoami response.
+// It looks for traits.role and returns "user" as the default when the trait
+// is absent or not a string.
+func extractRole(whoami *kratosWhoamiResponse) string {
+	raw, ok := whoami.Identity.Traits["role"]
+	if !ok {
+		return "user"
+	}
+	role, ok := raw.(string)
+	if !ok || role == "" {
+		return "user"
+	}
+	return role
+}
+
+// matchRequiredRole checks whether the request path requires a specific role
+// according to the configured RolePaths map. It returns the required role name
+// and true if a match is found, or ("", false) if no role restriction applies.
+func (h *AuthHandler) matchRequiredRole(reqPath string) (string, bool) {
+	for role, patterns := range h.Config.RolePaths {
+		for _, p := range patterns {
+			if strings.HasSuffix(p, "/*") {
+				prefix := strings.TrimSuffix(p, "/*")
+				if strings.HasPrefix(reqPath, prefix) {
+					return role, true
+				}
+			}
+			matched, _ := path.Match(p, reqPath)
+			if matched {
+				return role, true
+			}
+			if p == reqPath {
+				return role, true
+			}
+		}
+	}
+	return "", false
+}
+
 // ServeHTTP implements caddyhttp.MiddlewareHandler.
 func (h *AuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	// Public paths: optional auth — check session if cookie present, set
@@ -281,6 +325,22 @@ func (h *AuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 
 	// Set identity headers for the upstream app.
 	setIdentityHeaders(r, whoami)
+
+	// Always set the role header from traits.
+	role := extractRole(whoami)
+	r.Header.Set("X-User-Role", role)
+
+	// Enforce role-based path restrictions when configured.
+	if len(h.Config.RolePaths) > 0 {
+		if requiredRole, ok := h.matchRequiredRole(r.URL.Path); ok {
+			if role != requiredRole {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"error":"forbidden","message":"insufficient role for this path"}`))
+				return nil
+			}
+		}
+	}
 
 	return next.ServeHTTP(w, r)
 }

--- a/internal/adapters/caddy/auth_handler.go
+++ b/internal/adapters/caddy/auth_handler.go
@@ -13,6 +13,8 @@ import (
 
 	gocaddy "github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+
+	"github.com/vibewarden/vibewarden/internal/domain/identity"
 )
 
 func init() {
@@ -251,17 +253,27 @@ func setIdentityHeaders(r *http.Request, whoami *kratosWhoamiResponse) {
 	}
 }
 
-// extractRole extracts the role string from the Kratos whoami response.
-// It looks for traits.role and returns "user" as the default when the trait
-// is absent or not a string.
-func extractRole(whoami *kratosWhoamiResponse) string {
+// extractRole extracts the role string from the Kratos whoami response and
+// validates it via identity.NewRole. It returns identity.DefaultRole ("user")
+// when the trait is absent, not a string, or not a recognised role value.
+// When an unrecognised role value is encountered, a warning is logged.
+func extractRole(whoami *kratosWhoamiResponse, logger *slog.Logger) identity.Role {
 	raw, ok := whoami.Identity.Traits["role"]
 	if !ok {
-		return "user"
+		return identity.DefaultRole()
 	}
-	role, ok := raw.(string)
-	if !ok || role == "" {
-		return "user"
+	roleStr, ok := raw.(string)
+	if !ok || roleStr == "" {
+		return identity.DefaultRole()
+	}
+	role, err := identity.NewRole(roleStr)
+	if err != nil {
+		logger.Warn("authentication: ignoring invalid role from identity traits",
+			slog.String("role", roleStr),
+			slog.String("identity_id", whoami.Identity.ID),
+			slog.String("error", err.Error()),
+		)
+		return identity.DefaultRole()
 	}
 	return role
 }
@@ -326,14 +338,16 @@ func (h *AuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	// Set identity headers for the upstream app.
 	setIdentityHeaders(r, whoami)
 
-	// Always set the role header from traits.
-	role := extractRole(whoami)
-	r.Header.Set("X-User-Role", role)
+	// Always set the role header from traits. extractRole validates the
+	// role value through the domain layer; invalid values are logged as
+	// warnings and the default ("user") is used instead.
+	role := extractRole(whoami, h.logger)
+	r.Header.Set("X-User-Role", role.String())
 
 	// Enforce role-based path restrictions when configured.
 	if len(h.Config.RolePaths) > 0 {
 		if requiredRole, ok := h.matchRequiredRole(r.URL.Path); ok {
-			if role != requiredRole {
+			if role.String() != requiredRole {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusForbidden)
 				_, _ = w.Write([]byte(`{"error":"forbidden","message":"insufficient role for this path"}`))

--- a/internal/adapters/caddy/auth_handler.go
+++ b/internal/adapters/caddy/auth_handler.go
@@ -285,7 +285,7 @@ func (h *AuthHandler) matchRequiredRole(reqPath string) (string, bool) {
 	for role, patterns := range h.Config.RolePaths {
 		for _, p := range patterns {
 			if strings.HasSuffix(p, "/*") {
-				prefix := strings.TrimSuffix(p, "/*")
+				prefix := strings.TrimSuffix(p, "*")
 				if strings.HasPrefix(reqPath, prefix) {
 					return role, true
 				}
@@ -310,6 +310,8 @@ func (h *AuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 		if cookie, err := r.Cookie(h.Config.CookieName); err == nil {
 			if whoami, err := h.callWhoami(r.Context(), cookie.Value); err == nil {
 				setIdentityHeaders(r, whoami)
+				role := extractRole(whoami, h.logger)
+				r.Header.Set("X-User-Role", role.String())
 			}
 			// If whoami fails, proceed without headers (don't redirect, don't error).
 		}

--- a/internal/adapters/caddy/auth_handler_test.go
+++ b/internal/adapters/caddy/auth_handler_test.go
@@ -837,6 +837,61 @@ func TestAuthHandler_PublicPath_NoCookie_NoHeaders(t *testing.T) {
 	}
 }
 
+// TestAuthHandler_PublicPath_WithValidSession_SetsRoleHeader verifies that a
+// public path with a valid session also sets the X-User-Role header.
+//
+// Regression test: the public path code path called setIdentityHeaders but not
+// extractRole, so X-User-Role was missing on authenticated public paths.
+func TestAuthHandler_PublicPath_WithValidSession_SetsRoleHeader(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"identity": {
+				"id": "admin-1",
+				"traits": {"email": "admin@example.com", "role": "admin"},
+				"verifiable_addresses": [
+					{"value": "admin@example.com", "via": "email", "verified": true}
+				]
+			}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName:  "ory_kratos_session",
+		LoginURL:    "/login",
+		PublicPaths: []string{"/public"},
+		KratosURL:   kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	var capturedHeaders http.Header
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		capturedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/public", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "valid-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	if capturedHeaders == nil {
+		t.Fatal("next handler was not called")
+	}
+	if got := capturedHeaders.Get("X-User-Role"); got != "admin" {
+		t.Errorf("X-User-Role = %q, want %q", got, "admin")
+	}
+}
+
 // TestAuthHandler_RoleHeader_Set verifies that the X-User-Role header is set
 // from the Kratos identity traits.role field.
 func TestAuthHandler_RoleHeader_Set(t *testing.T) {
@@ -1315,6 +1370,39 @@ func TestMatchRequiredRole(t *testing.T) {
 			}
 			if gotOK && gotRole != tt.wantRole {
 				t.Errorf("matchRequiredRole(%q) role = %q, want %q", tt.reqPath, gotRole, tt.wantRole)
+			}
+		})
+	}
+}
+
+// TestMatchRequiredRole_PrefixBoundary verifies that /admin/* does not match
+// /administrator or /admins — only paths under /admin/.
+//
+// Regression test: TrimSuffix(p, "/*") produced "/admin" which matched
+// "/administrator". Fixed to TrimSuffix(p, "*") to preserve the trailing slash.
+func TestMatchRequiredRole_PrefixBoundary(t *testing.T) {
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		RolePaths: map[string][]string{
+			"admin": {"/admin/*"},
+		},
+	}}
+
+	tests := []struct {
+		path   string
+		wantOK bool
+	}{
+		{"/admin/dashboard", true},
+		{"/admin/users/edit", true},
+		{"/administrator", false},
+		{"/admins/list", false},
+		{"/admin-panel", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			_, ok := h.matchRequiredRole(tt.path)
+			if ok != tt.wantOK {
+				t.Errorf("matchRequiredRole(%q) ok = %v, want %v", tt.path, ok, tt.wantOK)
 			}
 		})
 	}

--- a/internal/adapters/caddy/auth_handler_test.go
+++ b/internal/adapters/caddy/auth_handler_test.go
@@ -3,12 +3,15 @@ package caddy
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	gocaddy "github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+
+	"github.com/vibewarden/vibewarden/internal/domain/identity"
 )
 
 // TestAuthHandler_CaddyModule verifies the Caddy module metadata.
@@ -1157,5 +1160,173 @@ func TestAuthHandler_ServeHTTP_KratosServerError(t *testing.T) {
 				t.Errorf("status = %d, want %d", w.Code, http.StatusFound)
 			}
 		})
+	}
+}
+
+// discardLogger returns a logger that discards all output.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(noopWriter{}, nil))
+}
+
+type noopWriter struct{}
+
+func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// ---------------------------------------------------------------------------
+// Direct unit tests for extractRole
+// ---------------------------------------------------------------------------
+
+// TestExtractRole verifies the extractRole function in isolation.
+func TestExtractRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		traits   map[string]any
+		wantRole string
+	}{
+		{
+			name:     "valid admin role",
+			traits:   map[string]any{"email": "u@e.com", "role": "admin"},
+			wantRole: "admin",
+		},
+		{
+			name:     "valid moderator role",
+			traits:   map[string]any{"email": "u@e.com", "role": "moderator"},
+			wantRole: "moderator",
+		},
+		{
+			name:     "valid user role",
+			traits:   map[string]any{"email": "u@e.com", "role": "user"},
+			wantRole: "user",
+		},
+		{
+			name:     "missing role defaults to user",
+			traits:   map[string]any{"email": "u@e.com"},
+			wantRole: "user",
+		},
+		{
+			name:     "empty string role defaults to user",
+			traits:   map[string]any{"email": "u@e.com", "role": ""},
+			wantRole: "user",
+		},
+		{
+			name:     "non-string role defaults to user",
+			traits:   map[string]any{"email": "u@e.com", "role": 42},
+			wantRole: "user",
+		},
+		{
+			name:     "invalid role value defaults to user and logs warning",
+			traits:   map[string]any{"email": "u@e.com", "role": "superadmin"},
+			wantRole: "user",
+		},
+		{
+			name:     "nil traits defaults to user",
+			traits:   nil,
+			wantRole: "user",
+		},
+	}
+
+	logger := discardLogger()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			whoami := &kratosWhoamiResponse{}
+			whoami.Identity.Traits = tt.traits
+			got := extractRole(whoami, logger)
+			if got.String() != tt.wantRole {
+				t.Errorf("extractRole() = %q, want %q", got.String(), tt.wantRole)
+			}
+		})
+	}
+}
+
+// TestExtractRole_InvalidValue_ReturnsDefaultRole verifies that an unrecognised
+// role value is rejected and the default role is returned.
+func TestExtractRole_InvalidValue_ReturnsDefaultRole(t *testing.T) {
+	logger := discardLogger()
+	whoami := &kratosWhoamiResponse{}
+	whoami.Identity.Traits = map[string]any{"role": "superadmin"}
+	whoami.Identity.ID = "user-123"
+
+	got := extractRole(whoami, logger)
+	if got != identity.DefaultRole() {
+		t.Errorf("extractRole() = %q for invalid role, want default %q", got.String(), identity.DefaultRole().String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Direct unit tests for matchRequiredRole
+// ---------------------------------------------------------------------------
+
+// TestMatchRequiredRole verifies the matchRequiredRole function in isolation.
+func TestMatchRequiredRole(t *testing.T) {
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		RolePaths: map[string][]string{
+			"admin":     {"/admin/*"},
+			"moderator": {"/mod/queue", "/mod/reports/*"},
+		},
+	}}
+
+	tests := []struct {
+		name     string
+		reqPath  string
+		wantRole string
+		wantOK   bool
+	}{
+		{
+			name:     "admin prefix match",
+			reqPath:  "/admin/dashboard",
+			wantRole: "admin",
+			wantOK:   true,
+		},
+		{
+			name:     "admin nested path",
+			reqPath:  "/admin/users/edit",
+			wantRole: "admin",
+			wantOK:   true,
+		},
+		{
+			name:     "moderator exact match",
+			reqPath:  "/mod/queue",
+			wantRole: "moderator",
+			wantOK:   true,
+		},
+		{
+			name:     "moderator prefix match",
+			reqPath:  "/mod/reports/123",
+			wantRole: "moderator",
+			wantOK:   true,
+		},
+		{
+			name:    "unmatched path",
+			reqPath: "/public/info",
+			wantOK:  false,
+		},
+		{
+			name:    "root path",
+			reqPath: "/",
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRole, gotOK := h.matchRequiredRole(tt.reqPath)
+			if gotOK != tt.wantOK {
+				t.Errorf("matchRequiredRole(%q) ok = %v, want %v", tt.reqPath, gotOK, tt.wantOK)
+			}
+			if gotOK && gotRole != tt.wantRole {
+				t.Errorf("matchRequiredRole(%q) role = %q, want %q", tt.reqPath, gotRole, tt.wantRole)
+			}
+		})
+	}
+}
+
+// TestMatchRequiredRole_NoRolePaths verifies that when RolePaths is empty,
+// no role is required for any path.
+func TestMatchRequiredRole_NoRolePaths(t *testing.T) {
+	h := &AuthHandler{Config: AuthHandlerConfig{}}
+
+	_, ok := h.matchRequiredRole("/admin/dashboard")
+	if ok {
+		t.Error("matchRequiredRole() ok = true with empty RolePaths, want false")
 	}
 }

--- a/internal/adapters/caddy/auth_handler_test.go
+++ b/internal/adapters/caddy/auth_handler_test.go
@@ -834,6 +834,289 @@ func TestAuthHandler_PublicPath_NoCookie_NoHeaders(t *testing.T) {
 	}
 }
 
+// TestAuthHandler_RoleHeader_Set verifies that the X-User-Role header is set
+// from the Kratos identity traits.role field.
+func TestAuthHandler_RoleHeader_Set(t *testing.T) {
+	tests := []struct {
+		name     string
+		traits   string
+		wantRole string
+	}{
+		{
+			name:     "admin role",
+			traits:   `{"email":"u@e.com","role":"admin"}`,
+			wantRole: "admin",
+		},
+		{
+			name:     "moderator role",
+			traits:   `{"email":"u@e.com","role":"moderator"}`,
+			wantRole: "moderator",
+		},
+		{
+			name:     "user role explicit",
+			traits:   `{"email":"u@e.com","role":"user"}`,
+			wantRole: "user",
+		},
+		{
+			name:     "missing role defaults to user",
+			traits:   `{"email":"u@e.com"}`,
+			wantRole: "user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{
+					"active": true,
+					"identity": {
+						"id": "user-123",
+						"traits": %s,
+						"verifiable_addresses": [
+							{"value": "u@e.com", "via": "email", "verified": true}
+						]
+					}
+				}`, tt.traits)
+			}))
+			defer kratosServer.Close()
+
+			h := &AuthHandler{Config: AuthHandlerConfig{
+				CookieName: "ory_kratos_session",
+				LoginURL:   "/login",
+				KratosURL:  kratosServer.URL,
+			}}
+			if err := h.Provision(gocaddy.Context{}); err != nil {
+				t.Fatalf("Provision() error = %v", err)
+			}
+
+			var capturedHeaders http.Header
+			next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+				capturedHeaders = r.Header.Clone()
+				w.WriteHeader(http.StatusOK)
+				return nil
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+			req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "valid-token"})
+			w := httptest.NewRecorder()
+
+			err := h.ServeHTTP(w, req, next)
+			if err != nil {
+				t.Fatalf("ServeHTTP() error = %v", err)
+			}
+
+			if capturedHeaders == nil {
+				t.Fatal("next handler was not called")
+			}
+			if got := capturedHeaders.Get("X-User-Role"); got != tt.wantRole {
+				t.Errorf("X-User-Role = %q, want %q", got, tt.wantRole)
+			}
+		})
+	}
+}
+
+// TestAuthHandler_RolePath_Allowed verifies that a user with the required role
+// can access a role-restricted path.
+func TestAuthHandler_RolePath_Allowed(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"identity": {
+				"id": "admin-1",
+				"traits": {"email": "admin@e.com", "role": "admin"},
+				"verifiable_addresses": [
+					{"value": "admin@e.com", "via": "email", "verified": true}
+				]
+			}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName: "ory_kratos_session",
+		LoginURL:   "/login",
+		KratosURL:  kratosServer.URL,
+		RolePaths: map[string][]string{
+			"admin": {"/admin/*"},
+		},
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	nextCalled := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/dashboard", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "valid-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+	if !nextCalled {
+		t.Error("expected next handler to be called for admin user on /admin/*")
+	}
+}
+
+// TestAuthHandler_RolePath_Denied verifies that a user without the required role
+// receives HTTP 403 with the correct JSON body.
+func TestAuthHandler_RolePath_Denied(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"identity": {
+				"id": "user-1",
+				"traits": {"email": "user@e.com", "role": "user"},
+				"verifiable_addresses": [
+					{"value": "user@e.com", "via": "email", "verified": true}
+				]
+			}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName: "ory_kratos_session",
+		LoginURL:   "/login",
+		KratosURL:  kratosServer.URL,
+		RolePaths: map[string][]string{
+			"admin": {"/admin/*"},
+		},
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	nextCalled := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/dashboard", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "valid-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+	if nextCalled {
+		t.Error("next handler should not be called for user role on /admin/*")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	wantBody := `{"error":"forbidden","message":"insufficient role for this path"}`
+	if got := w.Body.String(); got != wantBody {
+		t.Errorf("body = %q, want %q", got, wantBody)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+}
+
+// TestAuthHandler_RolePath_PublicPath_Skipped verifies that public paths bypass
+// role enforcement entirely.
+func TestAuthHandler_RolePath_PublicPath_Skipped(t *testing.T) {
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName:  "ory_kratos_session",
+		LoginURL:    "/login",
+		PublicPaths: []string{"/admin/public/*"},
+		KratosURL:   "http://unreachable:4433",
+		RolePaths: map[string][]string{
+			"admin": {"/admin/*"},
+		},
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	nextCalled := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	// /admin/public/info should bypass auth (and therefore role checks)
+	req := httptest.NewRequest(http.MethodGet, "/admin/public/info", nil)
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+	if !nextCalled {
+		t.Error("expected next handler to be called for public path")
+	}
+}
+
+// TestAuthHandler_NoRolePaths_HeaderOnly verifies that when no role_paths are
+// configured, the X-User-Role header is still set but no role enforcement occurs.
+func TestAuthHandler_NoRolePaths_HeaderOnly(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"identity": {
+				"id": "user-1",
+				"traits": {"email": "user@e.com", "role": "user"},
+				"verifiable_addresses": [
+					{"value": "user@e.com", "via": "email", "verified": true}
+				]
+			}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &AuthHandler{Config: AuthHandlerConfig{
+		CookieName: "ory_kratos_session",
+		LoginURL:   "/login",
+		KratosURL:  kratosServer.URL,
+		// No RolePaths configured
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	var capturedHeaders http.Header
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		capturedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	// Request to /admin/* should pass through since no role_paths are configured
+	req := httptest.NewRequest(http.MethodGet, "/admin/dashboard", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "valid-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, next)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	if capturedHeaders == nil {
+		t.Fatal("next handler was not called")
+	}
+	if got := capturedHeaders.Get("X-User-Role"); got != "user" {
+		t.Errorf("X-User-Role = %q, want %q", got, "user")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (no role enforcement expected)", w.Code, http.StatusOK)
+	}
+}
+
 // TestAuthHandler_ServeHTTP_KratosServerError verifies redirect when Kratos
 // returns a 5xx error.
 func TestAuthHandler_ServeHTTP_KratosServerError(t *testing.T) {

--- a/internal/adapters/caddy/config_handlers.go
+++ b/internal/adapters/caddy/config_handlers.go
@@ -11,7 +11,7 @@ import (
 var defaultCompressionAlgorithms = []string{"zstd", "gzip"}
 
 // buildUserHeaderStripHandler creates a Caddy headers handler that deletes the
-// X-User-Id, X-User-Email, and X-User-Verified request headers.
+// X-User-Id, X-User-Email, X-User-Verified, and X-User-Role request headers.
 //
 // This handler must be placed as the very first handler in every route's chain.
 // Removing these headers on every inbound request prevents a client from
@@ -21,7 +21,7 @@ func buildUserHeaderStripHandler() map[string]any {
 	return map[string]any{
 		"handler": "headers",
 		"request": map[string]any{
-			"delete": []string{"X-User-Id", "X-User-Email", "X-User-Verified"},
+			"delete": []string{"X-User-Id", "X-User-Email", "X-User-Verified", "X-User-Role"},
 		},
 	}
 }

--- a/internal/adapters/caddy/config_test.go
+++ b/internal/adapters/caddy/config_test.go
@@ -988,7 +988,7 @@ func TestBuildCaddyConfig_UserHeaderStripIsFirst(t *testing.T) {
 }
 
 // TestBuildCaddyConfig_UserHeaderStripDeletesCorrectHeaders verifies that the
-// strip handler targets exactly X-User-Id, X-User-Email, and X-User-Verified.
+// strip handler targets exactly X-User-Id, X-User-Email, X-User-Verified, and X-User-Role.
 func TestBuildCaddyConfig_UserHeaderStripDeletesCorrectHeaders(t *testing.T) {
 	cfg := &ports.ProxyConfig{
 		ListenAddr:   "127.0.0.1:8080",
@@ -1026,6 +1026,7 @@ func TestBuildCaddyConfig_UserHeaderStripDeletesCorrectHeaders(t *testing.T) {
 		"X-User-Id":       true,
 		"X-User-Email":    true,
 		"X-User-Verified": true,
+		"X-User-Role":     true,
 	}
 	for _, h := range deleted {
 		delete(wantDeleted, h)

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -34,6 +34,11 @@ When auth is enabled, read user identity from these headers:
 - `X-User-Id` — user identifier
 - `X-User-Email` — user email
 - `X-User-Verified` — email verification status ("true"/"false")
+- `X-User-Role` — user role from Kratos identity traits ("user", "admin", or "moderator"; defaults to "user")
+
+Role-based path restrictions can be configured in vibewarden.yaml via
+`auth.role_paths` (only when `auth.mode: kratos`). Requests to restricted
+paths by users without the required role receive HTTP 403.
 
 On public paths (`auth.public_paths`), these headers are set when a valid session
 cookie is present but are absent for anonymous visitors. Your app code should

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
+
+	"github.com/vibewarden/vibewarden/internal/domain/identity"
 )
 
 // hexColorRE matches valid CSS hex color values: #RGB or #RRGGBB.
@@ -1808,9 +1810,9 @@ func (c *Config) Validate() error {
 		errs = append(errs, "auth.role_paths is only valid when auth.mode is \"kratos\"")
 	}
 	// Validate that role names in role_paths are recognised values.
-	validRoleNames := map[string]bool{"user": true, "admin": true, "moderator": true}
+	// Delegates to identity.NewRole to keep the valid-role list in one place.
 	for roleName, paths := range c.Auth.RolePaths {
-		if !validRoleNames[roleName] {
+		if _, err := identity.NewRole(roleName); err != nil {
 			errs = append(errs, fmt.Sprintf(
 				"auth.role_paths: role %q is invalid; accepted values: user, admin, moderator",
 				roleName,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -792,6 +792,19 @@ type AuthConfig struct {
 	// Each entry requires at minimum a provider name, client_id, and client_secret.
 	SocialProviders []SocialProviderConfig `mapstructure:"social_providers"`
 
+	// RolePaths maps role names to URL path patterns that require that role.
+	// When configured, authenticated users whose Kratos identity trait "role"
+	// does not match the required role for a path receive HTTP 403 Forbidden.
+	// Only valid when Mode is "kratos".
+	//
+	// Example:
+	//   role_paths:
+	//     admin:
+	//       - /admin/*
+	//     moderator:
+	//       - /admin/moderation/*
+	RolePaths map[string][]string `mapstructure:"role_paths"`
+
 	// UI holds theme and URL settings for the built-in or custom auth pages.
 	UI AuthUIConfig `mapstructure:"ui"`
 }
@@ -1788,6 +1801,24 @@ func (c *Config) Validate() error {
 			"auth.on_kratos_unavailable %q is invalid; accepted values: \"503\", \"allow_public\"",
 			c.Auth.OnKratosUnavailable,
 		))
+	}
+
+	// auth.role_paths validation: only valid when mode is "kratos".
+	if len(c.Auth.RolePaths) > 0 && c.Auth.Mode != AuthModeKratos {
+		errs = append(errs, "auth.role_paths is only valid when auth.mode is \"kratos\"")
+	}
+	// Validate that role names in role_paths are recognised values.
+	validRoleNames := map[string]bool{"user": true, "admin": true, "moderator": true}
+	for roleName, paths := range c.Auth.RolePaths {
+		if !validRoleNames[roleName] {
+			errs = append(errs, fmt.Sprintf(
+				"auth.role_paths: role %q is invalid; accepted values: user, admin, moderator",
+				roleName,
+			))
+		}
+		if len(paths) == 0 {
+			errs = append(errs, fmt.Sprintf("auth.role_paths.%s: must have at least one path", roleName))
+		}
 	}
 
 	// Auth UI validation.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3204,3 +3204,102 @@ func TestResolvedBuildContext(t *testing.T) {
 		})
 	}
 }
+
+// TestValidate_RolePaths verifies validation of auth.role_paths.
+func TestValidate_RolePaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         config.Config
+		wantErr     bool
+		wantContain string
+	}{
+		{
+			name: "role_paths valid with kratos mode",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					Mode: "kratos",
+					RolePaths: map[string][]string{
+						"admin": {"/admin/*"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "role_paths rejected with jwt mode",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					Mode: "jwt",
+					RolePaths: map[string][]string{
+						"admin": {"/admin/*"},
+					},
+				},
+			},
+			wantErr:     true,
+			wantContain: "auth.role_paths is only valid when auth.mode is \"kratos\"",
+		},
+		{
+			name: "role_paths rejected with none mode",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					Mode: "none",
+					RolePaths: map[string][]string{
+						"admin": {"/admin/*"},
+					},
+				},
+			},
+			wantErr:     true,
+			wantContain: "auth.role_paths is only valid when auth.mode is \"kratos\"",
+		},
+		{
+			name: "invalid role name rejected",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					Mode: "kratos",
+					RolePaths: map[string][]string{
+						"superadmin": {"/admin/*"},
+					},
+				},
+			},
+			wantErr:     true,
+			wantContain: "role \"superadmin\" is invalid",
+		},
+		{
+			name: "empty paths for role rejected",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					Mode: "kratos",
+					RolePaths: map[string][]string{
+						"admin": {},
+					},
+				},
+			},
+			wantErr:     true,
+			wantContain: "must have at least one path",
+		},
+		{
+			name: "empty role_paths is valid (no enforcement)",
+			cfg: config.Config{
+				Auth: config.AuthConfig{
+					Mode: "kratos",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.wantContain != "" && err != nil {
+				if !strings.Contains(err.Error(), tt.wantContain) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantContain)
+				}
+			}
+		})
+	}
+}

--- a/internal/config/presets/email_only.json
+++ b/internal/config/presets/email_only.json
@@ -26,6 +26,12 @@
               "via": "email"
             }
           }
+        },
+        "role": {
+          "type": "string",
+          "title": "Role",
+          "default": "user",
+          "enum": ["user", "admin", "moderator"]
         }
       },
       "required": ["email"],

--- a/internal/config/presets/email_password.json
+++ b/internal/config/presets/email_password.json
@@ -25,6 +25,12 @@
               "via": "email"
             }
           }
+        },
+        "role": {
+          "type": "string",
+          "title": "Role",
+          "default": "user",
+          "enum": ["user", "admin", "moderator"]
         }
       },
       "required": ["email"],

--- a/internal/config/presets/social.json
+++ b/internal/config/presets/social.json
@@ -44,6 +44,12 @@
           "type": "string",
           "format": "uri",
           "title": "Profile Picture URL"
+        },
+        "role": {
+          "type": "string",
+          "title": "Role",
+          "default": "user",
+          "enum": ["user", "admin", "moderator"]
         }
       },
       "required": ["email"],

--- a/internal/config/presets/username_password.json
+++ b/internal/config/presets/username_password.json
@@ -20,6 +20,12 @@
               }
             }
           }
+        },
+        "role": {
+          "type": "string",
+          "title": "Role",
+          "default": "user",
+          "enum": ["user", "admin", "moderator"]
         }
       },
       "required": ["username"],

--- a/internal/domain/identity/identity.go
+++ b/internal/domain/identity/identity.go
@@ -100,6 +100,25 @@ func (i Identity) HasClaim(name string) bool {
 	return ok
 }
 
+// Role extracts the user's role from the claims map. It looks for a "role"
+// key in claims and attempts to parse it as a valid Role. If the claim is
+// absent or not a valid role string, DefaultRole ("user") is returned.
+func (i Identity) Role() Role {
+	raw, ok := i.claims["role"]
+	if !ok {
+		return DefaultRole()
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return DefaultRole()
+	}
+	r, err := NewRole(s)
+	if err != nil {
+		return DefaultRole()
+	}
+	return r
+}
+
 // IsZero reports whether this is the zero value (no identity).
 func (i Identity) IsZero() bool {
 	return i.id == ""

--- a/internal/domain/identity/identity_test.go
+++ b/internal/domain/identity/identity_test.go
@@ -172,3 +172,31 @@ func TestIdentity_ClaimReturnsNilForMissing(t *testing.T) {
 		t.Errorf("Claim(missing) = %v, want nil", got)
 	}
 }
+
+func TestIdentity_Role(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims map[string]any
+		want   string
+	}{
+		{"admin role from claims", map[string]any{"role": "admin"}, "admin"},
+		{"moderator role from claims", map[string]any{"role": "moderator"}, "moderator"},
+		{"user role from claims", map[string]any{"role": "user"}, "user"},
+		{"missing role defaults to user", map[string]any{}, "user"},
+		{"nil claims defaults to user", nil, "user"},
+		{"invalid role defaults to user", map[string]any{"role": "superadmin"}, "user"},
+		{"non-string role defaults to user", map[string]any{"role": 42}, "user"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ident, err := NewIdentity("id-1", "a@b.com", "kratos", false, tt.claims)
+			if err != nil {
+				t.Fatalf("NewIdentity() error = %v", err)
+			}
+			got := ident.Role()
+			if got.String() != tt.want {
+				t.Errorf("Role() = %q, want %q", got.String(), tt.want)
+			}
+		})
+	}
+}

--- a/internal/domain/identity/role.go
+++ b/internal/domain/identity/role.go
@@ -1,0 +1,43 @@
+package identity
+
+import "fmt"
+
+// Role is a value object representing a user's role within the application.
+// It is immutable and validated at construction time.
+//
+// Accepted values are "user", "admin", and "moderator". The zero value is
+// not a valid Role; use NewRole or DefaultRole to create instances.
+type Role struct{ value string }
+
+const (
+	roleUser      = "user"
+	roleAdmin     = "admin"
+	roleModerator = "moderator"
+)
+
+// validRoles is the set of accepted role strings.
+var validRoles = map[string]bool{
+	roleUser:      true,
+	roleAdmin:     true,
+	roleModerator: true,
+}
+
+// NewRole creates a Role from the given string. Returns an error if the
+// value is not one of the accepted roles: "user", "admin", "moderator".
+func NewRole(s string) (Role, error) {
+	if !validRoles[s] {
+		return Role{}, fmt.Errorf("invalid role %q: accepted values are user, admin, moderator", s)
+	}
+	return Role{value: s}, nil
+}
+
+// DefaultRole returns the default role ("user").
+func DefaultRole() Role {
+	return Role{value: roleUser}
+}
+
+// String returns the string representation of the role.
+func (r Role) String() string { return r.value }
+
+// IsZero reports whether this is the zero-value Role (uninitialised).
+func (r Role) IsZero() bool { return r.value == "" }

--- a/internal/domain/identity/role_test.go
+++ b/internal/domain/identity/role_test.go
@@ -1,0 +1,48 @@
+package identity
+
+import "testing"
+
+func TestNewRole(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"valid user", "user", "user", false},
+		{"valid admin", "admin", "admin", false},
+		{"valid moderator", "moderator", "moderator", false},
+		{"empty string", "", "", true},
+		{"unknown role", "superadmin", "", true},
+		{"uppercase", "Admin", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := NewRole(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewRole(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && r.String() != tt.want {
+				t.Errorf("NewRole(%q).String() = %q, want %q", tt.input, r.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultRole(t *testing.T) {
+	r := DefaultRole()
+	if r.String() != "user" {
+		t.Errorf("DefaultRole().String() = %q, want %q", r.String(), "user")
+	}
+	if r.IsZero() {
+		t.Error("DefaultRole().IsZero() = true, want false")
+	}
+}
+
+func TestRole_IsZero(t *testing.T) {
+	var r Role
+	if !r.IsZero() {
+		t.Error("zero-value Role.IsZero() = false, want true")
+	}
+}

--- a/internal/plugins/auth/config.go
+++ b/internal/plugins/auth/config.go
@@ -97,6 +97,12 @@ type Config struct {
 	// "username_password", or a filesystem path to a custom JSON file.
 	IdentitySchema string
 
+	// RolePaths maps role names to URL path patterns that require that role.
+	// When configured, the auth handler checks the user's Kratos identity
+	// trait "role" against these patterns and returns 403 for mismatches.
+	// Only valid when Mode is ModeKratos.
+	RolePaths map[string][]string
+
 	// UI holds configuration for the built-in auth UI pages.
 	// When UI.Mode is "built-in" (the default), VibeWarden serves its own
 	// login, registration, recovery, and verification pages.

--- a/internal/plugins/auth/plugin.go
+++ b/internal/plugins/auth/plugin.go
@@ -638,7 +638,7 @@ func (p *Plugin) ContributeCaddyHandlers() []ports.CaddyHandler {
 	// For the Caddy JSON config we use the auth cookie validation approach:
 	// inject a handler that checks for the session cookie and redirects
 	// missing sessions to the login URL.
-	authHandler := buildAuthHandler(cookieName, loginURL, publicPaths, p.cfg.KratosPublicURL)
+	authHandler := buildAuthHandler(cookieName, loginURL, publicPaths, p.cfg.KratosPublicURL, p.cfg.RolePaths)
 
 	// Identity-headers handler: sets upstream request headers from Kratos
 	// session data. These headers are consumed by the upstream application.
@@ -700,14 +700,18 @@ func validateKratosConfig(cfg Config) error {
 // In the Caddy JSON config the auth enforcement is represented as a
 // forward_auth handler that delegates session validation to the Kratos
 // whoami endpoint. Public paths bypass auth via a path matcher.
-func buildAuthHandler(cookieName, loginURL string, publicPaths []string, kratosURL string) map[string]any {
-	return map[string]any{
+func buildAuthHandler(cookieName, loginURL string, publicPaths []string, kratosURL string, rolePaths map[string][]string) map[string]any {
+	h := map[string]any{
 		"handler":      "vibewarden_authentication",
 		"cookie_name":  cookieName,
 		"login_url":    loginURL,
 		"public_paths": publicPaths,
 		"kratos_url":   kratosURL,
 	}
+	if len(rolePaths) > 0 {
+		h["role_paths"] = rolePaths
+	}
+	return h
 }
 
 // buildIdentityHeadersHandler creates the Caddy handler configuration that

--- a/internal/plugins/auth/plugin_test.go
+++ b/internal/plugins/auth/plugin_test.go
@@ -1538,3 +1538,84 @@ func TestPlugin_Health_NonKratosModes(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Wiring test: RolePaths flows into Caddy handler JSON
+// ---------------------------------------------------------------------------
+
+// TestPlugin_ContributeCaddyHandlers_RolePaths_Wiring verifies that
+// cfg.RolePaths flows through ContributeCaddyHandlers into the Caddy handler
+// JSON output. This ensures the plugin correctly wires role configuration
+// from the config layer to the Caddy auth handler.
+func TestPlugin_ContributeCaddyHandlers_RolePaths_Wiring(t *testing.T) {
+	tests := []struct {
+		name          string
+		rolePaths     map[string][]string
+		wantRolePaths bool
+	}{
+		{
+			name: "role_paths flows into handler JSON",
+			rolePaths: map[string][]string{
+				"admin":     {"/admin/*"},
+				"moderator": {"/mod/*"},
+			},
+			wantRolePaths: true,
+		},
+		{
+			name:          "empty role_paths omitted from handler JSON",
+			rolePaths:     nil,
+			wantRolePaths: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := defaultConfig()
+			cfg.RolePaths = tt.rolePaths
+			p := newPlugin(cfg)
+			if err := p.Init(context.Background()); err != nil {
+				t.Fatalf("Init() error: %v", err)
+			}
+			defer p.Stop(context.Background()) //nolint:errcheck
+
+			handlers := p.ContributeCaddyHandlers()
+			if len(handlers) < 1 {
+				t.Fatal("ContributeCaddyHandlers() returned no handlers")
+			}
+
+			authHandler := handlers[0].Handler
+			rpRaw, hasRP := authHandler["role_paths"]
+
+			if tt.wantRolePaths {
+				if !hasRP {
+					t.Fatal("auth handler JSON missing role_paths field")
+				}
+				rp, ok := rpRaw.(map[string][]string)
+				if !ok {
+					t.Fatalf("role_paths is %T, want map[string][]string", rpRaw)
+				}
+				// Verify each configured role is present with correct paths.
+				for wantRole, wantPaths := range tt.rolePaths {
+					gotPaths, found := rp[wantRole]
+					if !found {
+						t.Errorf("role_paths missing role %q", wantRole)
+						continue
+					}
+					if len(gotPaths) != len(wantPaths) {
+						t.Errorf("role_paths[%q] has %d paths, want %d", wantRole, len(gotPaths), len(wantPaths))
+						continue
+					}
+					for i, want := range wantPaths {
+						if gotPaths[i] != want {
+							t.Errorf("role_paths[%q][%d] = %q, want %q", wantRole, i, gotPaths[i], want)
+						}
+					}
+				}
+			} else {
+				if hasRP {
+					t.Errorf("auth handler JSON has role_paths when none were configured: %v", rpRaw)
+				}
+			}
+		})
+	}
+}

--- a/internal/plugins/builtin.go
+++ b/internal/plugins/builtin.go
@@ -240,6 +240,7 @@ func RegisterBuiltinPlugins(
 		LoginURL:          cfg.Auth.LoginURL,
 		PublicPaths:       cfg.Auth.PublicPaths,
 		IdentitySchema:    cfg.Auth.IdentitySchema,
+		RolePaths:         cfg.Auth.RolePaths,
 		JWT: authplugin.JWTPluginConfig{
 			JWKSURL:   cfg.Auth.JWT.JWKSURL,
 			IssuerURL: cfg.Auth.JWT.IssuerURL,

--- a/internal/ports/auth.go
+++ b/internal/ports/auth.go
@@ -90,4 +90,9 @@ type AuthConfig struct {
 	// be reached. Accepted values: "503" (default, fail-closed) or
 	// "allow_public" (serve public paths, block protected paths with 503).
 	OnKratosUnavailable KratosUnavailableBehavior
+
+	// RolePaths maps role names to URL path patterns that require that role.
+	// When configured, authenticated users whose Kratos identity trait "role"
+	// does not match the required role for a path receive HTTP 403 Forbidden.
+	RolePaths map[string][]string
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -244,6 +244,7 @@ Key sections:
 - `app.environment` — custom env vars injected into the app container (e.g. DATABASE_URL, REDIS_URL)
 - `tls.enabled`, `tls.provider` — TLS termination (letsencrypt, self-signed, external)
 - `auth.mode` — authentication strategy: `none`, `kratos`, `jwt`, or `api-key` (single source of truth; see ADR-065)
+- `auth.role_paths` — role-based access control via Kratos identity traits (maps role names to URL path patterns; only valid when `auth.mode` is `kratos`)
 - `rate_limit.enabled`, `rate_limit.per_ip` — per-IP rate limiting
 - `security_headers.enabled` — HSTS, X-Frame-Options, X-Content-Type-Options, etc.
 - `secrets.store` — secret store backend: `builtin` (default, AES-256-GCM encrypted file) or `openbao` (opt-in for dynamic creds)

--- a/vibewarden.reference.yaml
+++ b/vibewarden.reference.yaml
@@ -344,7 +344,7 @@ auth:
 
   # List of URL path glob patterns that bypass authentication entirely.
   # The /_vibewarden/* prefix is always public (health check etc.).
-  # Add your app's public routes here; supports * for single-segment wildcards.
+  # Add your app's public routes here. A trailing /* does prefix matching (e.g. /static/* matches /static/foo/bar).
   # Example:
   #   public_paths:
   #     - "/static/*"
@@ -373,7 +373,7 @@ auth:
   # the X-User-Role header is still set for the upstream app to use.
   #
   # Accepted roles: user, admin, moderator (matches the identity schema trait).
-  # Supports * for single-segment wildcards.
+  # A trailing /* does prefix matching (e.g. /admin/* matches /admin/users/edit).
   #
   # Example:
   #   role_paths:
@@ -507,7 +507,7 @@ rate_limit:
 
   # URL path glob patterns that bypass rate limiting entirely.
   # The /_vibewarden/* prefix (health check etc.) is always exempt.
-  # Supports * for single-segment wildcards (e.g. "/static/*").
+  # A trailing /* does prefix matching (e.g. "/static/*" matches "/static/css/main.css").
   # Example:
   #   exempt_paths:
   #     - "/public/*"

--- a/vibewarden.reference.yaml
+++ b/vibewarden.reference.yaml
@@ -362,6 +362,27 @@ auth:
   # Only relevant when mode is "kratos".
   login_url: ""
 
+  # Role-based path restrictions (only valid when mode is "kratos").
+  #
+  # Maps role names to URL path patterns. Authenticated users whose Kratos
+  # identity trait "role" does not match the required role for a path receive
+  # HTTP 403 Forbidden with JSON body:
+  #   {"error":"forbidden","message":"insufficient role for this path"}
+  #
+  # When role_paths is omitted or empty, no role enforcement is performed —
+  # the X-User-Role header is still set for the upstream app to use.
+  #
+  # Accepted roles: user, admin, moderator (matches the identity schema trait).
+  # Supports * for single-segment wildcards.
+  #
+  # Example:
+  #   role_paths:
+  #     admin:
+  #       - /admin/*
+  #     moderator:
+  #       - /admin/moderation/*
+  # role_paths: {}
+
 # Request body size limiting
 # VibeWarden can reject oversized request bodies before they reach the upstream.
 # This protects against payload-based denial-of-service attacks and enforces


### PR DESCRIPTION
Closes #985

## Summary

- Add `Role` value object to the domain layer (`internal/domain/identity/role.go`) with validated enum: `user`, `admin`, `moderator`
- Add `Role()` accessor to `Identity` that extracts the role from claims, defaulting to `"user"`
- Add `RolePaths map[string][]string` to `AuthConfig` (config, ports, auth plugin) for path-based role enforcement
- Extend the Caddy `AuthHandler` to set `X-User-Role` header from `traits.role` on every authenticated request
- Enforce role restrictions: requests to paths configured in `role_paths` by users without the matching role receive HTTP 403 with `{"error":"forbidden","message":"insufficient role for this path"}`
- Strip `X-User-Role` header on inbound requests to prevent client spoofing
- Validate that `role_paths` is only accepted when `auth.mode` is `"kratos"`
- Add `role` trait to all Kratos identity schema presets and dev/example schemas

## Test plan

- [x] `TestNewRole` -- validates accepted/rejected role strings
- [x] `TestDefaultRole` -- verifies default is "user"
- [x] `TestIdentity_Role` -- admin/moderator/user from claims, missing/invalid defaults to user
- [x] `TestAuthHandler_RoleHeader_Set` -- role from traits flows to X-User-Role header
- [x] `TestAuthHandler_RolePath_Allowed` -- admin role accessing /admin/* passes through
- [x] `TestAuthHandler_RolePath_Denied` -- user role accessing /admin/* returns 403 with JSON body
- [x] `TestAuthHandler_RolePath_PublicPath_Skipped` -- public path bypasses role check
- [x] `TestAuthHandler_NoRolePaths_HeaderOnly` -- when no role_paths configured, just sets header
- [x] `TestValidate_RolePaths` -- config validation: kratos-only, valid roles, non-empty paths
- [x] `TestBuildCaddyConfig_UserHeaderStripDeletesCorrectHeaders` -- X-User-Role included in strip list
- [x] `make check` passes (lint, build, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)