### PR TITLE
feat(#1021): serve /_vibewarden/me endpoint with session info

### DIFF
--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -36,6 +36,10 @@ Role-based path restrictions can be configured in vibewarden.yaml via
 `auth.role_paths` (only when `auth.mode: kratos`). Requests to restricted
 paths by users without the required role receive HTTP 403.
 
+For frontend JS, use `GET /_vibewarden/me` instead of reading headers directly.
+Returns `{"id","email","verified","role"}` when authenticated, 401 when not.
+Available when `auth.mode: kratos` is enabled.
+
 On public paths (`auth.public_paths`), these headers are set when a valid session
 cookie is present but are absent for anonymous visitors. Your app code should
 treat them as optional on public paths and required on protected paths.

--- a/internal/adapters/caddy/config.go
+++ b/internal/adapters/caddy/config.go
@@ -209,6 +209,14 @@ func BuildCaddyConfig(cfg *ports.ProxyConfig) (map[string]any, error) {
 	if cfg.Auth.Enabled && cfg.Auth.KratosPublicURL != "" {
 		kratosRoute := buildKratosFlowRoute(cfg.Auth.KratosPublicURL)
 		routes = append(routes, kratosRoute)
+
+		// Add /_vibewarden/me route when Kratos auth is active.
+		cookieName := cfg.Auth.SessionCookieName
+		if cookieName == "" {
+			cookieName = "ory_kratos_session"
+		}
+		meRoute := buildMeRoute(cfg.Auth.KratosPublicURL, cookieName)
+		routes = append(routes, meRoute)
 	}
 
 	if cfg.Admin.Enabled && cfg.Admin.InternalAddr != "" {

--- a/internal/adapters/caddy/config_routes.go
+++ b/internal/adapters/caddy/config_routes.go
@@ -181,6 +181,29 @@ func buildStaticReadyRoute() map[string]any {
 	}
 }
 
+// buildMeRoute constructs a Caddy route that serves the /_vibewarden/me
+// endpoint via the vibewarden_me handler module. The handler reads the Kratos
+// session cookie, validates it via the Kratos whoami endpoint, and returns a
+// JSON response with the authenticated user's session information.
+//
+// This route must be placed before the catch-all proxy route so that requests
+// to /_vibewarden/me are handled by the dedicated handler instead of being
+// forwarded to the upstream application.
+func buildMeRoute(kratosPublicURL, cookieName string) map[string]any {
+	return map[string]any{
+		"match": []map[string]any{
+			{"path": []string{"/_vibewarden/me"}},
+		},
+		"handle": []map[string]any{
+			{
+				"handler":     "vibewarden_me",
+				"cookie_name": cookieName,
+				"kratos_url":  kratosPublicURL,
+			},
+		},
+	}
+}
+
 // buildDynamicReadyRoute constructs a Caddy route that reverse-proxies
 // /_vibewarden/ready to the internal readiness HTTP server at internalAddr.
 // The internal server runs ReadyHandler which performs live plugin health and

--- a/internal/adapters/caddy/config_test.go
+++ b/internal/adapters/caddy/config_test.go
@@ -1485,9 +1485,9 @@ func TestBuildCaddyConfig_KratosFlowRoutes_Present(t *testing.T) {
 		t.Fatal("routes not found in server config")
 	}
 
-	// Expect: health (index 0), ready (index 1), Kratos flow route (index 2), catch-all proxy (index 3).
-	if len(routes) != 4 {
-		t.Fatalf("expected 4 routes (health + ready + kratos + proxy), got %d", len(routes))
+	// Expect: health (index 0), ready (index 1), Kratos flow route (index 2), me route (index 3), catch-all proxy (index 4).
+	if len(routes) != 5 {
+		t.Fatalf("expected 5 routes (health + ready + kratos + me + proxy), got %d", len(routes))
 	}
 
 	kratosRoute := routes[2]
@@ -1636,10 +1636,16 @@ func TestBuildCaddyConfig_KratosRouteBeforeCatchAll(t *testing.T) {
 		t.Error("routes[2] (Kratos flow) must have a path matcher")
 	}
 
-	// Index 3 — catch-all proxy: no path matcher (matches everything).
-	catchAll := routes[3]
+	// Index 3 — me route: has a path matcher for /_vibewarden/me.
+	meRoute := routes[3]
+	if _, hasMatcher := meRoute["match"]; !hasMatcher {
+		t.Error("routes[3] (me) must have a path matcher")
+	}
+
+	// Index 4 — catch-all proxy: no path matcher (matches everything).
+	catchAll := routes[4]
 	if _, hasMatcher := catchAll["match"]; hasMatcher {
-		t.Error("routes[3] (catch-all) must not have a path matcher")
+		t.Error("routes[4] (catch-all) must not have a path matcher")
 	}
 }
 

--- a/internal/adapters/caddy/me_handler.go
+++ b/internal/adapters/caddy/me_handler.go
@@ -1,0 +1,273 @@
+package caddy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	gocaddy "github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+
+	"github.com/vibewarden/vibewarden/internal/domain/identity"
+)
+
+func init() {
+	gocaddy.RegisterModule(MeHandler{})
+}
+
+// MeHandlerConfig is the JSON-serialisable configuration for the
+// MeHandler Caddy module.
+type MeHandlerConfig struct {
+	// CookieName is the name of the Kratos session cookie.
+	CookieName string `json:"cookie_name"`
+
+	// KratosURL is the base URL of the Kratos public API (e.g. "http://kratos:4433").
+	KratosURL string `json:"kratos_url"`
+}
+
+// MeHandler is a Caddy HTTP handler module that serves the /_vibewarden/me
+// endpoint. It reads the Kratos session cookie from the request, validates the
+// session via the Kratos whoami endpoint, and returns a JSON response with the
+// authenticated user's session information.
+//
+// Responses:
+//   - 200 + {"id","email","verified","role"} on valid session
+//   - 401 + {"authenticated":false} on missing or invalid session
+//   - 502 + {"error":"bad_gateway","message":"identity provider unavailable"} when Kratos is unreachable
+//
+// The Cache-Control: no-store header is always set to prevent caching of
+// session information.
+//
+// The module is registered under the name "vibewarden_me" and referenced from
+// the Caddy JSON configuration as:
+//
+//	{"handler": "vibewarden_me", "cookie_name": "...", "kratos_url": "..."}
+type MeHandler struct {
+	Config MeHandlerConfig `json:"config"`
+	logger *slog.Logger
+	client *http.Client
+}
+
+// CaddyModule returns the Caddy module information.
+func (MeHandler) CaddyModule() gocaddy.ModuleInfo {
+	return gocaddy.ModuleInfo{
+		ID:  "http.handlers.vibewarden_me",
+		New: func() gocaddy.Module { return new(MeHandler) },
+	}
+}
+
+// Provision sets up the handler.
+func (h *MeHandler) Provision(_ gocaddy.Context) error {
+	h.logger = slog.Default()
+	h.client = &http.Client{Timeout: 5 * time.Second}
+	return nil
+}
+
+// UnmarshalJSON implements custom unmarshalling to support both nested
+// {"config": {...}} and flat {"cookie_name": "...", ...} JSON layouts.
+func (h *MeHandler) UnmarshalJSON(data []byte) error {
+	// Try nested config first.
+	var nested struct {
+		Config MeHandlerConfig `json:"config"`
+	}
+	if err := json.Unmarshal(data, &nested); err == nil && nested.Config.CookieName != "" {
+		h.Config = nested.Config
+		return nil
+	}
+	// Try flat structure.
+	return json.Unmarshal(data, &h.Config)
+}
+
+// meWhoamiResponse mirrors the relevant fields from the Kratos
+// GET /sessions/whoami JSON response for the /me endpoint.
+type meWhoamiResponse struct {
+	Active   bool `json:"active"`
+	Identity struct {
+		ID                  string             `json:"id"`
+		Traits              map[string]any     `json:"traits"`
+		VerifiableAddresses []meVerifiableAddr `json:"verifiable_addresses"`
+	} `json:"identity"`
+}
+
+// meVerifiableAddr mirrors one entry in verifiable_addresses.
+type meVerifiableAddr struct {
+	Value    string `json:"value"`
+	Via      string `json:"via"`
+	Verified bool   `json:"verified"`
+}
+
+// meSuccessResponse is the JSON body returned on 200 OK.
+type meSuccessResponse struct {
+	ID       string `json:"id"`
+	Email    string `json:"email"`
+	Verified bool   `json:"verified"`
+	Role     string `json:"role"`
+}
+
+// meUnauthResponse is the JSON body returned on 401 Unauthorized.
+type meUnauthResponse struct {
+	Authenticated bool `json:"authenticated"`
+}
+
+// meErrorResponse is the JSON body returned on 502 Bad Gateway.
+type meErrorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
+}
+
+// callMeWhoami sends a GET request to the Kratos whoami endpoint with the
+// session cookie. It returns the parsed response, a flag indicating whether
+// the error is a connectivity issue (for 502 vs 401 distinction), and an error.
+func (h *MeHandler) callMeWhoami(ctx context.Context, cookieValue string) (*meWhoamiResponse, bool, error) {
+	url := h.Config.KratosURL + "/sessions/whoami"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("building whoami request: %w", err)
+	}
+	req.Header.Set("Cookie", h.Config.CookieName+"="+cookieValue)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		// Connection failure — Kratos is unreachable.
+		return nil, true, fmt.Errorf("kratos whoami request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, false, fmt.Errorf("session invalid (401)")
+	}
+	if resp.StatusCode >= 500 {
+		return nil, true, fmt.Errorf("kratos server error (%d)", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, false, fmt.Errorf("unexpected kratos status (%d)", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, false, fmt.Errorf("reading whoami response: %w", err)
+	}
+
+	var whoami meWhoamiResponse
+	if err := json.Unmarshal(body, &whoami); err != nil {
+		return nil, false, fmt.Errorf("parsing whoami response: %w", err)
+	}
+
+	if !whoami.Active {
+		return nil, false, fmt.Errorf("session not active")
+	}
+
+	return &whoami, false, nil
+}
+
+// meExtractEmail extracts the primary email from the whoami response,
+// checking verifiable_addresses first, then falling back to traits["email"].
+func meExtractEmail(whoami *meWhoamiResponse) string {
+	for _, addr := range whoami.Identity.VerifiableAddresses {
+		if addr.Via == "email" {
+			return addr.Value
+		}
+	}
+	if email, ok := whoami.Identity.Traits["email"].(string); ok {
+		return email
+	}
+	return ""
+}
+
+// meExtractVerified extracts the email verification status from the whoami response.
+func meExtractVerified(whoami *meWhoamiResponse) bool {
+	for _, addr := range whoami.Identity.VerifiableAddresses {
+		if addr.Via == "email" {
+			return addr.Verified
+		}
+	}
+	return false
+}
+
+// meExtractRole extracts the role string from the whoami response and validates
+// it via identity.NewRole. Returns identity.DefaultRole ("user") when the trait
+// is absent, not a string, or not a recognised role value.
+func meExtractRole(whoami *meWhoamiResponse, logger *slog.Logger) identity.Role {
+	raw, ok := whoami.Identity.Traits["role"]
+	if !ok {
+		return identity.DefaultRole()
+	}
+	roleStr, ok := raw.(string)
+	if !ok || roleStr == "" {
+		return identity.DefaultRole()
+	}
+	role, err := identity.NewRole(roleStr)
+	if err != nil {
+		logger.Warn("me: ignoring invalid role from identity traits",
+			slog.String("role", roleStr),
+			slog.String("identity_id", whoami.Identity.ID),
+			slog.String("error", err.Error()),
+		)
+		return identity.DefaultRole()
+	}
+	return role
+}
+
+// writeJSON is a helper that writes a JSON response with the given status code.
+func (h *MeHandler) writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		h.logger.Error("me: failed to write response",
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+// ServeHTTP implements caddyhttp.Handler. It terminates the request and returns
+// a JSON response — it does not call the next handler in the chain.
+func (h *MeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, _ caddyhttp.Handler) error {
+	// Check for session cookie.
+	cookie, err := r.Cookie(h.Config.CookieName)
+	if err != nil {
+		h.writeJSON(w, http.StatusUnauthorized, meUnauthResponse{Authenticated: false})
+		return nil
+	}
+
+	// Validate session via Kratos whoami.
+	whoami, isConnErr, err := h.callMeWhoami(r.Context(), cookie.Value)
+	if err != nil {
+		if isConnErr {
+			h.logger.Error("me: kratos unavailable",
+				slog.String("error", err.Error()),
+			)
+			h.writeJSON(w, http.StatusBadGateway, meErrorResponse{
+				Error:   "bad_gateway",
+				Message: "identity provider unavailable",
+			})
+			return nil
+		}
+		// Invalid/expired session.
+		h.writeJSON(w, http.StatusUnauthorized, meUnauthResponse{Authenticated: false})
+		return nil
+	}
+
+	role := meExtractRole(whoami, h.logger)
+
+	h.writeJSON(w, http.StatusOK, meSuccessResponse{
+		ID:       whoami.Identity.ID,
+		Email:    meExtractEmail(whoami),
+		Verified: meExtractVerified(whoami),
+		Role:     role.String(),
+	})
+	return nil
+}
+
+// Interface guards.
+var (
+	_ caddyhttp.MiddlewareHandler = (*MeHandler)(nil)
+	_ gocaddy.Module              = (*MeHandler)(nil)
+	_ gocaddy.Provisioner         = (*MeHandler)(nil)
+)

--- a/internal/adapters/caddy/me_handler_test.go
+++ b/internal/adapters/caddy/me_handler_test.go
@@ -1,0 +1,533 @@
+package caddy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gocaddy "github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+// TestMeHandler_CaddyModule verifies the Caddy module metadata.
+func TestMeHandler_CaddyModule(t *testing.T) {
+	info := MeHandler{}.CaddyModule()
+
+	if info.ID != "http.handlers.vibewarden_me" {
+		t.Errorf("CaddyModule().ID = %q, want %q", info.ID, "http.handlers.vibewarden_me")
+	}
+	if info.New == nil {
+		t.Fatal("CaddyModule().New is nil")
+	}
+
+	mod := info.New()
+	if mod == nil {
+		t.Fatal("CaddyModule().New() returned nil")
+	}
+	if _, ok := mod.(*MeHandler); !ok {
+		t.Errorf("CaddyModule().New() returned %T, want *MeHandler", mod)
+	}
+}
+
+// TestMeHandler_InterfaceGuards verifies the handler satisfies required Caddy interfaces.
+func TestMeHandler_InterfaceGuards(t *testing.T) {
+	var _ gocaddy.Provisioner = (*MeHandler)(nil)
+	var _ caddyhttp.MiddlewareHandler = (*MeHandler)(nil)
+	var _ gocaddy.Module = (*MeHandler)(nil)
+}
+
+// TestMeHandler_Provision verifies that Provision initialises the handler.
+func TestMeHandler_Provision(t *testing.T) {
+	h := &MeHandler{Config: MeHandlerConfig{
+		CookieName: "ory_kratos_session",
+		KratosURL:  "http://kratos:4433",
+	}}
+
+	err := h.Provision(gocaddy.Context{})
+	if err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	if h.logger == nil {
+		t.Error("Provision() did not set logger")
+	}
+	if h.client == nil {
+		t.Error("Provision() did not set HTTP client")
+	}
+}
+
+// TestMeHandler_UnmarshalJSON verifies both flat and nested JSON unmarshalling.
+func TestMeHandler_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		wantCookieName string
+		wantKratosURL  string
+		wantErr        bool
+	}{
+		{
+			name:           "flat structure",
+			input:          `{"cookie_name":"sess","kratos_url":"http://k:4433"}`,
+			wantCookieName: "sess",
+			wantKratosURL:  "http://k:4433",
+		},
+		{
+			name:           "nested config",
+			input:          `{"config":{"cookie_name":"sess","kratos_url":"http://k:4433"}}`,
+			wantCookieName: "sess",
+			wantKratosURL:  "http://k:4433",
+		},
+		{
+			name:    "invalid JSON",
+			input:   `{invalid}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var h MeHandler
+			err := json.Unmarshal([]byte(tt.input), &h)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if h.Config.CookieName != tt.wantCookieName {
+				t.Errorf("CookieName = %q, want %q", h.Config.CookieName, tt.wantCookieName)
+			}
+			if h.Config.KratosURL != tt.wantKratosURL {
+				t.Errorf("KratosURL = %q, want %q", h.Config.KratosURL, tt.wantKratosURL)
+			}
+		})
+	}
+}
+
+// TestMeHandler_ServeHTTP_NoCookie verifies 401 when no session cookie is present.
+func TestMeHandler_ServeHTTP_NoCookie(t *testing.T) {
+	h := &MeHandler{Config: MeHandlerConfig{
+		CookieName: "ory_kratos_session",
+		KratosURL:  "http://unreachable:4433",
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/me", nil)
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, nil)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+
+	var resp meUnauthResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if resp.Authenticated != false {
+		t.Errorf("authenticated = %v, want false", resp.Authenticated)
+	}
+
+	assertCacheControl(t, w)
+	assertContentTypeJSON(t, w)
+}
+
+// TestMeHandler_ServeHTTP_ValidSession verifies 200 with correct session info.
+func TestMeHandler_ServeHTTP_ValidSession(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/sessions/whoami" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"identity": {
+				"id": "user-123",
+				"traits": {"email": "user@example.com", "role": "admin"},
+				"verifiable_addresses": [
+					{"value": "user@example.com", "via": "email", "verified": true}
+				]
+			}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &MeHandler{Config: MeHandlerConfig{
+		CookieName: "ory_kratos_session",
+		KratosURL:  kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/me", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "valid-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, nil)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp meSuccessResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if resp.ID != "user-123" {
+		t.Errorf("id = %q, want %q", resp.ID, "user-123")
+	}
+	if resp.Email != "user@example.com" {
+		t.Errorf("email = %q, want %q", resp.Email, "user@example.com")
+	}
+	if resp.Verified != true {
+		t.Errorf("verified = %v, want true", resp.Verified)
+	}
+	if resp.Role != "admin" {
+		t.Errorf("role = %q, want %q", resp.Role, "admin")
+	}
+
+	assertCacheControl(t, w)
+	assertContentTypeJSON(t, w)
+}
+
+// TestMeHandler_ServeHTTP_InvalidSession verifies 401 when Kratos returns 401.
+func TestMeHandler_ServeHTTP_InvalidSession(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer kratosServer.Close()
+
+	h := &MeHandler{Config: MeHandlerConfig{
+		CookieName: "ory_kratos_session",
+		KratosURL:  kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/me", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "expired-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, nil)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+
+	var resp meUnauthResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if resp.Authenticated != false {
+		t.Errorf("authenticated = %v, want false", resp.Authenticated)
+	}
+
+	assertCacheControl(t, w)
+}
+
+// TestMeHandler_ServeHTTP_KratosUnavailable verifies 502 when Kratos is unreachable.
+func TestMeHandler_ServeHTTP_KratosUnavailable(t *testing.T) {
+	h := &MeHandler{Config: MeHandlerConfig{
+		CookieName: "ory_kratos_session",
+		KratosURL:  "http://127.0.0.1:19999", // nothing listening
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/me", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "some-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, nil)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadGateway)
+	}
+
+	var resp meErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if resp.Error != "bad_gateway" {
+		t.Errorf("error = %q, want %q", resp.Error, "bad_gateway")
+	}
+	if resp.Message != "identity provider unavailable" {
+		t.Errorf("message = %q, want %q", resp.Message, "identity provider unavailable")
+	}
+
+	assertCacheControl(t, w)
+}
+
+// TestMeHandler_ServeHTTP_KratosServerError verifies 502 when Kratos returns 5xx.
+func TestMeHandler_ServeHTTP_KratosServerError(t *testing.T) {
+	statusCodes := []int{500, 502, 503}
+
+	for _, code := range statusCodes {
+		t.Run(fmt.Sprintf("status_%d", code), func(t *testing.T) {
+			kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(code)
+			}))
+			defer kratosServer.Close()
+
+			h := &MeHandler{Config: MeHandlerConfig{
+				CookieName: "ory_kratos_session",
+				KratosURL:  kratosServer.URL,
+			}}
+			if err := h.Provision(gocaddy.Context{}); err != nil {
+				t.Fatalf("Provision() error = %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/_vibewarden/me", nil)
+			req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "token"})
+			w := httptest.NewRecorder()
+
+			_ = h.ServeHTTP(w, req, nil)
+
+			if w.Code != http.StatusBadGateway {
+				t.Errorf("status = %d, want %d", w.Code, http.StatusBadGateway)
+			}
+
+			assertCacheControl(t, w)
+		})
+	}
+}
+
+// TestMeHandler_ServeHTTP_InactiveSession verifies 401 when session is not active.
+func TestMeHandler_ServeHTTP_InactiveSession(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": false,
+			"identity": {"id": "user-123", "traits": {}}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &MeHandler{Config: MeHandlerConfig{
+		CookieName: "ory_kratos_session",
+		KratosURL:  kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/me", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "inactive-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, nil)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+
+	assertCacheControl(t, w)
+}
+
+// TestMeHandler_ServeHTTP_DefaultRole verifies that missing role trait defaults to "user".
+func TestMeHandler_ServeHTTP_DefaultRole(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"identity": {
+				"id": "user-456",
+				"traits": {"email": "noone@example.com"},
+				"verifiable_addresses": [
+					{"value": "noone@example.com", "via": "email", "verified": false}
+				]
+			}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &MeHandler{Config: MeHandlerConfig{
+		CookieName: "ory_kratos_session",
+		KratosURL:  kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/me", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "valid-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, nil)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp meSuccessResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if resp.Role != "user" {
+		t.Errorf("role = %q, want %q", resp.Role, "user")
+	}
+	if resp.Verified != false {
+		t.Errorf("verified = %v, want false", resp.Verified)
+	}
+}
+
+// TestMeHandler_ServeHTTP_EmailFromTraits verifies email extraction from traits
+// when verifiable_addresses is absent.
+func TestMeHandler_ServeHTTP_EmailFromTraits(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"identity": {
+				"id": "user-789",
+				"traits": {"email": "traits@example.com"}
+			}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &MeHandler{Config: MeHandlerConfig{
+		CookieName: "ory_kratos_session",
+		KratosURL:  kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/me", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "valid-token"})
+	w := httptest.NewRecorder()
+
+	err := h.ServeHTTP(w, req, nil)
+	if err != nil {
+		t.Fatalf("ServeHTTP() error = %v", err)
+	}
+
+	var resp meSuccessResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if resp.Email != "traits@example.com" {
+		t.Errorf("email = %q, want %q", resp.Email, "traits@example.com")
+	}
+}
+
+// TestMeHandler_ServeHTTP_DoesNotCallNext verifies that the handler terminates
+// the request and does not call the next handler.
+func TestMeHandler_ServeHTTP_DoesNotCallNext(t *testing.T) {
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"identity": {
+				"id": "user-123",
+				"traits": {"email": "u@e.com"},
+				"verifiable_addresses": [{"value": "u@e.com", "via": "email", "verified": true}]
+			}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &MeHandler{Config: MeHandlerConfig{
+		CookieName: "ory_kratos_session",
+		KratosURL:  kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	nextCalled := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/me", nil)
+	req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: "valid-token"})
+	w := httptest.NewRecorder()
+
+	_ = h.ServeHTTP(w, req, next)
+
+	if nextCalled {
+		t.Error("next handler should not be called — MeHandler terminates the request")
+	}
+}
+
+// TestMeHandler_ServeHTTP_ForwardsCookieToKratos verifies the handler sends
+// the correct cookie to the Kratos whoami endpoint.
+func TestMeHandler_ServeHTTP_ForwardsCookieToKratos(t *testing.T) {
+	var receivedCookie string
+	kratosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedCookie = r.Header.Get("Cookie")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"identity": {"id": "user-123", "traits": {"email": "u@e.com"}}
+		}`))
+	}))
+	defer kratosServer.Close()
+
+	h := &MeHandler{Config: MeHandlerConfig{
+		CookieName: "my_session",
+		KratosURL:  kratosServer.URL,
+	}}
+	if err := h.Provision(gocaddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/_vibewarden/me", nil)
+	req.AddCookie(&http.Cookie{Name: "my_session", Value: "token-abc"})
+	w := httptest.NewRecorder()
+
+	_ = h.ServeHTTP(w, req, nil)
+
+	want := "my_session=token-abc"
+	if receivedCookie != want {
+		t.Errorf("Kratos received cookie = %q, want %q", receivedCookie, want)
+	}
+}
+
+// assertCacheControl checks that Cache-Control: no-store is set.
+func assertCacheControl(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	cc := w.Header().Get("Cache-Control")
+	if cc != "no-store" {
+		t.Errorf("Cache-Control = %q, want %q", cc, "no-store")
+	}
+}
+
+// assertContentTypeJSON checks that Content-Type is application/json.
+func assertContentTypeJSON(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	ct := w.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+}

