### PR TITLE
fix(#1027): wire tls.email to Caddy ACME issuer in single-site mode

### DIFF
--- a/cmd/vibewarden/wiring_serve_helpers.go
+++ b/cmd/vibewarden/wiring_serve_helpers.go
@@ -70,6 +70,7 @@ func buildProxyConfig(cfg *config.Config, registry *plugins.Registry, version st
 			Enabled:     cfg.TLS.Enabled,
 			Provider:    ports.TLSProvider(cfg.TLS.Provider),
 			Domain:      cfg.TLS.Domain,
+			Email:       cfg.TLS.Email,
 			CertPath:    cfg.TLS.CertPath,
 			KeyPath:     cfg.TLS.KeyPath,
 			StoragePath: cfg.TLS.StoragePath,

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -49,6 +49,7 @@ once accepted, they are not edited. If a decision is superseded, a new ADR refer
 | [075](adr-075-redesign-vibew-deploy-local-resolution-no-remote-patching.md) | Redesign vibew deploy -- local resolution, no remote patching | #948 |
 | [076](adr-076-secret-uri-resolution-in-config.md) | secret:// URI resolution in vibewarden.yaml config | #1008 |
 | [077](adr-077-placeholder-substitution-for-composite-secret-values.md) | Placeholder substitution for composite secret values | #994 |
+| [078](adr-078-wire-acme-email-to-single-site-caddy-issuer.md) | Wire acme_email to single-site Caddy ACME issuer | #1027 |
 | [497](adr-497-graceful-shutdown-connection-draining.md) | Graceful Shutdown / Connection Draining | — |
 
 ## Numbering

--- a/decisions/adr-078-wire-acme-email-to-single-site-caddy-issuer.md
+++ b/decisions/adr-078-wire-acme-email-to-single-site-caddy-issuer.md
@@ -1,0 +1,61 @@
+## ADR-078: Wire acme_email to Single-Site Caddy ACME Issuer
+**Date**: 2026-04-20
+**Issue**: #1027
+**Status**: Accepted
+
+### Context
+
+The `acme_email` field is accepted in config and correctly wired to the Caddy
+ACME issuer in **multi-site** mode (`multisite_config.go`) but completely
+ignored in **single-site** mode (`config.go`). This causes two problems:
+
+1. ZeroSSL ACME fails in single-site mode because it requires an email for
+   automatic EAB registration.
+2. Let's Encrypt certificate expiry notifications are never sent because no
+   contact email is registered with the ACME account.
+
+The demo deploy agent had to PATCH the Caddy admin API directly to inject the
+email — a workaround that is lost on container restart.
+
+### Decision
+
+Add an `Email` field to the `ports.TLSConfig` struct and wire it into the ACME
+issuer JSON object in `buildLetsEncryptTLSApp()`, matching the existing pattern
+in `buildMultiSiteTLSApp()`.
+
+#### Modified files
+
+| File | Change |
+|------|--------|
+| `internal/ports/proxy.go` | Add `Email string` field to `TLSConfig` struct |
+| `internal/config/config.go` | Add `Email string` with `mapstructure:"email"` tag |
+| `internal/adapters/caddy/config.go` | Wire `cfg.Email` into ACME issuer in `buildLetsEncryptTLSApp` |
+| `cmd/vibewarden/wiring_serve_helpers.go` | Pass `cfg.TLS.Email` through to `ports.TLSConfig` |
+| `internal/app/eject/eject.go` | Pass `cfg.TLS.Email` through to `ports.TLSConfig` |
+| `internal/adapters/caddy/config_test.go` | Table-driven test for email presence in ACME issuer |
+
+#### YAML config example
+
+```yaml
+tls:
+  enabled: true
+  provider: letsencrypt
+  domain: myapp.example.com
+  email: admin@example.com        # <-- new field
+  acme_ca: https://acme.zerossl.com/v2/DV90  # optional
+```
+
+#### Behaviour
+
+- When `email` is non-empty, `"email": "<value>"` is added to the ACME issuer
+  JSON object in the Caddy TLS automation policy.
+- When `email` is empty (default), the field is omitted — backward compatible
+  with Let's Encrypt which does not require it.
+
+### Consequences
+
+- ZeroSSL works in single-site mode without any workaround.
+- Let's Encrypt sends expiry notifications to the configured email.
+- No breaking changes — existing configs without `email` continue to work.
+- The single-site and multi-site code paths now have consistent ACME email
+  handling.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,6 +103,8 @@ app:
 | `tls.provider` | string | `""` | Certificate provider: `letsencrypt` (or `acme`), `self-signed`, or `external` |
 | `tls.cert_path` | string | `""` | Path to PEM certificate. Required when `provider` is `external` |
 | `tls.key_path` | string | `""` | Path to PEM private key. Required when `provider` is `external` |
+| `tls.email` | string | `""` | ACME account email. Required for ZeroSSL, recommended for Let's Encrypt (cert expiry notifications) |
+| `tls.acme_ca` | string | `""` | Override ACME directory URL (e.g. ZeroSSL: `https://acme.zerossl.com/v2/DV90`) |
 | `tls.storage_path` | string | `""` | Directory for ACME certificate storage. Applies to `letsencrypt` only |
 
 ```yaml

--- a/internal/adapters/caddy/config.go
+++ b/internal/adapters/caddy/config.go
@@ -450,6 +450,11 @@ func buildLetsEncryptTLSApp(cfg ports.TLSConfig) map[string]any {
 	acmeIssuer := map[string]any{
 		"module": "acme",
 	}
+	// When Email is set, include it in the ACME issuer for certificate expiry
+	// notifications and automatic EAB registration (required by ZeroSSL).
+	if cfg.Email != "" {
+		acmeIssuer["email"] = cfg.Email
+	}
 	// When ACMECA is set, override the default ACME directory URL.
 	// This allows using Let's Encrypt staging, ZeroSSL, or any other
 	// ACME-compliant CA.

--- a/internal/adapters/caddy/config_test.go
+++ b/internal/adapters/caddy/config_test.go
@@ -562,6 +562,78 @@ func TestBuildCaddyConfig_LetsEncryptACMECA(t *testing.T) {
 	}
 }
 
+// TestBuildCaddyConfig_LetsEncryptACMEEmail verifies that when Email is set on
+// the TLS config, the ACME issuer includes an "email" field. When empty, no
+// "email" field is present — this maintains backward compatibility with Let's
+// Encrypt which does not require an email, while enabling ZeroSSL which does.
+func TestBuildCaddyConfig_LetsEncryptACMEEmail(t *testing.T) {
+	tests := []struct {
+		name      string
+		email     string
+		wantEmail bool
+	}{
+		{
+			name:      "no email (empty)",
+			email:     "",
+			wantEmail: false,
+		},
+		{
+			name:      "email set",
+			email:     "admin@example.com",
+			wantEmail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &ports.ProxyConfig{
+				ListenAddr:   "0.0.0.0:443",
+				UpstreamAddr: "127.0.0.1:3000",
+				TLS: ports.TLSConfig{
+					Enabled:  true,
+					Provider: ports.TLSProviderLetsEncrypt,
+					Domain:   "example.com",
+					Email:    tt.email,
+				},
+			}
+
+			result, err := BuildCaddyConfig(cfg)
+			if err != nil {
+				t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+			}
+
+			apps := result["apps"].(map[string]any)
+			tlsApp := apps["tls"].(map[string]any)
+			automation := tlsApp["automation"].(map[string]any)
+			policies := automation["policies"].([]map[string]any)
+
+			if len(policies) == 0 {
+				t.Fatal("expected at least one automation policy")
+			}
+
+			issuers, ok := policies[0]["issuers"].([]map[string]any)
+			if !ok || len(issuers) == 0 {
+				t.Fatal("issuers not found in automation policy")
+			}
+
+			acmeIssuer := issuers[0]
+			emailVal, hasEmail := acmeIssuer["email"]
+
+			if tt.wantEmail {
+				if !hasEmail {
+					t.Errorf("expected 'email' field in ACME issuer for email=%q", tt.email)
+				} else if emailVal != tt.email {
+					t.Errorf("email = %q, want %q", emailVal, tt.email)
+				}
+			} else {
+				if hasEmail {
+					t.Errorf("unexpected 'email' field in ACME issuer when email is empty: %v", emailVal)
+				}
+			}
+		})
+	}
+}
+
 // TestBuildCaddyConfig_StorageAtTopLevel verifies that when StoragePath is set,
 // the storage module appears at the top level of the Caddy config (not inside
 // apps.tls). Placing storage inside apps.tls causes Caddy to reject the config

--- a/internal/app/eject/eject.go
+++ b/internal/app/eject/eject.go
@@ -87,9 +87,11 @@ func buildProxyConfig(cfg *config.Config, extraHandlers []ports.CaddyHandler) *p
 			Enabled:     cfg.TLS.Enabled,
 			Provider:    ports.TLSProvider(cfg.TLS.Provider),
 			Domain:      cfg.TLS.Domain,
+			Email:       cfg.TLS.Email,
 			CertPath:    cfg.TLS.CertPath,
 			KeyPath:     cfg.TLS.KeyPath,
 			StoragePath: cfg.TLS.StoragePath,
+			ACMECA:      cfg.TLS.ACMECA,
 		},
 		SecurityHeaders: ports.SecurityHeadersConfig{
 			Enabled:                      cfg.SecurityHeaders.Enabled,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -504,6 +504,10 @@ type TLSConfig struct {
 	// StoragePath is the directory where Caddy stores ACME certificates.
 	// Only applies when Provider is "letsencrypt".
 	StoragePath string `mapstructure:"storage_path"`
+	// Email is the ACME account email address used for certificate expiry
+	// notifications and automatic EAB registration with CAs that require it
+	// (e.g. ZeroSSL). Optional for Let's Encrypt.
+	Email string `mapstructure:"email"`
 	// ACMECA is the ACME directory URL to use instead of Let's Encrypt production.
 	// Only applies when Provider is "letsencrypt".
 	// Example: "https://acme-staging-v02.api.letsencrypt.org/directory"

--- a/internal/ports/proxy.go
+++ b/internal/ports/proxy.go
@@ -331,6 +331,11 @@ type TLSConfig struct {
 	// Uses the Caddy default when empty (applicable to TLSProviderLetsEncrypt only).
 	StoragePath string
 
+	// Email is the ACME account email address used for certificate notifications
+	// and, for some CAs (e.g. ZeroSSL), automatic EAB registration.
+	// Optional for Let's Encrypt; required for ZeroSSL.
+	Email string
+
 	// ACMECA is the ACME directory URL to use instead of the default
 	// (Let's Encrypt production). Only applicable when Provider is
 	// TLSProviderLetsEncrypt.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -246,6 +246,7 @@ Key sections:
 - `app.image` — Docker image reference (used when `app.build` is empty)
 - `app.environment` — custom env vars injected into the app container (e.g. DATABASE_URL, REDIS_URL)
 - `tls.enabled`, `tls.provider` — TLS termination (letsencrypt, self-signed, external)
+- `tls.email` — ACME account email (required for ZeroSSL, recommended for Let's Encrypt)
 - `tls.acme_ca` — override ACME directory URL (e.g. ZeroSSL, Let's Encrypt staging). Use this
   when Let's Encrypt is rate-limited: `acme_ca: "https://acme.zerossl.com/v2/DV90"`
 - `auth.mode` — authentication strategy: `none`, `kratos`, `jwt`, or `api-key` (single source of truth; see ADR-065)

--- a/vibewarden.reference.yaml
+++ b/vibewarden.reference.yaml
@@ -199,6 +199,11 @@ tls:
   # Only applies when provider is "letsencrypt".
   storage_path: ""
 
+  # Email address for ACME account registration.
+  # Required for ZeroSSL (used for EAB auto-registration).
+  # Recommended for Let's Encrypt (receives cert expiry notifications).
+  email: ""
+
   # ACME directory URL to use instead of Let's Encrypt production.
   # Only applies when provider is "letsencrypt".
   # Use the staging URL for testing to avoid rate limits:


### PR DESCRIPTION
Closes #1027

## Summary
- Added `Email` field to `ports.TLSConfig` struct for ACME account email
- Added `email` mapstructure tag to `config.TLSConfig` so `tls.email` is parsed from vibewarden.yaml
- Wired `cfg.Email` into the ACME issuer JSON in `buildLetsEncryptTLSApp()` — matching the existing multi-site pattern
- Passed `Email` through in both serve (`wiring_serve_helpers.go`) and eject (`eject.go`) paths
- Also fixed missing `ACMECA` wiring in the eject path (pre-existing omission)
- Added ADR-078 documenting the decision
- Added table-driven test `TestBuildCaddyConfig_LetsEncryptACMEEmail` covering both email-present and email-absent cases

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `make check` passes (includes golangci-lint)
- [x] New test verifies email appears in ACME issuer JSON when set
- [x] New test verifies email is omitted when empty (backward compat)
- [ ] Manual: configure `tls.email: admin@example.com` with ZeroSSL CA — cert issuance succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)