### PR TITLE
feat(#1026): ACME fallback chain — automatic failover across LE, ZeroSSL, Buypass

### DIFF
--- a/cmd/vibewarden/wiring_serve_helpers.go
+++ b/cmd/vibewarden/wiring_serve_helpers.go
@@ -70,6 +70,7 @@ func buildProxyConfig(cfg *config.Config, registry *plugins.Registry, version st
 			Enabled:     cfg.TLS.Enabled,
 			Provider:    ports.TLSProvider(cfg.TLS.Provider),
 			Domain:      cfg.TLS.Domain,
+			Email:       cfg.TLS.Email,
 			CertPath:    cfg.TLS.CertPath,
 			KeyPath:     cfg.TLS.KeyPath,
 			StoragePath: cfg.TLS.StoragePath,

--- a/decisions/adr-079-acme-fallback-chain-multi-issuer.md
+++ b/decisions/adr-079-acme-fallback-chain-multi-issuer.md
@@ -1,0 +1,51 @@
+# ADR-079: ACME Fallback Chain (Multi-Issuer)
+
+## Status
+
+Accepted
+
+## Context
+
+Let's Encrypt occasionally experiences outages or rate limits that prevent
+certificate issuance. When this happens, VibeWarden users are left without
+valid TLS certificates until the CA recovers. Caddy natively supports multiple
+ACME issuers in a fallback chain, but VibeWarden previously only configured a
+single issuer.
+
+Additionally, users may want to use alternative ACME CAs (ZeroSSL, Buypass)
+as their primary issuer for business or compliance reasons.
+
+## Decision
+
+1. **Default fallback chain**: When `tls.provider: letsencrypt` and no
+   `acme_ca` override is set, configure 3 ACME issuers in order:
+   - Let's Encrypt (production)
+   - ZeroSSL
+   - Buypass Go SSL
+
+   Caddy tries them in order; if the first fails, it falls over to the next.
+
+2. **New provider constants**: Add `zerossl`, `buypass`, and
+   `letsencrypt-staging` as first-class provider values. Each configures a
+   single issuer targeting that specific CA.
+
+3. **Email field**: Add `tls.email` for ACME account registration. Required
+   for `zerossl` (EAB credential auto-registration), recommended for others
+   (cert expiry warnings).
+
+4. **Backward compatibility**: Setting `acme_ca` explicitly disables the
+   fallback chain and uses a single issuer with the specified CA URL. This
+   preserves the behavior for users who already set `acme_ca`.
+
+5. **Shared helper**: `buildACMEIssuers(cfg ports.TLSConfig)` is the single
+   source of truth for issuer chain construction, used by both single-site
+   and multi-site config builders.
+
+## Consequences
+
+- Users get automatic failover across CAs with zero configuration change.
+- ZeroSSL and Buypass are now first-class providers for users who need them.
+- The `letsencrypt-staging` provider replaces the need to manually set
+  `acme_ca` to the staging URL for testing.
+- All ACME issuers now include explicit `ca` URLs (previously the default LE
+  issuer had no `ca` field). This is a non-breaking change for Caddy.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,17 +99,24 @@ app:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `tls.enabled` | bool | `true` | Enable TLS |
-| `tls.domain` | string | `""` | Domain for the TLS certificate. Required when `provider` is `letsencrypt` |
-| `tls.provider` | string | `""` | Certificate provider: `letsencrypt` (or `acme`), `self-signed`, or `external` |
+| `tls.domain` | string | `""` | Domain for the TLS certificate. Required for all ACME providers |
+| `tls.provider` | string | `""` | Certificate provider: `letsencrypt` (or `acme`), `zerossl`, `buypass`, `letsencrypt-staging`, `self-signed`, or `external` |
+| `tls.email` | string | `""` | ACME account email. Required for `zerossl`. Recommended for others (cert expiry warnings) |
 | `tls.cert_path` | string | `""` | Path to PEM certificate. Required when `provider` is `external` |
 | `tls.key_path` | string | `""` | Path to PEM private key. Required when `provider` is `external` |
-| `tls.storage_path` | string | `""` | Directory for ACME certificate storage. Applies to `letsencrypt` only |
+| `tls.storage_path` | string | `""` | Directory for ACME certificate storage. Applies to all ACME providers |
+| `tls.acme_ca` | string | `""` | Custom ACME directory URL. Only for `letsencrypt` provider. When set, disables the fallback chain |
+
+When `provider: letsencrypt` (the default) and `acme_ca` is not set, VibeWarden
+configures a 3-issuer fallback chain: Let's Encrypt -> ZeroSSL -> Buypass.
+If one CA is down, Caddy automatically tries the next.
 
 ```yaml
 tls:
   enabled: true
   provider: letsencrypt
   domain: myapp.example.com
+  email: admin@example.com   # optional but recommended
 ```
 
 ---

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -470,8 +470,9 @@ All `vibewarden.yaml` settings can be overridden via environment variables using
 | `VIBEWARDEN_UPSTREAM_HOST` | `upstream.host` | Upstream app hostname |
 | `VIBEWARDEN_UPSTREAM_PORT` | `upstream.port` | Upstream app port |
 | `VIBEWARDEN_TLS_ENABLED` | `tls.enabled` | Enable TLS termination |
-| `VIBEWARDEN_TLS_PROVIDER` | `tls.provider` | `letsencrypt`, `self-signed`, or `external` |
+| `VIBEWARDEN_TLS_PROVIDER` | `tls.provider` | `letsencrypt`, `zerossl`, `buypass`, `letsencrypt-staging`, `self-signed`, or `external` |
 | `VIBEWARDEN_TLS_DOMAIN` | `tls.domain` | Domain for ACME certificate |
+| `VIBEWARDEN_TLS_EMAIL` | `tls.email` | ACME account email (required for zerossl) |
 | `VIBEWARDEN_TLS_CERT_PATH` | `tls.cert_path` | Path to certificate file (external provider) |
 | `VIBEWARDEN_TLS_KEY_PATH` | `tls.key_path` | Path to private key file (external provider) |
 | `VIBEWARDEN_KRATOS_PUBLIC_URL` | `kratos.public_url` | Kratos public API URL |

--- a/internal/adapters/caddy/acme_issuers.go
+++ b/internal/adapters/caddy/acme_issuers.go
@@ -1,0 +1,90 @@
+package caddy
+
+import "github.com/vibewarden/vibewarden/internal/ports"
+
+// ACME directory URLs for supported certificate authorities.
+const (
+	// acmeURLLetsEncrypt is the production ACME directory for Let's Encrypt.
+	acmeURLLetsEncrypt = "https://acme-v02.api.letsencrypt.org/directory"
+
+	// acmeURLLetsEncryptStaging is the staging ACME directory for Let's Encrypt.
+	// Certificates issued are not publicly trusted.
+	acmeURLLetsEncryptStaging = "https://acme-staging-v02.api.letsencrypt.org/directory"
+
+	// acmeURLZeroSSL is the ACME directory for ZeroSSL.
+	acmeURLZeroSSL = "https://acme.zerossl.com/v2/DV90"
+
+	// acmeURLBuypass is the ACME directory for Buypass Go SSL.
+	acmeURLBuypass = "https://api.buypass.com/acme/directory"
+)
+
+// buildACMEIssuers constructs the list of ACME issuer configurations for the
+// given TLS config. The returned slice is used in Caddy's TLS automation policy
+// "issuers" field.
+//
+// Behaviour:
+//   - provider "letsencrypt" without acme_ca: 3-issuer fallback chain
+//     (Let's Encrypt -> ZeroSSL -> Buypass) for maximum availability.
+//   - provider "letsencrypt" with acme_ca: single issuer with the specified CA
+//     (backward-compatible override).
+//   - provider "zerossl": single ZeroSSL issuer (requires email for EAB).
+//   - provider "buypass": single Buypass issuer.
+//   - provider "letsencrypt-staging": single Let's Encrypt staging issuer.
+func buildACMEIssuers(cfg ports.TLSConfig) []map[string]any {
+	switch cfg.Provider {
+	case ports.TLSProviderLetsEncrypt:
+		if cfg.ACMECA != "" {
+			// Explicit CA override — single issuer, backward compat.
+			return []map[string]any{buildSingleACMEIssuer(cfg.ACMECA, cfg.Email)}
+		}
+		// Default: 3-issuer fallback chain for maximum availability.
+		return []map[string]any{
+			buildSingleACMEIssuer(acmeURLLetsEncrypt, cfg.Email),
+			buildSingleACMEIssuer(acmeURLZeroSSL, cfg.Email),
+			buildSingleACMEIssuer(acmeURLBuypass, cfg.Email),
+		}
+
+	case ports.TLSProviderZeroSSL:
+		return []map[string]any{buildSingleACMEIssuer(acmeURLZeroSSL, cfg.Email)}
+
+	case ports.TLSProviderBuypass:
+		return []map[string]any{buildSingleACMEIssuer(acmeURLBuypass, cfg.Email)}
+
+	case ports.TLSProviderLetsEncryptStaging:
+		return []map[string]any{buildSingleACMEIssuer(acmeURLLetsEncryptStaging, cfg.Email)}
+
+	default:
+		// Non-ACME providers should not call this function.
+		// Return a single default LE issuer as a defensive fallback.
+		return []map[string]any{buildSingleACMEIssuer(acmeURLLetsEncrypt, cfg.Email)}
+	}
+}
+
+// buildSingleACMEIssuer constructs a single ACME issuer map for Caddy's JSON
+// config. The "ca" field is always set explicitly so each issuer in a fallback
+// chain targets a specific directory. The "email" field is included when
+// non-empty (required for ZeroSSL EAB, recommended for others).
+func buildSingleACMEIssuer(caURL, email string) map[string]any {
+	issuer := map[string]any{
+		"module": "acme",
+		"ca":     caURL,
+	}
+	if email != "" {
+		issuer["email"] = email
+	}
+	return issuer
+}
+
+// isACMEProvider returns true if the given TLS provider uses the ACME protocol
+// for certificate provisioning (i.e., requires a domain and supports issuers).
+func isACMEProvider(provider ports.TLSProvider) bool {
+	switch provider {
+	case ports.TLSProviderLetsEncrypt,
+		ports.TLSProviderZeroSSL,
+		ports.TLSProviderBuypass,
+		ports.TLSProviderLetsEncryptStaging:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/adapters/caddy/acme_issuers_test.go
+++ b/internal/adapters/caddy/acme_issuers_test.go
@@ -1,0 +1,210 @@
+package caddy
+
+import (
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+func TestBuildACMEIssuers(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         ports.TLSConfig
+		wantCount   int
+		wantFirstCA string
+		wantEmail   bool
+	}{
+		{
+			name: "letsencrypt without acme_ca produces 3-issuer fallback chain",
+			cfg: ports.TLSConfig{
+				Provider: ports.TLSProviderLetsEncrypt,
+				Domain:   "example.com",
+			},
+			wantCount:   3,
+			wantFirstCA: acmeURLLetsEncrypt,
+		},
+		{
+			name: "letsencrypt with acme_ca produces single issuer",
+			cfg: ports.TLSConfig{
+				Provider: ports.TLSProviderLetsEncrypt,
+				Domain:   "example.com",
+				ACMECA:   "https://custom-ca.example.com/directory",
+			},
+			wantCount:   1,
+			wantFirstCA: "https://custom-ca.example.com/directory",
+		},
+		{
+			name: "zerossl produces single issuer",
+			cfg: ports.TLSConfig{
+				Provider: ports.TLSProviderZeroSSL,
+				Domain:   "example.com",
+				Email:    "admin@example.com",
+			},
+			wantCount:   1,
+			wantFirstCA: acmeURLZeroSSL,
+			wantEmail:   true,
+		},
+		{
+			name: "buypass produces single issuer",
+			cfg: ports.TLSConfig{
+				Provider: ports.TLSProviderBuypass,
+				Domain:   "example.com",
+			},
+			wantCount:   1,
+			wantFirstCA: acmeURLBuypass,
+		},
+		{
+			name: "letsencrypt-staging produces single issuer",
+			cfg: ports.TLSConfig{
+				Provider: ports.TLSProviderLetsEncryptStaging,
+				Domain:   "example.com",
+			},
+			wantCount:   1,
+			wantFirstCA: acmeURLLetsEncryptStaging,
+		},
+		{
+			name: "letsencrypt with email includes email in all issuers",
+			cfg: ports.TLSConfig{
+				Provider: ports.TLSProviderLetsEncrypt,
+				Domain:   "example.com",
+				Email:    "admin@example.com",
+			},
+			wantCount:   3,
+			wantFirstCA: acmeURLLetsEncrypt,
+			wantEmail:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issuers := buildACMEIssuers(tt.cfg)
+
+			if len(issuers) != tt.wantCount {
+				t.Fatalf("got %d issuers, want %d", len(issuers), tt.wantCount)
+			}
+
+			// Verify all issuers have module "acme".
+			for i, issuer := range issuers {
+				if issuer["module"] != "acme" {
+					t.Errorf("issuer[%d].module = %q, want %q", i, issuer["module"], "acme")
+				}
+			}
+
+			// Verify first issuer has expected CA.
+			if issuers[0]["ca"] != tt.wantFirstCA {
+				t.Errorf("first issuer ca = %q, want %q", issuers[0]["ca"], tt.wantFirstCA)
+			}
+
+			// Verify email presence.
+			for i, issuer := range issuers {
+				_, hasEmail := issuer["email"]
+				if tt.wantEmail && !hasEmail {
+					t.Errorf("issuer[%d] missing email field", i)
+				}
+				if !tt.wantEmail && hasEmail {
+					t.Errorf("issuer[%d] has unexpected email field", i)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildACMEIssuers_FallbackChainOrder(t *testing.T) {
+	cfg := ports.TLSConfig{
+		Provider: ports.TLSProviderLetsEncrypt,
+		Domain:   "example.com",
+	}
+
+	issuers := buildACMEIssuers(cfg)
+
+	if len(issuers) != 3 {
+		t.Fatalf("expected 3 issuers, got %d", len(issuers))
+	}
+
+	wantOrder := []string{
+		acmeURLLetsEncrypt,
+		acmeURLZeroSSL,
+		acmeURLBuypass,
+	}
+
+	for i, want := range wantOrder {
+		got := issuers[i]["ca"]
+		if got != want {
+			t.Errorf("issuer[%d].ca = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestBuildSingleACMEIssuer(t *testing.T) {
+	tests := []struct {
+		name      string
+		caURL     string
+		email     string
+		wantCA    string
+		wantEmail string
+	}{
+		{
+			name:   "with email",
+			caURL:  acmeURLLetsEncrypt,
+			email:  "admin@example.com",
+			wantCA: acmeURLLetsEncrypt,
+		},
+		{
+			name:   "without email",
+			caURL:  acmeURLBuypass,
+			email:  "",
+			wantCA: acmeURLBuypass,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issuer := buildSingleACMEIssuer(tt.caURL, tt.email)
+
+			if issuer["module"] != "acme" {
+				t.Errorf("module = %q, want %q", issuer["module"], "acme")
+			}
+			if issuer["ca"] != tt.wantCA {
+				t.Errorf("ca = %q, want %q", issuer["ca"], tt.wantCA)
+			}
+
+			emailVal, hasEmail := issuer["email"]
+			if tt.email != "" {
+				if !hasEmail {
+					t.Error("expected email field in issuer")
+				} else if emailVal != tt.email {
+					t.Errorf("email = %q, want %q", emailVal, tt.email)
+				}
+			} else {
+				if hasEmail {
+					t.Errorf("unexpected email field in issuer: %v", emailVal)
+				}
+			}
+		})
+	}
+}
+
+func TestIsACMEProvider(t *testing.T) {
+	tests := []struct {
+		provider ports.TLSProvider
+		want     bool
+	}{
+		{ports.TLSProviderLetsEncrypt, true},
+		{ports.TLSProviderZeroSSL, true},
+		{ports.TLSProviderBuypass, true},
+		{ports.TLSProviderLetsEncryptStaging, true},
+		{ports.TLSProviderSelfSigned, false},
+		{ports.TLSProviderExternal, false},
+		{"", false},
+		{"unknown", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.provider), func(t *testing.T) {
+			got := isACMEProvider(tt.provider)
+			if got != tt.want {
+				t.Errorf("isACMEProvider(%q) = %v, want %v", tt.provider, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/adapters/caddy/config.go
+++ b/internal/adapters/caddy/config.go
@@ -231,9 +231,9 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 	}
 	// Add a host matcher so Caddy's auto-HTTPS knows which domain to manage
 	// certificates for. Without this, Caddy won't proactively obtain or generate
-	// any server certificate. This is critical for letsencrypt (ACME) and
+	// any server certificate. This is critical for ACME providers and
 	// self-signed (internal CA) providers.
-	if cfg.TLS.Enabled && (cfg.TLS.Provider == ports.TLSProviderSelfSigned || cfg.TLS.Provider == ports.TLSProviderLetsEncrypt) {
+	if cfg.TLS.Enabled && (cfg.TLS.Provider == ports.TLSProviderSelfSigned || isACMEProvider(cfg.TLS.Provider)) {
 		domain := cfg.TLS.Domain
 		if domain == "" {
 			domain = "localhost"
@@ -263,8 +263,8 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 	}
 
 	if cfg.TLS.Enabled {
-		if cfg.TLS.Provider == ports.TLSProviderLetsEncrypt {
-			// For Let's Encrypt, do NOT disable redirects. Caddy's built-in
+		if isACMEProvider(cfg.TLS.Provider) {
+			// For ACME providers, do NOT disable redirects. Caddy's built-in
 			// automatic HTTPS will:
 			//   1. Serve ACME HTTP-01 challenges on port 80
 			//   2. Redirect all other HTTP traffic to HTTPS
@@ -298,13 +298,13 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 		"vibewarden": server,
 	}
 
-	// When TLS is enabled and the provider is NOT Let's Encrypt, add a manual
+	// When TLS is enabled and the provider is NOT an ACME provider, add a manual
 	// HTTP→HTTPS redirect server on :80.
-	// For Let's Encrypt, Caddy's automatic HTTPS handles both ACME challenges and
+	// For ACME providers, Caddy's automatic HTTPS handles both ACME challenges and
 	// HTTP→HTTPS redirects on port 80 natively. Adding a manual redirect server
 	// would intercept /.well-known/acme-challenge/* before Caddy's ACME solver,
 	// causing certificate issuance to fail.
-	if cfg.TLS.Enabled && cfg.TLS.Provider != ports.TLSProviderLetsEncrypt {
+	if cfg.TLS.Enabled && !isACMEProvider(cfg.TLS.Provider) {
 		httpServers["vibewarden_redirect"] = buildHTTPRedirectServer()
 	}
 
@@ -359,22 +359,25 @@ func buildExtraRoute(r ports.CaddyRoute) map[string]any {
 
 // validateTLSConfig checks that the TLS configuration is self-consistent.
 func validateTLSConfig(cfg ports.TLSConfig) error {
-	switch cfg.Provider {
-	case ports.TLSProviderLetsEncrypt:
+	switch {
+	case isACMEProvider(cfg.Provider):
 		if cfg.Domain == "" {
 			return fmt.Errorf("domain is required for provider %q", cfg.Provider)
 		}
-	case ports.TLSProviderExternal:
+		if cfg.Provider == ports.TLSProviderZeroSSL && cfg.Email == "" {
+			return fmt.Errorf("email is required for provider %q (needed for EAB credential registration)", cfg.Provider)
+		}
+	case cfg.Provider == ports.TLSProviderExternal:
 		if cfg.CertPath == "" {
 			return fmt.Errorf("cert_path is required for provider %q", cfg.Provider)
 		}
 		if cfg.KeyPath == "" {
 			return fmt.Errorf("key_path is required for provider %q", cfg.Provider)
 		}
-	case ports.TLSProviderSelfSigned, "":
+	case cfg.Provider == ports.TLSProviderSelfSigned || cfg.Provider == "":
 		// No additional fields required.
 	default:
-		return fmt.Errorf("unknown tls provider %q; valid values: letsencrypt, self-signed, external", cfg.Provider)
+		return fmt.Errorf("unknown tls provider %q; valid values: letsencrypt, zerossl, buypass, letsencrypt-staging, self-signed, external", cfg.Provider)
 	}
 	return nil
 }
@@ -403,10 +406,10 @@ func buildTLSPolicy(cfg ports.TLSConfig) []map[string]any {
 		return []map[string]any{{"default_sni": domain}}
 	}
 
-	// For Let's Encrypt, include a match.sni entry for the domain.
+	// For ACME providers, include a match.sni entry for the domain.
 	// Without this, Caddy does not associate the TLS connection policy with the
 	// domain and will not trigger proactive ACME certificate issuance.
-	if cfg.Provider == ports.TLSProviderLetsEncrypt && cfg.Domain != "" {
+	if isACMEProvider(cfg.Provider) && cfg.Domain != "" {
 		return []map[string]any{{
 			"match": map[string]any{
 				"sni": []string{cfg.Domain},
@@ -421,12 +424,12 @@ func buildTLSPolicy(cfg ports.TLSConfig) []map[string]any {
 // buildTLSApp builds the Caddy "tls" app configuration for the chosen provider.
 // Returns nil when no TLS app section is needed.
 func buildTLSApp(cfg ports.TLSConfig) (map[string]any, error) {
-	switch cfg.Provider {
-	case ports.TLSProviderLetsEncrypt:
-		return buildLetsEncryptTLSApp(cfg), nil
-	case ports.TLSProviderSelfSigned, "":
+	switch {
+	case isACMEProvider(cfg.Provider):
+		return buildACMETLSApp(cfg), nil
+	case cfg.Provider == ports.TLSProviderSelfSigned || cfg.Provider == "":
 		return buildSelfSignedTLSApp(cfg), nil
-	case ports.TLSProviderExternal:
+	case cfg.Provider == ports.TLSProviderExternal:
 		return buildExternalTLSApp(cfg), nil
 	default:
 		// Already validated in validateTLSConfig; this is a defensive fallback.
@@ -434,32 +437,18 @@ func buildTLSApp(cfg ports.TLSConfig) (map[string]any, error) {
 	}
 }
 
-// buildLetsEncryptTLSApp returns a Caddy TLS app configuration that provisions
-// certificates automatically via ACME (Let's Encrypt).
-//
-// The ACME issuer is configured with explicit HTTP-01 challenge support.
-// The HTTP-01 challenge listener is bound to the same :80 port as the redirect
-// server — Caddy manages both from within the same embedded instance, so no
-// port conflict occurs.
+// buildACMETLSApp returns a Caddy TLS app configuration that provisions
+// certificates automatically via ACME. The issuer chain is built by
+// buildACMEIssuers based on the provider and acme_ca settings.
 //
 // Note: storage is intentionally NOT set here. Caddy's storage backend is a
 // top-level field on the Config struct; placing it inside apps.tls causes Caddy
 // to reject the config with "unknown field: storage". Storage is set at the
 // top-level in BuildCaddyConfig when cfg.StoragePath is non-empty.
-func buildLetsEncryptTLSApp(cfg ports.TLSConfig) map[string]any {
-	acmeIssuer := map[string]any{
-		"module": "acme",
-	}
-	// When ACMECA is set, override the default ACME directory URL.
-	// This allows using Let's Encrypt staging, ZeroSSL, or any other
-	// ACME-compliant CA.
-	if cfg.ACMECA != "" {
-		acmeIssuer["ca"] = cfg.ACMECA
-	}
-
+func buildACMETLSApp(cfg ports.TLSConfig) map[string]any {
 	policy := map[string]any{
 		"subjects": []string{cfg.Domain},
-		"issuers":  []map[string]any{acmeIssuer},
+		"issuers":  buildACMEIssuers(cfg),
 	}
 
 	return map[string]any{

--- a/internal/adapters/caddy/config_test.go
+++ b/internal/adapters/caddy/config_test.go
@@ -445,8 +445,8 @@ func TestBuildCaddyConfig_LetsEncryptDomainInPolicy(t *testing.T) {
 	}
 }
 
-// TestBuildCaddyConfig_LetsEncryptACMEIssuer verifies the ACME issuer is configured
-// without explicit challenge settings so Caddy uses TLS-ALPN-01 automatically.
+// TestBuildCaddyConfig_LetsEncryptACMEIssuer verifies the fallback chain
+// produces 3 ACME issuers with explicit CA URLs and no challenge overrides.
 func TestBuildCaddyConfig_LetsEncryptACMEIssuer(t *testing.T) {
 	cfg := &ports.ProxyConfig{
 		ListenAddr:   "0.0.0.0:443",
@@ -477,38 +477,62 @@ func TestBuildCaddyConfig_LetsEncryptACMEIssuer(t *testing.T) {
 		t.Fatal("issuers not found in automation policy")
 	}
 
-	acmeIssuer := issuers[0]
-	if acmeIssuer["module"] != "acme" {
-		t.Fatalf("expected acme issuer module, got %q", acmeIssuer["module"])
+	// Default letsencrypt provider produces 3-issuer fallback chain.
+	if len(issuers) != 3 {
+		t.Fatalf("expected 3 issuers in fallback chain, got %d", len(issuers))
 	}
-	// No explicit challenges — Caddy uses TLS-ALPN-01 automatically.
-	if _, hasChallenge := acmeIssuer["challenges"]; hasChallenge {
-		t.Error("ACME issuer should not have explicit challenges config")
+
+	// All issuers must be ACME modules.
+	for i, issuer := range issuers {
+		if issuer["module"] != "acme" {
+			t.Errorf("issuer[%d].module = %q, want %q", i, issuer["module"], "acme")
+		}
+		// No explicit challenges — Caddy uses TLS-ALPN-01 automatically.
+		if _, hasChallenge := issuer["challenges"]; hasChallenge {
+			t.Errorf("issuer[%d] should not have explicit challenges config", i)
+		}
+	}
+
+	// Verify the fallback order: LE, ZeroSSL, Buypass.
+	wantCAs := []string{
+		"https://acme-v02.api.letsencrypt.org/directory",
+		"https://acme.zerossl.com/v2/DV90",
+		"https://api.buypass.com/acme/directory",
+	}
+	for i, wantCA := range wantCAs {
+		if issuers[i]["ca"] != wantCA {
+			t.Errorf("issuer[%d].ca = %q, want %q", i, issuers[i]["ca"], wantCA)
+		}
 	}
 }
 
 // TestBuildCaddyConfig_LetsEncryptACMECA verifies that when ACMECA is set, the
-// ACME issuer includes a "ca" field pointing to the custom directory URL.
+// fallback chain is disabled and a single issuer with the specified CA is used.
+// When ACMECA is empty, the 3-issuer fallback chain is produced.
 func TestBuildCaddyConfig_LetsEncryptACMECA(t *testing.T) {
 	tests := []struct {
-		name   string
-		acmeCA string
-		wantCA bool
+		name        string
+		acmeCA      string
+		wantIssuers int
+		wantFirstCA string
 	}{
 		{
-			name:   "default CA (empty)",
-			acmeCA: "",
-			wantCA: false,
+			name:        "default CA (empty) produces 3-issuer fallback chain",
+			acmeCA:      "",
+			wantIssuers: 3,
+			wantFirstCA: "https://acme-v02.api.letsencrypt.org/directory",
 		},
 		{
-			name:   "staging CA",
-			acmeCA: "https://acme-staging-v02.api.letsencrypt.org/directory",
-			wantCA: true,
+			name:        "staging CA override produces single issuer",
+			acmeCA:      "https://acme-staging-v02.api.letsencrypt.org/directory",
+			wantIssuers: 1,
+			wantFirstCA: "https://acme-staging-v02.api.letsencrypt.org/directory",
 		},
 		{
-			name:   "custom CA",
-			acmeCA: "https://acme.zerossl.com/v2/DV90",
-			wantCA: true,
+			name:        "custom CA override produces single issuer",
+			acmeCA:      "https://acme.zerossl.com/v2/DV90",
+			wantIssuers: 1,
+			wantFirstCA: "https://acme.zerossl.com/v2/DV90",
 		},
 	}
 
@@ -544,19 +568,17 @@ func TestBuildCaddyConfig_LetsEncryptACMECA(t *testing.T) {
 				t.Fatal("issuers not found in automation policy")
 			}
 
-			acmeIssuer := issuers[0]
-			caVal, hasCA := acmeIssuer["ca"]
+			if len(issuers) != tt.wantIssuers {
+				t.Errorf("got %d issuers, want %d", len(issuers), tt.wantIssuers)
+			}
 
-			if tt.wantCA {
-				if !hasCA {
-					t.Errorf("expected 'ca' field in ACME issuer for acme_ca=%q", tt.acmeCA)
-				} else if caVal != tt.acmeCA {
-					t.Errorf("ca = %q, want %q", caVal, tt.acmeCA)
-				}
-			} else {
-				if hasCA {
-					t.Errorf("unexpected 'ca' field in ACME issuer when acme_ca is empty: %v", caVal)
-				}
+			firstIssuer := issuers[0]
+			caVal, hasCA := firstIssuer["ca"]
+			if !hasCA {
+				t.Fatal("expected 'ca' field in first ACME issuer")
+			}
+			if caVal != tt.wantFirstCA {
+				t.Errorf("first issuer ca = %q, want %q", caVal, tt.wantFirstCA)
 			}
 		})
 	}
@@ -2659,4 +2681,173 @@ func TestBuildCaddyConfig_LetsEncryptFullJSON(t *testing.T) {
 
 	// Log the full JSON for debugging if any assertions fail.
 	t.Logf("full letsencrypt Caddy JSON:\n%s", jsonStr)
+}
+
+// TestBuildCaddyConfig_NewACMEProviders verifies that the new ACME providers
+// (zerossl, buypass, letsencrypt-staging) produce valid Caddy configs with
+// correct issuers and no redirect server (Caddy handles port 80 for ACME).
+func TestBuildCaddyConfig_NewACMEProviders(t *testing.T) {
+	tests := []struct {
+		name            string
+		provider        ports.TLSProvider
+		email           string
+		wantCA          string
+		wantIssuerCount int
+		wantEmail       bool
+		wantRedirect    bool
+	}{
+		{
+			name:            "zerossl provider",
+			provider:        ports.TLSProviderZeroSSL,
+			email:           "admin@example.com",
+			wantCA:          "https://acme.zerossl.com/v2/DV90",
+			wantIssuerCount: 1,
+			wantEmail:       true,
+			wantRedirect:    false,
+		},
+		{
+			name:            "buypass provider",
+			provider:        ports.TLSProviderBuypass,
+			email:           "",
+			wantCA:          "https://api.buypass.com/acme/directory",
+			wantIssuerCount: 1,
+			wantEmail:       false,
+			wantRedirect:    false,
+		},
+		{
+			name:            "letsencrypt-staging provider",
+			provider:        ports.TLSProviderLetsEncryptStaging,
+			email:           "dev@example.com",
+			wantCA:          "https://acme-staging-v02.api.letsencrypt.org/directory",
+			wantIssuerCount: 1,
+			wantEmail:       true,
+			wantRedirect:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &ports.ProxyConfig{
+				ListenAddr:   "0.0.0.0:443",
+				UpstreamAddr: "127.0.0.1:3000",
+				TLS: ports.TLSConfig{
+					Enabled:  true,
+					Provider: tt.provider,
+					Domain:   "example.com",
+					Email:    tt.email,
+				},
+			}
+
+			result, err := BuildCaddyConfig(cfg)
+			if err != nil {
+				t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+			}
+
+			apps := result["apps"].(map[string]any)
+
+			// Verify TLS app with correct issuers.
+			tlsApp, ok := apps["tls"].(map[string]any)
+			if !ok {
+				t.Fatal("tls app not found")
+			}
+			automation := tlsApp["automation"].(map[string]any)
+			policies := automation["policies"].([]map[string]any)
+			if len(policies) == 0 {
+				t.Fatal("expected at least one automation policy")
+			}
+
+			issuers := policies[0]["issuers"].([]map[string]any)
+			if len(issuers) != tt.wantIssuerCount {
+				t.Fatalf("got %d issuers, want %d", len(issuers), tt.wantIssuerCount)
+			}
+
+			firstIssuer := issuers[0]
+			if firstIssuer["ca"] != tt.wantCA {
+				t.Errorf("first issuer ca = %q, want %q", firstIssuer["ca"], tt.wantCA)
+			}
+
+			_, hasEmail := firstIssuer["email"]
+			if tt.wantEmail && !hasEmail {
+				t.Error("expected email in issuer")
+			}
+			if !tt.wantEmail && hasEmail {
+				t.Error("unexpected email in issuer")
+			}
+
+			// Verify no redirect server (Caddy handles port 80 for ACME).
+			httpApp := apps["http"].(map[string]any)
+			servers := httpApp["servers"].(map[string]any)
+			_, hasRedirect := servers["vibewarden_redirect"]
+			if hasRedirect != tt.wantRedirect {
+				t.Errorf("redirect server present = %v, want %v", hasRedirect, tt.wantRedirect)
+			}
+
+			// Verify automatic_https is not set (Caddy owns port 80 for ACME).
+			server := servers["vibewarden"].(map[string]any)
+			if _, hasAutoHTTPS := server["automatic_https"]; hasAutoHTTPS {
+				t.Error("automatic_https should not be set for ACME providers")
+			}
+		})
+	}
+}
+
+// TestBuildCaddyConfig_ZeroSSLRequiresEmail verifies that the zerossl provider
+// fails validation when email is not provided.
+func TestBuildCaddyConfig_ZeroSSLRequiresEmail(t *testing.T) {
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "0.0.0.0:443",
+		UpstreamAddr: "127.0.0.1:3000",
+		TLS: ports.TLSConfig{
+			Enabled:  true,
+			Provider: ports.TLSProviderZeroSSL,
+			Domain:   "example.com",
+			Email:    "", // missing — should fail
+		},
+	}
+
+	_, err := BuildCaddyConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for zerossl without email, got nil")
+	}
+	if !strings.Contains(err.Error(), "email is required") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "email is required")
+	}
+}
+
+// TestBuildCaddyConfig_LetsEncryptFallbackChainWithEmail verifies that when
+// email is set with the default letsencrypt provider, all 3 issuers in the
+// fallback chain include the email field.
+func TestBuildCaddyConfig_LetsEncryptFallbackChainWithEmail(t *testing.T) {
+	cfg := &ports.ProxyConfig{
+		ListenAddr:   "0.0.0.0:443",
+		UpstreamAddr: "127.0.0.1:3000",
+		TLS: ports.TLSConfig{
+			Enabled:  true,
+			Provider: ports.TLSProviderLetsEncrypt,
+			Domain:   "example.com",
+			Email:    "ops@example.com",
+		},
+	}
+
+	result, err := BuildCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("BuildCaddyConfig() unexpected error: %v", err)
+	}
+
+	apps := result["apps"].(map[string]any)
+	tlsApp := apps["tls"].(map[string]any)
+	automation := tlsApp["automation"].(map[string]any)
+	policies := automation["policies"].([]map[string]any)
+	issuers := policies[0]["issuers"].([]map[string]any)
+
+	if len(issuers) != 3 {
+		t.Fatalf("expected 3 issuers, got %d", len(issuers))
+	}
+
+	for i, issuer := range issuers {
+		email, ok := issuer["email"].(string)
+		if !ok || email != "ops@example.com" {
+			t.Errorf("issuer[%d].email = %q, want %q", i, email, "ops@example.com")
+		}
+	}
 }

--- a/internal/adapters/caddy/multisite_config.go
+++ b/internal/adapters/caddy/multisite_config.go
@@ -87,6 +87,7 @@ func BuildMultiSiteConfig(sites []*site.Site, globalCfg site.GlobalConfig, perSi
 		tlsEntries = append(tlsEntries, multiSiteTLSEntry{
 			domain:   domain,
 			provider: cfg.TLS.Provider,
+			email:    cfg.TLS.Email,
 			certPath: cfg.TLS.CertPath,
 			keyPath:  cfg.TLS.KeyPath,
 		})
@@ -254,10 +255,12 @@ func buildSiteRoutes(s *site.Site, domain string, extraHandlers []ports.CaddyHan
 
 // multiSiteTLSEntry pairs a domain with its TLS provider so that
 // buildMultiSiteTLSApp can generate the correct issuer configuration
-// (ACME for letsencrypt, internal for self-signed, load_files for external).
+// (ACME for letsencrypt/zerossl/buypass/letsencrypt-staging, internal for
+// self-signed, load_files for external).
 type multiSiteTLSEntry struct {
 	domain   string
 	provider string
+	email    string // used for ACME account registration (required for ZeroSSL)
 	certPath string // only used when provider is "external"
 	keyPath  string // only used when provider is "external"
 }
@@ -266,10 +269,12 @@ type multiSiteTLSEntry struct {
 // automation policies. Each domain gets its own policy entry. The issuer
 // module is chosen based on the site's TLS provider:
 //   - "self-signed" (or empty) uses Caddy's internal issuer (self-signed CA).
-//   - "letsencrypt" (or "acme") uses the ACME issuer for public certificates.
+//   - ACME providers (letsencrypt, zerossl, buypass, letsencrypt-staging) use
+//     buildACMEIssuers for the issuer chain.
+//   - "external" loads cert files via the load_files block.
 //
-// When acmeEmail is non-empty and the issuer is ACME, it is included in the
-// issuer configuration.
+// When acmeEmail is non-empty and the site entry does not have its own email,
+// acmeEmail is used as fallback for ACME account registration.
 func buildMultiSiteTLSApp(entries []multiSiteTLSEntry, acmeEmail string) map[string]any {
 	if len(entries) == 0 {
 		return nil
@@ -280,17 +285,17 @@ func buildMultiSiteTLSApp(entries []multiSiteTLSEntry, acmeEmail string) map[str
 		loadFiles []map[string]any
 	)
 	for _, entry := range entries {
-		var issuer map[string]any
-
 		switch entry.provider {
 		case string(ports.TLSProviderSelfSigned), "":
-			issuer = map[string]any{
-				"module": "internal",
+			policy := map[string]any{
+				"subjects": []string{entry.domain},
+				"issuers":  []map[string]any{{"module": "internal"}},
 			}
+			policies = append(policies, policy)
+
 		case string(ports.TLSProviderExternal):
 			// External provider: operator supplies cert + key files.
 			// No issuer — certificates are loaded via the load_files block below.
-			// Skip adding an issuer-based policy; add a load_files entry instead.
 			if entry.certPath != "" && entry.keyPath != "" {
 				loadFiles = append(loadFiles, map[string]any{
 					"certificate": entry.certPath,
@@ -298,22 +303,25 @@ func buildMultiSiteTLSApp(entries []multiSiteTLSEntry, acmeEmail string) map[str
 					"tags":        []string{"vibewarden_external_" + entry.domain},
 				})
 			}
-			continue // skip the issuer-based policy for this entry
-		default:
-			// letsencrypt / acme — use ACME issuer.
-			issuer = map[string]any{
-				"module": "acme",
-			}
-			if acmeEmail != "" {
-				issuer["email"] = acmeEmail
-			}
-		}
 
-		policy := map[string]any{
-			"subjects": []string{entry.domain},
-			"issuers":  []map[string]any{issuer},
+		default:
+			// ACME provider — use buildACMEIssuers for the issuer chain.
+			// Prefer the per-site email; fall back to the global acmeEmail.
+			email := entry.email
+			if email == "" {
+				email = acmeEmail
+			}
+			tlsCfg := ports.TLSConfig{
+				Provider: ports.TLSProvider(entry.provider),
+				Domain:   entry.domain,
+				Email:    email,
+			}
+			policy := map[string]any{
+				"subjects": []string{entry.domain},
+				"issuers":  buildACMEIssuers(tlsCfg),
+			}
+			policies = append(policies, policy)
 		}
-		policies = append(policies, policy)
 	}
 
 	tlsApp := map[string]any{}

--- a/internal/adapters/caddy/multisite_config_test.go
+++ b/internal/adapters/caddy/multisite_config_test.go
@@ -935,3 +935,54 @@ func verifyUpstreamInRoutes(t *testing.T, routes []any, upstream string) {
 	}
 	t.Errorf("no route found with upstream %q", upstream)
 }
+
+// TestBuildMultiSiteConfig_FallbackChain verifies that the letsencrypt provider
+// produces a 3-issuer fallback chain in the multisite TLS app.
+func TestBuildMultiSiteConfig_FallbackChain(t *testing.T) {
+	cfg := helperMinimalConfig("app.example.com", 3000)
+	s := helperNewSite(t, "app", cfg)
+
+	global := site.DefaultGlobalConfig()
+	global.ACMEEmail = "ops@example.com"
+	result, err := BuildMultiSiteConfig([]*site.Site{s}, global, nil, slog.Default())
+	if err != nil {
+		t.Fatalf("BuildMultiSiteConfig() error = %v", err)
+	}
+
+	data, _ := json.Marshal(result)
+	var parsed map[string]any
+	_ = json.Unmarshal(data, &parsed)
+
+	apps := parsed["apps"].(map[string]any)
+	tlsApp := apps["tls"].(map[string]any)
+	automation := tlsApp["automation"].(map[string]any)
+	policies := automation["policies"].([]any)
+
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 TLS policy, got %d", len(policies))
+	}
+
+	policy := policies[0].(map[string]any)
+	issuers := policy["issuers"].([]any)
+
+	// Default letsencrypt provider should produce 3-issuer fallback chain.
+	if len(issuers) != 3 {
+		t.Fatalf("expected 3 issuers in fallback chain, got %d", len(issuers))
+	}
+
+	wantCAs := []string{
+		"https://acme-v02.api.letsencrypt.org/directory",
+		"https://acme.zerossl.com/v2/DV90",
+		"https://api.buypass.com/acme/directory",
+	}
+	for i, wantCA := range wantCAs {
+		issuer := issuers[i].(map[string]any)
+		if issuer["ca"] != wantCA {
+			t.Errorf("issuer[%d].ca = %q, want %q", i, issuer["ca"], wantCA)
+		}
+		// All issuers in the chain should have the global email.
+		if issuer["email"] != "ops@example.com" {
+			t.Errorf("issuer[%d].email = %q, want %q", i, issuer["email"], "ops@example.com")
+		}
+	}
+}

--- a/internal/app/eject/eject.go
+++ b/internal/app/eject/eject.go
@@ -87,9 +87,11 @@ func buildProxyConfig(cfg *config.Config, extraHandlers []ports.CaddyHandler) *p
 			Enabled:     cfg.TLS.Enabled,
 			Provider:    ports.TLSProvider(cfg.TLS.Provider),
 			Domain:      cfg.TLS.Domain,
+			Email:       cfg.TLS.Email,
 			CertPath:    cfg.TLS.CertPath,
 			KeyPath:     cfg.TLS.KeyPath,
 			StoragePath: cfg.TLS.StoragePath,
+			ACMECA:      cfg.TLS.ACMECA,
 		},
 		SecurityHeaders: ports.SecurityHeadersConfig{
 			Enabled:                      cfg.SecurityHeaders.Enabled,

--- a/internal/cli/cmd/add_tls.go
+++ b/internal/cli/cmd/add_tls.go
@@ -43,15 +43,19 @@ When TLS is already enabled, vibewarden.yaml is left unchanged and the domain
 is written only to vibewarden.production.yaml.
 
 Supported providers:
-  letsencrypt   Automatic certificate from Let's Encrypt (default, requires public domain)
-  self-signed   Self-signed certificate for local/internal use
-  external      You manage the certificate (Cloudflare, registrar, AWS ACM, etc.)
+  letsencrypt          Automatic certificate with fallback chain: LE -> ZeroSSL -> Buypass (default)
+  zerossl              ZeroSSL only (requires --email for EAB registration)
+  buypass              Buypass Go SSL only
+  letsencrypt-staging  Let's Encrypt staging (for testing, certs not publicly trusted)
+  self-signed          Self-signed certificate for local/internal use
+  external             You manage the certificate (Cloudflare, registrar, AWS ACM, etc.)
 
 Run 'vibew wrap' first if vibewarden.yaml does not exist.
 
 Examples:
   vibew add tls --domain example.com
   vibew add tls --domain example.com --provider letsencrypt
+  vibew add tls --domain example.com --provider zerossl --email admin@example.com
   vibew add tls --domain internal.corp --provider self-signed`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -109,7 +113,7 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&domain, "domain", "", "domain for TLS certificate (required)")
-	cmd.Flags().StringVar(&provider, "provider", "letsencrypt", `TLS provider: "letsencrypt", "self-signed", or "external"`)
+	cmd.Flags().StringVar(&provider, "provider", "letsencrypt", `TLS provider: "letsencrypt", "zerossl", "buypass", "letsencrypt-staging", "self-signed", or "external"`)
 
 	return cmd
 }

--- a/internal/cli/cmd/validate.go
+++ b/internal/cli/cmd/validate.go
@@ -11,9 +11,13 @@ import (
 
 // validTLSProviders is the set of accepted TLS provider values.
 var validTLSProviders = map[string]bool{
-	"letsencrypt": true,
-	"self-signed": true,
-	"external":    true,
+	"letsencrypt":         true,
+	"acme":                true,
+	"zerossl":             true,
+	"buypass":             true,
+	"letsencrypt-staging": true,
+	"self-signed":         true,
+	"external":            true,
 }
 
 // validLogLevels is the set of accepted log level values.
@@ -58,8 +62,8 @@ Checks performed:
   - File exists and is valid YAML
   - server.port is in the range 1-65535
   - upstream.port is in the range 1-65535
-  - tls.provider is one of: letsencrypt, self-signed, external
-  - tls.domain is required when provider is letsencrypt
+  - tls.provider is one of: letsencrypt, acme, zerossl, buypass, letsencrypt-staging, self-signed, external
+  - tls.domain is required when provider is an ACME provider
   - tls.cert_path and tls.key_path are required when provider is external
   - log.level is one of: debug, info, warn, error
   - log.format is one of: json, text
@@ -150,12 +154,18 @@ func validateConfig(cfg *config.Config) []string {
 
 	// tls.provider
 	if !validTLSProviders[cfg.TLS.Provider] {
-		errs = append(errs, fmt.Sprintf("tls.provider must be one of letsencrypt, self-signed, external; got %q", cfg.TLS.Provider))
+		errs = append(errs, fmt.Sprintf("tls.provider must be one of letsencrypt, acme, zerossl, buypass, letsencrypt-staging, self-signed, external; got %q", cfg.TLS.Provider))
 	}
 
-	// tls: letsencrypt requires a domain
-	if cfg.TLS.Enabled && cfg.TLS.Provider == "letsencrypt" && cfg.TLS.Domain == "" {
-		errs = append(errs, "tls.domain is required when tls.provider is letsencrypt")
+	// tls: ACME providers require a domain
+	acmeProviders := map[string]bool{"letsencrypt": true, "acme": true, "zerossl": true, "buypass": true, "letsencrypt-staging": true}
+	if cfg.TLS.Enabled && acmeProviders[cfg.TLS.Provider] && cfg.TLS.Domain == "" {
+		errs = append(errs, fmt.Sprintf("tls.domain is required when tls.provider is %q", cfg.TLS.Provider))
+	}
+
+	// tls: zerossl requires email for EAB auto-registration
+	if cfg.TLS.Enabled && cfg.TLS.Provider == "zerossl" && cfg.TLS.Email == "" {
+		errs = append(errs, "tls.email is required when tls.provider is zerossl (needed for EAB auto-registration)")
 	}
 
 	// tls: external requires cert_path and key_path

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -491,10 +491,15 @@ type TLSCertMonitoringConfig struct {
 type TLSConfig struct {
 	// Enabled toggles TLS (default: false for local dev)
 	Enabled bool `mapstructure:"enabled"`
-	// Domain for TLS certificate (required if enabled with provider "letsencrypt")
+	// Domain for TLS certificate (required for all ACME providers)
 	Domain string `mapstructure:"domain"`
-	// Provider: "letsencrypt" (or alias "acme"), "self-signed", or "external"
+	// Provider: "letsencrypt" (or alias "acme"), "zerossl", "buypass",
+	// "letsencrypt-staging", "self-signed", or "external"
 	Provider string `mapstructure:"provider"`
+	// Email is the ACME account registration email address.
+	// Required for ZeroSSL (used for EAB credential auto-registration).
+	// Recommended for Let's Encrypt and Buypass (cert expiry warnings).
+	Email string `mapstructure:"email"`
 	// CertPath is the path to a PEM-encoded certificate file.
 	// Required when Provider is "external".
 	CertPath string `mapstructure:"cert_path"`
@@ -502,10 +507,11 @@ type TLSConfig struct {
 	// Required when Provider is "external".
 	KeyPath string `mapstructure:"key_path"`
 	// StoragePath is the directory where Caddy stores ACME certificates.
-	// Only applies when Provider is "letsencrypt".
+	// Only applies when ACME providers.
 	StoragePath string `mapstructure:"storage_path"`
-	// ACMECA is the ACME directory URL to use instead of Let's Encrypt production.
-	// Only applies when Provider is "letsencrypt".
+	// ACMECA is the ACME directory URL to use instead of the default.
+	// Only applies when Provider is "letsencrypt". When set, disables
+	// the automatic 3-issuer fallback chain and uses a single issuer.
 	// Example: "https://acme-staging-v02.api.letsencrypt.org/directory"
 	ACMECA string `mapstructure:"acme_ca"`
 	// CertMonitoring holds configuration for the background certificate expiry monitor.
@@ -1718,23 +1724,35 @@ func (c *Config) Validate() error {
 	// "acme" is accepted as an alias for "letsencrypt"; Load() normalises it
 	// before Validate() runs, but direct callers of Validate() may still pass
 	// it, so we permit it here as well.
+	acmeProviders := map[string]bool{
+		"letsencrypt": true, "acme": true, "zerossl": true,
+		"buypass": true, "letsencrypt-staging": true,
+	}
 	switch c.TLS.Provider {
-	case "", "self-signed", "letsencrypt", "acme", "external":
+	case "", "self-signed", "letsencrypt", "acme", "zerossl", "buypass", "letsencrypt-staging", "external":
 		// valid — empty string is accepted (defaults to "self-signed" via Load)
 	default:
 		errs = append(errs, fmt.Sprintf(
-			"tls.provider %q is invalid; accepted values: \"self-signed\", \"letsencrypt\" (or alias \"acme\"), \"external\" — "+
+			"tls.provider %q is invalid; accepted values: \"self-signed\", \"letsencrypt\" (or alias \"acme\"), "+
+				"\"zerossl\", \"buypass\", \"letsencrypt-staging\", \"external\" — "+
 				"set tls.provider to one of those values",
 			c.TLS.Provider,
 		))
 	}
 
-	// TLS letsencrypt provider requires domain.
-	// Also checked for "acme" — the alias — in case Validate() is called
-	// before Load() has had a chance to normalise the value.
-	if c.TLS.Enabled && (c.TLS.Provider == "letsencrypt" || c.TLS.Provider == "acme") && c.TLS.Domain == "" {
-		errs = append(errs, "tls.domain is required when tls.provider is \"letsencrypt\" — "+
-			"set tls.domain to your domain name (e.g., myapp.example.com)")
+	// ACME providers require domain.
+	if c.TLS.Enabled && acmeProviders[c.TLS.Provider] && c.TLS.Domain == "" {
+		errs = append(errs, fmt.Sprintf(
+			"tls.domain is required when tls.provider is %q — "+
+				"set tls.domain to your domain name (e.g., myapp.example.com)",
+			c.TLS.Provider,
+		))
+	}
+
+	// ZeroSSL requires email for EAB credential auto-registration.
+	if c.TLS.Enabled && c.TLS.Provider == "zerossl" && c.TLS.Email == "" {
+		errs = append(errs, "tls.email is required when tls.provider is \"zerossl\" — "+
+			"set tls.email to your ACME account email (needed for EAB credential registration)")
 	}
 
 	// TLS external provider requires cert_path and key_path.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2518,13 +2518,52 @@ func TestValidate_TLSProvider(t *testing.T) {
 			name:        "unknown provider cloudflare is rejected with actionable message",
 			cfg:         config.Config{TLS: config.TLSConfig{Provider: "cloudflare"}},
 			wantErr:     true,
-			wantContain: "accepted values: \"self-signed\", \"letsencrypt\" (or alias \"acme\"), \"external\"",
+			wantContain: "accepted values: \"self-signed\", \"letsencrypt\" (or alias \"acme\"), \"zerossl\", \"buypass\", \"letsencrypt-staging\", \"external\"",
 		},
 		{
 			name:        "error message suggests fix",
 			cfg:         config.Config{TLS: config.TLSConfig{Provider: "cloudflare"}},
 			wantErr:     true,
 			wantContain: "set tls.provider to one of those values",
+		},
+		{
+			name:    "zerossl is valid with domain and email",
+			cfg:     config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "zerossl", Domain: "example.com", Email: "admin@example.com"}},
+			wantErr: false,
+		},
+		{
+			name:        "zerossl enabled without email is invalid",
+			cfg:         config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "zerossl", Domain: "example.com"}},
+			wantErr:     true,
+			wantContain: "tls.email is required when tls.provider is \"zerossl\"",
+		},
+		{
+			name:        "zerossl enabled without domain is invalid",
+			cfg:         config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "zerossl", Email: "admin@example.com"}},
+			wantErr:     true,
+			wantContain: "tls.domain is required",
+		},
+		{
+			name:    "buypass is valid with domain",
+			cfg:     config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "buypass", Domain: "example.com"}},
+			wantErr: false,
+		},
+		{
+			name:        "buypass enabled without domain is invalid",
+			cfg:         config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "buypass"}},
+			wantErr:     true,
+			wantContain: "tls.domain is required",
+		},
+		{
+			name:    "letsencrypt-staging is valid with domain",
+			cfg:     config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "letsencrypt-staging", Domain: "example.com"}},
+			wantErr: false,
+		},
+		{
+			name:        "letsencrypt-staging enabled without domain is invalid",
+			cfg:         config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "letsencrypt-staging"}},
+			wantErr:     true,
+			wantContain: "tls.domain is required",
 		},
 	}
 

--- a/internal/config/load_raw.go
+++ b/internal/config/load_raw.go
@@ -68,7 +68,12 @@ func loadInternal(configPath string, validate bool) (*Config, error) {
 		cfg.TLS.Provider = "letsencrypt"
 	}
 
-	if cfg.TLS.Provider == "letsencrypt" && cfg.TLS.StoragePath == "" {
+	// Set default storage path for all ACME providers when not explicitly configured.
+	acmeProviders := map[string]bool{
+		"letsencrypt": true, "zerossl": true,
+		"buypass": true, "letsencrypt-staging": true,
+	}
+	if acmeProviders[cfg.TLS.Provider] && cfg.TLS.StoragePath == "" {
 		cfg.TLS.StoragePath = "/root/.local/share/caddy"
 	}
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -761,9 +761,13 @@ func validateConfig(cfg *config.Config) []string {
 	var errs []string
 
 	validTLSProviders := map[string]bool{
-		"letsencrypt": true,
-		"self-signed": true,
-		"external":    true,
+		"letsencrypt":         true,
+		"acme":                true,
+		"zerossl":             true,
+		"buypass":             true,
+		"letsencrypt-staging": true,
+		"self-signed":         true,
+		"external":            true,
 	}
 	validLogLevels := map[string]bool{
 		"debug": true,
@@ -788,10 +792,14 @@ func validateConfig(cfg *config.Config) []string {
 		errs = append(errs, fmt.Sprintf("upstream.port must be between 1 and 65535, got %d", cfg.Upstream.Port))
 	}
 	if !validTLSProviders[cfg.TLS.Provider] {
-		errs = append(errs, fmt.Sprintf("tls.provider must be one of letsencrypt, self-signed, external; got %q", cfg.TLS.Provider))
+		errs = append(errs, fmt.Sprintf("tls.provider must be one of letsencrypt, acme, zerossl, buypass, letsencrypt-staging, self-signed, external; got %q", cfg.TLS.Provider))
 	}
-	if cfg.TLS.Enabled && cfg.TLS.Provider == "letsencrypt" && cfg.TLS.Domain == "" {
-		errs = append(errs, "tls.domain is required when tls.provider is letsencrypt")
+	acmeProviders := map[string]bool{"letsencrypt": true, "acme": true, "zerossl": true, "buypass": true, "letsencrypt-staging": true}
+	if cfg.TLS.Enabled && acmeProviders[cfg.TLS.Provider] && cfg.TLS.Domain == "" {
+		errs = append(errs, fmt.Sprintf("tls.domain is required when tls.provider is %q", cfg.TLS.Provider))
+	}
+	if cfg.TLS.Enabled && cfg.TLS.Provider == "zerossl" && cfg.TLS.Email == "" {
+		errs = append(errs, "tls.email is required when tls.provider is zerossl")
 	}
 	if cfg.TLS.Enabled && cfg.TLS.Provider == "external" {
 		if cfg.TLS.CertPath == "" {

--- a/internal/plugins/catalog.go
+++ b/internal/plugins/catalog.go
@@ -130,11 +130,11 @@ var Catalog = []PluginDescriptor{
 	},
 	{
 		Name:        "tls",
-		Description: "TLS termination with Let's Encrypt, self-signed, or external certificates",
+		Description: "TLS termination with ACME (Let's Encrypt, ZeroSSL, Buypass), self-signed, or external certificates",
 		ConfigSchema: map[string]string{
 			"enabled":      "Enable TLS (default: false)",
-			"provider":     "Certificate provider: letsencrypt, self-signed, external",
-			"domain":       "Domain for certificate (required for letsencrypt)",
+			"provider":     "Certificate provider: letsencrypt (with LE→ZeroSSL→Buypass fallback), zerossl, buypass, letsencrypt-staging, self-signed, external",
+			"domain":       "Domain for certificate (required for ACME providers)",
 			"cert_path":    "Path to certificate file (external provider)",
 			"key_path":     "Path to key file (external provider)",
 			"storage_path": "Directory for certificate storage",

--- a/internal/plugins/tls/meta.go
+++ b/internal/plugins/tls/meta.go
@@ -2,16 +2,16 @@ package tls
 
 // Description returns a short description of the TLS plugin.
 func (p *Plugin) Description() string {
-	return "TLS termination with Let's Encrypt, self-signed, or external certificates"
+	return "TLS termination with ACME (Let's Encrypt, ZeroSSL, Buypass), self-signed, or external certificates"
 }
 
 // ConfigSchema returns the configuration field descriptions for the TLS plugin.
 func (p *Plugin) ConfigSchema() map[string]string {
 	return map[string]string{
 		"enabled":      "Enable TLS (default: false)",
-		"provider":     "Certificate provider: letsencrypt, self-signed, external",
-		"domain":       "Domain for certificate (required for letsencrypt)",
-		"email":        "Email for Let's Encrypt notifications",
+		"provider":     "Certificate provider: letsencrypt (with LE→ZeroSSL→Buypass fallback), zerossl, buypass, letsencrypt-staging, self-signed, external",
+		"domain":       "Domain for certificate (required for ACME providers)",
+		"email":        "ACME account email (required for ZeroSSL, recommended for Let's Encrypt)",
 		"cert_path":    "Path to certificate file (external provider)",
 		"key_path":     "Path to key file (external provider)",
 		"storage_path": "Directory for certificate storage",

--- a/internal/plugins/tls/monitor.go
+++ b/internal/plugins/tls/monitor.go
@@ -58,10 +58,10 @@ type caddyCertReader struct {
 // For letsencrypt/self-signed it scans the storage directory for PEM files.
 // For external it reads cfg.CertPath and cfg.KeyPath directly.
 func (r *caddyCertReader) ReadCert() (*x509.Certificate, error) {
-	switch r.cfg.Provider {
-	case ports.TLSProviderExternal:
+	switch {
+	case r.cfg.Provider == ports.TLSProviderExternal:
 		return r.reader.ReadCert(r.cfg.CertPath, r.cfg.KeyPath)
-	case ports.TLSProviderLetsEncrypt, ports.TLSProviderSelfSigned, "":
+	case isACMEProvider(r.cfg.Provider) || r.cfg.Provider == ports.TLSProviderSelfSigned || r.cfg.Provider == "":
 		return r.readCaddyStoredCert()
 	default:
 		return nil, fmt.Errorf("unsupported provider %q for certificate monitoring", r.cfg.Provider)

--- a/internal/plugins/tls/plugin.go
+++ b/internal/plugins/tls/plugin.go
@@ -179,24 +179,40 @@ func (p *Plugin) RedirectServer() map[string]any {
 
 // validateTLSConfig checks that the TLS configuration is self-consistent.
 func validateTLSConfig(cfg ports.TLSConfig) error {
-	switch cfg.Provider {
-	case ports.TLSProviderLetsEncrypt:
+	switch {
+	case isACMEProvider(cfg.Provider):
 		if cfg.Domain == "" {
 			return fmt.Errorf("domain is required for provider %q", cfg.Provider)
 		}
-	case ports.TLSProviderExternal:
+		if cfg.Provider == ports.TLSProviderZeroSSL && cfg.Email == "" {
+			return fmt.Errorf("email is required for provider %q (needed for EAB credential registration)", cfg.Provider)
+		}
+	case cfg.Provider == ports.TLSProviderExternal:
 		if cfg.CertPath == "" {
 			return fmt.Errorf("cert_path is required for provider %q", cfg.Provider)
 		}
 		if cfg.KeyPath == "" {
 			return fmt.Errorf("key_path is required for provider %q", cfg.Provider)
 		}
-	case ports.TLSProviderSelfSigned, "":
+	case cfg.Provider == ports.TLSProviderSelfSigned || cfg.Provider == "":
 		// No additional fields required.
 	default:
-		return fmt.Errorf("unknown tls provider %q; valid values: letsencrypt, self-signed, external", cfg.Provider)
+		return fmt.Errorf("unknown tls provider %q; valid values: letsencrypt, zerossl, buypass, letsencrypt-staging, self-signed, external", cfg.Provider)
 	}
 	return nil
+}
+
+// isACMEProvider returns true if the given TLS provider uses the ACME protocol.
+func isACMEProvider(provider ports.TLSProvider) bool {
+	switch provider {
+	case ports.TLSProviderLetsEncrypt,
+		ports.TLSProviderZeroSSL,
+		ports.TLSProviderBuypass,
+		ports.TLSProviderLetsEncryptStaging:
+		return true
+	default:
+		return false
+	}
 }
 
 // buildTLSConnectionPolicies creates the Caddy tls_connection_policies slice.
@@ -218,12 +234,12 @@ func buildTLSConnectionPolicies(cfg ports.TLSConfig) []map[string]any {
 // buildTLSApp returns the Caddy "tls" app configuration for the chosen provider.
 // Returns nil when no TLS app section is required.
 func buildTLSApp(cfg ports.TLSConfig) (map[string]any, error) {
-	switch cfg.Provider {
-	case ports.TLSProviderLetsEncrypt:
-		return buildLetsEncryptTLSApp(cfg), nil
-	case ports.TLSProviderSelfSigned, "":
+	switch {
+	case isACMEProvider(cfg.Provider):
+		return buildACMETLSApp(cfg), nil
+	case cfg.Provider == ports.TLSProviderSelfSigned || cfg.Provider == "":
 		return buildSelfSignedTLSApp(cfg), nil
-	case ports.TLSProviderExternal:
+	case cfg.Provider == ports.TLSProviderExternal:
 		return buildExternalTLSApp(cfg), nil
 	default:
 		// Should have been caught by validateTLSConfig — defensive fallback.
@@ -231,26 +247,18 @@ func buildTLSApp(cfg ports.TLSConfig) (map[string]any, error) {
 	}
 }
 
-// buildLetsEncryptTLSApp returns a Caddy TLS app configuration that provisions
-// certificates automatically via ACME (Let's Encrypt).
-//
-// The ACME issuer is configured with explicit HTTP-01 challenge support. The
-// HTTP-01 challenge listener is bound to the same :80 port as the redirect
-// server — Caddy manages both from within the same embedded instance, so no
-// port conflict occurs.
+// buildACMETLSApp returns a Caddy TLS app configuration that provisions
+// certificates automatically via ACME. The issuer chain is built by
+// buildACMEIssuers based on the provider and acme_ca settings.
 //
 // Note: storage is intentionally NOT set here. Caddy's storage backend is a
 // top-level field on the Config struct; placing it inside apps.tls causes Caddy
 // to reject the config with "unknown field: storage". Storage is set at the
 // top-level in BuildCaddyConfig when cfg.StoragePath is non-empty.
-func buildLetsEncryptTLSApp(cfg ports.TLSConfig) map[string]any {
+func buildACMETLSApp(cfg ports.TLSConfig) map[string]any {
 	policy := map[string]any{
 		"subjects": []string{cfg.Domain},
-		"issuers": []map[string]any{
-			{
-				"module": "acme",
-			},
-		},
+		"issuers":  buildACMEIssuers(cfg),
 	}
 
 	return map[string]any{
@@ -258,6 +266,50 @@ func buildLetsEncryptTLSApp(cfg ports.TLSConfig) map[string]any {
 			"policies": []map[string]any{policy},
 		},
 	}
+}
+
+// ACME directory URLs for supported certificate authorities.
+const (
+	acmeURLLetsEncrypt        = "https://acme-v02.api.letsencrypt.org/directory"
+	acmeURLLetsEncryptStaging = "https://acme-staging-v02.api.letsencrypt.org/directory"
+	acmeURLZeroSSL            = "https://acme.zerossl.com/v2/DV90"
+	acmeURLBuypass            = "https://api.buypass.com/acme/directory"
+)
+
+// buildACMEIssuers constructs the list of ACME issuer configurations for the
+// given TLS config.
+func buildACMEIssuers(cfg ports.TLSConfig) []map[string]any {
+	switch cfg.Provider {
+	case ports.TLSProviderLetsEncrypt:
+		if cfg.ACMECA != "" {
+			return []map[string]any{buildSingleACMEIssuer(cfg.ACMECA, cfg.Email)}
+		}
+		return []map[string]any{
+			buildSingleACMEIssuer(acmeURLLetsEncrypt, cfg.Email),
+			buildSingleACMEIssuer(acmeURLZeroSSL, cfg.Email),
+			buildSingleACMEIssuer(acmeURLBuypass, cfg.Email),
+		}
+	case ports.TLSProviderZeroSSL:
+		return []map[string]any{buildSingleACMEIssuer(acmeURLZeroSSL, cfg.Email)}
+	case ports.TLSProviderBuypass:
+		return []map[string]any{buildSingleACMEIssuer(acmeURLBuypass, cfg.Email)}
+	case ports.TLSProviderLetsEncryptStaging:
+		return []map[string]any{buildSingleACMEIssuer(acmeURLLetsEncryptStaging, cfg.Email)}
+	default:
+		return []map[string]any{buildSingleACMEIssuer(acmeURLLetsEncrypt, cfg.Email)}
+	}
+}
+
+// buildSingleACMEIssuer constructs a single ACME issuer map.
+func buildSingleACMEIssuer(caURL, email string) map[string]any {
+	issuer := map[string]any{
+		"module": "acme",
+		"ca":     caURL,
+	}
+	if email != "" {
+		issuer["email"] = email
+	}
+	return issuer
 }
 
 // buildSelfSignedTLSApp returns a Caddy TLS app configuration that instructs

--- a/internal/ports/proxy.go
+++ b/internal/ports/proxy.go
@@ -274,7 +274,21 @@ type TLSProvider string
 
 const (
 	// TLSProviderLetsEncrypt provisions certificates automatically via ACME (Let's Encrypt).
+	// When no acme_ca override is set, this provider configures a 3-issuer fallback
+	// chain: Let's Encrypt -> ZeroSSL -> Buypass for maximum availability.
 	TLSProviderLetsEncrypt TLSProvider = "letsencrypt"
+
+	// TLSProviderZeroSSL provisions certificates via ZeroSSL's ACME endpoint.
+	// Requires an email address for EAB credential auto-registration.
+	TLSProviderZeroSSL TLSProvider = "zerossl"
+
+	// TLSProviderBuypass provisions certificates via Buypass Go SSL's ACME endpoint.
+	TLSProviderBuypass TLSProvider = "buypass"
+
+	// TLSProviderLetsEncryptStaging provisions certificates via Let's Encrypt's
+	// staging environment. Useful for testing ACME flows without hitting production
+	// rate limits. Certificates issued are not publicly trusted.
+	TLSProviderLetsEncryptStaging TLSProvider = "letsencrypt-staging"
 
 	// TLSProviderSelfSigned instructs Caddy to generate a self-signed certificate.
 	// Intended for local development and testing only.
@@ -311,13 +325,20 @@ type TLSConfig struct {
 	Enabled bool
 
 	// Provider selects how certificates are provisioned.
-	// Valid values: "letsencrypt", "self-signed", "external".
+	// Valid values: "letsencrypt", "zerossl", "buypass", "letsencrypt-staging",
+	// "self-signed", "external".
 	// Defaults to "self-signed" when empty and Enabled is true.
 	Provider TLSProvider
 
 	// Domain is the hostname for certificate provisioning.
-	// Required when Provider is TLSProviderLetsEncrypt.
+	// Required when Provider is an ACME provider (letsencrypt, zerossl, buypass,
+	// letsencrypt-staging).
 	Domain string
+
+	// Email is the ACME account registration email address.
+	// Required for ZeroSSL (used for EAB credential auto-registration).
+	// Recommended for Let's Encrypt and Buypass (cert expiry warnings).
+	Email string
 
 	// CertPath is the path to a PEM-encoded certificate file.
 	// Required when Provider is TLSProviderExternal.
@@ -328,12 +349,13 @@ type TLSConfig struct {
 	KeyPath string
 
 	// StoragePath is where Caddy stores ACME certificates on disk.
-	// Uses the Caddy default when empty (applicable to TLSProviderLetsEncrypt only).
+	// Uses the Caddy default when empty (applicable to ACME providers only).
 	StoragePath string
 
-	// ACMECA is the ACME directory URL to use instead of the default
-	// (Let's Encrypt production). Only applicable when Provider is
-	// TLSProviderLetsEncrypt.
+	// ACMECA is the ACME directory URL to use instead of the default.
+	// Only applicable when Provider is TLSProviderLetsEncrypt.
+	// When set, disables the automatic 3-issuer fallback chain and uses
+	// a single issuer with the specified CA URL.
 	// Example: "https://acme-staging-v02.api.letsencrypt.org/directory"
 	ACMECA string
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -144,7 +144,7 @@ support `--tls` or `--domain` — use `vibew add tls` after init for TLS.
 or `vibew wrap`.
 
 - `vibew add tls --domain <domain>` -- enable TLS (--domain is required)
-  - `--provider` (default letsencrypt) -- letsencrypt, self-signed, or external
+  - `--provider` (default letsencrypt) -- letsencrypt, zerossl, buypass, letsencrypt-staging, self-signed, or external
 - `vibew cert trust` -- install Caddy's local CA certificate into the OS trust store (macOS/Linux)
 - `vibew add auth` -- enable Ory Kratos authentication (no extra flags)
 - `vibew add rate-limiting` -- enable rate limiting (no extra flags)
@@ -245,9 +245,11 @@ Key sections:
 - `app.build` — Docker build context; `vibew build` builds locally, `vibew deploy` transfers the image (no source on server)
 - `app.image` — Docker image reference (used when `app.build` is empty)
 - `app.environment` — custom env vars injected into the app container (e.g. DATABASE_URL, REDIS_URL)
-- `tls.enabled`, `tls.provider` — TLS termination (letsencrypt, self-signed, external)
-- `tls.acme_ca` — override ACME directory URL (e.g. ZeroSSL, Let's Encrypt staging). Use this
-  when Let's Encrypt is rate-limited: `acme_ca: "https://acme.zerossl.com/v2/DV90"`
+- `tls.enabled`, `tls.provider` — TLS termination (letsencrypt, zerossl, buypass, letsencrypt-staging, self-signed, external)
+- `tls.email` — ACME account email (required for zerossl, recommended for others)
+- `tls.acme_ca` — override ACME directory URL for letsencrypt provider only. When set, disables
+  the 3-issuer fallback chain. Prefer `provider: letsencrypt-staging` for testing.
+  Default letsencrypt provider automatically fails over: LE -> ZeroSSL -> Buypass.
 - `auth.mode` — authentication strategy: `none`, `kratos`, `jwt`, or `api-key` (single source of truth; see ADR-065)
 - `auth.role_paths` — role-based access control via Kratos identity traits (maps role names to URL path patterns; only valid when `auth.mode` is `kratos`)
 - `rate_limit.enabled`, `rate_limit.per_ip` — per-IP rate limiting

--- a/schema/v1/config.json
+++ b/schema/v1/config.json
@@ -230,12 +230,16 @@
         },
         "domain": {
           "type": "string",
-          "description": "Domain for TLS certificate. Required when provider is 'letsencrypt'."
+          "description": "Domain for TLS certificate. Required for all ACME providers (letsencrypt, zerossl, buypass, letsencrypt-staging)."
         },
         "provider": {
           "type": "string",
-          "enum": ["letsencrypt", "self-signed", "external"],
-          "description": "TLS provider. 'letsencrypt': automatic ACME certificate. 'self-signed': generated self-signed certificate for local dev. 'external': bring your own certificate (requires cert_path and key_path)."
+          "enum": ["letsencrypt", "zerossl", "buypass", "letsencrypt-staging", "self-signed", "external"],
+          "description": "TLS provider. 'letsencrypt': automatic ACME with fallback chain (LE -> ZeroSSL -> Buypass). 'zerossl': ZeroSSL only (requires email). 'buypass': Buypass Go SSL only. 'letsencrypt-staging': LE staging for testing. 'self-signed': generated self-signed certificate for local dev. 'external': bring your own certificate (requires cert_path and key_path)."
+        },
+        "email": {
+          "type": "string",
+          "description": "ACME account registration email. Required for 'zerossl' (EAB registration). Recommended for other ACME providers (cert expiry warnings)."
         },
         "cert_path": {
           "type": "string",
@@ -247,7 +251,7 @@
         },
         "storage_path": {
           "type": "string",
-          "description": "Directory where Caddy stores ACME certificates. Only applies when provider is 'letsencrypt'."
+          "description": "Directory where Caddy stores ACME certificates. Applies to all ACME providers."
         },
         "cert_monitoring": {
           "$ref": "#/$defs/TLSCertMonitoringConfig"

--- a/vibewarden.reference.yaml
+++ b/vibewarden.reference.yaml
@@ -170,10 +170,24 @@ tls:
 
   # Provider selects how TLS certificates are obtained. Valid values:
   #
-  #   letsencrypt  — Automatic ACME certificate via Let's Encrypt.
+  #   letsencrypt  — Automatic ACME certificate with a 3-issuer fallback chain:
+  #                  Let's Encrypt -> ZeroSSL -> Buypass. If one CA is down,
+  #                  Caddy tries the next automatically.
   #                  (Alias: "acme". Both values select the same behaviour.)
   #                  Requires a public domain and open port 443.
   #                  Also requires the "domain" field to be set.
+  #
+  #   zerossl      — ZeroSSL ACME endpoint only (no fallback chain).
+  #                  Requires "email" for EAB credential auto-registration.
+  #                  Requires "domain".
+  #
+  #   buypass      — Buypass Go SSL ACME endpoint only (no fallback chain).
+  #                  Requires "domain".
+  #
+  #   letsencrypt-staging — Let's Encrypt staging environment.
+  #                  Useful for testing ACME flows without hitting production
+  #                  rate limits. Certificates are not publicly trusted.
+  #                  Requires "domain".
   #
   #   self-signed  — Caddy generates an internal self-signed certificate.
   #                  Suitable for local development and internal services.
@@ -186,9 +200,14 @@ tls:
   provider: "self-signed"
 
   # Domain for certificate provisioning.
-  # Required when provider is "letsencrypt".
+  # Required for all ACME providers (letsencrypt, zerossl, buypass, letsencrypt-staging).
   # Optional for "self-signed" (scopes the certificate to that hostname).
   domain: ""
+
+  # ACME account registration email.
+  # Required for "zerossl" (needed for EAB credential auto-registration).
+  # Recommended for "letsencrypt" and "buypass" (cert expiry warnings).
+  email: ""
 
   # Certificate and key paths — required when provider is "external".
   cert_path: ""
@@ -196,14 +215,12 @@ tls:
 
   # Directory where Caddy stores ACME certificates.
   # Uses the Caddy default (~/.local/share/caddy) when empty.
-  # Only applies when provider is "letsencrypt".
+  # Applies to all ACME providers.
   storage_path: ""
 
-  # ACME directory URL to use instead of Let's Encrypt production.
-  # Only applies when provider is "letsencrypt".
-  # Use the staging URL for testing to avoid rate limits:
-  #   acme_ca: "https://acme-staging-v02.api.letsencrypt.org/directory"
-  # Other ACME CAs (ZeroSSL, Buypass, etc.) are also supported.
+  # ACME directory URL override. Only applies when provider is "letsencrypt".
+  # When set, disables the 3-issuer fallback chain and uses a single issuer
+  # with this CA URL. Use letsencrypt-staging provider instead for testing.
   acme_ca: ""
 
 # Ory Kratos (identity/auth) settings


### PR DESCRIPTION
Closes #1026

## Summary

- **Default fallback chain**: `provider: letsencrypt` (without `acme_ca`) now configures 3 ACME issuers: Let's Encrypt -> ZeroSSL -> Buypass. If one CA is down, Caddy tries the next automatically.
- **New providers**: `zerossl`, `buypass`, `letsencrypt-staging` as first-class provider values, each targeting a single CA.
- **New field**: `tls.email` for ACME account registration (required for ZeroSSL, recommended for others).
- **Backward compatible**: Setting `acme_ca` still disables the fallback chain and uses a single issuer.
- **Shared helper**: `buildACMEIssuers()` is the single source of truth for issuer chain construction, used by both single-site and multi-site config paths.

## Test plan

- [x] Unit tests for `buildACMEIssuers()` — verifies fallback chain order, single-issuer providers, email propagation
- [x] Unit tests for `isACMEProvider()` — all providers classified correctly
- [x] Config validation tests for new providers (zerossl requires email, all ACME require domain)
- [x] Caddy config builder tests for new providers (correct CA URLs, no redirect server for ACME)
- [x] Multi-site fallback chain test (3 issuers with global email)
- [x] Existing tests updated for new behavior (ACME issuers always have explicit `ca` field)
- [x] `go build ./...`, `go test -race ./...`, `golangci-lint run ./...` all pass
- [x] Schema validation tests pass with updated config.json enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)