--- a/internal/domain/identity/session_info.go
+++ b/internal/domain/identity/session_info.go
@@ -1,0 +1,49 @@
+package identity
+
+import "errors"
+
+// SessionInfo is an immutable value object representing the publicly-visible
+// attributes of an authenticated user session. It is returned by the
+// /_vibewarden/me endpoint so that client-side code can inspect the current
+// user without calling the identity provider directly.
+//
+// SessionInfo contains only the subset of session data that is safe to expose
+// to the browser: user ID, email, verification status, and role.
+type SessionInfo struct {
+	id       string
+	email    string
+	verified bool
+	role     Role
+}
+
+// NewSessionInfo creates a SessionInfo with the given attributes.
+// Returns an error if required fields are invalid.
+func NewSessionInfo(id, email string, verified bool, role Role) (SessionInfo, error) {
+	if id == "" {
+		return SessionInfo{}, errors.New("session info id cannot be empty")
+	}
+	if role.IsZero() {
+		return SessionInfo{}, errors.New("session info role cannot be zero")
+	}
+	return SessionInfo{
+		id:       id,
+		email:    email,
+		verified: verified,
+		role:     role,
+	}, nil
+}
+
+// ID returns the user's unique identifier.
+func (s SessionInfo) ID() string { return s.id }
+
+// Email returns the user's email address. May be empty.
+func (s SessionInfo) Email() string { return s.email }
+
+// Verified returns true if the user's email has been verified.
+func (s SessionInfo) Verified() bool { return s.verified }
+
+// Role returns the user's role.
+func (s SessionInfo) Role() Role { return s.role }
+
+// IsZero reports whether this is the zero value (no session info).
+func (s SessionInfo) IsZero() bool { return s.id == "" }

