### PR TITLE
feat(#1034): add vibew tls status command for remote certificate inspection

### DIFF
--- a/internal/app/tlsstatus/parse.go
+++ b/internal/app/tlsstatus/parse.go
@@ -1,0 +1,152 @@
+// Package tlsstatus provides the application service for inspecting remote TLS
+// certificates via SSH. It runs openssl s_client on the remote host and parses
+// the output into a domain CertInfo value object.
+package tlsstatus
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+)
+
+// opensslTimeLayout is the time format used by openssl x509 -dates output.
+// Example: "Apr 20 12:00:00 2026 GMT"
+const opensslTimeLayout = "Jan  2 15:04:05 2006 GMT"
+
+// opensslTimeLayoutSingleDigit handles single-digit days without leading space.
+// Example: "Apr 2 12:00:00 2026 GMT"
+const opensslTimeLayoutSingleDigit = "Jan 2 15:04:05 2006 GMT"
+
+// ParseOpenSSLOutput parses the combined text output of:
+//
+//	echo | openssl s_client -connect host:443 -servername host 2>/dev/null | openssl x509 -noout -subject -issuer -dates -serial -ext subjectAltName
+//
+// It extracts subject, issuer, validity dates, serial, and SANs into a CertInfo.
+func ParseOpenSSLOutput(output string) (tlsdomain.CertInfo, error) {
+	var (
+		subject   string
+		issuer    string
+		notBefore time.Time
+		notAfter  time.Time
+		serial    string
+		sans      []string
+	)
+
+	lines := strings.Split(output, "\n")
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+
+		switch {
+		case strings.HasPrefix(line, "subject="):
+			subject = strings.TrimSpace(strings.TrimPrefix(line, "subject="))
+
+		case strings.HasPrefix(line, "issuer="):
+			issuer = strings.TrimSpace(strings.TrimPrefix(line, "issuer="))
+
+		case strings.HasPrefix(line, "notBefore="):
+			raw := strings.TrimSpace(strings.TrimPrefix(line, "notBefore="))
+			t, err := parseOpenSSLTime(raw)
+			if err != nil {
+				return tlsdomain.CertInfo{}, fmt.Errorf("parsing notBefore %q: %w", raw, err)
+			}
+			notBefore = t
+
+		case strings.HasPrefix(line, "notAfter="):
+			raw := strings.TrimSpace(strings.TrimPrefix(line, "notAfter="))
+			t, err := parseOpenSSLTime(raw)
+			if err != nil {
+				return tlsdomain.CertInfo{}, fmt.Errorf("parsing notAfter %q: %w", raw, err)
+			}
+			notAfter = t
+
+		case strings.HasPrefix(line, "serial="):
+			serial = strings.TrimSpace(strings.TrimPrefix(line, "serial="))
+
+		case strings.Contains(line, "Subject Alternative Name"):
+			// The SANs are on the next line(s) as comma-separated DNS:name entries.
+			if i+1 < len(lines) {
+				sans = parseSANLine(lines[i+1])
+			}
+		}
+	}
+
+	if subject == "" {
+		return tlsdomain.CertInfo{}, fmt.Errorf("subject not found in openssl output")
+	}
+	if issuer == "" {
+		return tlsdomain.CertInfo{}, fmt.Errorf("issuer not found in openssl output")
+	}
+	if notBefore.IsZero() {
+		return tlsdomain.CertInfo{}, fmt.Errorf("notBefore not found in openssl output")
+	}
+	if notAfter.IsZero() {
+		return tlsdomain.CertInfo{}, fmt.Errorf("notAfter not found in openssl output")
+	}
+
+	return tlsdomain.NewCertInfo(subject, issuer, notBefore, notAfter, sans, serial)
+}
+
+// parseOpenSSLTime parses a time string from openssl x509 output.
+// OpenSSL uses a format like "Apr 20 12:00:00 2026 GMT" but may also
+// produce single-digit days like "Apr  2 12:00:00 2026 GMT" (with two
+// spaces) or "Apr 2 12:00:00 2026 GMT" (after trimming).
+func parseOpenSSLTime(raw string) (time.Time, error) {
+	// Normalize multiple spaces to single space for consistent parsing.
+	normalized := normalizeSpaces(raw)
+
+	t, err := time.Parse(opensslTimeLayout, normalized)
+	if err == nil {
+		return t, nil
+	}
+
+	t, err2 := time.Parse(opensslTimeLayoutSingleDigit, normalized)
+	if err2 == nil {
+		return t, nil
+	}
+
+	return time.Time{}, fmt.Errorf("cannot parse %q as openssl time: %w", raw, err)
+}
+
+// normalizeSpaces collapses runs of whitespace into single spaces.
+func normalizeSpaces(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	prevSpace := false
+	for _, r := range s {
+		if r == ' ' || r == '\t' {
+			if !prevSpace {
+				b.WriteByte(' ')
+			}
+			prevSpace = true
+		} else {
+			b.WriteRune(r)
+			prevSpace = false
+		}
+	}
+	return b.String()
+}
+
+// parseSANLine parses the SAN line from openssl x509 -ext subjectAltName output.
+// The line looks like: "DNS:example.com, DNS:www.example.com, DNS:*.example.com"
+func parseSANLine(line string) []string {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return nil
+	}
+
+	parts := strings.Split(line, ",")
+	var sans []string
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, "DNS:") {
+			name := strings.TrimPrefix(part, "DNS:")
+			name = strings.TrimSpace(name)
+			if name != "" {
+				sans = append(sans, name)
+			}
+		}
+	}
+	return sans
+}

