### PR TITLE
docs: add tls.acme_ca and vibew cert trust to llms-full.txt

### DIFF
--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -133,6 +133,8 @@ Key rules:
 - `vibew add tls --domain` writes the domain to vibewarden.production.yaml.
 - Production-only settings (domain, letsencrypt, port 443) belong in the
   production override, not the base config.
+- If Let's Encrypt is rate-limited, set `tls.acme_ca` to use an alternative CA:
+  `acme_ca: "https://acme.zerossl.com/v2/DV90"` (ZeroSSL, free, separate rate limits).
 
 ## Writing your Dockerfile
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -145,6 +145,7 @@ or `vibew wrap`.
 
 - `vibew add tls --domain <domain>` -- enable TLS (--domain is required)
   - `--provider` (default letsencrypt) -- letsencrypt, self-signed, or external
+- `vibew cert trust` -- install Caddy's local CA certificate into the OS trust store (macOS/Linux)
 - `vibew add auth` -- enable Ory Kratos authentication (no extra flags)
 - `vibew add rate-limiting` -- enable rate limiting (no extra flags)
 - `vibew add metrics` -- enable Prometheus metrics (no extra flags)
@@ -245,6 +246,8 @@ Key sections:
 - `app.image` — Docker image reference (used when `app.build` is empty)
 - `app.environment` — custom env vars injected into the app container (e.g. DATABASE_URL, REDIS_URL)
 - `tls.enabled`, `tls.provider` — TLS termination (letsencrypt, self-signed, external)
+- `tls.acme_ca` — override ACME directory URL (e.g. ZeroSSL, Let's Encrypt staging). Use this
+  when Let's Encrypt is rate-limited: `acme_ca: "https://acme.zerossl.com/v2/DV90"`
 - `auth.mode` — authentication strategy: `none`, `kratos`, `jwt`, or `api-key` (single source of truth; see ADR-065)
 - `auth.role_paths` — role-based access control via Kratos identity traits (maps role names to URL path patterns; only valid when `auth.mode` is `kratos`)
 - `rate_limit.enabled`, `rate_limit.per_ip` — per-IP rate limiting


### PR DESCRIPTION
## Summary

These features shipped in v0.13.1 (#976) but were only documented in vibewarden.reference.yaml. AI agents reading llms-full.txt had no way to discover:

- `tls.acme_ca` — override ACME directory URL (ZeroSSL, staging) when Let's Encrypt is rate-limited
- `vibew cert trust` — install local CA certificate into OS trust store

This caused the demo deploy agent to hit Let's Encrypt rate limits without knowing it could switch to ZeroSSL.

## Test plan

- [x] Documentation-only change
- [x] Verified `acme_ca` field exists in vibewarden.reference.yaml (line 207)
- [x] Verified `vibew cert trust` command exists in CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)