--- a/internal/domain/identity/session_info_test.go
+++ b/internal/domain/identity/session_info_test.go
@@ -1,0 +1,106 @@
+package identity
+
+import "testing"
+
+func TestNewSessionInfo(t *testing.T) {
+	adminRole, _ := NewRole("admin")
+	userRole := DefaultRole()
+
+	tests := []struct {
+		name     string
+		id       string
+		email    string
+		verified bool
+		role     Role
+		wantErr  bool
+	}{
+		{
+			name:     "valid with all fields",
+			id:       "usr-123",
+			email:    "user@example.com",
+			verified: true,
+			role:     adminRole,
+			wantErr:  false,
+		},
+		{
+			name:     "valid with empty email",
+			id:       "usr-456",
+			email:    "",
+			verified: false,
+			role:     userRole,
+			wantErr:  false,
+		},
+		{
+			name:     "empty id",
+			id:       "",
+			email:    "user@example.com",
+			verified: true,
+			role:     adminRole,
+			wantErr:  true,
+		},
+		{
+			name:     "zero role",
+			id:       "usr-789",
+			email:    "user@example.com",
+			verified: true,
+			role:     Role{},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := NewSessionInfo(tt.id, tt.email, tt.verified, tt.role)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewSessionInfo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if info.ID() != tt.id {
+				t.Errorf("ID() = %q, want %q", info.ID(), tt.id)
+			}
+			if info.Email() != tt.email {
+				t.Errorf("Email() = %q, want %q", info.Email(), tt.email)
+			}
+			if info.Verified() != tt.verified {
+				t.Errorf("Verified() = %v, want %v", info.Verified(), tt.verified)
+			}
+			if info.Role() != tt.role {
+				t.Errorf("Role() = %v, want %v", info.Role(), tt.role)
+			}
+		})
+	}
+}
+
+func TestSessionInfo_IsZero(t *testing.T) {
+	tests := []struct {
+		name string
+		info SessionInfo
+		want bool
+	}{
+		{
+			name: "zero value",
+			info: SessionInfo{},
+			want: true,
+		},
+		{
+			name: "non-zero",
+			info: func() SessionInfo {
+				r := DefaultRole()
+				s, _ := NewSessionInfo("usr-1", "a@b.com", true, r)
+				return s
+			}(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.info.IsZero(); got != tt.want {
+				t.Errorf("IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -251,6 +251,9 @@ Key sections:
   when Let's Encrypt is rate-limited: `acme_ca: "https://acme.zerossl.com/v2/DV90"`
 - `auth.mode` — authentication strategy: `none`, `kratos`, `jwt`, or `api-key` (single source of truth; see ADR-065)
 - `auth.role_paths` — role-based access control via Kratos identity traits (maps role names to URL path patterns; only valid when `auth.mode` is `kratos`)
+- When `auth.mode: kratos`, the sidecar serves `GET /_vibewarden/me` returning the current
+  user's session info as JSON (`{"id","email","verified","role"}`). Returns 401 when
+  unauthenticated. Use this from frontend JS instead of calling Kratos directly.
 - `rate_limit.enabled`, `rate_limit.per_ip` — per-IP rate limiting
 - `security_headers.enabled` — HSTS, X-Frame-Options, X-Content-Type-Options, etc.
 - `secrets.store` — secret store backend: `builtin` (default, AES-256-GCM encrypted file) or `openbao` (opt-in for dynamic creds)


### PR DESCRIPTION
Closes #1021

## Summary
- Add `SessionInfo` domain value object in `internal/domain/identity/session_info.go` representing the publicly-visible attributes of an authenticated session (id, email, verified, role)
- Add `MeHandler` Caddy module (`http.handlers.vibewarden_me`) in `internal/adapters/caddy/me_handler.go` that reads the Kratos session cookie, validates it via whoami, and returns JSON
- Wire `/_vibewarden/me` route via `buildMeRoute` in `config_routes.go`, activated when auth.mode is kratos (auth enabled with KratosPublicURL set)
- Response semantics: 200 + session info, 401 + `{authenticated:false}`, 502 when Kratos unreachable
- `Cache-Control: no-store` always set on responses

## Test plan
- [x] `TestNewSessionInfo` — domain value object validation (empty id, zero role rejected)
- [x] `TestSessionInfo_IsZero` — zero-value detection
- [x] `TestMeHandler_CaddyModule` — module registration metadata
- [x] `TestMeHandler_Provision` — handler initialisation
- [x] `TestMeHandler_UnmarshalJSON` — flat and nested JSON config
- [x] `TestMeHandler_ServeHTTP_NoCookie` — 401 without cookie
- [x] `TestMeHandler_ServeHTTP_ValidSession` — 200 with correct fields
- [x] `TestMeHandler_ServeHTTP_InvalidSession` — 401 on expired session
- [x] `TestMeHandler_ServeHTTP_KratosUnavailable` — 502 on connection failure
- [x] `TestMeHandler_ServeHTTP_KratosServerError` — 502 on 5xx from Kratos
- [x] `TestMeHandler_ServeHTTP_InactiveSession` — 401 on inactive session
- [x] `TestMeHandler_ServeHTTP_DefaultRole` — missing role trait defaults to "user"
- [x] `TestMeHandler_ServeHTTP_EmailFromTraits` — fallback email extraction
- [x] `TestMeHandler_ServeHTTP_DoesNotCallNext` — handler terminates request
- [x] `TestMeHandler_ServeHTTP_ForwardsCookieToKratos` — correct cookie forwarding
- [x] Updated `TestBuildCaddyConfig_KratosFlowRoutes_Present` and `TestBuildCaddyConfig_KratosRouteBeforeCatchAll` for new route
- [x] `make check` passes (lint, build, race tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)