### PR TITLE
fix(#1030): unify project name derivation across deploy, status, and logs

### DIFF
--- a/internal/cli/cmd/deploy.go
+++ b/internal/cli/cmd/deploy.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -151,6 +152,20 @@ func runDeploy(cmd *cobra.Command, configPath, target, sshKey, secretsFrom, unse
 	prodConfigPath := prodConfigPathForEnv(absConfig, envName)
 
 	projectName := cfg.Name
+	if projectName == "" && cfg.App.Image != "" {
+		// Strip the ":tag" suffix (e.g. "myapp:latest" → "myapp").
+		image := cfg.App.Image
+		if idx := strings.LastIndex(image, ":"); idx > 0 {
+			image = image[:idx]
+		}
+		// Strip any registry prefix (e.g. "ghcr.io/org/myapp" → "myapp").
+		if idx := strings.LastIndex(image, "/"); idx >= 0 {
+			image = image[idx+1:]
+		}
+		if image != "" {
+			projectName = image
+		}
+	}
 	if projectName == "" {
 		projectName = deployapp.ProjectNameFromConfig(absConfig)
 	}
@@ -317,14 +332,11 @@ Examples:
 				return svc.StatusMultiApp(cmd.Context(), app, cmd.OutOrStdout())
 			}
 
-			absConfig, err := filepath.Abs(configPath)
-			if err != nil {
-				absConfig = configPath
-			}
+			projectName := resolveProjectName(configPath)
 
 			return svc.Status(cmd.Context(), deployapp.StatusOptions{
-				ConfigPath: absConfig,
-				Out:        cmd.OutOrStdout(),
+				ProjectName: projectName,
+				Out:         cmd.OutOrStdout(),
 			})
 		},
 	}
@@ -407,20 +419,9 @@ Examples:
 				})
 			}
 
