### PR TITLE
docs(#1035): add image tag convention, TLS keys table, VPS deploy section

### DIFF
--- a/docs/deploy-reference.md
+++ b/docs/deploy-reference.md
@@ -42,6 +42,9 @@ vibew deploy --target ssh://user@host --config vibewarden.prod.yaml
 | `--secrets-from` | No | -- | Path to a `.env`-format file whose KEY=VALUE pairs are seeded into OpenBao |
 | `--rotate-secrets` | No | `false` | Re-seed secrets from `--secrets-from` on subsequent deploys |
 | `--unseal-key` | No | stored key | OpenBao unseal key; overrides the key stored in `~/vibewarden/<project>/.openbao-credentials` on the remote |
+| `--force` | No | `false` | Overwrite remote files even if they have been modified since last deploy (skips drift detection) |
+| `--env` | No | `production` | Deployment environment name; reads `vibewarden.<env>.yaml` as the production override |
+| `--dry-run` | No | `false` | Generate the deploy bundle and list its contents without actually deploying (does not require `--target`) |
 
 #### Deploy mode detection
 
@@ -250,6 +253,10 @@ vibew deploy logs --target ssh://ubuntu@203.0.113.10 --app blog --follow
 | `loading config: ...` | Invalid or missing vibewarden.yaml | Run `vibew validate --config <path>` locally |
 | `cannot add a site without a TLS domain` | Adding a site to a multi-app host without `tls.domain` | Set `tls.domain` in vibewarden.yaml |
 | `rsync: connection refused` | SSH not reachable | Verify `ssh user@host echo OK` works first |
+| `remote files modified since last deploy` | Files on remote were edited manually (drift detected) | Use `--force` to overwrite, or inspect with `vibew deploy status` first |
+| `architecture mismatch: image is arm64, remote is amd64` | Image built for the wrong platform | Rebuild with `vibew build --platform linux/amd64` |
+| `health check failed after deploy` | App container did not become healthy in time | Check `vibew deploy logs --target ...`; ensure `/health` returns 200 |
+| `docker load: no such file` | Image not built before deploy | Run `vibew build` before `vibew deploy` |
 
 ---
 

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -135,7 +135,7 @@ CMD ["/app/server"]
 resolved in this order:
 
 1. `name` field in vibewarden.yaml (explicit)
-2. `app.image` field in vibewarden.yaml (if set, used as-is)
+2. `app.image` with registry prefix and tag stripped (e.g. `ghcr.io/org/myapp:latest` → `myapp`)
 3. Directory name containing vibewarden.yaml (fallback)
 
 For example, a project in `~/code/mysite` with no explicit `name` produces the

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -81,11 +81,23 @@ vibew add tls --domain example.com
 ## Troubleshooting
 
 ```bash
-vibew doctor       # diagnose common issues
-vibew doctor --json  # machine-readable output for AI agents
-vibew status       # check sidecar health
-vibew logs         # pretty-print structured logs
+vibew doctor             # diagnose common issues
+vibew doctor --json      # machine-readable output for AI agents
+vibew doctor --target ssh://user@host  # include production reachability checks
+vibew tls status --domain example.com --target ssh://user@host  # inspect remote TLS cert
+vibew status             # check sidecar health
+vibew logs               # pretty-print structured logs
 ```
+
+`vibew doctor` checks (in order): config validity, Docker daemon, Docker Compose,
+proxy port availability, generated files, container health, ACME email, image tag
+consistency, upstream reachability, local TLS cert validity. When `--target` is
+provided it also checks SSH connectivity, architecture compatibility, remote
+container health, DNS resolution, and remote TLS certificate expiry.
+
+`vibew tls status` connects to the remote host via SSH, inspects the TLS
+certificate with openssl, and reports subject, issuer, validity, SANs, and
+expiry status (OK / WARNING / CRITICAL / EXPIRED).
 
 ## Writing your Dockerfile
 
@@ -117,6 +129,33 @@ EXPOSE 3000
 CMD ["/app/server"]
 ```
 
+## Image tag convention
+
+`vibew build` tags the image as `<project>-app:latest`. The project name is
+resolved in this order:
+
+1. `name` field in vibewarden.yaml (explicit)
+2. `app.image` field in vibewarden.yaml (if set, used as-is)
+3. Directory name containing vibewarden.yaml (fallback)
+
+For example, a project in `~/code/mysite` with no explicit `name` produces the
+image `mysite-app:latest`. This tag must match what Docker Compose expects for
+the app service.
+
+## TLS configuration keys
+
+These keys live under the `tls` section in vibewarden.yaml (or
+vibewarden.production.yaml for prod-only values):
+
+| Key | Values | What vibew does with it |
+|-----|--------|------------------------|
+| `tls.provider` | `letsencrypt` (alias: `acme`), `self-signed`, `external` | Selects the TLS provisioning strategy. `letsencrypt` uses ACME automation; `self-signed` generates a dev cert; `external` expects you to supply cert files. |
+| `tls.email` | ACME account email | Registered with the CA for expiry warnings. Required by ZeroSSL; optional for Let's Encrypt. |
+| `tls.acme_ca` | ACME directory URL | Overrides the default Let's Encrypt production CA. Use `https://acme.zerossl.com/v2/DV90` for ZeroSSL or the LE staging URL for testing. |
+| `tls.domain` | FQDN (e.g. `app.example.com`) | The domain for the TLS certificate. Required when provider is `letsencrypt`. Used for DNS checks by `vibew doctor`. |
+| `tls.cert_path` | File path to PEM certificate | Only used when provider is `external`. The sidecar reads this file on startup. |
+| `tls.key_path` | File path to PEM private key | Only used when provider is `external`. Must match `cert_path`. |
+
 ## Deploy model
 
 `vibew build` builds the Docker image locally from your Dockerfile. `vibew deploy`
@@ -127,6 +166,39 @@ production-ready (all dependencies installed, assets compiled, etc.).
 **Cross-architecture builds:** If deploying from Apple Silicon (arm64) to an amd64
 server, use `vibew build --platform linux/amd64`. Deploy auto-detects the mismatch
 and errors with a fix-it message if you forget.
+
+## Deploying to a VPS
+
+### Automated (recommended)
+
+```bash
+vibew build --platform linux/amd64   # build for the target architecture
+vibew deploy --target ssh://user@host --config vibewarden.prod.yaml
+```
+
+`vibew deploy` handles image transfer, config generation, and container startup
+in a single command.
+
+### Manual fallback
+
+When `vibew deploy` fails or you need more control, use standard commands:
+
+```bash
+# 1. Build for the target architecture
+vibew build --platform linux/amd64
+
+# 2. Transfer the image via SSH
+docker save <project>-app:latest | ssh user@host docker load
+
+# 3. Copy the deploy bundle (config, compose files)
+rsync -az .vibewarden/deploy/production/ user@host:~/vibewarden/<project>/
+
+# 4. Start the stack on the remote
+ssh user@host 'cd ~/vibewarden/<project> && docker compose up -d'
+```
+
+Each of these commands produces standard error messages that are searchable --
+use them as a plan B when debugging deploy issues.
 
 Use `app.environment` in vibewarden.yaml for runtime configuration:
 ```yaml

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,8 +25,11 @@ pre-flight scripts.
 |------|---------|-------------|
 | `--config <path>` | `./vibewarden.yaml` | Path to a non-default config file |
 | `--json` | `false` | Emit results as a JSON array instead of the human-readable table |
+| `--target <ssh://...>` | (none) | Remote target for production checks; when omitted, only local checks run |
 
 ### Checks performed (in order)
+
+#### Layer 1: Config and Docker
 
 | # | Check name | What it tests |
 |---|------------|---------------|
@@ -36,6 +39,25 @@ pre-flight scripts.
 | 4 | **Proxy port** | The port configured in `server.port` (default `8443`) is not already bound |
 | 5 | **Generated files** | `.vibewarden/generated/docker-compose.yml` is present on disk |
 | 6 | **Container health** | `docker compose ps` shows all containers in `running` / `healthy` state |
+| 7 | **ACME email** | `tls.email` is set when using `letsencrypt` provider (warns if missing) |
+| 8 | **Image tag** | `app.image` matches a locally available Docker image (skipped when unset) |
+
+#### Layer 2: Local Runtime
+
+| # | Check name | What it tests |
+|---|------------|---------------|
+| 9 | **Upstream reachable** | The configured upstream port is listening locally |
+| 10 | **TLS cert valid** | Local TLS certificate (when using `self-signed` or `external`) is not expired or expiring within 7 days |
+
+#### Layer 3: Production (only with `--target`)
+
+| # | Check name | What it tests |
+|---|------------|---------------|
+| 11 | **SSH connectivity** | SSH connection to the remote host succeeds |
+| 12 | **Arch compatibility** | Local build architecture matches the remote server architecture |
+| 13 | **Remote containers** | Remote Docker Compose services are healthy |
+| 14 | **Domain DNS** | `tls.domain` resolves to the target host IP (only when domain is set) |
+| 15 | **Remote TLS cert** | Remote certificate is valid and not expiring within 30 days (only when domain is set) |
 
 ### Severity levels
 
@@ -367,6 +389,68 @@ secrets:
 ```
 
 Save the master key somewhere safe -- if you lose it, your secrets are unrecoverable.
+
+---
+
+### Architecture mismatch between build and deploy target
+
+**Symptom**
+
+```
+[FAIL]  Arch compatibility  image is arm64, remote is amd64
+```
+
+**Cause**
+
+You built the Docker image on Apple Silicon (arm64) without specifying the
+target platform. The remote server runs amd64 and cannot execute the image.
+
+**Fix**
+
+Rebuild with the correct platform:
+
+```bash
+vibew build --platform linux/amd64
+```
+
+Then redeploy:
+
+```bash
+vibew deploy --target ssh://user@host
+```
+
+---
+
+### Remote TLS certificate expiring or invalid
+
+**Symptom**
+
+```
+[WARN]  Remote TLS cert  certificate expires in 12 days
+[FAIL]  Remote TLS cert  certificate expired 2 days ago
+```
+
+**Cause**
+
+The TLS certificate on the remote host is nearing expiry or has already expired.
+If you are using `tls.provider: letsencrypt`, the ACME renewal may have failed.
+
+**Fix**
+
+Inspect the certificate details:
+
+```bash
+vibew tls status --domain example.com --target ssh://user@host
+```
+
+If renewal failed, check the sidecar logs for ACME errors:
+
+```bash
+vibew deploy logs --target ssh://user@host --lines 100
+```
+
+Common causes: DNS not pointing to the server, port 80 blocked (HTTP-01 challenge
+requires it), or rate limits exhausted (switch to ZeroSSL via `tls.acme_ca`).
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,7 +39,7 @@ pre-flight scripts.
 | 4 | **Proxy port** | The port configured in `server.port` (default `8443`) is not already bound |
 | 5 | **Generated files** | `.vibewarden/generated/docker-compose.yml` is present on disk |
 | 6 | **Container health** | `docker compose ps` shows all containers in `running` / `healthy` state |
-| 7 | **ACME email** | `tls.email` is set when using `letsencrypt` provider (warns if missing) |
+| 7 | **ACME email** | `tls.email` is set when `tls.acme_ca` contains "zerossl" (fails if missing) |
 | 8 | **Image tag** | `app.image` matches a locally available Docker image (skipped when unset) |
 
 #### Layer 2: Local Runtime
@@ -47,7 +47,7 @@ pre-flight scripts.
 | # | Check name | What it tests |
 |---|------------|---------------|
 | 9 | **Upstream reachable** | The configured upstream port is listening locally |
-| 10 | **TLS cert valid** | Local TLS certificate (when using `self-signed` or `external`) is not expired or expiring within 7 days |
+| 10 | **TLS cert valid** | Local TLS certificate (when using `self-signed`) is not expired or expiring within 7 days |
 
 #### Layer 3: Production (only with `--target`)
 
@@ -397,7 +397,7 @@ Save the master key somewhere safe -- if you lose it, your secrets are unrecover
 **Symptom**
 
 ```
-[FAIL]  Arch compatibility  image is arm64, remote is amd64
+[WARN]  Arch compatibility  local build is arm64 but remote server is amd64
 ```
 
 **Cause**

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -148,7 +148,7 @@ Key rules:
 resolved in this order:
 
 1. `name` field in vibewarden.yaml (explicit)
-2. `app.image` field in vibewarden.yaml (if set, used as-is)
+2. `app.image` with registry prefix and tag stripped (e.g. `ghcr.io/org/myapp:latest` → `myapp`)
 3. Directory name containing vibewarden.yaml (fallback)
 
 For example, a project in `~/code/mysite` with no explicit `name` produces the
@@ -193,7 +193,7 @@ vibew build --platform linux/amd64
 docker save <project>-app:latest | ssh user@host docker load
 
 # 3. Copy the deploy bundle (config, compose files)
-rsync -az .vibewarden/generated/ user@host:~/vibewarden/<project>/
+rsync -az .vibewarden/deploy/production/ user@host:~/vibewarden/<project>/
 
 # 4. Start the stack on the remote
 ssh user@host 'cd ~/vibewarden/<project> && docker compose up -d'

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -63,6 +63,8 @@ vibew dev --watch  # Start with hot reload
 vibew restart      # Restart without full rebuild
 vibew status       # Check component health
 vibew doctor       # Diagnose issues
+vibew doctor --target ssh://user@host  # Include production checks
+vibew tls status --domain example.com --target ssh://user@host  # Inspect remote TLS cert
 ```
 
 Access the app at https://localhost:8443 (through the sidecar). Never expose the
@@ -75,10 +77,14 @@ app port directly — it has no security.
 | `vibew dev` | Start dev environment |
 | `vibew dev --watch` | Start with file watching |
 | `vibew build` | Build Docker image |
+| `vibew build --platform linux/amd64` | Build for a specific architecture |
+| `vibew deploy --target ssh://user@host` | Deploy to remote server |
 | `vibew restart` | Restart containers |
 | `vibew status` | Show component health |
 | `vibew logs` | Tail logs |
 | `vibew doctor` | Diagnose issues |
+| `vibew doctor --target ssh://user@host` | Diagnose including production checks |
+| `vibew tls status --domain x --target y` | Inspect remote TLS certificate |
 | `vibew token` | Generate dev JWT |
 | `vibew secret get/set/list` | Manage secrets |
 | `vibew cert export` | Export TLS certificate |
@@ -135,6 +141,66 @@ Key rules:
   production override, not the base config.
 - If Let's Encrypt is rate-limited, set `tls.acme_ca` to use an alternative CA:
   `acme_ca: "https://acme.zerossl.com/v2/DV90"` (ZeroSSL, free, separate rate limits).
+
+## Image tag convention
+
+`vibew build` tags the image as `<project>-app:latest`. The project name is
+resolved in this order:
+
+1. `name` field in vibewarden.yaml (explicit)
+2. `app.image` field in vibewarden.yaml (if set, used as-is)
+3. Directory name containing vibewarden.yaml (fallback)
+
+For example, a project in `~/code/mysite` with no explicit `name` produces the
+image `mysite-app:latest`. This tag must match what Docker Compose expects for
+the app service.
+
+## TLS configuration keys
+
+These keys live under the `tls` section in vibewarden.yaml (or
+vibewarden.production.yaml for prod-only values):
+
+| Key | Values | What vibew does with it |
+|-----|--------|------------------------|
+| `tls.provider` | `letsencrypt` (alias: `acme`), `self-signed`, `external` | Selects the TLS provisioning strategy. `letsencrypt` uses ACME automation; `self-signed` generates a dev cert; `external` expects you to supply cert files. |
+| `tls.email` | ACME account email | Registered with the CA for expiry warnings. Required by ZeroSSL; optional for Let's Encrypt. |
+| `tls.acme_ca` | ACME directory URL | Overrides the default Let's Encrypt production CA. Use `https://acme.zerossl.com/v2/DV90` for ZeroSSL or the LE staging URL for testing. |
+| `tls.domain` | FQDN (e.g. `app.example.com`) | The domain for the TLS certificate. Required when provider is `letsencrypt`. Used for DNS checks by `vibew doctor`. |
+| `tls.cert_path` | File path to PEM certificate | Only used when provider is `external`. The sidecar reads this file on startup. |
+| `tls.key_path` | File path to PEM private key | Only used when provider is `external`. Must match `cert_path`. |
+
+## Deploying to a VPS
+
+### Automated (recommended)
+
+```bash
+vibew build --platform linux/amd64   # build for the target architecture
+vibew deploy --target ssh://user@host --config vibewarden.prod.yaml
+```
+
+`vibew deploy` handles image transfer, config generation, and container startup
+in a single command.
+
+### Manual fallback
+
+When `vibew deploy` fails or you need more control, use standard commands:
+
+```bash
+# 1. Build for the target architecture
+vibew build --platform linux/amd64
+
+# 2. Transfer the image via SSH
+docker save <project>-app:latest | ssh user@host docker load
+
+# 3. Copy the deploy bundle (config, compose files)
+rsync -az .vibewarden/generated/ user@host:~/vibewarden/<project>/
+
+# 4. Start the stack on the remote
+ssh user@host 'cd ~/vibewarden/<project> && docker compose up -d'
+```
+
+Each of these commands produces standard error messages that are searchable --
+use them as a plan B when debugging deploy issues.
 
 ## Writing your Dockerfile
 


### PR DESCRIPTION
Closes #1035

## Summary

- **AGENTS-VIBEWARDEN.md** and its template (`agents-vibewarden.md.tmpl`): added image tag convention (`<project>-app:latest` derivation order), TLS configuration keys table (all `tls.*` fields with descriptions), "Deploying to a VPS" section (automated via `vibew deploy` + manual fallback with `docker save`/`rsync`), `vibew tls status` usage, and expanded `vibew doctor` description listing all checks
- **deploy-reference.md**: added missing `--force`, `--env`, and `--dry-run` flags to the flags table; added 4 new entries to the common errors table (drift detection, arch mismatch, health check failure, missing image)
- **troubleshooting.md**: restructured checks table into 3 layers (Config & Docker, Local Runtime, Production) covering all 15 current checks; added `--target` flag documentation; added troubleshooting sections for architecture mismatch and remote TLS certificate expiry

## Test plan

- [x] `go build ./...` passes (template compiles)
- [x] `make check` passes (lint, build, all tests green)
- [ ] Visual review of rendered markdown tables and code blocks
- [ ] Verify no conflicts with PR #1047 (changes are in non-overlapping sections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)