--- a/internal/app/tlsstatus/parse_test.go
+++ b/internal/app/tlsstatus/parse_test.go
@@ -1,0 +1,225 @@
+package tlsstatus
+
+import (
+	"testing"
+	"time"
+)
+
+// cannedOpenSSLOutput is a realistic output from:
+//
+//	echo | openssl s_client -connect example.com:443 -servername example.com 2>/dev/null | \
+//	    openssl x509 -noout -subject -issuer -dates -serial -ext subjectAltName
+const cannedOpenSSLOutput = `subject=CN = example.com
+issuer=C = US, O = Let's Encrypt, CN = R3
+notBefore=Mar 15 00:00:00 2026 GMT
+notAfter=Jun 13 00:00:00 2026 GMT
+serial=03A1B2C3D4E5F6
+X509v3 Subject Alternative Name:
+    DNS:example.com, DNS:www.example.com`
+
+func TestParseOpenSSLOutput(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantSubject string
+		wantIssuer  string
+		wantBefore  time.Time
+		wantAfter   time.Time
+		wantSANs    []string
+		wantSerial  string
+		wantErr     bool
+	}{
+		{
+			name:        "standard output",
+			input:       cannedOpenSSLOutput,
+			wantSubject: "CN = example.com",
+			wantIssuer:  "C = US, O = Let's Encrypt, CN = R3",
+			wantBefore:  time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC),
+			wantAfter:   time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC),
+			wantSANs:    []string{"example.com", "www.example.com"},
+			wantSerial:  "03A1B2C3D4E5F6",
+			wantErr:     false,
+		},
+		{
+			name: "wildcard SAN",
+			input: `subject=CN = *.example.com
+issuer=C = US, O = Let's Encrypt, CN = R3
+notBefore=Mar 15 00:00:00 2026 GMT
+notAfter=Jun 13 00:00:00 2026 GMT
+serial=AABBCCDD
+X509v3 Subject Alternative Name:
+    DNS:*.example.com, DNS:example.com`,
+			wantSubject: "CN = *.example.com",
+			wantIssuer:  "C = US, O = Let's Encrypt, CN = R3",
+			wantBefore:  time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC),
+			wantAfter:   time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC),
+			wantSANs:    []string{"*.example.com", "example.com"},
+			wantSerial:  "AABBCCDD",
+			wantErr:     false,
+		},
+		{
+			name: "no SANs section",
+			input: `subject=CN = simple.test
+issuer=CN = Test CA
+notBefore=Jan  5 10:30:00 2026 GMT
+notAfter=Apr 20 10:30:00 2026 GMT
+serial=01`,
+			wantSubject: "CN = simple.test",
+			wantIssuer:  "CN = Test CA",
+			wantBefore:  time.Date(2026, 1, 5, 10, 30, 0, 0, time.UTC),
+			wantAfter:   time.Date(2026, 4, 20, 10, 30, 0, 0, time.UTC),
+			wantSANs:    nil,
+			wantSerial:  "01",
+			wantErr:     false,
+		},
+		{
+			name:    "empty output",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name: "missing subject",
+			input: `issuer=CN = Test CA
+notBefore=Jan  5 10:30:00 2026 GMT
+notAfter=Apr 20 10:30:00 2026 GMT
+serial=01`,
+			wantErr: true,
+		},
+		{
+			name: "missing issuer",
+			input: `subject=CN = test.com
+notBefore=Jan  5 10:30:00 2026 GMT
+notAfter=Apr 20 10:30:00 2026 GMT
+serial=01`,
+			wantErr: true,
+		},
+		{
+			name: "missing notBefore",
+			input: `subject=CN = test.com
+issuer=CN = Test CA
+notAfter=Apr 20 10:30:00 2026 GMT
+serial=01`,
+			wantErr: true,
+		},
+		{
+			name: "missing notAfter",
+			input: `subject=CN = test.com
+issuer=CN = Test CA
+notBefore=Jan  5 10:30:00 2026 GMT
+serial=01`,
+			wantErr: true,
+		},
+		{
+			name: "invalid date format",
+			input: `subject=CN = test.com
+issuer=CN = Test CA
+notBefore=2026-01-05
+notAfter=2026-04-20
+serial=01`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ci, err := ParseOpenSSLOutput(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseOpenSSLOutput() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if ci.Subject() != tt.wantSubject {
+				t.Errorf("Subject() = %q, want %q", ci.Subject(), tt.wantSubject)
+			}
+			if ci.Issuer() != tt.wantIssuer {
+				t.Errorf("Issuer() = %q, want %q", ci.Issuer(), tt.wantIssuer)
+			}
+			if !ci.NotBefore().Equal(tt.wantBefore) {
+				t.Errorf("NotBefore() = %v, want %v", ci.NotBefore(), tt.wantBefore)
+			}
+			if !ci.NotAfter().Equal(tt.wantAfter) {
+				t.Errorf("NotAfter() = %v, want %v", ci.NotAfter(), tt.wantAfter)
+			}
+			if ci.Serial() != tt.wantSerial {
+				t.Errorf("Serial() = %q, want %q", ci.Serial(), tt.wantSerial)
+			}
+
+			gotSANs := ci.SANs()
+			if len(gotSANs) != len(tt.wantSANs) {
+				t.Errorf("SANs() len = %d, want %d", len(gotSANs), len(tt.wantSANs))
+			} else {
+				for i, want := range tt.wantSANs {
+					if gotSANs[i] != want {
+						t.Errorf("SANs()[%d] = %q, want %q", i, gotSANs[i], want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestParseSANLine(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{
+			name: "multiple DNS entries",
+			line: "    DNS:example.com, DNS:www.example.com, DNS:*.example.com",
+			want: []string{"example.com", "www.example.com", "*.example.com"},
+		},
+		{
+			name: "single entry",
+			line: "DNS:only.com",
+			want: []string{"only.com"},
+		},
+		{
+			name: "empty line",
+			line: "",
+			want: nil,
+		},
+		{
+			name: "IP entries ignored",
+			line: "DNS:example.com, IP Address:1.2.3.4",
+			want: []string{"example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSANLine(tt.line)
+			if len(got) != len(tt.want) {
+				t.Errorf("parseSANLine(%q) len = %d, want %d; got %v", tt.line, len(got), len(tt.want), got)
+				return
+			}
+			for i, want := range tt.want {
+				if got[i] != want {
+					t.Errorf("parseSANLine(%q)[%d] = %q, want %q", tt.line, i, got[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeSpaces(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Jan  5 10:30:00 2026 GMT", "Jan 5 10:30:00 2026 GMT"},
+		{"Apr 20 12:00:00 2026 GMT", "Apr 20 12:00:00 2026 GMT"},
+		{"no  extra   spaces", "no extra spaces"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := normalizeSpaces(tt.input); got != tt.want {
+				t.Errorf("normalizeSpaces(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/app/tlsstatus/service.go
+++ b/internal/app/tlsstatus/service.go
@@ -3,6 +3,7 @@ package tlsstatus
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/vibewarden/vibewarden/internal/domain/tls"
 	"github.com/vibewarden/vibewarden/internal/ports"
@@ -30,12 +31,18 @@ func opensslCmd(domain string, port int) string {
 	)
 }
 
+// validDomain matches safe domain names and wildcards (no shell metacharacters).
+var validDomain = regexp.MustCompile(`^[a-zA-Z0-9*][a-zA-Z0-9.*-]*$`)
+
 // Inspect runs openssl on the remote host to retrieve the TLS certificate for
 // the given domain and port, parses the output, and returns the certificate
 // information as a domain value object.
 func (s *Service) Inspect(ctx context.Context, domain string, port int) (tls.CertInfo, error) {
 	if domain == "" {
 		return tls.CertInfo{}, fmt.Errorf("domain cannot be empty")
+	}
+	if !validDomain.MatchString(domain) {
+		return tls.CertInfo{}, fmt.Errorf("invalid domain %q: contains unsafe characters", domain)
 	}
 	if port < 1 || port > 65535 {
 		return tls.CertInfo{}, fmt.Errorf("port %d is out of range (1-65535)", port)

--- a/internal/app/tlsstatus/service.go
+++ b/internal/app/tlsstatus/service.go
@@ -1,0 +1,56 @@
+package tlsstatus
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vibewarden/vibewarden/internal/domain/tls"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// Service is the application service that inspects remote TLS certificates by
+// running openssl commands over SSH. It orchestrates the remote executor and the
+// openssl output parser.
+type Service struct {
+	executor ports.RemoteExecutor
+}
+
+// NewService creates a new TLS status service using the provided remote executor
+// for running commands on the remote host.
+func NewService(executor ports.RemoteExecutor) *Service {
+	return &Service{executor: executor}
+}
+
+// opensslCmd returns the shell command to inspect a TLS certificate for the
+// given domain and port.
+func opensslCmd(domain string, port int) string {
+	return fmt.Sprintf(
+		"echo | openssl s_client -connect %s:%d -servername %s 2>/dev/null | openssl x509 -noout -subject -issuer -dates -serial -ext subjectAltName",
+		domain, port, domain,
+	)
+}
+
+// Inspect runs openssl on the remote host to retrieve the TLS certificate for
+// the given domain and port, parses the output, and returns the certificate
+// information as a domain value object.
+func (s *Service) Inspect(ctx context.Context, domain string, port int) (tls.CertInfo, error) {
+	if domain == "" {
+		return tls.CertInfo{}, fmt.Errorf("domain cannot be empty")
+	}
+	if port < 1 || port > 65535 {
+		return tls.CertInfo{}, fmt.Errorf("port %d is out of range (1-65535)", port)
+	}
+
+	cmd := opensslCmd(domain, port)
+	output, err := s.executor.Run(ctx, cmd)
+	if err != nil {
+		return tls.CertInfo{}, fmt.Errorf("running openssl on remote host: %w", err)
+	}
+
+	certInfo, err := ParseOpenSSLOutput(output)
+	if err != nil {
+		return tls.CertInfo{}, fmt.Errorf("parsing certificate output for %s:%d: %w", domain, port, err)
+	}
+
+	return certInfo, nil
+}

--- a/internal/app/tlsstatus/service_test.go
+++ b/internal/app/tlsstatus/service_test.go
@@ -1,0 +1,163 @@
+package tlsstatus_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/app/tlsstatus"
+)
+
+// fakeExecutor is a simple test double for ports.RemoteExecutor.
+type fakeExecutor struct {
+	output string
+	err    error
+}
+
+func (f *fakeExecutor) Run(_ context.Context, _ string) (string, error) {
+	return f.output, f.err
+}
+
+func (f *fakeExecutor) RunStream(_ context.Context, _ string, _, _ io.Writer) error {
+	return nil
+}
+
+func (f *fakeExecutor) Transfer(_ context.Context, _, _ string, _ bool) error {
+	return nil
+}
+
+func (f *fakeExecutor) TransferFile(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (f *fakeExecutor) TransferExcluding(_ context.Context, _, _ string, _ bool, _ []string) error {
+	return nil
+}
+
+func (f *fakeExecutor) DryRunTransfer(_ context.Context, _, _ string) ([]string, error) {
+	return nil, nil
+}
+
+const testOpenSSLOutput = `subject=CN = myapp.example.com
+issuer=C = US, O = Let's Encrypt, CN = R3
+notBefore=Mar 15 00:00:00 2026 GMT
+notAfter=Jun 13 00:00:00 2026 GMT
+serial=03A1B2C3D4E5F6
+X509v3 Subject Alternative Name:
+    DNS:myapp.example.com, DNS:www.myapp.example.com`
+
+func TestService_Inspect(t *testing.T) {
+	tests := []struct {
+		name        string
+		domain      string
+		port        int
+		output      string
+		execErr     error
+		wantErr     bool
+		wantSubject string
+	}{
+		{
+			name:        "successful inspection",
+			domain:      "myapp.example.com",
+			port:        443,
+			output:      testOpenSSLOutput,
+			wantErr:     false,
+			wantSubject: "CN = myapp.example.com",
+		},
+		{
+			name:    "empty domain",
+			domain:  "",
+			port:    443,
+			output:  testOpenSSLOutput,
+			wantErr: true,
+		},
+		{
+			name:    "invalid port zero",
+			domain:  "example.com",
+			port:    0,
+			output:  testOpenSSLOutput,
+			wantErr: true,
+		},
+		{
+			name:    "invalid port too high",
+			domain:  "example.com",
+			port:    70000,
+			output:  testOpenSSLOutput,
+			wantErr: true,
+		},
+		{
+			name:    "executor error",
+			domain:  "example.com",
+			port:    443,
+			output:  "",
+			execErr: fmt.Errorf("connection refused"),
+			wantErr: true,
+		},
+		{
+			name:    "unparseable output",
+			domain:  "example.com",
+			port:    443,
+			output:  "garbage data that openssl did not produce",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec := &fakeExecutor{output: tt.output, err: tt.execErr}
+			svc := tlsstatus.NewService(exec)
+
+			ci, err := svc.Inspect(context.Background(), tt.domain, tt.port)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Inspect() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if ci.Subject() != tt.wantSubject {
+				t.Errorf("Subject() = %q, want %q", ci.Subject(), tt.wantSubject)
+			}
+
+			// Verify dates are parsed correctly.
+			wantBefore := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+			if !ci.NotBefore().Equal(wantBefore) {
+				t.Errorf("NotBefore() = %v, want %v", ci.NotBefore(), wantBefore)
+			}
+
+			wantAfter := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+			if !ci.NotAfter().Equal(wantAfter) {
+				t.Errorf("NotAfter() = %v, want %v", ci.NotAfter(), wantAfter)
+			}
+
+			// Verify SANs.
+			sans := ci.SANs()
+			if len(sans) != 2 {
+				t.Fatalf("SANs() len = %d, want 2", len(sans))
+			}
+			if sans[0] != "myapp.example.com" {
+				t.Errorf("SANs()[0] = %q, want %q", sans[0], "myapp.example.com")
+			}
+			if sans[1] != "www.myapp.example.com" {
+				t.Errorf("SANs()[1] = %q, want %q", sans[1], "www.myapp.example.com")
+			}
+		})
+	}
+}
+
+func TestService_Inspect_CustomPort(t *testing.T) {
+	exec := &fakeExecutor{output: testOpenSSLOutput}
+	svc := tlsstatus.NewService(exec)
+
+	ci, err := svc.Inspect(context.Background(), "myapp.example.com", 8443)
+	if err != nil {
+		t.Fatalf("Inspect() unexpected error: %v", err)
+	}
+
+	if ci.Subject() != "CN = myapp.example.com" {
+		t.Errorf("Subject() = %q, want %q", ci.Subject(), "CN = myapp.example.com")
+	}
+}

--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -49,6 +49,7 @@ Zero-to-secure in minutes.`,
 	root.AddCommand(NewRestartCmd())
 	root.AddCommand(NewMCPCmd())
 	root.AddCommand(NewDeployCmd())
+	root.AddCommand(NewTLSCmd())
 
 	return root
 }

--- a/internal/cli/cmd/tls.go
+++ b/internal/cli/cmd/tls.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	sshadapter "github.com/vibewarden/vibewarden/internal/adapters/ssh"
+	"github.com/vibewarden/vibewarden/internal/app/tlsstatus"
+)
+
+// NewTLSCmd creates the "vibew tls" subcommand group.
+//
+// The tls command group provides utilities for inspecting TLS certificates
+// on remote VibeWarden deployments.
+func NewTLSCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tls",
+		Short: "TLS certificate inspection utilities",
+		Long: `Utilities for inspecting TLS certificates on remote VibeWarden deployments.
+
+Examples:
+  vibew tls status --domain example.com --target ssh://ubuntu@203.0.113.10
+  vibew tls status --domain example.com --target ssh://ubuntu@203.0.113.10 --port 8443`,
+		// Default: print help when no subcommand is given.
+		Run: func(cmd *cobra.Command, _ []string) {
+			cmd.Help() //nolint:errcheck
+		},
+	}
+
+	cmd.AddCommand(newTLSStatusCmd())
+
+	return cmd
+}
+
+// newTLSStatusCmd creates the "vibew tls status" subcommand.
+//
+// It connects to the remote host via SSH, runs openssl to inspect the TLS
+// certificate for the given domain, and displays certificate details including
+// subject, issuer, validity period, SANs, and expiry status.
+func newTLSStatusCmd() *cobra.Command {
+	var (
+		domain string
+		target string
+		sshKey string
+		port   int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show TLS certificate details for a remote domain",
+		Long: `Connect to the remote host via SSH, run openssl to inspect the TLS
+certificate presented for the specified domain, and display the results.
+
+The command runs on the remote host so that the certificate is inspected from
+the server's perspective (useful when the domain resolves differently from
+your local machine, or when testing a newly deployed certificate before DNS
+propagation).
+
+Displayed fields:
+  - Subject (CN)
+  - Issuer (CA)
+  - Valid from / to
+  - Serial number
+  - Subject Alternative Names (SANs)
+  - Expiry status (OK / WARNING / CRITICAL / EXPIRED)
+
+Examples:
+  vibew tls status --domain example.com --target ssh://ubuntu@203.0.113.10
+  vibew tls status --domain example.com --target ssh://ubuntu@203.0.113.10 --port 8443
+  vibew tls status --domain example.com --target ssh://ubuntu@203.0.113.10 --ssh-key ~/.ssh/id_ed25519`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if domain == "" {
+				return fmt.Errorf("--domain is required")
+			}
+			if target == "" {
+				return fmt.Errorf("--target is required (e.g. ssh://user@host)")
+			}
+
+			t, err := sshadapter.ParseTarget(target)
+			if err != nil {
+				return fmt.Errorf("invalid --target: %w", err)
+			}
+
+			var executor *sshadapter.Executor
+			if sshKey != "" {
+				executor = sshadapter.NewExecutorWithKey(t, sshKey)
+			} else {
+				executor = sshadapter.NewExecutor(t)
+			}
+
+			svc := tlsstatus.NewService(executor)
+			certInfo, err := svc.Inspect(cmd.Context(), domain, port)
+			if err != nil {
+				return fmt.Errorf("inspecting certificate: %w", err)
+			}
+
+			out := cmd.OutOrStdout()
+			now := time.Now()
+
+			fmt.Fprintf(out, "TLS Certificate Status for %s:%d\n", domain, port)
+			fmt.Fprintln(out, "──────────────────────────────────────────")
+			fmt.Fprintf(out, "Subject:    %s\n", certInfo.Subject())
+			fmt.Fprintf(out, "Issuer:     %s\n", certInfo.Issuer())
+			fmt.Fprintf(out, "Not Before: %s\n", certInfo.NotBefore().Format(time.RFC3339))
+			fmt.Fprintf(out, "Not After:  %s\n", certInfo.NotAfter().Format(time.RFC3339))
+			if certInfo.Serial() != "" {
+				fmt.Fprintf(out, "Serial:     %s\n", certInfo.Serial())
+			}
+
+			sans := certInfo.SANs()
+			if len(sans) > 0 {
+				fmt.Fprintf(out, "SANs:       %s\n", sans[0])
+				for _, san := range sans[1:] {
+					fmt.Fprintf(out, "            %s\n", san)
+				}
+			}
+
+			fmt.Fprintf(out, "Status:     %s\n", certInfo.ExpiryStatus(now))
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&domain, "domain", "", "domain name to inspect (required)")
+	cmd.Flags().StringVar(&target, "target", "", "remote target in ssh://user@host[:port] format (required)")
+	cmd.Flags().StringVar(&sshKey, "ssh-key", "", "path to the SSH private key file (default: use SSH agent / ~/.ssh/config)")
+	cmd.Flags().IntVar(&port, "port", 443, "TLS port to connect to on the remote")
+
+	if err := cmd.MarkFlagRequired("domain"); err != nil {
+		fmt.Fprintln(os.Stderr, "warning: flag required registration failed:", err)
+	}
+	if err := cmd.MarkFlagRequired("target"); err != nil {
+		fmt.Fprintln(os.Stderr, "warning: flag required registration failed:", err)
+	}
+
+	return cmd
+}

--- a/internal/cli/cmd/tls_test.go
+++ b/internal/cli/cmd/tls_test.go
@@ -1,0 +1,124 @@
+package cmd_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/cli/cmd"
+)
+
+func TestTLSCmd_HelpWhenNoSubcommand(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var outBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetArgs([]string{"tls", "--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	out := outBuf.String()
+	if !strings.Contains(out, "status") {
+		t.Errorf("help output does not mention 'status', got: %q", out)
+	}
+}
+
+func TestTLSStatusCmd_Registered(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	statusCmd, _, err := root.Find([]string{"tls", "status"})
+	if err != nil {
+		t.Fatalf("Find(tls status) error: %v", err)
+	}
+	if statusCmd == nil || statusCmd.Use != "status" {
+		t.Fatal("expected 'status' subcommand to be registered on 'tls'")
+	}
+}
+
+func TestTLSStatusCmd_RequiresDomain(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var errBuf bytes.Buffer
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"tls", "status", "--target", "ssh://user@host"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute() expected error for missing --domain, got nil")
+	}
+	if !strings.Contains(err.Error(), "domain") {
+		t.Errorf("error = %q, want it to mention 'domain'", err.Error())
+	}
+}
+
+func TestTLSStatusCmd_RequiresTarget(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var errBuf bytes.Buffer
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"tls", "status", "--domain", "example.com"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute() expected error for missing --target, got nil")
+	}
+	if !strings.Contains(err.Error(), "target") {
+		t.Errorf("error = %q, want it to mention 'target'", err.Error())
+	}
+}
+
+func TestTLSStatusCmd_InvalidTarget(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var errBuf bytes.Buffer
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"tls", "status", "--domain", "example.com", "--target", "http://invalid"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute() expected error for invalid target, got nil")
+	}
+	if !strings.Contains(err.Error(), "ssh") {
+		t.Errorf("error = %q, want it to mention 'ssh'", err.Error())
+	}
+}
+
+func TestTLSStatusCmd_HasFlags(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	statusCmd, _, _ := root.Find([]string{"tls", "status"})
+
+	flags := []string{"domain", "target", "ssh-key", "port"}
+	for _, flag := range flags {
+		if statusCmd.Flags().Lookup(flag) == nil {
+			t.Errorf("expected --%s flag on 'tls status' command", flag)
+		}
+	}
+}
+
+func TestTLSStatusCmd_DefaultPort(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	statusCmd, _, _ := root.Find([]string{"tls", "status"})
+
+	portFlag := statusCmd.Flags().Lookup("port")
+	if portFlag == nil {
+		t.Fatal("expected --port flag")
+	}
+	if portFlag.DefValue != "443" {
+		t.Errorf("--port default = %q, want %q", portFlag.DefValue, "443")
+	}
+}
+
+func TestTLSStatusCmd_HelpContainsExpectedContent(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var outBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetArgs([]string{"tls", "status", "--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	out := outBuf.String()
+	for _, want := range []string{"domain", "target", "openssl", "certificate", "SSH"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("help output missing %q, got: %q", want, out)
+		}
+	}
+}

--- a/internal/domain/tls/cert_info.go
+++ b/internal/domain/tls/cert_info.go
@@ -1,0 +1,103 @@
+// Package tls provides domain value objects for TLS certificate inspection.
+package tls
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// CertInfo is an immutable value object representing the relevant fields of a
+// remote TLS certificate as presented during a TLS handshake. It is produced
+// by parsing the text output of an `openssl s_client` invocation.
+type CertInfo struct {
+	subject   string
+	issuer    string
+	notBefore time.Time
+	notAfter  time.Time
+	sans      []string
+	serial    string
+}
+
+// NewCertInfo creates a CertInfo value object. Subject and issuer are required.
+// notAfter must be after notBefore.
+func NewCertInfo(subject, issuer string, notBefore, notAfter time.Time, sans []string, serial string) (CertInfo, error) {
+	if subject == "" {
+		return CertInfo{}, errors.New("certificate subject cannot be empty")
+	}
+	if issuer == "" {
+		return CertInfo{}, errors.New("certificate issuer cannot be empty")
+	}
+	if !notAfter.After(notBefore) {
+		return CertInfo{}, fmt.Errorf("notAfter (%s) must be after notBefore (%s)", notAfter, notBefore)
+	}
+
+	// Defensive copy of SANs slice.
+	sansCopy := make([]string, len(sans))
+	copy(sansCopy, sans)
+
+	return CertInfo{
+		subject:   subject,
+		issuer:    issuer,
+		notBefore: notBefore,
+		notAfter:  notAfter,
+		sans:      sansCopy,
+		serial:    serial,
+	}, nil
+}
+
+// Subject returns the certificate subject (e.g. "CN=example.com").
+func (c CertInfo) Subject() string { return c.subject }
+
+// Issuer returns the certificate issuer (e.g. "O=Let's Encrypt, CN=R3").
+func (c CertInfo) Issuer() string { return c.issuer }
+
+// NotBefore returns the start of the certificate's validity period.
+func (c CertInfo) NotBefore() time.Time { return c.notBefore }
+
+// NotAfter returns the end of the certificate's validity period.
+func (c CertInfo) NotAfter() time.Time { return c.notAfter }
+
+// SANs returns the Subject Alternative Names (DNS names) on the certificate.
+// The returned slice is a copy; mutating it does not affect the value object.
+func (c CertInfo) SANs() []string {
+	out := make([]string, len(c.sans))
+	copy(out, c.sans)
+	return out
+}
+
+// Serial returns the certificate serial number as a hex string.
+func (c CertInfo) Serial() string { return c.serial }
+
+// IsExpired returns true when the certificate's notAfter time is in the past
+// relative to the provided reference time.
+func (c CertInfo) IsExpired(now time.Time) bool {
+	return now.After(c.notAfter)
+}
+
+// DaysUntilExpiry returns the number of days remaining until the certificate
+// expires, relative to the provided reference time. Returns 0 if already
+// expired.
+func (c CertInfo) DaysUntilExpiry(now time.Time) int {
+	if c.IsExpired(now) {
+		return 0
+	}
+	d := c.notAfter.Sub(now)
+	return int(d.Hours() / 24)
+}
+
+// ExpiryStatus returns a human-readable status string describing the
+// certificate's expiry relative to the provided reference time.
+func (c CertInfo) ExpiryStatus(now time.Time) string {
+	if c.IsExpired(now) {
+		return "EXPIRED"
+	}
+	days := c.DaysUntilExpiry(now)
+	if days <= 7 {
+		return fmt.Sprintf("CRITICAL (%d days)", days)
+	}
+	if days <= 30 {
+		return fmt.Sprintf("WARNING (%d days)", days)
+	}
+	return fmt.Sprintf("OK (%d days)", days)
+}

--- a/internal/domain/tls/cert_info_test.go
+++ b/internal/domain/tls/cert_info_test.go
@@ -1,0 +1,240 @@
+package tls_test
+
+import (
+	"testing"
+	"time"
+
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+)
+
+func TestNewCertInfo(t *testing.T) {
+	now := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	validBefore := now.Add(-24 * time.Hour)
+	validAfter := now.Add(90 * 24 * time.Hour)
+
+	tests := []struct {
+		name      string
+		subject   string
+		issuer    string
+		notBefore time.Time
+		notAfter  time.Time
+		sans      []string
+		serial    string
+		wantErr   bool
+	}{
+		{
+			name:      "valid cert info",
+			subject:   "CN=example.com",
+			issuer:    "O=Let's Encrypt, CN=R3",
+			notBefore: validBefore,
+			notAfter:  validAfter,
+			sans:      []string{"example.com", "www.example.com"},
+			serial:    "03:A1:B2:C3",
+			wantErr:   false,
+		},
+		{
+			name:      "empty subject",
+			subject:   "",
+			issuer:    "O=Let's Encrypt, CN=R3",
+			notBefore: validBefore,
+			notAfter:  validAfter,
+			sans:      nil,
+			serial:    "03:A1",
+			wantErr:   true,
+		},
+		{
+			name:      "empty issuer",
+			subject:   "CN=example.com",
+			issuer:    "",
+			notBefore: validBefore,
+			notAfter:  validAfter,
+			sans:      nil,
+			serial:    "03:A1",
+			wantErr:   true,
+		},
+		{
+			name:      "notAfter before notBefore",
+			subject:   "CN=example.com",
+			issuer:    "O=Let's Encrypt, CN=R3",
+			notBefore: validAfter,
+			notAfter:  validBefore,
+			sans:      nil,
+			serial:    "03:A1",
+			wantErr:   true,
+		},
+		{
+			name:      "notAfter equals notBefore",
+			subject:   "CN=example.com",
+			issuer:    "O=Let's Encrypt, CN=R3",
+			notBefore: validBefore,
+			notAfter:  validBefore,
+			sans:      nil,
+			serial:    "03:A1",
+			wantErr:   true,
+		},
+		{
+			name:      "nil sans is valid",
+			subject:   "CN=example.com",
+			issuer:    "O=Let's Encrypt, CN=R3",
+			notBefore: validBefore,
+			notAfter:  validAfter,
+			sans:      nil,
+			serial:    "",
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ci, err := tlsdomain.NewCertInfo(tt.subject, tt.issuer, tt.notBefore, tt.notAfter, tt.sans, tt.serial)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewCertInfo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if ci.Subject() != tt.subject {
+				t.Errorf("Subject() = %q, want %q", ci.Subject(), tt.subject)
+			}
+			if ci.Issuer() != tt.issuer {
+				t.Errorf("Issuer() = %q, want %q", ci.Issuer(), tt.issuer)
+			}
+			if !ci.NotBefore().Equal(tt.notBefore) {
+				t.Errorf("NotBefore() = %v, want %v", ci.NotBefore(), tt.notBefore)
+			}
+			if !ci.NotAfter().Equal(tt.notAfter) {
+				t.Errorf("NotAfter() = %v, want %v", ci.NotAfter(), tt.notAfter)
+			}
+			if ci.Serial() != tt.serial {
+				t.Errorf("Serial() = %q, want %q", ci.Serial(), tt.serial)
+			}
+		})
+	}
+}
+
+func TestCertInfo_SANsDefensiveCopy(t *testing.T) {
+	now := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	sans := []string{"example.com", "www.example.com"}
+
+	ci, err := tlsdomain.NewCertInfo("CN=example.com", "CN=R3", now.Add(-time.Hour), now.Add(90*24*time.Hour), sans, "03:A1")
+	if err != nil {
+		t.Fatalf("NewCertInfo() unexpected error: %v", err)
+	}
+
+	// Mutate the original slice.
+	sans[0] = "mutated.com"
+	if ci.SANs()[0] == "mutated.com" {
+		t.Error("SANs should be a defensive copy; mutating the input affected the value object")
+	}
+
+	// Mutate the returned slice.
+	returned := ci.SANs()
+	returned[0] = "mutated-again.com"
+	if ci.SANs()[0] == "mutated-again.com" {
+		t.Error("SANs() should return a copy; mutating the return value affected the value object")
+	}
+}
+
+func TestCertInfo_IsExpired(t *testing.T) {
+	notBefore := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	notAfter := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	ci, err := tlsdomain.NewCertInfo("CN=test.com", "CN=CA", notBefore, notAfter, nil, "01")
+	if err != nil {
+		t.Fatalf("NewCertInfo() unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		now     time.Time
+		expired bool
+	}{
+		{"before expiry", time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC), false},
+		{"at expiry", time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), false},
+		{"after expiry", time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ci.IsExpired(tt.now); got != tt.expired {
+				t.Errorf("IsExpired(%v) = %v, want %v", tt.now, got, tt.expired)
+			}
+		})
+	}
+}
+
+func TestCertInfo_DaysUntilExpiry(t *testing.T) {
+	notBefore := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	notAfter := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+
+	ci, err := tlsdomain.NewCertInfo("CN=test.com", "CN=CA", notBefore, notAfter, nil, "01")
+	if err != nil {
+		t.Fatalf("NewCertInfo() unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		now      time.Time
+		wantDays int
+	}{
+		{"30 days left", time.Date(2026, 3, 21, 0, 0, 0, 0, time.UTC), 30},
+		{"1 day left", time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC), 1},
+		{"already expired", time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC), 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ci.DaysUntilExpiry(tt.now); got != tt.wantDays {
+				t.Errorf("DaysUntilExpiry(%v) = %d, want %d", tt.now, got, tt.wantDays)
+			}
+		})
+	}
+}
+
+func TestCertInfo_ExpiryStatus(t *testing.T) {
+	notBefore := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	notAfter := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	ci, err := tlsdomain.NewCertInfo("CN=test.com", "CN=CA", notBefore, notAfter, nil, "01")
+	if err != nil {
+		t.Fatalf("NewCertInfo() unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		now          time.Time
+		wantContains string
+	}{
+		{"expired", time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC), "EXPIRED"},
+		{"critical 5 days", time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC), "CRITICAL"},
+		{"warning 20 days", time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC), "WARNING"},
+		{"ok 60 days", time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC), "OK"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ci.ExpiryStatus(tt.now)
+			if got == "" {
+				t.Error("ExpiryStatus() returned empty string")
+			}
+			if !contains(got, tt.wantContains) {
+				t.Errorf("ExpiryStatus(%v) = %q, want it to contain %q", tt.now, got, tt.wantContains)
+			}
+		})
+	}
+}
+
+// contains is a simple substring check helper for tests.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstr(s, substr))
+}
+
+func containsSubstr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -111,6 +111,7 @@ VibeWarden is operated via the `vibew` CLI. Below is the complete command list.
 | `vibew cert export` | Export the local CA certificate |
 | `vibew validate` | Validate configuration |
 | `vibew context refresh` | Regenerate AI agent context files |
+| `vibew tls status` | Show remote TLS certificate details (issuer, expiry, domain) |
 | `vibew eject` | Export raw proxy config to graduate past VibeWarden |
 | `vibew mcp` | Start MCP server for AI agent integration |
 


### PR DESCRIPTION
Closes #1034

## Summary

- Adds `vibew tls status` CLI command that SSH-es into a remote host, runs openssl to inspect the TLS certificate for a given domain, and renders certificate details (subject, issuer, validity dates, serial, SANs, expiry status)
- New domain value object `internal/domain/tls.CertInfo` -- immutable, pure methods for expiry logic (IsExpired, DaysUntilExpiry, ExpiryStatus)
- New application service `internal/app/tlsstatus.Service` orchestrating the RemoteExecutor and a pure openssl output parser
- Reuses existing `ports.RemoteExecutor` interface and `ssh.Executor` adapter -- no new dependencies

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] Unit tests for CertInfo value object (creation, validation, expiry calculations, defensive copy)
- [x] Unit tests for openssl output parser (standard output, wildcards, missing fields, malformed dates)
- [x] Unit tests for Service.Inspect with mock executor (success, errors, unparseable output)
- [x] CLI integration tests (command registration, flag validation, help text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)