-			absConfig, err := filepath.Abs(configPath)
-			if err != nil {
-				absConfig = configPath
-			}
-
-			// Load config to get the project name (cfg.Name).
-			logsCfg, loadErr := config.Load(absConfig)
-			var projectName string
-			if loadErr == nil && logsCfg.Name != "" {
-				projectName = logsCfg.Name
-			}
+			projectName := resolveProjectName(configPath)
 
 			return svc.Logs(cmd.Context(), deployapp.LogsOptions{
-				ConfigPath:  absConfig,
 				ProjectName: projectName,
 				Lines:       lines,
 				Follow:      follow,
@@ -524,4 +525,50 @@ func prodConfigPathForEnv(configPath, envName string) string {
 		return prodFile
 	}
 	return ""
+}
+
+// resolveProjectName derives the project name from configPath using the same
+// chain used by `vibew deploy`:
+//
+//  1. cfg.Name (explicit name in vibewarden.yaml)
+//  2. cfg.App.Image (strip the ":tag" suffix if present)
+//  3. directory name fallback (via ProjectNameFromConfig)
+//
+// When the config file cannot be loaded (e.g. missing or malformed), the
+// function falls back directly to the directory-based derivation. This ensures
+// that `vibew deploy status` and `vibew deploy logs` always target the same
+// remote directory as the original `vibew deploy`.
+func resolveProjectName(configPath string) string {
+	// Normalise path: default to vibewarden.yaml in the cwd.
+	resolved := configPath
+	if resolved == "" {
+		resolved = "vibewarden.yaml"
+	}
+	absConfig, err := filepath.Abs(resolved)
+	if err != nil {
+		absConfig = resolved
+	}
+
+	cfg, loadErr := config.Load(absConfig)
+	if loadErr == nil {
+		if cfg.Name != "" {
+			return cfg.Name
+		}
+		if cfg.App.Image != "" {
+			// Strip the ":tag" suffix (e.g. "myapp:latest" → "myapp").
+			image := cfg.App.Image
+			if idx := strings.LastIndex(image, ":"); idx > 0 {
+				image = image[:idx]
+			}
+			// Strip any registry prefix (e.g. "ghcr.io/org/myapp" → "myapp").
+			if idx := strings.LastIndex(image, "/"); idx >= 0 {
+				image = image[idx+1:]
+			}
+			if image != "" {
+				return image
+			}
+		}
+	}
+
+	return deployapp.ProjectNameFromConfig(absConfig)
 }

--- a/internal/cli/cmd/deploy_project_name_test.go
+++ b/internal/cli/cmd/deploy_project_name_test.go
@@ -1,0 +1,160 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	deployapp "github.com/vibewarden/vibewarden/internal/app/deploy"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+func TestResolveProjectName(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		dirName    string
+		want       string
+	}{
+		{
+			name:       "explicit name wins",
+			configYAML: "name: my-project\nserver:\n  port: 8443\nupstream:\n  port: 3000\n",
+			dirName:    "some-dir",
+			want:       "my-project",
+		},
+		{
+			name:       "app.image used when name is empty",
+			configYAML: "server:\n  port: 8443\nupstream:\n  port: 3000\napp:\n  image: myapp:latest\n",
+			dirName:    "some-dir",
+			want:       "myapp",
+		},
+		{
+			name:       "app.image without tag",
+			configYAML: "server:\n  port: 8443\nupstream:\n  port: 3000\napp:\n  image: myapp\n",
+			dirName:    "some-dir",
+			want:       "myapp",
+		},
+		{
+			name:       "app.image with registry prefix",
+			configYAML: "server:\n  port: 8443\nupstream:\n  port: 3000\napp:\n  image: ghcr.io/org/myapp:v2\n",
+			dirName:    "some-dir",
+			want:       "myapp",
+		},
+		{
+			name:       "directory fallback when both name and image are empty",
+			configYAML: "server:\n  port: 8443\nupstream:\n  port: 3000\n",
+			dirName:    "cool-project",
+			want:       "cool-project",
+		},
+		{
+			name:       "name takes priority over app.image",
+			configYAML: "name: explicit\nserver:\n  port: 8443\nupstream:\n  port: 3000\napp:\n  image: fromimage:latest\n",
+			dirName:    "some-dir",
+			want:       "explicit",
+		},
+		{
+			name:       "config file missing falls back to directory name",
+			configYAML: "", // empty means no file written
+			dirName:    "fallback-dir",
+			want:       "fallback-dir",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), tt.dirName)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+
+			var configPath string
+			if tt.configYAML != "" {
+				configPath = filepath.Join(dir, "vibewarden.yaml")
+				if err := os.WriteFile(configPath, []byte(tt.configYAML), 0o644); err != nil {
+					t.Fatalf("writing config: %v", err)
+				}
+			} else {
+				// Point to a non-existent file inside the directory so the
+				// directory-based fallback uses tt.dirName.
+				configPath = filepath.Join(dir, "vibewarden.yaml")
+			}
+
+			got := resolveProjectName(configPath)
+			if got != tt.want {
+				t.Errorf("resolveProjectName(%q) = %q, want %q", configPath, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveProjectName_MatchesDeploy verifies that the derivation chain in
+// resolveProjectName produces the same result that the deploy command's inline
+// logic would produce for the same config. This is the regression guard against
+// the bug where status/logs diverged from deploy.
+func TestResolveProjectName_MatchesDeploy(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		dirName    string
+	}{
+		{
+			name:       "with explicit name",
+			configYAML: "name: prod-app\nserver:\n  port: 8443\nupstream:\n  port: 3000\n",
+			dirName:    "ignored-dir",
+		},
+		{
+			name:       "with app.image only",
+			configYAML: "server:\n  port: 8443\nupstream:\n  port: 3000\napp:\n  image: webapp:latest\n",
+			dirName:    "ignored-dir",
+		},
+		{
+			name:       "with neither -- directory fallback",
+			configYAML: "server:\n  port: 8443\nupstream:\n  port: 3000\n",
+			dirName:    "my-directory",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), tt.dirName)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+
+			configPath := filepath.Join(dir, "vibewarden.yaml")
+			if err := os.WriteFile(configPath, []byte(tt.configYAML), 0o644); err != nil {
+				t.Fatalf("writing config: %v", err)
+			}
+
+			fromHelper := resolveProjectName(configPath)
+
+			// Simulate deploy's inline logic: load config, check Name,
+			// check App.Image (with tag/registry stripping), then directory fallback.
+			absConfig, _ := filepath.Abs(configPath)
+			cfg, loadErr := config.Load(absConfig)
+
+			var fromDeploy string
+			if loadErr == nil && cfg.Name != "" {
+				fromDeploy = cfg.Name
+			}
+			if fromDeploy == "" && loadErr == nil && cfg.App.Image != "" {
+				image := cfg.App.Image
+				if idx := strings.LastIndex(image, ":"); idx > 0 {
+					image = image[:idx]
+				}
+				if idx := strings.LastIndex(image, "/"); idx >= 0 {
+					image = image[idx+1:]
+				}
+				if image != "" {
+					fromDeploy = image
+				}
+			}
+			if fromDeploy == "" {
+				fromDeploy = deployapp.ProjectNameFromConfig(absConfig)
+			}
+
+			if fromHelper != fromDeploy {
+				t.Errorf("resolveProjectName and deploy logic diverge: helper=%q deploy=%q", fromHelper, fromDeploy)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1030

## Summary

- Extracted a shared `resolveProjectName(configPath string) string` helper in the CLI layer that loads config and applies the full derivation chain: `cfg.Name` -> `cfg.App.Image` (stripped of tag and registry prefix) -> directory name fallback
- Updated `vibew deploy` to also check `App.Image` as an intermediate fallback (previously it went straight from `cfg.Name` to directory name)
- Updated `vibew deploy status` to use `resolveProjectName` instead of passing the raw config path to the service (which only did directory-based derivation)
- Updated `vibew deploy logs` to use `resolveProjectName` instead of its incomplete logic that only checked `cfg.Name`

## Test plan

- [x] Table-driven unit tests for `resolveProjectName` covering all fallback levels (name, image with tag, image with registry prefix, image without tag, directory fallback, missing config)
- [x] Regression test verifying `resolveProjectName` output matches the deploy command's inline logic for the same config
- [x] `go build ./...` passes
- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `make check` passes (full pre-push gate including demo-app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)