### PR TITLE
feat(#1033): vibew doctor advertised on deploy failure + arch/email/image checks

### DIFF
--- a/internal/app/ops/doctor.go
+++ b/internal/app/ops/doctor.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -56,6 +57,7 @@ type DoctorService struct {
 	portChecker    ports.PortChecker
 	healthChecker  ports.HealthChecker
 	remoteExecutor ports.RemoteExecutor
+	imageChecker   ports.DockerImageChecker
 }
 
 // NewDoctorService creates a new DoctorService.
@@ -73,6 +75,15 @@ func NewDoctorService(compose ports.ComposeRunner, portChecker ports.PortChecker
 func (s *DoctorService) WithRemoteExecutor(executor ports.RemoteExecutor) *DoctorService {
 	cp := *s
 	cp.remoteExecutor = executor
+	return &cp
+}
+
+// WithImageChecker returns a copy of the DoctorService with the given
+// DockerImageChecker set for image tag consistency checks. When nil, the
+// image tag check is skipped.
+func (s *DoctorService) WithImageChecker(checker ports.DockerImageChecker) *DoctorService {
+	cp := *s
+	cp.imageChecker = checker
 	return &cp
 }
 
@@ -158,6 +169,10 @@ func (s *DoctorService) runChecks(ctx context.Context, cfg *config.Config, opts 
 	generatedCompose := filepath.Join(workDir, ".vibewarden", "generated", "docker-compose.yml")
 	results = append(results, withSection(checkGeneratedFiles(generatedCompose), sectionConfigDocker))
 	results = append(results, withSection(s.checkContainerHealth(ctx, generatedCompose), sectionConfigDocker))
+	results = append(results, withSection(checkACMEEmail(cfg), sectionConfigDocker))
+	if s.imageChecker != nil && cfg.App.Image != "" {
+		results = append(results, withSection(s.checkImageTagConsistency(ctx, cfg.App.Image), sectionConfigDocker))
+	}
 
 	// --- Layer 2: Local Runtime ---
 	results = append(results, withSection(s.checkUpstreamReachable(ctx, cfg), sectionLocalRuntime))
@@ -166,6 +181,7 @@ func (s *DoctorService) runChecks(ctx context.Context, cfg *config.Config, opts 
 	// --- Layer 3: Production (only when target is set and executor is available) ---
 	if opts.Target != "" && s.remoteExecutor != nil {
 		results = append(results, withSection(s.checkSSHConnectivity(ctx), sectionProduction))
+		results = append(results, withSection(s.checkArchCompatibility(ctx), sectionProduction))
 		results = append(results, withSection(s.checkRemoteContainerHealth(ctx), sectionProduction))
 		if cfg.TLS.Domain != "" {
 			results = append(results, withSection(checkDomainDNS(ctx, cfg.TLS.Domain, opts.Target), sectionProduction))
@@ -650,6 +666,110 @@ func checkRemoteTLSCert(ctx context.Context, domain string) CheckResult {
 		Name:     "Remote TLS cert",
 		Severity: SeverityOK,
 		Detail:   fmt.Sprintf("valid until %s (%d days)", leaf.NotAfter.Format(time.DateOnly), daysUntilExpiry),
+	}
+}
+
+// checkACMEEmail verifies that an ACME account email is configured when the
+// ACME CA URL contains "zerossl". ZeroSSL requires an email address for
+// External Account Binding (EAB) registration.
+func checkACMEEmail(cfg *config.Config) CheckResult {
+	acmeCA := strings.ToLower(cfg.TLS.ACMECA)
+	if !strings.Contains(acmeCA, "zerossl") {
+		return CheckResult{
+			Name:     "ACME email",
+			Severity: SeverityOK,
+			Detail:   "not using ZeroSSL — email not required",
+		}
+	}
+	if cfg.TLS.Email == "" {
+		return CheckResult{
+			Name:     "ACME email",
+			Severity: SeverityFail,
+			Detail:   "ZeroSSL requires tls.email for EAB registration",
+		}
+	}
+	return CheckResult{
+		Name:     "ACME email",
+		Severity: SeverityOK,
+		Detail:   fmt.Sprintf("email configured: %s", cfg.TLS.Email),
+	}
+}
+
+// checkImageTagConsistency verifies that the configured app.image exists in
+// the local Docker daemon. A missing image often causes deploy failures because
+// docker save cannot export an image that does not exist locally.
+func (s *DoctorService) checkImageTagConsistency(ctx context.Context, image string) CheckResult {
+	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	exists, err := s.imageChecker.ImageExists(checkCtx, image)
+	if err != nil {
+		return CheckResult{
+			Name:     "Image tag",
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("could not check image %q: %v", image, err),
+		}
+	}
+	if !exists {
+		return CheckResult{
+			Name:     "Image tag",
+			Severity: SeverityFail,
+			Detail:   fmt.Sprintf("image %q not found locally — build it before deploying", image),
+		}
+	}
+	return CheckResult{
+		Name:     "Image tag",
+		Severity: SeverityOK,
+		Detail:   fmt.Sprintf("image %q exists locally", image),
+	}
+}
+
+// normalizeArch maps the output of "uname -m" to Go's runtime.GOARCH naming
+// convention so that local and remote architectures can be compared.
+func normalizeArch(unameMachine string) string {
+	s := strings.TrimSpace(strings.ToLower(unameMachine))
+	switch s {
+	case "x86_64":
+		return "amd64"
+	case "aarch64", "arm64":
+		return "arm64"
+	case "armv7l":
+		return "arm"
+	default:
+		return s
+	}
+}
+
+// checkArchCompatibility compares the local runtime.GOARCH with the remote
+// host's architecture (via "uname -m"). A mismatch means Docker images built
+// locally may not run on the remote without emulation.
+func (s *DoctorService) checkArchCompatibility(ctx context.Context) CheckResult {
+	checkCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	output, err := s.remoteExecutor.Run(checkCtx, "uname -m")
+	if err != nil {
+		return CheckResult{
+			Name:     "Arch compatibility",
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("could not determine remote architecture: %v", err),
+		}
+	}
+
+	remoteArch := normalizeArch(output)
+	localArch := runtime.GOARCH
+
+	if localArch != remoteArch {
+		return CheckResult{
+			Name:     "Arch compatibility",
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("local=%s remote=%s — use --platform linux/%s when building images", localArch, remoteArch, remoteArch),
+		}
+	}
+	return CheckResult{
+		Name:     "Arch compatibility",
+		Severity: SeverityOK,
+		Detail:   fmt.Sprintf("local=%s remote=%s", localArch, remoteArch),
 	}
 }
 

--- a/internal/app/ops/doctor_internal_test.go
+++ b/internal/app/ops/doctor_internal_test.go
@@ -66,3 +66,66 @@ func TestExtractHostFromTarget(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeArch(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "x86_64 maps to amd64",
+			input: "x86_64",
+			want:  "amd64",
+		},
+		{
+			name:  "aarch64 maps to arm64",
+			input: "aarch64",
+			want:  "arm64",
+		},
+		{
+			name:  "arm64 maps to arm64",
+			input: "arm64",
+			want:  "arm64",
+		},
+		{
+			name:  "armv7l maps to arm",
+			input: "armv7l",
+			want:  "arm",
+		},
+		{
+			name:  "X86_64 case insensitive",
+			input: "X86_64",
+			want:  "amd64",
+		},
+		{
+			name:  "AARCH64 case insensitive",
+			input: "AARCH64",
+			want:  "arm64",
+		},
+		{
+			name:  "whitespace trimmed",
+			input: "  x86_64\n",
+			want:  "amd64",
+		},
+		{
+			name:  "unknown arch passes through",
+			input: "riscv64",
+			want:  "riscv64",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeArch(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeArch(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/app/ops/doctor_test.go
+++ b/internal/app/ops/doctor_test.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -907,5 +908,328 @@ func TestDoctorService_Run_JSONOutput_IncludesSection(t *testing.T) {
 		if r.Section == "" {
 			t.Errorf("check %q has empty section in JSON output", r.Name)
 		}
+	}
+}
+
+// --- Tests for ACME email check ---
+
+func TestDoctorService_Run_ACMEEmail_ZeroSSLWithoutEmail(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+	cfg.TLS.Provider = "letsencrypt"
+	cfg.TLS.ACMECA = "https://acme.zerossl.com/v2/DV90"
+	cfg.TLS.Email = ""
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allOK {
+		t.Error("expected allOK = false when ZeroSSL is configured without email")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "ACME email") {
+		t.Errorf("expected 'ACME email' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ZeroSSL requires") {
+		t.Errorf("expected 'ZeroSSL requires' in detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_ACMEEmail_ZeroSSLWithEmail(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+	cfg.TLS.Provider = "letsencrypt"
+	cfg.TLS.ACMECA = "https://acme.zerossl.com/v2/DV90"
+	cfg.TLS.Email = "admin@example.com"
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allOK {
+		t.Errorf("expected allOK = true when ZeroSSL has email set\noutput:\n%s", buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "ACME email") {
+		t.Errorf("expected 'ACME email' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "admin@example.com") {
+		t.Errorf("expected email in detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_ACMEEmail_NonZeroSSL(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	svc := ops.NewDoctorService(fc, pc, hc)
+	cfg := defaultConfig()
+	cfg.TLS.Provider = "letsencrypt"
+	cfg.TLS.ACMECA = "" // default Let's Encrypt
+	cfg.TLS.Email = ""
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allOK {
+		t.Errorf("expected allOK = true when not using ZeroSSL\noutput:\n%s", buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "ACME email") {
+		t.Errorf("expected 'ACME email' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "not using ZeroSSL") {
+		t.Errorf("expected 'not using ZeroSSL' in detail, got:\n%s", out)
+	}
+}
+
+// --- Tests for image tag consistency check ---
+
+func TestDoctorService_Run_ImageTag_Exists(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	ic := &fakeImageChecker{exists: true}
+	svc := ops.NewDoctorService(fc, pc, hc).WithImageChecker(ic)
+	cfg := defaultConfig()
+	cfg.App.Image = "myapp:latest"
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allOK {
+		t.Errorf("expected allOK = true when image exists\noutput:\n%s", buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Image tag") {
+		t.Errorf("expected 'Image tag' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "exists locally") {
+		t.Errorf("expected 'exists locally' in detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_ImageTag_Missing(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	ic := &fakeImageChecker{exists: false}
+	svc := ops.NewDoctorService(fc, pc, hc).WithImageChecker(ic)
+	cfg := defaultConfig()
+	cfg.App.Image = "myapp:latest"
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allOK {
+		t.Error("expected allOK = false when image does not exist locally")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Image tag") {
+		t.Errorf("expected 'Image tag' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "not found locally") {
+		t.Errorf("expected 'not found locally' in detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_ImageTag_CheckerError(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	ic := &fakeImageChecker{err: errors.New("docker daemon unavailable")}
+	svc := ops.NewDoctorService(fc, pc, hc).WithImageChecker(ic)
+	cfg := defaultConfig()
+	cfg.App.Image = "myapp:latest"
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// WARN does not cause allOK = false.
+	if !allOK {
+		t.Errorf("expected allOK = true because image checker error is WARN\noutput:\n%s", buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Image tag") {
+		t.Errorf("expected 'Image tag' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "could not check image") {
+		t.Errorf("expected 'could not check image' in detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_ImageTag_NoImage_Skipped(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	ic := &fakeImageChecker{exists: false} // Should not be called.
+	svc := ops.NewDoctorService(fc, pc, hc).WithImageChecker(ic)
+	cfg := defaultConfig()
+	cfg.App.Image = "" // No image configured.
+
+	var buf bytes.Buffer
+	_, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "Image tag") {
+		t.Errorf("expected 'Image tag' check to be skipped when no image is configured, got:\n%s", out)
+	}
+}
+
+// --- Tests for arch compatibility check ---
+
+func TestDoctorService_Run_ArchCompatibility_Match(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+
+	// Simulate remote returning the same arch as local (mapped via normalizeArch).
+	var remoteUname string
+	switch runtime.GOARCH {
+	case "amd64":
+		remoteUname = "x86_64"
+	case "arm64":
+		remoteUname = "aarch64"
+	default:
+		remoteUname = runtime.GOARCH
+	}
+
+	executor := &fakeRemoteExecutor{
+		runResponses: map[string]runResult{
+			"echo ok":  {output: "ok", err: nil},
+			"uname -m": {output: remoteUname, err: nil},
+			"docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null": {
+				output: "", err: nil,
+			},
+		},
+	}
+	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
+	cfg := defaultConfig()
+
+	opts := defaultOpts(t)
+	opts.Target = "ssh://user@192.0.2.1"
+
+	var buf bytes.Buffer
+	_, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Arch compatibility") {
+		t.Errorf("expected 'Arch compatibility' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[OK]") || !strings.Contains(out, "local=") {
+		t.Errorf("expected arch match to show OK with local= detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_ArchCompatibility_Mismatch(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+
+	// Simulate remote arch different from local. Pick an arch that won't
+	// match the CI runner.
+	remoteUname := "aarch64"
+	if runtime.GOARCH == "arm64" {
+		remoteUname = "x86_64"
+	}
+
+	executor := &fakeRemoteExecutor{
+		runResponses: map[string]runResult{
+			"echo ok":  {output: "ok", err: nil},
+			"uname -m": {output: remoteUname, err: nil},
+			"docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null": {
+				output: "", err: nil,
+			},
+		},
+	}
+	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
+	cfg := defaultConfig()
+
+	opts := defaultOpts(t)
+	opts.Target = "ssh://user@192.0.2.1"
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Arch mismatch is WARN, so allOK should still be true.
+	if !allOK {
+		t.Errorf("expected allOK = true because arch mismatch is WARN\noutput:\n%s", buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Arch compatibility") {
+		t.Errorf("expected 'Arch compatibility' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "--platform") {
+		t.Errorf("expected '--platform' hint in arch mismatch detail, got:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_ArchCompatibility_RemoteError(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+	executor := &fakeRemoteExecutor{
+		runResponses: map[string]runResult{
+			"echo ok":  {output: "ok", err: nil},
+			"uname -m": {output: "", err: errors.New("command not found")},
+			"docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null": {
+				output: "", err: nil,
+			},
+		},
+	}
+	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
+	cfg := defaultConfig()
+
+	opts := defaultOpts(t)
+	opts.Target = "ssh://user@192.0.2.1"
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// WARN does not cause allOK = false.
+	if !allOK {
+		t.Errorf("expected allOK = true because arch check error is WARN\noutput:\n%s", buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Arch compatibility") {
+		t.Errorf("expected 'Arch compatibility' check in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "could not determine") {
+		t.Errorf("expected 'could not determine' in arch detail, got:\n%s", out)
 	}
 }

--- a/internal/cli/cmd/deploy.go
+++ b/internal/cli/cmd/deploy.go
@@ -74,153 +74,12 @@ Examples:
   vibew deploy --config vibewarden.prod.yaml --target ssh://ubuntu@203.0.113.10 --rotate-secrets --secrets-from .env.prod
   vibew deploy --dry-run --target ssh://ubuntu@203.0.113.10`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := requireScaffolding(); err != nil {
-				return err
-			}
-
-			if !dryRun && target == "" {
-				return fmt.Errorf("--target is required (e.g. ssh://user@host)")
-			}
-
-			// Determine the deployment environment name.
-			envName := env
-			if envName == "" {
-				envName = "production"
-			}
-
-			cfg, err := loadAndResolve(cmd.Context(), configPath)
+			err := runDeploy(cmd, configPath, target, sshKey, secretsFrom, unsealKey, env, force, dryRun, rotateSecrets)
 			if err != nil {
-				return err
+				fmt.Fprintln(cmd.ErrOrStderr(), "")
+				fmt.Fprintln(cmd.ErrOrStderr(), "Hint: Run 'vibew doctor' to diagnose common issues.")
 			}
-
-			// Resolve the config path to an absolute path. When --config is
-			// not provided, default to vibewarden.yaml in the current directory
-			// so that filepath.Dir returns the project directory (not ".").
-			resolvedConfig := configPath
-			if resolvedConfig == "" {
-				resolvedConfig = "vibewarden.yaml"
-			}
-			absConfig, err := filepath.Abs(resolvedConfig)
-			if err != nil {
-				absConfig = resolvedConfig
-			}
-
-			// Determine the production override file path after resolving the
-			// base config to an absolute path.
-			prodConfigPath := prodConfigPathForEnv(absConfig, envName)
-
-			projectName := cfg.Name
-			if projectName == "" {
-				projectName = deployapp.ProjectNameFromConfig(absConfig)
-			}
-
-			renderer := templateadapter.NewRenderer(configtemplates.FS)
-			generator := generateapp.NewServiceWithCredentials(
-				renderer,
-				credentialsadapter.NewGenerator(),
-				credentialsadapter.NewStore(),
-			).WithConfigSourcePath(configPath)
-
-			// --dry-run: generate bundle, list contents, and exit.
-			if dryRun {
-				svc := deployapp.NewService(nil, generator)
-				return runDeployDryRun(cmd, svc, cfg, absConfig, prodConfigPath, projectName, envName)
-			}
-
-			t, err := sshadapter.ParseTarget(target)
-			if err != nil {
-				return fmt.Errorf("invalid --target: %w", err)
-			}
-
-			var executor *sshadapter.Executor
-			if sshKey != "" {
-				executor = sshadapter.NewExecutorWithKey(t, sshKey)
-			} else {
-				executor = sshadapter.NewExecutor(t)
-			}
-			svc := deployapp.NewService(executor, generator).
-				WithImageExporter(opsadapter.NewImageExportAdapter())
-
-			remoteDir := "~/vibewarden/" + projectName + "/"
-
-			opts := deployapp.RunOptions{
-				ConfigPath:     absConfig,
-				ProdConfigPath: prodConfigPath,
-				Env:            envName,
-				Force:          force,
-				Out:            cmd.OutOrStdout(),
-			}
-
-			// Check if the production overlay explicitly disables secrets.
-			// The typed Config overlay can't distinguish "not set" from "set
-			// to false" for booleans, so we read the raw YAML map.
-			secretsEnabled := cfg.Secrets.Enabled
-			if prodConfigPath != "" {
-				if data, readErr := os.ReadFile(prodConfigPath); readErr == nil { //nolint:gosec // prodConfigPath is derived from trusted config
-					var m map[string]any
-					if yaml.Unmarshal(data, &m) == nil {
-						if secrets, ok := m["secrets"].(map[string]any); ok {
-							if enabled, ok := secrets["enabled"].(bool); ok {
-								secretsEnabled = enabled
-							}
-						}
-					}
-				}
-			}
-
-			// Bootstrap OpenBao when the secrets plugin is enabled.
-			if secretsEnabled {
-				bootstrapper := deployapp.NewOpenBaoBootstrapper(executor)
-				result, err := bootstrapper.Bootstrap(cmd.Context(), deployapp.BootstrapOptions{
-					SecretsFile:   secretsFrom,
-					RotateSecrets: rotateSecrets,
-					UnsealKey:     unsealKey,
-					RemoteDir:     remoteDir,
-					Out:           cmd.OutOrStdout(),
-				})
-				if err != nil {
-					return fmt.Errorf("openbao bootstrap: %w", err)
-				}
-				if result.UnsealKey != "" {
-					fmt.Fprintln(cmd.OutOrStdout())
-					fmt.Fprintln(cmd.OutOrStdout(), "  IMPORTANT: Save your OpenBao unseal key now!")
-					fmt.Fprintln(cmd.OutOrStdout(), "  You will need it to unseal OpenBao after a restart.")
-					fmt.Fprintln(cmd.OutOrStdout(), "  This key will NOT be shown again.")
-					fmt.Fprintf(cmd.OutOrStdout(), "  Unseal Key : %s\n", result.UnsealKey)
-					fmt.Fprintf(cmd.OutOrStdout(), "  Root Token : %s\n", result.RootToken)
-					fmt.Fprintf(cmd.OutOrStdout(), "  Role ID    : %s\n", result.RoleID)
-					fmt.Fprintf(cmd.OutOrStdout(), "  Secret ID  : %s\n", result.SecretID)
-					fmt.Fprintln(cmd.OutOrStdout())
-				}
-			}
-
-			// Detect deploy mode: fresh install or add-site.
-			hasDomain := cfg.TLS.Domain != ""
-
-			mode, err := deployapp.Detect(cmd.Context(), executor)
-			if err != nil {
-				return fmt.Errorf("detecting deploy mode: %w", err)
-			}
-
-			switch mode {
-			case deployapp.ModeFreshInstall:
-				if hasDomain {
-					// Multi-app bootstrap: create sidecar + first site.
-					return svc.BootstrapSidecar(cmd.Context(), cfg, opts)
-				}
-				// Legacy single-app deploy (backward compatible).
-				return svc.Deploy(cmd.Context(), cfg, opts)
-
-			case deployapp.ModeAddSite:
-				if hasDomain {
-					// Add a new site to existing sidecar.
-					return svc.DeployMultiApp(cmd.Context(), cfg, opts)
-				}
-				return fmt.Errorf("cannot add a site without a TLS domain; set tls.domain in %s", absConfig)
-
-			default:
-				return fmt.Errorf("unexpected deploy mode: %v", mode)
-			}
+			return err
 		},
 	}
 
@@ -251,6 +110,158 @@ Examples:
 	cmd.AddCommand(newDeployLogsCmd())
 
 	return cmd
+}
+
+// runDeploy implements the core deploy logic, extracted so the caller can add
+// a hint message on failure.
+func runDeploy(cmd *cobra.Command, configPath, target, sshKey, secretsFrom, unsealKey, env string, force, dryRun, rotateSecrets bool) error {
+	if err := requireScaffolding(); err != nil {
+		return err
+	}
+
+	if !dryRun && target == "" {
+		return fmt.Errorf("--target is required (e.g. ssh://user@host)")
+	}
+
+	// Determine the deployment environment name.
+	envName := env
+	if envName == "" {
+		envName = "production"
+	}
+
+	cfg, err := loadAndResolve(cmd.Context(), configPath)
+	if err != nil {
+		return err
+	}
+
+	// Resolve the config path to an absolute path. When --config is
+	// not provided, default to vibewarden.yaml in the current directory
+	// so that filepath.Dir returns the project directory (not ".").
+	resolvedConfig := configPath
+	if resolvedConfig == "" {
+		resolvedConfig = "vibewarden.yaml"
+	}
+	absConfig, err := filepath.Abs(resolvedConfig)
+	if err != nil {
+		absConfig = resolvedConfig
+	}
+
+	// Determine the production override file path after resolving the
+	// base config to an absolute path.
+	prodConfigPath := prodConfigPathForEnv(absConfig, envName)
+
+	projectName := cfg.Name
+	if projectName == "" {
+		projectName = deployapp.ProjectNameFromConfig(absConfig)
+	}
+
+	renderer := templateadapter.NewRenderer(configtemplates.FS)
+	generator := generateapp.NewServiceWithCredentials(
+		renderer,
+		credentialsadapter.NewGenerator(),
+		credentialsadapter.NewStore(),
+	).WithConfigSourcePath(configPath)
+
+	// --dry-run: generate bundle, list contents, and exit.
+	if dryRun {
+		svc := deployapp.NewService(nil, generator)
+		return runDeployDryRun(cmd, svc, cfg, absConfig, prodConfigPath, projectName, envName)
+	}
+
+	t, err := sshadapter.ParseTarget(target)
+	if err != nil {
+		return fmt.Errorf("invalid --target: %w", err)
+	}
+
+	var executor *sshadapter.Executor
+	if sshKey != "" {
+		executor = sshadapter.NewExecutorWithKey(t, sshKey)
+	} else {
+		executor = sshadapter.NewExecutor(t)
+	}
+	svc := deployapp.NewService(executor, generator).
+		WithImageExporter(opsadapter.NewImageExportAdapter())
+
+	remoteDir := "~/vibewarden/" + projectName + "/"
+
+	opts := deployapp.RunOptions{
+		ConfigPath:     absConfig,
+		ProdConfigPath: prodConfigPath,
+		Env:            envName,
+		Force:          force,
+		Out:            cmd.OutOrStdout(),
+	}
+
+	// Check if the production overlay explicitly disables secrets.
+	// The typed Config overlay can't distinguish "not set" from "set
+	// to false" for booleans, so we read the raw YAML map.
+	secretsEnabled := cfg.Secrets.Enabled
+	if prodConfigPath != "" {
+		if data, readErr := os.ReadFile(prodConfigPath); readErr == nil { //nolint:gosec // prodConfigPath is derived from trusted config
+			var m map[string]any
+			if yaml.Unmarshal(data, &m) == nil {
+				if secrets, ok := m["secrets"].(map[string]any); ok {
+					if enabled, ok := secrets["enabled"].(bool); ok {
+						secretsEnabled = enabled
+					}
+				}
+			}
+		}
+	}
+
+	// Bootstrap OpenBao when the secrets plugin is enabled.
+	if secretsEnabled {
+		bootstrapper := deployapp.NewOpenBaoBootstrapper(executor)
+		result, err := bootstrapper.Bootstrap(cmd.Context(), deployapp.BootstrapOptions{
+			SecretsFile:   secretsFrom,
+			RotateSecrets: rotateSecrets,
+			UnsealKey:     unsealKey,
+			RemoteDir:     remoteDir,
+			Out:           cmd.OutOrStdout(),
+		})
+		if err != nil {
+			return fmt.Errorf("openbao bootstrap: %w", err)
+		}
+		if result.UnsealKey != "" {
+			fmt.Fprintln(cmd.OutOrStdout())
+			fmt.Fprintln(cmd.OutOrStdout(), "  IMPORTANT: Save your OpenBao unseal key now!")
+			fmt.Fprintln(cmd.OutOrStdout(), "  You will need it to unseal OpenBao after a restart.")
+			fmt.Fprintln(cmd.OutOrStdout(), "  This key will NOT be shown again.")
+			fmt.Fprintf(cmd.OutOrStdout(), "  Unseal Key : %s\n", result.UnsealKey)
+			fmt.Fprintf(cmd.OutOrStdout(), "  Root Token : %s\n", result.RootToken)
+			fmt.Fprintf(cmd.OutOrStdout(), "  Role ID    : %s\n", result.RoleID)
+			fmt.Fprintf(cmd.OutOrStdout(), "  Secret ID  : %s\n", result.SecretID)
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
+	}
+
+	// Detect deploy mode: fresh install or add-site.
+	hasDomain := cfg.TLS.Domain != ""
+
+	mode, err := deployapp.Detect(cmd.Context(), executor)
+	if err != nil {
+		return fmt.Errorf("detecting deploy mode: %w", err)
+	}
+
+	switch mode {
+	case deployapp.ModeFreshInstall:
+		if hasDomain {
+			// Multi-app bootstrap: create sidecar + first site.
+			return svc.BootstrapSidecar(cmd.Context(), cfg, opts)
+		}
+		// Legacy single-app deploy (backward compatible).
+		return svc.Deploy(cmd.Context(), cfg, opts)
+
+	case deployapp.ModeAddSite:
+		if hasDomain {
+			// Add a new site to existing sidecar.
+			return svc.DeployMultiApp(cmd.Context(), cfg, opts)
+		}
+		return fmt.Errorf("cannot add a site without a TLS domain; set tls.domain in %s", absConfig)
+
+	default:
+		return fmt.Errorf("unexpected deploy mode: %v", mode)
+	}
 }
 
 // newDeployStatusCmd creates the "vibew deploy status" subcommand.

--- a/internal/cli/cmd/deploy_test.go
+++ b/internal/cli/cmd/deploy_test.go
@@ -280,6 +280,25 @@ func TestDeployCmd_HelpContainsRotateSecretsExample(t *testing.T) {
 	}
 }
 
+func TestDeployCmd_FailureHintPrintsDoctor(t *testing.T) {
+	// When deploy fails (e.g. missing --target), stderr should contain
+	// the doctor hint message.
+	root := cmd.NewRootCmd("test")
+	var stderr strings.Builder
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"deploy"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error when --target is not provided")
+	}
+
+	errOut := stderr.String()
+	if !strings.Contains(errOut, "vibew doctor") {
+		t.Errorf("expected 'vibew doctor' hint in stderr on deploy failure, got:\n%s", errOut)
+	}
+}
+
 func TestDeployCmd_DryRunFlagRegistered(t *testing.T) {
 	root := cmd.NewRootCmd("test")
 	deployCmd, _, err := root.Find([]string{"deploy"})

--- a/internal/cli/cmd/doctor.go
+++ b/internal/cli/cmd/doctor.go
@@ -84,7 +84,8 @@ Examples:
 			portChecker := opsadapter.NewNetPortChecker()
 			httpClient := &http.Client{Timeout: 5 * time.Second}
 			healthChecker := opsadapter.NewHTTPHealthChecker(httpClient)
-			svc := opsapp.NewDoctorService(compose, portChecker, healthChecker)
+			svc := opsapp.NewDoctorService(compose, portChecker, healthChecker).
+				WithImageChecker(opsadapter.NewImageCheckerAdapter())
 
 			// When --target is provided, create an SSH executor for production checks.
 			if target != "" {

--- a/internal/cli/cmd/doctor.go
+++ b/internal/cli/cmd/doctor.go
@@ -41,6 +41,8 @@ Checks are organised into three layers:
     - Required ports are available (proxy port)
     - Generated files are present (.vibewarden/generated/docker-compose.yml)
     - If the stack is running: containers are healthy (docker compose ps)
+    - ACME email configured when using ZeroSSL
+    - Expected app image exists locally (image tag consistency)
 
   Local Runtime (always runs):
     - Upstream application is reachable (HTTP GET)
@@ -51,6 +53,7 @@ Checks are organised into three layers:
     - Remote container health
     - Domain DNS resolves to target IP
     - Remote TLS certificate expiry
+    - Architecture compatibility (local build arch vs remote server arch)
 
 Each check runs independently — a failure does not stop subsequent checks.
 Exit code is 1 when any check fails.


### PR DESCRIPTION
Closes #1033

## Summary
- Print "Hint: Run 'vibew doctor' to diagnose common issues." to stderr whenever `vibew deploy` fails
- Add **arch compatibility** check: compares local `runtime.GOARCH` with remote `uname -m`, warns on mismatch with `--platform` hint
- Add **ACME email** check: fails when `tls.acme_ca` contains "zerossl" and `tls.email` is empty (ZeroSSL requires EAB email)
- Add **image tag consistency** check: verifies `app.image` exists in local Docker daemon before deploy
- Wire `ImageCheckerAdapter` into the doctor CLI command
- Extract deploy logic into `runDeploy()` helper for clean error wrapping

## Test plan
- [x] `TestDoctorService_Run_ACMEEmail_ZeroSSLWithoutEmail` — verifies FAIL when ZeroSSL configured without email
- [x] `TestDoctorService_Run_ACMEEmail_ZeroSSLWithEmail` — verifies OK when email is present
- [x] `TestDoctorService_Run_ACMEEmail_NonZeroSSL` — verifies OK (skip) when not using ZeroSSL
- [x] `TestDoctorService_Run_ImageTag_Exists` — verifies OK when image found locally
- [x] `TestDoctorService_Run_ImageTag_Missing` — verifies FAIL when image missing
- [x] `TestDoctorService_Run_ImageTag_CheckerError` — verifies WARN on docker daemon error
- [x] `TestDoctorService_Run_ImageTag_NoImage_Skipped` — verifies check skipped when no app.image
- [x] `TestDoctorService_Run_ArchCompatibility_Match` — verifies OK when arches match
- [x] `TestDoctorService_Run_ArchCompatibility_Mismatch` — verifies WARN with platform hint
- [x] `TestDoctorService_Run_ArchCompatibility_RemoteError` — verifies WARN on uname failure
- [x] `TestNormalizeArch` — table-driven unit test for arch string normalization
- [x] `TestDeployCmd_FailureHintPrintsDoctor` — verifies hint appears in stderr on deploy error
- [x] All existing tests continue to pass
- [x] `make check` passes (lint, build, tests with race detector)

🤖 Generated with [Claude Code](https://claude.com/claude-code)