### PR TITLE
feat(#994): composite secret placeholders -- ${secret://path/key} in strings

### DIFF
--- a/decisions/README.md
+++ b/decisions/README.md
@@ -48,6 +48,7 @@ once accepted, they are not edited. If a decision is superseded, a new ADR refer
 | [072](adr-072-cli-ux-wiring-for-multi-app.md) | CLI UX wiring for multi-app | #879 |
 | [075](adr-075-redesign-vibew-deploy-local-resolution-no-remote-patching.md) | Redesign vibew deploy -- local resolution, no remote patching | #948 |
 | [076](adr-076-secret-uri-resolution-in-config.md) | secret:// URI resolution in vibewarden.yaml config | #1008 |
+| [077](adr-077-placeholder-substitution-for-composite-secret-values.md) | Placeholder substitution for composite secret values | #994 |
 | [497](adr-497-graceful-shutdown-connection-draining.md) | Graceful Shutdown / Connection Draining | — |
 
 ## Numbering

--- a/decisions/adr-077-placeholder-substitution-for-composite-secret-values.md
+++ b/decisions/adr-077-placeholder-substitution-for-composite-secret-values.md
@@ -1,0 +1,153 @@
+## ADR-077: Placeholder Substitution for Composite Secret Values
+**Date**: 2026-04-18
+**Issue**: #994
+**Status**: Accepted
+
+### Context
+
+ADR-076 introduced `secret://` URI resolution in `vibewarden.yaml`, allowing
+any string field to be replaced entirely by a secret from the encrypted store.
+However, this only supports full-field replacement -- a field value is either
+entirely a secret or entirely literal.
+
+Users need to embed secrets inside larger strings (composite values):
+
+```yaml
+app:
+  environment:
+    DATABASE_URL: "postgres://user:${secret://db/password}@host:5432/db"
+    AUTH_HEADER: "Bearer ${secret://auth/api/token}"
+```
+
+Today this requires making the entire connection string a secret (losing
+visibility into the non-secret parts) or templating outside VibeWarden
+(defeating the sidecar model).
+
+### Decision
+
+Extend the existing `secret://` URI scheme with a `${secret://path/key}`
+placeholder syntax. Placeholders can appear anywhere inside a string value
+and multiple placeholders can coexist in a single field. The existing
+full-field `secret://` resolution (ADR-076) continues to work unchanged.
+
+#### Syntax
+
+- **Placeholder**: `${secret://path/key}` -- the existing `secret://` URI
+  wrapped in `${}` delimiters.
+- **Escape**: `$${secret://path/key}` -- a literal `$` before `{` produces
+  the literal string `${secret://path/key}` with no resolution.
+- **Full-field** (unchanged): `secret://path/key` -- the entire field value
+  is a secret URI (ADR-076 behavior).
+
+Resolution priority:
+1. If a string starts with `secret://` -- full-field resolution (existing).
+2. If a string contains `${secret://...}` -- placeholder substitution (new).
+3. If a string contains `$${secret://...}` -- unescape to literal (no resolution).
+4. Otherwise -- literal passthrough.
+
+#### Domain Model Changes
+
+New types and functions in `internal/domain/secret/uri.go`:
+
+```go
+// Placeholder represents a single ${secret://path/key} occurrence in a string.
+type Placeholder struct {
+    Raw string // full match including ${...} delimiters
+    URI URI    // parsed secret URI
+}
+
+// ContainsPlaceholder reports whether s contains at least one ${secret://...} placeholder.
+func ContainsPlaceholder(s string) bool
+
+// FindPlaceholders extracts all ${secret://...} placeholders from s.
+// Escaped placeholders ($${secret://...}) are not included.
+func FindPlaceholders(s string) []Placeholder
+
+// UnescapePlaceholders converts $${secret://...} to literal ${secret://...}.
+func UnescapePlaceholders(s string) string
+```
+
+These are pure functions with zero external dependencies, appropriate for the
+domain layer.
+
+#### Config Changes
+
+Add `ValueTemplate` field to `SecretsHeaderInjection` and `SecretsEnvInjection`
+in `internal/config/config.go`:
+
+```go
+type SecretsHeaderInjection struct {
+    SecretPath    string `mapstructure:"secret_path"`
+    SecretKey     string `mapstructure:"secret_key"`
+    Header        string `mapstructure:"header"`
+    ValueTemplate string `mapstructure:"value_template"`
+}
+
+type SecretsEnvInjection struct {
+    SecretPath    string `mapstructure:"secret_path"`
+    SecretKey     string `mapstructure:"secret_key"`
+    EnvVar        string `mapstructure:"env_var"`
+    ValueTemplate string `mapstructure:"value_template"`
+}
+```
+
+When `ValueTemplate` is set, the resolved secret value is substituted into
+the template at `${secret://...}` positions. When empty, behavior is
+unchanged (the raw secret value is used directly).
+
+Mirror in `internal/plugins/secrets/config.go`.
+
+#### Resolution Changes
+
+Extend `resolveStringField` in `internal/config/resolve_secrets.go`:
+
+1. If the string starts with `secret://` -- existing full-field resolution.
+2. If the string contains `${secret://...}` -- find all placeholders, resolve
+   each, replace in the string, then unescape any `$${...}`.
+3. Otherwise -- no-op.
+
+#### Plugin Changes
+
+Extend the secrets plugin header handler and env file writer to support
+`ValueTemplate`:
+
+- When `ValueTemplate` is non-empty, resolve `${secret://...}` placeholders
+  in it using the cache, then use the result as the header/env value.
+- When empty, use the direct secret value (existing behavior).
+
+#### File Layout
+
+Modified files:
+```
+internal/domain/secret/uri.go            # add Placeholder, ContainsPlaceholder, FindPlaceholders, UnescapePlaceholders
+internal/domain/secret/uri_test.go       # placeholder parsing tests
+internal/config/resolve_secrets.go       # extend resolveStringField, resolveMap for composite values
+internal/config/resolve_secrets_test.go  # composite resolution tests
+internal/config/config.go               # add ValueTemplate to SecretsHeaderInjection, SecretsEnvInjection
+internal/plugins/secrets/config.go      # add ValueTemplate to HeaderInjection, EnvInjection
+internal/plugins/secrets/plugin.go      # extend header handler and env file writer
+internal/plugins/secrets/plugin_test.go # composite injection tests
+internal/plugins/builtin_helpers.go     # wire ValueTemplate from config to plugin config
+```
+
+#### New Dependencies
+
+None. Uses only Go stdlib (`regexp`, `strings`).
+
+### Consequences
+
+**Benefits:**
+
+- Users can embed secrets inside connection strings, authorization headers,
+  and other composite values without making the entire string opaque.
+- The `${secret://...}` syntax reuses the existing URI scheme, so users do
+  not need to learn a new vocabulary.
+- Backward-compatible: existing full-field `secret://` resolution is unchanged.
+- Escape hatch (`$${...}`) allows literal `${secret://...}` strings when needed.
+
+**Trade-offs:**
+
+- Adds regex-based placeholder detection. Contained in domain-layer pure
+  functions with comprehensive tests.
+- The `ValueTemplate` field is an additional config surface. However, it is
+  optional and backward-compatible.

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -128,6 +128,14 @@ admin:
   token: secret://admin/api/token
 ```
 
+For composite values (secrets embedded in larger strings), use `${secret://...}`:
+
+```yaml
+app:
+  environment:
+    DATABASE_URL: "postgres://user:${secret://db/password}@host:5432/db"
+```
+
 Store secrets with `vibew secret set <path> <key>=<value>`. The `secrets.*`
 config section itself cannot use `secret://` URIs (bootstrap constraint).
 See docs/secret-management.md for details.

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -136,7 +136,8 @@ app:
     DATABASE_URL: "postgres://user:${secret://db/password}@host:5432/db"
 ```
 
-Store secrets with `vibew secret set <path> <key>=<value>`. The `secrets.*`
+Store secrets with `vibew secret set <path> <key>=<value>`. The `secrets.inject`
+entries also support a `value_template` field for composite values. The `secrets.*`
 config section itself cannot use `secret://` URIs (bootstrap constraint).
 See docs/secret-management.md for details.
 

--- a/docs/secret-management.md
+++ b/docs/secret-management.md
@@ -382,6 +382,58 @@ includes the struct field path:
 config field Config.Admin.Token: resolving secret://admin/api/token: secret path "admin/api" not found in store
 ```
 
+### Composite values -- embedding secrets in strings
+
+Sometimes a secret is only part of a larger value, such as a database connection
+string or an authorization header. Use `${secret://path/key}` placeholders to
+embed secrets inside strings:
+
+```yaml
+app:
+  environment:
+    DATABASE_URL: "postgres://user:${secret://db/password}@host:5432/db"
+    AUTH_HEADER: "Bearer ${secret://auth/api/token}"
+```
+
+Multiple placeholders can appear in a single value:
+
+```yaml
+app:
+  environment:
+    DATABASE_URL: "postgres://${secret://db/user}:${secret://db/password}@host:5432/db"
+```
+
+The `secrets.inject` section also supports composite values via `value_template`:
+
+```yaml
+secrets:
+  inject:
+    headers:
+      - secret_path: app/auth
+        secret_key: token
+        header: Authorization
+        value_template: "Bearer ${secret://app/auth/token}"
+    env:
+      - secret_path: app/database
+        secret_key: password
+        env_var: DATABASE_URL
+        value_template: "postgres://user:${secret://app/database/password}@host:5432/db"
+```
+
+To include a literal `${secret://...}` string without resolution, escape it
+with a double dollar sign:
+
+```yaml
+app:
+  environment:
+    EXAMPLE: "literal $${secret://not/resolved}"
+    # Resolves to: literal ${secret://not/resolved}
+```
+
+Composite resolution follows the same fail-fast behavior as full-field
+resolution: if any placeholder cannot be resolved, VibeWarden refuses to start
+with a descriptive error.
+
 ---
 
 ## Dynamic Postgres Credentials

--- a/docs/secret-management.md
+++ b/docs/secret-management.md
@@ -369,7 +369,8 @@ dependency where the store would need to be available to configure itself.
 
 1. `config.LoadRaw()` reads and unmarshals the YAML (no validation).
 2. The secret store is constructed from `cfg.Secrets.*`.
-3. `config.ResolveSecrets()` walks all string fields and resolves `secret://` URIs.
+3. `config.ResolveSecrets()` walks all string fields and resolves `secret://` URIs,
+   `${secret://...}` composite placeholders, and unescapes `$${...}` sequences.
 4. `cfg.Validate()` validates the fully-resolved config.
 
 ### Error handling

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1485,6 +1485,11 @@ type SecretsHeaderInjection struct {
 
 	// Header is the HTTP header name to set.
 	Header string `mapstructure:"header"`
+
+	// ValueTemplate is an optional template string containing ${secret://path/key}
+	// placeholders. When set, the resolved template is used as the header value
+	// instead of the raw secret. When empty, the secret value is used directly.
+	ValueTemplate string `mapstructure:"value_template"`
 }
 
 // SecretsEnvInjection maps a secret key to an environment variable name.
@@ -1497,6 +1502,11 @@ type SecretsEnvInjection struct {
 
 	// EnvVar is the environment variable name to write in the env file.
 	EnvVar string `mapstructure:"env_var"`
+
+	// ValueTemplate is an optional template string containing ${secret://path/key}
+	// placeholders. When set, the resolved template is used as the env var value
+	// instead of the raw secret. When empty, the secret value is used directly.
+	ValueTemplate string `mapstructure:"value_template"`
 }
 
 // SecretsDynamicConfig holds settings for dynamic credential generation.

--- a/internal/config/resolve_secrets.go
+++ b/internal/config/resolve_secrets.go
@@ -13,10 +13,16 @@ import (
 
 // ResolveSecrets walks all string fields in cfg using reflection and replaces
 // any value starting with "secret://" with the resolved plaintext from store.
+// It also resolves ${secret://path/key} placeholders embedded inside strings
+// (composite secret values).
 //
 // The URI format is secret://path/key where the last segment is the key and
 // everything before it is the store path. For example,
 // secret://auth/google/client_id resolves path "auth/google", key "client_id".
+//
+// For composite values, ${secret://path/key} placeholders are resolved and
+// replaced inline. Escaped placeholders ($${secret://...}) are converted to
+// their literal ${secret://...} form without resolution.
 //
 // Fields under cfg.Secrets (the bootstrap config section) are skipped because
 // the secret store itself is initialised from that section -- it cannot
@@ -108,8 +114,9 @@ func resolveSlice(ctx context.Context, v reflect.Value, store ports.SecretKVRead
 	return nil
 }
 
-// resolveMap handles map[string]string fields by resolving secret URIs in
-// values. Other map types with string values are handled similarly.
+// resolveMap handles map[string]string fields by resolving secret URIs and
+// ${secret://...} placeholders in values. Other map types with string values
+// are handled similarly.
 func resolveMap(ctx context.Context, v reflect.Value, store ports.SecretKVReader, fieldPath string) error {
 	if v.IsNil() {
 		return nil
@@ -118,36 +125,98 @@ func resolveMap(ctx context.Context, v reflect.Value, store ports.SecretKVReader
 	for _, key := range v.MapKeys() {
 		val := v.MapIndex(key)
 
-		if val.Kind() == reflect.String {
-			raw := val.String()
-			if domainsecret.IsURI(raw) {
-				entryPath := fmt.Sprintf("%s[%s]", fieldPath, key.String())
-				resolved, err := resolveURI(ctx, raw, store, entryPath)
-				if err != nil {
-					return err
-				}
-				v.SetMapIndex(key, reflect.ValueOf(resolved))
+		if val.Kind() != reflect.String {
+			continue
+		}
+
+		raw := val.String()
+		entryPath := fmt.Sprintf("%s[%s]", fieldPath, key.String())
+
+		// Full-field secret URI.
+		if domainsecret.IsURI(raw) {
+			resolved, err := resolveURI(ctx, raw, store, entryPath)
+			if err != nil {
+				return err
 			}
+			v.SetMapIndex(key, reflect.ValueOf(resolved))
+			continue
+		}
+
+		// Composite value with ${secret://...} placeholders.
+		placeholders := domainsecret.FindPlaceholders(raw)
+		if len(placeholders) > 0 {
+			resolved, err := resolvePlaceholders(ctx, raw, placeholders, store, entryPath)
+			if err != nil {
+				return err
+			}
+			v.SetMapIndex(key, reflect.ValueOf(resolved))
+			continue
+		}
+
+		// Escaped-only placeholders: unescape $${...} to literal ${...}.
+		if domainsecret.ContainsEscapedPlaceholder(raw) {
+			v.SetMapIndex(key, reflect.ValueOf(domainsecret.UnescapePlaceholders(raw)))
 		}
 	}
 	return nil
 }
 
-// resolveStringField checks whether a string field value is a secret:// URI
-// and, if so, resolves it from the store and replaces the field value.
+// resolveStringField checks whether a string field value is a full-field
+// secret:// URI or contains ${secret://...} placeholders, and resolves
+// accordingly.
+//
+// Resolution priority:
+//  1. Full-field: string starts with "secret://" -- resolve the entire value.
+//  2. Composite: string contains ${secret://...} -- resolve each placeholder
+//     inline, then unescape any $${...} occurrences.
+//  3. Otherwise: no-op.
 func resolveStringField(ctx context.Context, fv reflect.Value, store ports.SecretKVReader, fieldPath string) error {
 	raw := fv.String()
-	if !domainsecret.IsURI(raw) {
+
+	// Case 1: full-field secret URI (existing ADR-076 behavior).
+	if domainsecret.IsURI(raw) {
+		resolved, err := resolveURI(ctx, raw, store, fieldPath)
+		if err != nil {
+			return err
+		}
+		fv.SetString(resolved)
 		return nil
 	}
 
-	resolved, err := resolveURI(ctx, raw, store, fieldPath)
-	if err != nil {
-		return err
+	// Case 2: composite value with ${secret://...} placeholders.
+	placeholders := domainsecret.FindPlaceholders(raw)
+	if len(placeholders) > 0 {
+		resolved, err := resolvePlaceholders(ctx, raw, placeholders, store, fieldPath)
+		if err != nil {
+			return err
+		}
+		fv.SetString(resolved)
+		return nil
 	}
 
-	fv.SetString(resolved)
+	// Case 3: string contains only escaped placeholders ($${secret://...}).
+	// Unescape them to their literal ${secret://...} form.
+	if domainsecret.ContainsEscapedPlaceholder(raw) {
+		fv.SetString(domainsecret.UnescapePlaceholders(raw))
+	}
+
 	return nil
+}
+
+// resolvePlaceholders replaces all ${secret://...} placeholders in s with
+// their resolved values from the store, then unescapes any $${...} sequences.
+func resolvePlaceholders(ctx context.Context, s string, placeholders []domainsecret.Placeholder, store ports.SecretKVReader, fieldPath string) (string, error) {
+	result := s
+	for _, p := range placeholders {
+		resolved, err := resolveURI(ctx, p.URI.String(), store, fieldPath)
+		if err != nil {
+			return "", err
+		}
+		result = strings.Replace(result, p.Raw, resolved, 1)
+	}
+	// Unescape any $${secret://...} to literal ${secret://...}.
+	result = domainsecret.UnescapePlaceholders(result)
+	return result, nil
 }
 
 // resolveURI parses a secret:// URI, fetches the data from the store, extracts

--- a/internal/config/resolve_secrets_test.go
+++ b/internal/config/resolve_secrets_test.go
@@ -241,3 +241,157 @@ func TestResolveSecrets_StringSliceField(t *testing.T) {
 		t.Errorf("PublicPaths[2] = %q, want %q", cfg.Auth.PublicPaths[2], "/ready")
 	}
 }
+
+func TestResolveSecrets_CompositeSinglePlaceholder(t *testing.T) {
+	store := &fakeSecretReader{
+		data: map[string]map[string]string{
+			"infra/db": {
+				"password": "s3cr3t!",
+			},
+		},
+	}
+
+	cfg := &config.Config{}
+	cfg.Database.URL = "postgres://user:${secret://infra/db/password}@host:5432/db"
+
+	err := config.ResolveSecrets(context.Background(), cfg, store)
+	if err != nil {
+		t.Fatalf("ResolveSecrets() error = %v", err)
+	}
+
+	want := "postgres://user:s3cr3t!@host:5432/db"
+	if cfg.Database.URL != want {
+		t.Errorf("Database.URL = %q, want %q", cfg.Database.URL, want)
+	}
+}
+
+func TestResolveSecrets_CompositeMultiplePlaceholders(t *testing.T) {
+	store := &fakeSecretReader{
+		data: map[string]map[string]string{
+			"infra/db": {
+				"user":     "admin",
+				"password": "s3cr3t!",
+			},
+		},
+	}
+
+	cfg := &config.Config{}
+	cfg.Database.URL = "postgres://${secret://infra/db/user}:${secret://infra/db/password}@host:5432/db"
+
+	err := config.ResolveSecrets(context.Background(), cfg, store)
+	if err != nil {
+		t.Fatalf("ResolveSecrets() error = %v", err)
+	}
+
+	want := "postgres://admin:s3cr3t!@host:5432/db"
+	if cfg.Database.URL != want {
+		t.Errorf("Database.URL = %q, want %q", cfg.Database.URL, want)
+	}
+}
+
+func TestResolveSecrets_CompositeEscapedPlaceholder(t *testing.T) {
+	store := &fakeSecretReader{data: map[string]map[string]string{}}
+
+	cfg := &config.Config{}
+	cfg.Admin.Token = "literal $${secret://admin/api/token} text"
+
+	err := config.ResolveSecrets(context.Background(), cfg, store)
+	if err != nil {
+		t.Fatalf("ResolveSecrets() error = %v", err)
+	}
+
+	want := "literal ${secret://admin/api/token} text"
+	if cfg.Admin.Token != want {
+		t.Errorf("Admin.Token = %q, want %q", cfg.Admin.Token, want)
+	}
+}
+
+func TestResolveSecrets_CompositeMixedEscapedAndUnescaped(t *testing.T) {
+	store := &fakeSecretReader{
+		data: map[string]map[string]string{
+			"infra/db": {
+				"password": "s3cr3t!",
+			},
+		},
+	}
+
+	cfg := &config.Config{}
+	cfg.Database.URL = "postgres://user:${secret://infra/db/password}@host $${secret://literal/example}"
+
+	err := config.ResolveSecrets(context.Background(), cfg, store)
+	if err != nil {
+		t.Fatalf("ResolveSecrets() error = %v", err)
+	}
+
+	want := "postgres://user:s3cr3t!@host ${secret://literal/example}"
+	if cfg.Database.URL != want {
+		t.Errorf("Database.URL = %q, want %q", cfg.Database.URL, want)
+	}
+}
+
+func TestResolveSecrets_CompositeFullFieldStillWorks(t *testing.T) {
+	store := &fakeSecretReader{
+		data: map[string]map[string]string{
+			"admin/api": {
+				"token": "my-secure-token",
+			},
+		},
+	}
+
+	cfg := &config.Config{}
+	cfg.Admin.Token = "secret://admin/api/token"
+
+	err := config.ResolveSecrets(context.Background(), cfg, store)
+	if err != nil {
+		t.Fatalf("ResolveSecrets() error = %v", err)
+	}
+
+	if cfg.Admin.Token != "my-secure-token" {
+		t.Errorf("Admin.Token = %q, want %q", cfg.Admin.Token, "my-secure-token")
+	}
+}
+
+func TestResolveSecrets_CompositeFailsOnMissingSecret(t *testing.T) {
+	store := &fakeSecretReader{data: map[string]map[string]string{}}
+
+	cfg := &config.Config{}
+	cfg.Database.URL = "postgres://user:${secret://missing/path/key}@host:5432/db"
+
+	err := config.ResolveSecrets(context.Background(), cfg, store)
+	if err == nil {
+		t.Fatal("ResolveSecrets() expected error for missing placeholder secret, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "missing/path") {
+		t.Errorf("error should mention the missing path, got: %v", err)
+	}
+}
+
+func TestResolveSecrets_CompositeInMapField(t *testing.T) {
+	store := &fakeSecretReader{
+		data: map[string]map[string]string{
+			"infra/db": {
+				"password": "s3cr3t!",
+			},
+		},
+	}
+
+	cfg := &config.Config{}
+	cfg.App.Environment = map[string]string{
+		"DATABASE_URL": "postgres://user:${secret://infra/db/password}@host:5432/db",
+		"PLAIN_VAR":    "no-secret-here",
+	}
+
+	err := config.ResolveSecrets(context.Background(), cfg, store)
+	if err != nil {
+		t.Fatalf("ResolveSecrets() error = %v", err)
+	}
+
+	want := "postgres://user:s3cr3t!@host:5432/db"
+	if cfg.App.Environment["DATABASE_URL"] != want {
+		t.Errorf("App.Environment[DATABASE_URL] = %q, want %q", cfg.App.Environment["DATABASE_URL"], want)
+	}
+	if cfg.App.Environment["PLAIN_VAR"] != "no-secret-here" {
+		t.Errorf("App.Environment[PLAIN_VAR] = %q, want %q", cfg.App.Environment["PLAIN_VAR"], "no-secret-here")
+	}
+}

--- a/internal/domain/secret/uri.go
+++ b/internal/domain/secret/uri.go
@@ -77,7 +77,7 @@ func (u URI) String() string {
 }
 
 // placeholderRe matches ${secret://...} placeholders that are NOT preceded by
-// an extra $. It uses a negative lookbehind is not available in Go's RE2, so
+// an extra $. A negative lookbehind is not available in Go's RE2, so
 // FindPlaceholders filters escaped matches manually.
 //
 // The regex captures the inner secret:// URI (everything between ${ and }).

--- a/internal/domain/secret/uri.go
+++ b/internal/domain/secret/uri.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -73,4 +74,76 @@ func (u URI) Key() string { return u.key }
 // String returns the canonical string representation of the URI.
 func (u URI) String() string {
 	return secretURIPrefix + u.path + "/" + u.key
+}
+
+// placeholderRe matches ${secret://...} placeholders that are NOT preceded by
+// an extra $. It uses a negative lookbehind is not available in Go's RE2, so
+// FindPlaceholders filters escaped matches manually.
+//
+// The regex captures the inner secret:// URI (everything between ${ and }).
+var placeholderRe = regexp.MustCompile(`\$\{(secret://[^}]+)\}`)
+
+// escapedPlaceholderRe matches $${secret://...} — escaped placeholders that
+// should be converted to their literal ${secret://...} form.
+var escapedPlaceholderRe = regexp.MustCompile(`\$\$\{(secret://[^}]+)\}`)
+
+// Placeholder represents a single ${secret://path/key} occurrence in a string.
+type Placeholder struct {
+	// Raw is the full matched text including the ${} delimiters.
+	Raw string
+
+	// URI is the parsed secret URI extracted from the placeholder.
+	URI URI
+}
+
+// ContainsPlaceholder reports whether s contains at least one
+// ${secret://...} placeholder that is not escaped with $${...}.
+func ContainsPlaceholder(s string) bool {
+	return len(FindPlaceholders(s)) > 0
+}
+
+// FindPlaceholders extracts all ${secret://...} placeholders from s.
+// Escaped placeholders ($${secret://...}) are not included in the result.
+// Returns nil when no unescaped placeholders are found.
+func FindPlaceholders(s string) []Placeholder {
+	matches := placeholderRe.FindAllStringSubmatchIndex(s, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	var result []Placeholder
+	for _, loc := range matches {
+		// loc[0] is the start of the full match (${secret://...})
+		// Check whether it is preceded by an extra $ (escaped).
+		if loc[0] > 0 && s[loc[0]-1] == '$' {
+			continue
+		}
+
+		raw := s[loc[0]:loc[1]]
+		inner := s[loc[2]:loc[3]]
+
+		uri, err := ParseURI(inner)
+		if err != nil {
+			// Malformed URI inside placeholder — skip silently so callers
+			// can validate later or report the error.
+			continue
+		}
+
+		result = append(result, Placeholder{Raw: raw, URI: uri})
+	}
+
+	return result
+}
+
+// ContainsEscapedPlaceholder reports whether s contains at least one
+// $${secret://...} escaped placeholder.
+func ContainsEscapedPlaceholder(s string) bool {
+	return escapedPlaceholderRe.MatchString(s)
+}
+
+// UnescapePlaceholders converts all $${secret://...} occurrences in s to
+// their literal ${secret://...} form. This allows users to include literal
+// placeholder text in config values without triggering resolution.
+func UnescapePlaceholders(s string) string {
+	return escapedPlaceholderRe.ReplaceAllString(s, `${$1}`)
 }

--- a/internal/domain/secret/uri_test.go
+++ b/internal/domain/secret/uri_test.go
@@ -125,3 +125,205 @@ func TestIsURI(t *testing.T) {
 		})
 	}
 }
+
+func TestContainsPlaceholder(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "single placeholder",
+			input: "postgres://user:${secret://db/password}@host:5432/db",
+			want:  true,
+		},
+		{
+			name:  "multiple placeholders",
+			input: "${secret://db/user}:${secret://db/password}",
+			want:  true,
+		},
+		{
+			name:  "placeholder at start",
+			input: "${secret://auth/token}-suffix",
+			want:  true,
+		},
+		{
+			name:  "placeholder at end",
+			input: "prefix-${secret://auth/token}",
+			want:  true,
+		},
+		{
+			name:  "no placeholder plain string",
+			input: "just a plain string",
+			want:  false,
+		},
+		{
+			name:  "full-field secret URI not a placeholder",
+			input: "secret://db/password",
+			want:  false,
+		},
+		{
+			name:  "escaped placeholder",
+			input: "literal $${secret://db/password} text",
+			want:  false,
+		},
+		{
+			name:  "env var syntax no collision",
+			input: "${SOME_ENV_VAR}",
+			want:  false,
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  false,
+		},
+		{
+			name:  "malformed URI inside placeholder",
+			input: "${secret://nokeyseparator}",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := secret.ContainsPlaceholder(tt.input)
+			if got != tt.want {
+				t.Errorf("ContainsPlaceholder(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindPlaceholders(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantLen  int
+		wantRaws []string
+		wantURIs []string
+	}{
+		{
+			name:     "single placeholder in composite string",
+			input:    "postgres://user:${secret://db/password}@host:5432/db",
+			wantLen:  1,
+			wantRaws: []string{"${secret://db/password}"},
+			wantURIs: []string{"secret://db/password"},
+		},
+		{
+			name:     "two placeholders",
+			input:    "${secret://db/user}:${secret://db/password}",
+			wantLen:  2,
+			wantRaws: []string{"${secret://db/user}", "${secret://db/password}"},
+			wantURIs: []string{"secret://db/user", "secret://db/password"},
+		},
+		{
+			name:     "placeholder with deep path",
+			input:    "Bearer ${secret://auth/google/api/token}",
+			wantLen:  1,
+			wantRaws: []string{"${secret://auth/google/api/token}"},
+			wantURIs: []string{"secret://auth/google/api/token"},
+		},
+		{
+			name:    "no placeholders",
+			input:   "just a string with no secrets",
+			wantLen: 0,
+		},
+		{
+			name:    "escaped placeholder excluded",
+			input:   "$${secret://db/password}",
+			wantLen: 0,
+		},
+		{
+			name:     "mix of escaped and unescaped",
+			input:    "${secret://db/user} and $${secret://db/password}",
+			wantLen:  1,
+			wantRaws: []string{"${secret://db/user}"},
+			wantURIs: []string{"secret://db/user"},
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantLen: 0,
+		},
+		{
+			name:    "malformed URI in placeholder skipped",
+			input:   "${secret://nokeyseparator}",
+			wantLen: 0,
+		},
+		{
+			name:    "full-field URI not a placeholder",
+			input:   "secret://db/password",
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			placeholders := secret.FindPlaceholders(tt.input)
+			if len(placeholders) != tt.wantLen {
+				t.Fatalf("FindPlaceholders(%q) returned %d placeholders, want %d", tt.input, len(placeholders), tt.wantLen)
+			}
+			for i, p := range placeholders {
+				if i < len(tt.wantRaws) && p.Raw != tt.wantRaws[i] {
+					t.Errorf("placeholder[%d].Raw = %q, want %q", i, p.Raw, tt.wantRaws[i])
+				}
+				if i < len(tt.wantURIs) && p.URI.String() != tt.wantURIs[i] {
+					t.Errorf("placeholder[%d].URI = %q, want %q", i, p.URI.String(), tt.wantURIs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestUnescapePlaceholders(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "single escaped placeholder",
+			input: "$${secret://db/password}",
+			want:  "${secret://db/password}",
+		},
+		{
+			name:  "multiple escaped placeholders",
+			input: "$${secret://db/user}:$${secret://db/password}",
+			want:  "${secret://db/user}:${secret://db/password}",
+		},
+		{
+			name:  "no escaped placeholders",
+			input: "just a plain string",
+			want:  "just a plain string",
+		},
+		{
+			name:  "unescaped placeholder unchanged",
+			input: "${secret://db/password}",
+			want:  "${secret://db/password}",
+		},
+		{
+			name:  "mix of escaped and unescaped",
+			input: "${secret://db/user} and $${secret://db/password}",
+			want:  "${secret://db/user} and ${secret://db/password}",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "escaped with surrounding text",
+			input: "literal $${secret://auth/token} text here",
+			want:  "literal ${secret://auth/token} text here",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := secret.UnescapePlaceholders(tt.input)
+			if got != tt.want {
+				t.Errorf("UnescapePlaceholders(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/domain/secret/uri_test.go
+++ b/internal/domain/secret/uri_test.go
@@ -275,6 +275,30 @@ func TestFindPlaceholders(t *testing.T) {
 	}
 }
 
+func TestContainsEscapedPlaceholder(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"escaped placeholder present", "$${secret://db/password}", true},
+		{"unescaped placeholder only", "${secret://db/password}", false},
+		{"plain string", "no secrets here", false},
+		{"empty string", "", false},
+		{"escaped among text", "prefix $${secret://a/b} suffix", true},
+		{"multiple escaped", "$${secret://a/b} and $${secret://c/d}", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := secret.ContainsEscapedPlaceholder(tt.input)
+			if got != tt.want {
+				t.Errorf("ContainsEscapedPlaceholder(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUnescapePlaceholders(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/plugins/builtin_helpers.go
+++ b/internal/plugins/builtin_helpers.go
@@ -70,18 +70,20 @@ func buildSecretsPlugin(cfg *config.Config, eventLogger ports.EventLogger, logge
 	// Map header injections.
 	for _, inj := range cfg.Secrets.Inject.Headers {
 		secretsCfg.Inject.Headers = append(secretsCfg.Inject.Headers, secretsplugin.HeaderInjection{
-			SecretPath: inj.SecretPath,
-			SecretKey:  inj.SecretKey,
-			Header:     inj.Header,
+			SecretPath:    inj.SecretPath,
+			SecretKey:     inj.SecretKey,
+			Header:        inj.Header,
+			ValueTemplate: inj.ValueTemplate,
 		})
 	}
 
 	// Map env injections.
 	for _, inj := range cfg.Secrets.Inject.Env {
 		secretsCfg.Inject.Env = append(secretsCfg.Inject.Env, secretsplugin.EnvInjection{
-			SecretPath: inj.SecretPath,
-			SecretKey:  inj.SecretKey,
-			EnvVar:     inj.EnvVar,
+			SecretPath:    inj.SecretPath,
+			SecretKey:     inj.SecretKey,
+			EnvVar:        inj.EnvVar,
+			ValueTemplate: inj.ValueTemplate,
 		})
 	}
 

--- a/internal/plugins/secrets/config.go
+++ b/internal/plugins/secrets/config.go
@@ -95,6 +95,11 @@ type HeaderInjection struct {
 
 	// Header is the HTTP header name to set (e.g. "X-Internal-Token").
 	Header string
+
+	// ValueTemplate is an optional template string containing ${secret://path/key}
+	// placeholders. When set, the resolved template is used as the header value
+	// instead of the raw secret. When empty, the secret value is used directly.
+	ValueTemplate string
 }
 
 // EnvInjection maps a secret key to an environment variable name.
@@ -107,6 +112,11 @@ type EnvInjection struct {
 
 	// EnvVar is the environment variable name to write in the env file.
 	EnvVar string
+
+	// ValueTemplate is an optional template string containing ${secret://path/key}
+	// placeholders. When set, the resolved template is used as the env var value
+	// instead of the raw secret. When empty, the secret value is used directly.
+	ValueTemplate string
 }
 
 // DynamicConfig holds settings for dynamic credential generation.

--- a/internal/plugins/secrets/plugin.go
+++ b/internal/plugins/secrets/plugin.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vibewarden/vibewarden/internal/adapters/builtin"
 	"github.com/vibewarden/vibewarden/internal/adapters/openbao"
 	"github.com/vibewarden/vibewarden/internal/domain/events"
+	domainsecret "github.com/vibewarden/vibewarden/internal/domain/secret"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
@@ -309,14 +310,17 @@ func (p *Plugin) ContributeCaddyHandlers() []ports.CaddyHandler {
 
 // buildRequestHeadersHandler creates a Caddy headers handler that injects
 // the current cached secret values as request headers.
+// When a header injection has a ValueTemplate, ${secret://...} placeholders
+// in the template are resolved from the cache and the result is used as the
+// header value. When ValueTemplate is empty, the direct secret value is used.
 func (p *Plugin) buildRequestHeadersHandler() map[string]any {
 	p.cacheMu.RLock()
 	defer p.cacheMu.RUnlock()
 
 	set := map[string][]string{}
 	for _, inj := range p.cfg.Inject.Headers {
-		cacheKey := cacheKeyFor(inj.SecretPath, inj.SecretKey)
-		if val, ok := p.cache[cacheKey]; ok && val != "" {
+		val := p.resolveInjectionValue(inj.SecretPath, inj.SecretKey, inj.ValueTemplate)
+		if val != "" {
 			set[inj.Header] = []string{val}
 		}
 	}
@@ -327,6 +331,37 @@ func (p *Plugin) buildRequestHeadersHandler() map[string]any {
 			"set": set,
 		},
 	}
+}
+
+// resolveInjectionValue returns the value to inject for a given secret
+// injection entry. When valueTemplate is non-empty, ${secret://...}
+// placeholders in the template are resolved from the cache. When empty,
+// the direct cached value for secretPath/secretKey is returned.
+//
+// Must be called with cacheMu held (at least RLock).
+func (p *Plugin) resolveInjectionValue(secretPath, secretKey, valueTemplate string) string {
+	if valueTemplate == "" {
+		cacheKey := cacheKeyFor(secretPath, secretKey)
+		val, ok := p.cache[cacheKey]
+		if !ok {
+			return ""
+		}
+		return val
+	}
+
+	// Resolve ${secret://...} placeholders in the template.
+	result := valueTemplate
+	placeholders := domainsecret.FindPlaceholders(valueTemplate)
+	for _, ph := range placeholders {
+		cacheKey := cacheKeyFor(ph.URI.Path(), ph.URI.Key())
+		val, ok := p.cache[cacheKey]
+		if !ok {
+			return "" // unresolvable placeholder — return empty
+		}
+		result = strings.Replace(result, ph.Raw, val, 1)
+	}
+	result = domainsecret.UnescapePlaceholders(result)
+	return result
 }
 
 // GetCachedSecret returns the cached value for the given path/key combination.
@@ -340,16 +375,23 @@ func (p *Plugin) GetCachedSecret(path, key string) (string, bool) {
 }
 
 // refreshCache fetches all secrets referenced by inject.headers and inject.env
-// and stores them in the in-memory cache. Non-fatal: missing secrets are logged
-// but do not block the refresh.
+// (including paths from ValueTemplate placeholders) and stores them in the
+// in-memory cache. Non-fatal: missing secrets are logged but do not block the
+// refresh.
 func (p *Plugin) refreshCache(ctx context.Context) error {
 	// Collect all unique paths to fetch.
 	paths := make(map[string]struct{})
 	for _, inj := range p.cfg.Inject.Headers {
 		paths[inj.SecretPath] = struct{}{}
+		for _, ph := range domainsecret.FindPlaceholders(inj.ValueTemplate) {
+			paths[ph.URI.Path()] = struct{}{}
+		}
 	}
 	for _, inj := range p.cfg.Inject.Env {
 		paths[inj.SecretPath] = struct{}{}
+		for _, ph := range domainsecret.FindPlaceholders(inj.ValueTemplate) {
+			paths[ph.URI.Path()] = struct{}{}
+		}
 	}
 
 	p.cacheMu.Lock()
@@ -433,8 +475,8 @@ func (p *Plugin) writeEnvFile() error {
 	// Static env injections.
 	p.cacheMu.RLock()
 	for _, inj := range p.cfg.Inject.Env {
-		cacheKey := cacheKeyFor(inj.SecretPath, inj.SecretKey)
-		if val, ok := p.cache[cacheKey]; ok {
+		val := p.resolveInjectionValue(inj.SecretPath, inj.SecretKey, inj.ValueTemplate)
+		if val != "" {
 			sb.WriteString(inj.EnvVar)
 			sb.WriteString("=")
 			sb.WriteString(val)

--- a/internal/plugins/secrets/plugin_test.go
+++ b/internal/plugins/secrets/plugin_test.go
@@ -397,3 +397,102 @@ func TestPlugin_Meta(t *testing.T) {
 		t.Errorf("Example() does not mention openbao; got:\n%s", example)
 	}
 }
+
+func TestPlugin_ContributeCaddyHandlers_WithValueTemplate(t *testing.T) {
+	srv := newOpenBaoTestServer(t, map[string]map[string]string{
+		"app/auth": {"token": "my-secret-token"},
+	})
+	defer srv.Close()
+
+	p := secrets.New(secrets.Config{
+		Enabled: true,
+		Store:   "openbao",
+		OpenBao: secrets.OpenBaoConfig{
+			Address: srv.URL,
+			Auth:    secrets.OpenBaoAuthConfig{Method: "token", Token: "root"},
+		},
+		Inject: secrets.InjectConfig{
+			Headers: []secrets.HeaderInjection{
+				{
+					SecretPath:    "app/auth",
+					SecretKey:     "token",
+					Header:        "Authorization",
+					ValueTemplate: "Bearer ${secret://app/auth/token}",
+				},
+			},
+		},
+	}, nil, slog.Default())
+
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	handlers := p.ContributeCaddyHandlers()
+	if len(handlers) != 1 {
+		t.Fatalf("ContributeCaddyHandlers() returned %d handlers, want 1", len(handlers))
+	}
+
+	h := handlers[0].Handler
+	req, ok := h["request"].(map[string]any)
+	if !ok {
+		t.Fatal("handler missing request field")
+	}
+	setMap, ok := req["set"].(map[string][]string)
+	if !ok {
+		t.Fatal("handler missing set field")
+	}
+
+	authValues, ok := setMap["Authorization"]
+	if !ok || len(authValues) != 1 {
+		t.Fatalf("Authorization header not set; set map = %v", setMap)
+	}
+
+	want := "Bearer my-secret-token"
+	if authValues[0] != want {
+		t.Errorf("Authorization header value = %q, want %q", authValues[0], want)
+	}
+}
+
+func TestPlugin_WriteEnvFile_WithValueTemplate(t *testing.T) {
+	envFile := filepath.Join(t.TempDir(), "secrets", ".env.secrets")
+
+	srv := newOpenBaoTestServer(t, map[string]map[string]string{
+		"app/db": {"password": "s3cr3t!", "user": "admin"},
+	})
+	defer srv.Close()
+
+	p := secrets.New(secrets.Config{
+		Enabled: true,
+		Store:   "openbao",
+		OpenBao: secrets.OpenBaoConfig{
+			Address: srv.URL,
+			Auth:    secrets.OpenBaoAuthConfig{Method: "token", Token: "root"},
+		},
+		Inject: secrets.InjectConfig{
+			EnvFile: envFile,
+			Env: []secrets.EnvInjection{
+				{
+					SecretPath:    "app/db",
+					SecretKey:     "password",
+					EnvVar:        "DATABASE_URL",
+					ValueTemplate: "postgres://${secret://app/db/user}:${secret://app/db/password}@host:5432/db",
+				},
+			},
+		},
+	}, nil, slog.Default())
+
+	if err := p.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	content, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", envFile, err)
+	}
+
+	envContent := string(content)
+	want := "DATABASE_URL=postgres://admin:s3cr3t!@host:5432/db"
+	if !strings.Contains(envContent, want) {
+		t.Errorf("env file does not contain %q; content:\n%s", want, envContent)
+	}
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -251,6 +251,9 @@ Key sections:
 - `plugins.fleet` — opt-in telemetry to the Pro fleet dashboard
 - Any string field supports `secret://` URIs (e.g. `admin.token: secret://admin/api/token`).
   At load time, URIs are resolved from the encrypted secret store before validation.
+  For composite values, use `${secret://path/key}` placeholders inside strings
+  (e.g. `DATABASE_URL: "postgres://user:${secret://db/password}@host:5432/db"`).
+  Escape with `$${secret://...}` to produce a literal placeholder string.
   Store secrets with `vibew secret set <path> <key>=<value>`.
   The `secrets.*` section itself cannot use `secret://` (bootstrap constraint).
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -254,6 +254,8 @@ Key sections:
   For composite values, use `${secret://path/key}` placeholders inside strings
   (e.g. `DATABASE_URL: "postgres://user:${secret://db/password}@host:5432/db"`).
   Escape with `$${secret://...}` to produce a literal placeholder string.
+  The `secrets.inject.headers` and `secrets.inject.env` entries support a `value_template`
+  field for composite values (e.g. `value_template: "Bearer ${secret://app/auth/token}"`).
   Store secrets with `vibew secret set <path> <key>=<value>`.
   The `secrets.*` section itself cannot use `secret://` (bootstrap constraint).
 

--- a/vibewarden.reference.yaml
+++ b/vibewarden.reference.yaml
@@ -26,7 +26,7 @@
 #   - path:  the secret store path (everything before the last segment)
 #   - key:   the individual key within that path (the last segment)
 #
-# Examples:
+# Full-field resolution (entire value is a secret):
 #   admin:
 #     token: secret://admin/api/token
 #   auth:
@@ -34,6 +34,17 @@
 #       audience: secret://auth/jwt/audience
 #   database:
 #     external_url: secret://infra/db/connection_string
+#
+# Composite values -- embed secrets inside larger strings with ${secret://...}:
+#   app:
+#     environment:
+#       DATABASE_URL: "postgres://user:${secret://db/password}@host:5432/db"
+#       AUTH_HEADER: "Bearer ${secret://auth/api/token}"
+#
+# Escape with $${secret://...} to produce a literal ${secret://...} string:
+#   app:
+#     environment:
+#       EXAMPLE: "literal $${secret://not/resolved}"
 #
 # Store secrets with:
 #   vibew secret set auth/google client_id=xxx client_secret=xxx
@@ -867,11 +878,19 @@ secrets:
   inject:
     # Inject secrets as HTTP request headers on every proxied request.
     # The upstream app receives these headers like any other request header.
-    # Example:
+    #
+    # Simple example (secret value used directly):
     #   headers:
     #     - secret_path: app/internal-api
     #       secret_key: token
     #       header: X-Internal-Token
+    #
+    # Composite example (secret embedded in a larger string via value_template):
+    #   headers:
+    #     - secret_path: app/auth
+    #       secret_key: token
+    #       header: Authorization
+    #       value_template: "Bearer ${secret://app/auth/token}"
     headers: []
 
     # Write secrets to a .env file that the upstream app reads at startup.
@@ -880,11 +899,19 @@ secrets:
     env_file: ""
 
     # Secrets to write into the env file.
-    # Example:
+    #
+    # Simple example (secret value used directly):
     #   env:
     #     - secret_path: app/database
     #       secret_key: password
     #       env_var: DATABASE_PASSWORD
+    #
+    # Composite example (secret embedded in a connection string):
+    #   env:
+    #     - secret_path: app/database
+    #       secret_key: password
+    #       env_var: DATABASE_URL
+    #       value_template: "postgres://user:${secret://app/database/password}@host:5432/db"
     env: []
 
   # Dynamic Postgres credentials via OpenBao's database engine.


### PR DESCRIPTION
Closes #994

## Summary

- Add `${secret://path/key}` placeholder syntax for embedding secrets inside composite string values (e.g. `DATABASE_URL: "postgres://user:${secret://db/password}@host:5432/db"`)
- Add escape syntax `$${secret://...}` to produce literal placeholder strings without resolution
- Add `value_template` field to header and env injection config for the secrets plugin
- Maintain full backward compatibility: existing `secret://` full-field resolution unchanged
- ADR-077 documents the design decision

## Test plan

- [x] `make check` passes (formatting, golangci-lint, build, tests with race detection)
- [ ] Domain tests: `TestContainsPlaceholder`, `TestFindPlaceholders`, `TestUnescapePlaceholders` cover single, multiple, escaped, malformed, and edge cases
- [ ] Config resolver tests: `TestResolveSecrets_CompositeSinglePlaceholder`, `TestResolveSecrets_CompositeMultiplePlaceholders`, `TestResolveSecrets_CompositeEscapedPlaceholder`, `TestResolveSecrets_CompositeMixedEscapedAndUnescaped`, `TestResolveSecrets_CompositeFullFieldStillWorks`, `TestResolveSecrets_CompositeFailsOnMissingSecret`, `TestResolveSecrets_CompositeInMapField`
- [ ] Plugin tests: `TestPlugin_ContributeCaddyHandlers_WithValueTemplate`, `TestPlugin_WriteEnvFile_WithValueTemplate`
- [ ] All existing tests continue to pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)