### PR TITLE
fix(#1054): doctor port/TLS/remote checks — no more false positives, no shell leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,27 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Fixes
 
+- **`vibew doctor` no longer flags a running sidecar as a port conflict**
+  (#1054, ADR-084). When `vibew dev` is already running on the proxy port,
+  doctor probes `/_vibewarden/health` and reports
+  `[OK] Proxy port  in use by local vibew dev (expected)` instead of
+  `[FAIL] Proxy port  port 8443 is already in use`. Foreign processes
+  continue to FAIL as before.
+- **`vibew doctor` TLS cert check now inspects the live sidecar**
+  (#1054, ADR-084). The self-signed cert check performs a live TLS
+  handshake against the proxy and reads the leaf certificate from
+  `tls.Conn.ConnectionState().PeerCertificates`, instead of looking for a
+  hardcoded `server.crt` path on disk. This fixes the false-positive
+  "certificate file not found" reported when the self-signed cert lived
+  under Caddy's PKI storage path. When the sidecar is not reachable the
+  check is WARN with `sidecar not reachable on <addr> — start 'vibew dev'`.
+- **`vibew doctor` remote-containers errors no longer leak raw shell
+  fragments** (#1054, ADR-084). `checkRemoteContainerHealth` previously
+  surfaced errors containing literal `2>/dev/null` and
+  `|| docker-compose ps`. Errors are now rendered as a single clean line
+  of the form `exit <code>: <first stderr line> (<hint>)` — for example
+  `exit 127: docker: command not found; docker compose not installed on
+  remote`.
 - **Production override preserves every schema field** (#1053). `tls.email`,
   `tls.acme_ca`, `tls.cert_monitoring.*`, `server.host`, and any other field
   set only in `vibewarden.production.yaml` now reach the runtime

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -55,6 +55,7 @@ once accepted, they are not edited. If a decision is superseded, a new ADR refer
 | [081](adr-081-auto-detect-arch-mismatch-during-deploy-prerequisites.md) | Auto-detect arch mismatch during deploy prerequisites | — |
 | [082](adr-082-strict-config-merge-unknown-keys-fail-loudly.md) | Strict config merge — unknown keys fail loudly | #1053 |
 | [083](adr-083-acme-chain-hardening-email-preflight-buypass-removed.md) | ACME chain hardening — email preflight for ZeroSSL, Buypass removed from default chain | #1055 |
+| [084](adr-084-doctor-port-ownership-via-vibewarden-health-signature.md) | Doctor port ownership via VibeWarden health-signature probe | #1054 |
 | [497](adr-497-graceful-shutdown-connection-draining.md) | Graceful Shutdown / Connection Draining | — |
 
 ## Numbering

--- a/decisions/adr-084-doctor-port-ownership-via-vibewarden-health-signature.md
+++ b/decisions/adr-084-doctor-port-ownership-via-vibewarden-health-signature.md
@@ -1,0 +1,418 @@
+# ADR-084: Doctor port ownership via VibeWarden health-signature probe
+
+**Date**: 2026-04-20
+**Issue**: #1054
+**Status**: Accepted
+
+## Context
+
+`vibew doctor` performs a blind `net.Listen` probe on the proxy port (default
+`127.0.0.1:8443`). When a sibling `vibew dev` is already running — i.e. the
+expected state — the listener bind fails with `EADDRINUSE` and the doctor
+reports `port 8443 is already in use` as FAIL. The user sees a red error for
+the exact state the sidecar is supposed to be in.
+
+A correct port-ownership decision must distinguish two cases deterministically,
+on macOS and Linux:
+
+1. `host:port` is bound by a local `vibew dev` — expected, report OK.
+2. `host:port` is bound by any other process — conflict, report FAIL.
+
+Four implementation options were considered:
+
+| Option | Cross-platform | Coupling | Fragility |
+|---|---|---|---|
+| (a) PID file / lockfile written by `vibew dev` | yes, pure Go | new coupling between `dev` and `doctor` via the filesystem; PID staleness on crashes is a known failure mode | medium |
+| (b) `lsof` / `ss` / `netstat` scrape | different binary per OS; format differs; `ss` absent on macOS | shell-out; output parsing | high |
+| (c) TLS probe of `https://host:port/_vibewarden/health` looking for the VibeWarden JSON signature | pure Go (`crypto/tls` + `net/http`); identical code paths on all supported dev platforms | zero new coupling — `/_vibewarden/health` is an already-published route (see `internal/adapters/caddy/config.go` lines 164-184) | low |
+| (d) Downgrade severity on `EADDRINUSE` | cross-platform but imprecise | no new mechanism | high — hides real conflicts |
+
+Option (c) wins on all three axes. The `/_vibewarden/health` endpoint already
+returns a deterministic JSON body whose prefix (`{"status":"ok","version":`) is
+unique to VibeWarden and stable across versions (it is part of the published
+liveness contract). Detecting the signature over TLS with
+`InsecureSkipVerify: true` (self-signed certs in dev are normal) is robust,
+fast (single handshake + single tiny HTTPS GET), and requires no new coupling
+between `vibew dev` and `vibew doctor` beyond the already-published liveness
+endpoint.
+
+This ADR is cross-cutting because port-ownership detection will be reused by
+other health tools (MCP, future admin CLI). Codifying the strategy once
+prevents re-deriving it every time a new tool needs the same answer.
+
+## Decision
+
+Introduce a new outbound port `ports.PortOwnerProbe` that, given a `host:port`,
+returns one of three ownership verdicts:
+
+- `OwnerVibeWarden` — a VibeWarden sidecar responded on `/_vibewarden/health`.
+- `OwnerForeign` — something else is listening (TLS handshake succeeded but
+  body did not match, or handshake failed with `EADDRINUSE`-consistent
+  symptoms), or a plain-TCP listener is present that does not speak TLS.
+- `OwnerUnknown` — the port is free.
+
+The doctor `checkPort` function composes the existing `PortChecker` result
+with the `PortOwnerProbe` result:
+
+| `PortChecker.available` | `PortOwnerProbe` | Severity | Detail |
+|---|---|---|---|
+| true | (not queried) | OK | `port N is available` |
+| false | `OwnerVibeWarden` | OK | `in use by local vibew dev (expected)` |
+| false | `OwnerForeign` | FAIL | `port N is already in use` |
+| false | `OwnerUnknown` (probe error) | FAIL | `port N is already in use` |
+
+Probe errors intentionally degrade to FAIL — a foreign listener that rejects
+the TLS handshake is indistinguishable from a probe that failed for any other
+reason, and FAIL is the safe default.
+
+### Domain model changes
+
+No domain entities are introduced. `OwnerVerdict` is a value object (a typed
+string constant) defined in `internal/ports/ops.go` so it is accessible from
+both the port contract and the app service.
+
+### Ports (interfaces)
+
+Add to `internal/ports/ops.go`:
+
+```go
+// PortOwner identifies who is listening on a TCP port.
+type PortOwner string
+
+const (
+    OwnerUnknown    PortOwner = "unknown"
+    OwnerVibeWarden PortOwner = "vibewarden"
+    OwnerForeign    PortOwner = "foreign"
+)
+
+// PortOwnerProbe identifies the owner of a listener on host:port by probing
+// the /_vibewarden/health endpoint over TLS. Implementations must be safe to
+// call with InsecureSkipVerify because self-signed certs are the norm in dev.
+type PortOwnerProbe interface {
+    // ProbeOwner returns the identity of the process bound to host:port.
+    // Never returns an error — ambiguous results map to OwnerUnknown.
+    ProbeOwner(ctx context.Context, host string, port int) PortOwner
+}
+```
+
+### Adapters
+
+Add a new adapter in `internal/adapters/ops/port_owner.go`:
+
+```go
+// VibeWardenHealthProbe implements ports.PortOwnerProbe by issuing a short
+// TLS GET to https://host:port/_vibewarden/health and inspecting the body.
+type VibeWardenHealthProbe struct {
+    client *http.Client
+}
+
+func NewVibeWardenHealthProbe(client *http.Client) *VibeWardenHealthProbe { ... }
+
+func (p *VibeWardenHealthProbe) ProbeOwner(ctx context.Context, host string, port int) ports.PortOwner {
+    // 1. GET https://host:port/_vibewarden/health with InsecureSkipVerify
+    //    and a 2-second deadline derived from ctx.
+    // 2. On transport error (connection refused, timeout on a reachable host,
+    //    TLS handshake failure) return OwnerForeign.
+    // 3. On 2xx + body prefix match `{"status":"ok","version":` → OwnerVibeWarden.
+    // 4. On 2xx with no prefix match → OwnerForeign.
+    // 5. On any other status → OwnerForeign.
+}
+```
+
+Client construction (in `NewVibeWardenHealthProbe`) injects a dedicated
+`http.Client` with `Transport: &http.Transport{TLSClientConfig:
+&tls.Config{InsecureSkipVerify: true}}` and a 2-second timeout. The probe is
+only ever run against localhost during local diagnostics, so
+`InsecureSkipVerify` is safe and already the pattern used by
+`checkRemoteTLSCert` (see `doctor.go` line 615).
+
+### Application service
+
+Modify `DoctorService` (`internal/app/ops/doctor.go`):
+
+- Add field `ownerProbe ports.PortOwnerProbe` and a setter
+  `WithPortOwnerProbe(...)` that returns a copy (same pattern as
+  `WithRemoteExecutor`). `NewDoctorService` signature is **not** changed — to
+  avoid churning every call site. When `ownerProbe` is nil the port check
+  degrades to the current FAIL-on-busy behaviour so pre-existing tests that
+  do not set it still pass.
+- Rewrite `checkPort` to consult `ownerProbe` when `available == false` and
+  map the verdict per the table above.
+- `checkTLSCertValid` rewrite (bug 2, see below) calls the same `ownerProbe`
+  transitively via a new local helper that performs a live TLS handshake
+  against the sidecar — but we do **not** add a second port; the handshake
+  reuses standard `crypto/tls` directly from the check. The rationale is
+  that the cert-inspection check needs the leaf certificate, not just an
+  ownership verdict, so a separate tiny helper `probeLocalLeafCert(host,
+  port)` is added in the same package rather than a new port.
+
+#### Bug 2 — TLS certificate
+
+Replace the hardcoded `filepath.Join(workDir, ".vibewarden", "generated",
+"certs", "server.crt")` with a **live TLS probe first, filesystem fallback
+never** strategy:
+
+- If `cfg.TLS.Provider != "self-signed"` → leave the existing "provider is
+  X — skipping local cert check" result. No change.
+- Otherwise, perform a TLS handshake against `proxyHost:proxyPort` with
+  `InsecureSkipVerify: true`, read the leaf from `ConnectionState().
+  PeerCertificates[0]`, and apply the existing expiry/notAfter severity
+  logic to it.
+- If the handshake fails:
+  - severity = WARN
+  - detail = `"sidecar not reachable on <host>:<port> — start 'vibew dev'"`
+
+The filesystem scan is **deleted**. Self-signed cert paths are owned by Caddy
+and the correct place to inspect them is through the live TLS handshake that
+Caddy itself terminates. Doctor does not peek into Caddy's storage — this
+keeps `app/ops/doctor.go` free of knowledge of Caddy's internal storage
+layout (which is `adapters/caddy/`'s concern, not `app/ops/`'s).
+
+This avoids option (b) from PM's open question — we never need to resolve
+`cfg.TLS.StoragePath` in the doctor; Caddy already serves the cert we want.
+
+#### Bug 3 — remote container check reshape
+
+The command string is rewritten and the error surface is sanitised. Location:
+`checkRemoteContainerHealth` in `doctor.go`.
+
+New remote command:
+
+```
+docker compose ps --format json
+```
+
+That is the complete remote command string. Rationale:
+
+- The `|| docker-compose ps` fallback is dropped. Docker Compose v1
+  (`docker-compose`, hyphenated) reached end-of-life in June 2023 and has
+  been removed from the official Docker distribution. The production
+  environments this check runs against are provisioned via `vibew deploy`,
+  which guarantees Compose v2. If v1 ever matters again it is a
+  documentation problem, not a doctor-check problem.
+- `2>/dev/null` is removed. Stderr is needed for the user-facing error
+  message. The SSH adapter already merges stderr into the combined output
+  (see `internal/adapters/ssh/executor.go` line 104) and wraps `exec.Run`
+  errors with `%w`, so stderr surfaces naturally.
+
+Error formatting is factored into a **pure function** in a new file
+`internal/app/ops/remote_error.go` (kept in the app layer — see next
+paragraph):
+
+```go
+// formatRemoteError converts a ports.RemoteExecutor error into a single-line,
+// user-safe detail string. It never echoes the raw remote command, strips
+// the "ssh <cmd>: " prefix written by ssh.Executor.Run, extracts the exit
+// code when present, and includes at most one line of stderr.
+func formatRemoteError(err error) string
+```
+
+Contract:
+
+- Input: `err` returned from `ports.RemoteExecutor.Run`.
+- Output: single line, no trailing newline, no shell fragments (`2>/dev/null`,
+  `||`, `ssh `), at most `~180` chars.
+- The exit code is extracted via `errors.As(err, &exitErr)` where
+  `exitErr *exec.ExitError` — so the function depends on `os/exec` but not
+  on the ssh package.
+- The first non-empty line of stderr is surfaced; subsequent lines dropped.
+- Followed by one of a small set of hard-coded hints keyed off exit code:
+  - `127` → `"docker compose not installed on remote (expected after deploy)"`
+  - `126` → `"docker compose not executable — check permissions"`
+  - default → `"check remote docker compose installation"`
+
+The reason this lives in `app/ops/` (and not in the SSH adapter) is
+separation of concerns: the adapter returns structured errors; the
+application layer decides how to render them for this particular use case.
+A different caller (e.g. `vibew deploy`) may render the same error
+differently.
+
+**Bonus micro-fix to the ssh adapter**: the `"output:"` fragment in
+`executor.go:106` is removed from the `Run` error format to stop echoing
+the entire captured output inside the error itself — the caller already
+gets the output as the `(string, error)` tuple's first return value, so
+appending `"output: ..."` to the error string is duplication and the root
+cause of the raw-pipe leak. New format:
+
+```go
+return buf.String(), fmt.Errorf("ssh exit: %w", err)
+```
+
+`cmd` is deliberately **not** interpolated into the error message — callers
+that need the command string already have it (they passed it in). Dropping
+it eliminates the "raw shell in user-facing error" leak structurally.
+
+### File layout
+
+New files:
+
+- `internal/ports/ops.go` — edit: add `PortOwner` type + constants and
+  `PortOwnerProbe` interface.
+- `internal/adapters/ops/port_owner.go` — new: `VibeWardenHealthProbe`.
+- `internal/adapters/ops/port_owner_test.go` — new: unit tests using
+  `httptest.NewTLSServer` for VibeWarden signature match, foreign 200
+  body, connection refused, wrong status.
+- `internal/app/ops/remote_error.go` — new: `formatRemoteError(err error)
+  string` (pure function).
+- `internal/app/ops/remote_error_test.go` — new: table-driven tests for
+  formatRemoteError.
+- `internal/app/ops/doctor.go` — edit:
+  - add `ownerProbe ports.PortOwnerProbe` field
+  - add `WithPortOwnerProbe(p) *DoctorService` setter
+  - rewrite `checkPort` to consult `ownerProbe`
+  - rewrite `checkTLSCertValid(cfg, workDir)` → `checkTLSCertValid(ctx,
+    cfg, proxyHost, proxyPort)` — signature change; `workDir` becomes
+    unused and is removed from the call site in `runChecks`
+  - rewrite `checkRemoteContainerHealth` to call `formatRemoteError` and
+    use the simplified remote command
+- `internal/app/ops/doctor_test.go` — edit: add new cases, update
+  existing cases for the `checkTLSCertValid` signature.
+- `internal/adapters/ssh/executor.go` — edit: simplify `Run` error
+  format per "Bonus micro-fix" above.
+- `internal/adapters/ssh/executor_test.go` — edit: update any tests
+  that assert on the `"output:"` prefix (grep first; if none exist, no
+  edit).
+- `internal/cli/cmd/doctor.go` — edit: construct the new probe and pass
+  via `.WithPortOwnerProbe(...)`.
+- `internal/cli/cmd/mcp.go` — edit: same wiring as `doctor.go`.
+
+### Sequence — bug 1 path (port 8443 bound by sibling `vibew dev`)
+
+1. `DoctorService.checkPort(ctx, "Proxy port", "127.0.0.1", 8443)` is called.
+2. `portChecker.IsPortAvailable(ctx, "127.0.0.1", 8443)` returns `(false, nil)`
+   — bind failed.
+3. `checkPort` consults `ownerProbe.ProbeOwner(ctx, "127.0.0.1", 8443)`.
+4. The probe issues `GET https://127.0.0.1:8443/_vibewarden/health` with
+   `InsecureSkipVerify`.
+5. Caddy's static response handler returns
+   `{"status":"ok","version":"<v>","components":{...}}` with HTTP 200.
+6. The probe matches the `{"status":"ok","version":` prefix and returns
+   `OwnerVibeWarden`.
+7. `checkPort` returns `CheckResult{Severity: SeverityOK, Detail: "in use by
+   local vibew dev (expected)"}`.
+
+### Sequence — bug 1 path (port 8443 bound by some other service)
+
+1–3 identical to above.
+4. The probe issues the TLS GET. The foreign service either (a) rejects the
+   TLS handshake, (b) returns a non-2xx response, or (c) returns a 2xx
+   response whose body does not start with the VibeWarden signature.
+5. Probe returns `OwnerForeign`.
+6. `checkPort` returns `CheckResult{Severity: SeverityFail, Detail: "port
+   8443 is already in use"}`.
+
+### Error cases
+
+| Case | Outcome |
+|---|---|
+| `ownerProbe` is nil (legacy wiring, or test without probe) | `checkPort` falls back to the current "busy = FAIL" behaviour — back-compat safe. |
+| Probe times out on a reachable host | Returns `OwnerForeign`. FAIL is the safe default. |
+| `cfg.Server.Host` is `0.0.0.0` | Probe uses `127.0.0.1` for the actual HTTP request (documented in the adapter godoc). |
+| `checkTLSCertValid` fails the handshake but the port check itself said OK (owner = vibewarden) | WARN — "sidecar reachable but cert handshake failed: <one-line error>". |
+| `formatRemoteError` receives an error that is not an `*exec.ExitError` | Returns `"remote command failed: <first line of err>"` with the default hint. |
+| PM open question (1) — route via health endpoint | Answered: yes, that is the recommended implementation. |
+| PM open question (2) — TLS probe vs storage scan vs both | Answered: TLS probe only. Storage scan is deleted. |
+
+### Test strategy
+
+**Unit tests (new/updated in `internal/adapters/ops/port_owner_test.go`):**
+
+- `TestVibeWardenHealthProbe_VibeWardenSignature` — `httptest.NewTLSServer`
+  returning the signature JSON → `OwnerVibeWarden`.
+- `TestVibeWardenHealthProbe_ForeignHTTPS` — TLS server returning `{"foo":
+  "bar"}` → `OwnerForeign`.
+- `TestVibeWardenHealthProbe_NonTLS` — `net.Listen("tcp", ...)` and accept
+  nothing → `OwnerForeign` (handshake fails).
+- `TestVibeWardenHealthProbe_PortClosed` — no listener → `OwnerForeign`.
+- `TestVibeWardenHealthProbe_Non2xx` — TLS server returning 500 with the
+  signature body → `OwnerForeign` (status takes precedence over body).
+
+**Unit tests (new/updated in `internal/app/ops/doctor_test.go`):**
+
+- `TestCheckPort_InUseByVibeWarden_OK` — fake probe returns
+  `OwnerVibeWarden` → severity OK, detail contains "vibew dev".
+- `TestCheckPort_InUseByForeign_Fail` — probe returns `OwnerForeign` →
+  severity FAIL.
+- `TestCheckPort_NoProbe_BusyStillFails` — `ownerProbe` nil + busy → FAIL
+  (back-compat).
+- `TestCheckTLSCertValid_LiveSidecarCertOK` — fake handshake returns a
+  cert valid >30 days → severity OK, detail mentions "valid until".
+- `TestCheckTLSCertValid_LiveSidecarCertExpiringSoon` — cert valid 3 days →
+  WARN.
+- `TestCheckTLSCertValid_SidecarUnreachable` — handshake fails → WARN,
+  detail contains "start 'vibew dev'".
+- `TestCheckTLSCertValid_ProviderNotSelfSigned` — cfg.TLS.Provider = "external"
+  → existing OK path unchanged.
+
+**Unit tests (new in `internal/app/ops/remote_error_test.go`):**
+
+Table-driven, cases cover:
+- `exit status 127` + stderr `"docker: command not found"`.
+- `exit status 126` + stderr `"permission denied"`.
+- `exit status 1` + stderr containing `2>/dev/null` (pre-existing leak) —
+  must strip the literal redirection from output.
+- `exit status 1` + multi-line stderr — must emit only the first non-empty
+  line.
+- nil error — empty string.
+
+Assertions (for every case):
+- no newline in output
+- no substring `"2>/dev/null"`, `"||"`, `"ssh "`
+- exit code present when non-zero
+- trailing hint present
+
+**Integration test (new in `internal/app/ops/doctor_integration_test.go`)
+guarded by `//go:build integration` tag:**
+
+- Start a real `vibew dev` against an ephemeral project directory.
+- Poll `/_vibewarden/health` until it returns 200.
+- Run `DoctorService.Run` with the real probe wired.
+- Assert zero FAIL and zero WARN on "Proxy port", "TLS certificate", and
+  "Container health".
+- Cleanup via `t.Cleanup(...)`.
+- Skip on CI when Docker is unavailable via `testing.Short()`.
+
+### New dependencies
+
+None. Uses only `crypto/tls`, `net/http`, `encoding/json`, `context`,
+`errors`, `os/exec` — all stdlib.
+
+## Consequences
+
+**Positive**
+
+- Deterministic, pure-Go port-ownership detection on macOS and Linux.
+  No binary dependencies (`lsof`, `ss`, `netstat`) and no new coupling
+  between `vibew dev` and `vibew doctor` beyond the already-published
+  liveness endpoint.
+- The TLS cert check is now honest: it reports whether the sidecar is
+  actually serving a valid cert rather than whether a file sits at a
+  hard-coded path that has been wrong since the switch to Caddy-managed
+  storage.
+- User-facing doctor output contains no shell fragments — the cosmetic
+  bug is fixed structurally at the SSH adapter boundary, not by
+  string-munging inside the doctor check.
+- `PortOwnerProbe` is reusable — future tools (MCP diagnostics, admin
+  CLI) that need the same "is this my sidecar?" answer share one
+  implementation.
+
+**Negative**
+
+- `/_vibewarden/health` becomes a soft public contract for doctor — the
+  JSON prefix `{"status":"ok","version":` must remain stable. This is
+  already effectively the case (it is the liveness endpoint users and
+  monitoring tools hit). Any future change to the body must keep the
+  prefix or update this ADR.
+- TLS handshake + HTTP round-trip costs ~5-20ms on localhost on top of
+  the current ~1ms bind probe. Acceptable — doctor is interactive and
+  one extra roundtrip is imperceptible.
+
+**Follow-up**
+
+- Full deletion of the production-only doctor checks (`checkSSHConnectivity`,
+  `checkArchCompatibility`, `checkRemoteContainerHealth`, `checkDomainDNS`,
+  `checkRemoteTLSCert`, and the `Target` / `RemoteExecutor` plumbing) is
+  tracked as a separate chore issue blocked on `#1051` (deploy sunset).
+  This is not ADR-worthy — the architectural decision (delete production
+  surface from doctor when deploy is sunset) was already made in the
+  scope of #1051. The follow-up is scoped tracking work.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -47,7 +47,7 @@ pre-flight scripts.
 | # | Check name | What it tests |
 |---|------------|---------------|
 | 9 | **Upstream reachable** | The configured upstream port is listening locally |
-| 10 | **TLS cert valid** | Local TLS certificate (when using `self-signed`) is not expired or expiring within 7 days |
+| 10 | **TLS cert valid** | Performs a live TLS handshake against the sidecar, reads the leaf certificate from the handshake, and verifies it is not expired or expiring within 7 days. Reports WARN (`sidecar not reachable — start 'vibew dev'`) when the handshake fails, so the check no longer depends on a file-on-disk at a hardcoded path (ADR-084) |
 
 #### Layer 3: Production (only with `--target`)
 
@@ -97,7 +97,28 @@ VibeWarden Doctor
   [WARN]          Container health       no containers found — run 'vibewarden dev' to start the stack
 ```
 
-### Port conflict + Docker not running
+### Proxy port already owned by a running `vibew dev`
+
+When `vibew dev` is already running locally, port 8443 is expected to be in use.
+`vibew doctor` probes `/_vibewarden/health` and recognises the sidecar as the owner,
+so the check is `[OK]` — not `[FAIL]` — per ADR-084.
+
+```
+VibeWarden Doctor
+─────────────────────────────────────────
+  [OK]            Config file            vibewarden.yaml — valid
+  [OK]            Docker daemon          running
+  [OK]            Docker Compose         Docker Compose version v2.27.0
+  [OK]            Proxy port             in use by local vibew dev (expected)
+  [OK]            Generated files        .vibewarden/generated/docker-compose.yml
+  [OK]            Container health       4 container(s) running
+```
+
+### Port conflict (foreign process) + Docker not running
+
+The `[FAIL] Proxy port` line only fires when the port is owned by a **non-VibeWarden**
+process (i.e., the health probe does not find a `vibewarden` signature on the port).
+A running `vibew dev` never triggers this FAIL — see the sample above.
 
 ```
 VibeWarden Doctor
@@ -162,9 +183,16 @@ needs to consume the results programmatically:
 [FAIL]  Proxy port  port 8443 is already in use
 ```
 
+> This `[FAIL]` no longer fires for a running `vibew dev`. Since ADR-084 the doctor
+> probes `/_vibewarden/health` and reports
+> `[OK] Proxy port  in use by local vibew dev (expected)` when the owner is the
+> local sidecar. The FAIL below only applies when a **foreign** process owns the
+> port.
+
 **Cause**
 
-Another process is listening on the port configured in `server.port` (default `8443`).
+A non-VibeWarden process is listening on the port configured in `server.port`
+(default `8443`).
 
 **Fix — option 1: change VibeWarden's port**
 

--- a/internal/adapters/ops/port_owner.go
+++ b/internal/adapters/ops/port_owner.go
@@ -1,0 +1,114 @@
+package ops
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// healthSignaturePrefix is the JSON body prefix served by the VibeWarden
+// sidecar on /_vibewarden/health. It is stable across sidecar versions
+// because it is part of the published liveness contract. See ADR-084 and
+// internal/adapters/caddy/config.go (healthBody).
+const healthSignaturePrefix = `{"status":"ok","version":`
+
+// probeReadLimit caps how much of the health response body is read. The
+// signature lives in the first ~30 bytes, so 512 bytes is generous and
+// prevents a malicious foreign listener from streaming indefinitely.
+const probeReadLimit = 512
+
+// defaultProbeTimeout is the per-probe timeout when the caller's context has
+// no earlier deadline.
+const defaultProbeTimeout = 2 * time.Second
+
+// healthProbePath is the path of the VibeWarden liveness endpoint.
+const healthProbePath = "/_vibewarden/health"
+
+// VibeWardenHealthProbe implements ports.PortOwnerProbe by issuing a short
+// TLS-protected HTTP GET to /_vibewarden/health and matching the response
+// body against the VibeWarden JSON signature.
+//
+// The probe always runs against localhost during local diagnostics, so it is
+// configured with InsecureSkipVerify — self-signed certificates are the norm
+// in dev and the probe's purpose is to detect a sibling sidecar, not to
+// validate trust.
+type VibeWardenHealthProbe struct {
+	client *http.Client
+}
+
+// NewVibeWardenHealthProbe returns a new probe. If client is nil a dedicated
+// client with a 2-second timeout and InsecureSkipVerify is created.
+func NewVibeWardenHealthProbe(client *http.Client) *VibeWardenHealthProbe {
+	if client == nil {
+		client = &http.Client{
+			Timeout: defaultProbeTimeout,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true, //nolint:gosec // local diagnostics; see godoc
+				},
+			},
+		}
+	}
+	return &VibeWardenHealthProbe{client: client}
+}
+
+// ProbeOwner returns the identity of the process bound to host:port.
+//
+// When host is "0.0.0.0" the probe targets 127.0.0.1 because wildcard
+// addresses are not valid HTTP destinations.
+//
+// Contract (per ADR-084):
+//   - port closed or TLS handshake fails → OwnerForeign.
+//   - 2xx response whose body starts with `{"status":"ok","version":` → OwnerVibeWarden.
+//   - 2xx response with any other body → OwnerForeign.
+//   - non-2xx response → OwnerForeign.
+//
+// The function never returns OwnerUnknown — callers map "port available"
+// (no probe needed) to OwnerUnknown themselves.
+func (p *VibeWardenHealthProbe) ProbeOwner(ctx context.Context, host string, port int) ports.PortOwner {
+	if host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+
+	probeCtx := ctx
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		probeCtx, cancel = context.WithTimeout(ctx, defaultProbeTimeout)
+		defer cancel()
+	}
+
+	url := fmt.Sprintf("https://%s:%d%s", host, port, healthProbePath)
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return ports.OwnerForeign
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return ports.OwnerForeign
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return ports.OwnerForeign
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, probeReadLimit))
+	if err != nil {
+		return ports.OwnerForeign
+	}
+
+	if strings.HasPrefix(string(body), healthSignaturePrefix) {
+		return ports.OwnerVibeWarden
+	}
+	return ports.OwnerForeign
+}
+
+// Compile-time assertion that VibeWardenHealthProbe satisfies the port.
+var _ ports.PortOwnerProbe = (*VibeWardenHealthProbe)(nil)

--- a/internal/adapters/ops/port_owner_test.go
+++ b/internal/adapters/ops/port_owner_test.go
@@ -1,0 +1,205 @@
+package ops_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	opsadapter "github.com/vibewarden/vibewarden/internal/adapters/ops"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// hostPortFromURL splits a URL like https://127.0.0.1:12345 into host and port.
+func hostPortFromURL(t *testing.T, raw string) (string, int) {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse url %q: %v", raw, err)
+	}
+	portStr := u.Port()
+	if portStr == "" {
+		portStr = "443"
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse port %q: %v", portStr, err)
+	}
+	return u.Hostname(), port
+}
+
+func TestVibeWardenHealthProbe_ProbeOwner(t *testing.T) {
+	t.Parallel()
+
+	okBody := `{"status":"ok","version":"test","components":{"sidecar":"ok"}}`
+	foreignBody := `{"hello":"world"}`
+
+	tests := []struct {
+		name     string
+		handler  http.HandlerFunc
+		wantCode int // 0 => no server
+		want     ports.PortOwner
+	}{
+		{
+			name: "vibewarden signature matches → OwnerVibeWarden",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprint(w, okBody)
+			},
+			want: ports.OwnerVibeWarden,
+		},
+		{
+			name: "200 with non-signature body → OwnerForeign",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprint(w, foreignBody)
+			},
+			want: ports.OwnerForeign,
+		},
+		{
+			name: "200 with signature on wrong path still matches (static handler)",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				// Probe path mismatch — foreign servers that return 200+signature
+				// on any path still look like a VibeWarden sidecar by contract.
+				// This test case asserts the path is actually hit.
+				if r.URL.Path != "/_vibewarden/health" {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprint(w, okBody)
+			},
+			want: ports.OwnerVibeWarden,
+		},
+		{
+			name: "non-2xx takes precedence over body → OwnerForeign",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = fmt.Fprint(w, okBody)
+			},
+			want: ports.OwnerForeign,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewTLSServer(tt.handler)
+			defer srv.Close()
+
+			probe := opsadapter.NewVibeWardenHealthProbe(srv.Client())
+			host, port := hostPortFromURL(t, srv.URL)
+
+			got := probe.ProbeOwner(context.Background(), host, port)
+			if got != tt.want {
+				t.Errorf("ProbeOwner() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVibeWardenHealthProbe_ConnectionRefused(t *testing.T) {
+	t.Parallel()
+
+	// Bind and immediately release a port so we know it's closed.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().(*net.TCPAddr)
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	probe := opsadapter.NewVibeWardenHealthProbe(nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	got := probe.ProbeOwner(ctx, "127.0.0.1", addr.Port)
+	if got != ports.OwnerForeign {
+		t.Errorf("ProbeOwner() on closed port = %q, want %q", got, ports.OwnerForeign)
+	}
+}
+
+func TestVibeWardenHealthProbe_NonTLSListener(t *testing.T) {
+	t.Parallel()
+
+	// Plain TCP listener that accepts and closes — TLS handshake must fail.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	addr := ln.Addr().(*net.TCPAddr)
+	probe := opsadapter.NewVibeWardenHealthProbe(nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	got := probe.ProbeOwner(ctx, "127.0.0.1", addr.Port)
+	if got != ports.OwnerForeign {
+		t.Errorf("ProbeOwner() on plain-TCP listener = %q, want %q", got, ports.OwnerForeign)
+	}
+}
+
+func TestVibeWardenHealthProbe_WildcardHostRewritten(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `{"status":"ok","version":"x"}`)
+	}))
+	defer srv.Close()
+
+	// Use the test server's client so the TLS cert trust is set up.
+	probe := opsadapter.NewVibeWardenHealthProbe(srv.Client())
+	_, port := hostPortFromURL(t, srv.URL)
+
+	// The probe should rewrite 0.0.0.0 to 127.0.0.1 internally.
+	got := probe.ProbeOwner(context.Background(), "0.0.0.0", port)
+	if got != ports.OwnerVibeWarden {
+		t.Errorf("ProbeOwner(0.0.0.0) = %q, want %q", got, ports.OwnerVibeWarden)
+	}
+}
+
+// TestVibeWardenHealthProbe_SignaturePrefixExact ensures the prefix match is
+// strict: a body that merely contains the signature substring but does not
+// start with it must be rejected.
+func TestVibeWardenHealthProbe_SignaturePrefixExact(t *testing.T) {
+	t.Parallel()
+
+	body := `prefix-garbage{"status":"ok","version":"test"}`
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	probe := opsadapter.NewVibeWardenHealthProbe(srv.Client())
+	host, port := hostPortFromURL(t, srv.URL)
+
+	got := probe.ProbeOwner(context.Background(), host, port)
+	if got != ports.OwnerForeign {
+		t.Errorf("ProbeOwner() with non-prefix signature = %q, want %q", got, ports.OwnerForeign)
+	}
+	if strings.HasPrefix(body, `{"status":"ok"`) {
+		t.Fatalf("test body unexpectedly has the signature prefix")
+	}
+}

--- a/internal/adapters/ssh/executor.go
+++ b/internal/adapters/ssh/executor.go
@@ -89,8 +89,11 @@ func NewExecutorWithKey(target Target, keyPath string) *Executor {
 }
 
 // Run executes cmd on the remote host via ssh and returns the combined
-// stdout+stderr output. A non-zero exit code is wrapped and returned as an
-// error that includes the captured output for diagnosis.
+// stdout+stderr output. A non-zero exit code is wrapped with a short
+// "ssh exit: <err>" prefix; the raw command is deliberately NOT
+// interpolated into the error so doctor/CLI output does not leak shell
+// fragments (see ADR-084). Callers that need the raw output already get
+// it via the first return value.
 func (e *Executor) Run(ctx context.Context, cmd string) (string, error) {
 	args := e.sshArgs(cmd)
 	//nolint:gosec // cmd is caller-supplied; callers in this codebase use only
@@ -103,7 +106,7 @@ func (e *Executor) Run(ctx context.Context, cmd string) (string, error) {
 	c.Stderr = &buf
 
 	if err := c.Run(); err != nil {
-		return buf.String(), fmt.Errorf("ssh %s: %w\noutput: %s", cmd, err, strings.TrimSpace(buf.String()))
+		return buf.String(), fmt.Errorf("ssh exit: %w", err)
 	}
 	return strings.TrimSpace(buf.String()), nil
 }

--- a/internal/app/ops/doctor.go
+++ b/internal/app/ops/doctor.go
@@ -531,10 +531,15 @@ func (s *DoctorService) checkRemoteContainerHealth(ctx context.Context) CheckRes
 	// of ADR-084 so stderr surfaces naturally for the error formatter.
 	output, err := s.remoteExecutor.Run(checkCtx, "docker compose ps --format json")
 	if err != nil {
+		// ssh.Executor.Run merges stdout+stderr into `output` and never
+		// populates *exec.ExitError.Stderr, so we must forward `output`
+		// to the formatter — otherwise the real stderr line (e.g.
+		// "docker: command not found") is discarded and the user only
+		// sees the canned exit-code hint.
 		return CheckResult{
 			Name:     "Remote containers",
 			Severity: SeverityFail,
-			Detail:   formatRemoteError(err, "docker compose"),
+			Detail:   formatRemoteError(err, output, "docker compose"),
 		}
 	}
 

--- a/internal/app/ops/doctor.go
+++ b/internal/app/ops/doctor.go
@@ -3,9 +3,7 @@ package ops
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"io"
 	"net"
@@ -59,6 +57,7 @@ type DoctorService struct {
 	healthChecker  ports.HealthChecker
 	remoteExecutor ports.RemoteExecutor
 	imageChecker   ports.DockerImageChecker
+	ownerProbe     ports.PortOwnerProbe
 }
 
 // NewDoctorService creates a new DoctorService.
@@ -85,6 +84,17 @@ func (s *DoctorService) WithRemoteExecutor(executor ports.RemoteExecutor) *Docto
 func (s *DoctorService) WithImageChecker(checker ports.DockerImageChecker) *DoctorService {
 	cp := *s
 	cp.imageChecker = checker
+	return &cp
+}
+
+// WithPortOwnerProbe returns a copy of the DoctorService with the given
+// PortOwnerProbe wired for port-ownership detection. When nil (or no probe
+// is supplied) the proxy-port check falls back to "busy = FAIL" semantics —
+// this preserves back-compat with existing tests that do not set a probe.
+// See ADR-084.
+func (s *DoctorService) WithPortOwnerProbe(probe ports.PortOwnerProbe) *DoctorService {
+	cp := *s
+	cp.ownerProbe = probe
 	return &cp
 }
 
@@ -177,7 +187,7 @@ func (s *DoctorService) runChecks(ctx context.Context, cfg *config.Config, opts 
 
 	// --- Layer 2: Local Runtime ---
 	results = append(results, withSection(s.checkUpstreamReachable(ctx, cfg), sectionLocalRuntime))
-	results = append(results, withSection(checkTLSCertValid(cfg, workDir), sectionLocalRuntime))
+	results = append(results, withSection(checkTLSCertValid(ctx, cfg, proxyHost, proxyPort), sectionLocalRuntime))
 
 	// --- Layer 3: Production (only when target is set and executor is available) ---
 	if opts.Target != "" && s.remoteExecutor != nil {
@@ -257,6 +267,10 @@ func checkConfigFile(cfg *config.Config, configPath string) CheckResult {
 	}
 }
 
+// checkPort combines the TCP-bind probe (PortChecker) with the optional
+// ownership probe (PortOwnerProbe) to distinguish the expected "sibling
+// vibew dev is running" state from a real foreign-process conflict. See
+// ADR-084 for the decision table.
 func (s *DoctorService) checkPort(ctx context.Context, label, host string, port int) CheckResult {
 	checkCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
@@ -269,17 +283,29 @@ func (s *DoctorService) checkPort(ctx context.Context, label, host string, port 
 			Detail:   fmt.Sprintf("port %d check failed: %v", port, err),
 		}
 	}
-	if !available {
+	if available {
 		return CheckResult{
 			Name:     label,
-			Severity: SeverityFail,
-			Detail:   fmt.Sprintf("port %d is already in use", port),
+			Severity: SeverityOK,
+			Detail:   fmt.Sprintf("port %d is available", port),
 		}
 	}
+
+	// Port is bound. Ask the owner probe who is there.
+	if s.ownerProbe != nil {
+		if s.ownerProbe.ProbeOwner(checkCtx, host, port) == ports.OwnerVibeWarden {
+			return CheckResult{
+				Name:     label,
+				Severity: SeverityOK,
+				Detail:   fmt.Sprintf("port %d in use by local vibew dev (expected)", port),
+			}
+		}
+	}
+
 	return CheckResult{
 		Name:     label,
-		Severity: SeverityOK,
-		Detail:   fmt.Sprintf("port %d is available", port),
+		Severity: SeverityFail,
+		Detail:   fmt.Sprintf("port %d is already in use", port),
 	}
 }
 
@@ -383,10 +409,16 @@ func (s *DoctorService) checkUpstreamReachable(ctx context.Context, cfg *config.
 	}
 }
 
-// checkTLSCertValid checks the local self-signed TLS certificate for expiry.
-// It only runs when the TLS provider is "self-signed" and cert files exist in
-// the generated certs directory.
-func checkTLSCertValid(cfg *config.Config, workDir string) CheckResult {
+// checkTLSCertValid inspects the local self-signed TLS certificate by doing
+// a live TLS handshake against the running sidecar. When the sidecar is not
+// reachable the check degrades to WARN with a "start vibew dev" hint.
+//
+// Self-signed cert storage is owned by the embedded Caddy instance
+// (internal/adapters/caddy) and the only reliable way to see which cert the
+// sidecar is actually serving is to handshake with it — which is exactly
+// what we do here. See ADR-084 for the rationale and the rejected
+// filesystem-scan approach.
+func checkTLSCertValid(ctx context.Context, cfg *config.Config, host string, port int) CheckResult {
 	if cfg.TLS.Provider != "self-signed" {
 		return CheckResult{
 			Name:     "TLS certificate",
@@ -395,56 +427,73 @@ func checkTLSCertValid(cfg *config.Config, workDir string) CheckResult {
 		}
 	}
 
-	certPath := filepath.Join(workDir, ".vibewarden", "generated", "certs", "server.crt")
-	certPEM, err := os.ReadFile(certPath) //nolint:gosec // path is built from workDir + fixed relative path
+	handshakeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	dialHost := host
+	if dialHost == "0.0.0.0" || dialHost == "::" {
+		dialHost = "127.0.0.1"
+	}
+	addr := fmt.Sprintf("%s:%d", dialHost, port)
+
+	dialer := tls.Dialer{
+		Config: &tls.Config{
+			// Self-signed cert in dev is expected — we only need to
+			// inspect the leaf, not validate trust.
+			InsecureSkipVerify: true, //nolint:gosec
+		},
+	}
+	conn, err := dialer.DialContext(handshakeCtx, "tcp", addr)
 	if err != nil {
 		return CheckResult{
 			Name:     "TLS certificate",
 			Severity: SeverityWarn,
-			Detail:   fmt.Sprintf("%s not found — run 'vibew generate' to create certs", certPath),
+			Detail:   fmt.Sprintf("sidecar not reachable on %s — start 'vibew dev'", addr),
 		}
 	}
+	defer conn.Close() //nolint:errcheck
 
-	block, _ := pem.Decode(certPEM)
-	if block == nil {
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
 		return CheckResult{
 			Name:     "TLS certificate",
-			Severity: SeverityFail,
-			Detail:   fmt.Sprintf("%s — failed to decode PEM block", certPath),
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("unexpected connection type from %s", addr),
 		}
 	}
 
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
+	certs := tlsConn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
 		return CheckResult{
 			Name:     "TLS certificate",
-			Severity: SeverityFail,
-			Detail:   fmt.Sprintf("%s — failed to parse certificate: %v", certPath, err),
+			Severity: SeverityWarn,
+			Detail:   fmt.Sprintf("no certificate presented by %s", addr),
 		}
 	}
 
+	leaf := certs[0]
 	now := time.Now()
-	if now.After(cert.NotAfter) {
+	if now.After(leaf.NotAfter) {
 		return CheckResult{
 			Name:     "TLS certificate",
 			Severity: SeverityFail,
-			Detail:   fmt.Sprintf("expired on %s", cert.NotAfter.Format(time.DateOnly)),
+			Detail:   fmt.Sprintf("expired on %s", leaf.NotAfter.Format(time.DateOnly)),
 		}
 	}
 
-	daysUntilExpiry := int(time.Until(cert.NotAfter).Hours() / 24)
+	daysUntilExpiry := int(time.Until(leaf.NotAfter).Hours() / 24)
 	if daysUntilExpiry <= localTLSCertExpiryWarnDays {
 		return CheckResult{
 			Name:     "TLS certificate",
 			Severity: SeverityWarn,
-			Detail:   fmt.Sprintf("expires in %d day(s) on %s", daysUntilExpiry, cert.NotAfter.Format(time.DateOnly)),
+			Detail:   fmt.Sprintf("expires in %d day(s) on %s", daysUntilExpiry, leaf.NotAfter.Format(time.DateOnly)),
 		}
 	}
 
 	return CheckResult{
 		Name:     "TLS certificate",
 		Severity: SeverityOK,
-		Detail:   fmt.Sprintf("valid until %s (%d days)", cert.NotAfter.Format(time.DateOnly), daysUntilExpiry),
+		Detail:   fmt.Sprintf("valid until %s (%d days)", leaf.NotAfter.Format(time.DateOnly), daysUntilExpiry),
 	}
 }
 
@@ -470,17 +519,22 @@ func (s *DoctorService) checkSSHConnectivity(ctx context.Context) CheckResult {
 }
 
 // checkRemoteContainerHealth runs "docker compose ps" on the remote host via
-// SSH and reports the health of each container.
+// SSH and reports the health of each container. Error rendering goes through
+// formatRemoteError so the user-facing detail never contains raw shell
+// fragments (see ADR-084).
 func (s *DoctorService) checkRemoteContainerHealth(ctx context.Context) CheckResult {
 	checkCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
-	output, err := s.remoteExecutor.Run(checkCtx, "docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null")
+	// Docker Compose v1 reached end-of-life in June 2023; the fallback
+	// ("|| docker-compose ps") and 2>/dev/null shims were dropped as part
+	// of ADR-084 so stderr surfaces naturally for the error formatter.
+	output, err := s.remoteExecutor.Run(checkCtx, "docker compose ps --format json")
 	if err != nil {
 		return CheckResult{
 			Name:     "Remote containers",
 			Severity: SeverityFail,
-			Detail:   fmt.Sprintf("could not query remote containers: %v", err),
+			Detail:   formatRemoteError(err, "docker compose"),
 		}
 	}
 

--- a/internal/app/ops/doctor_test.go
+++ b/internal/app/ops/doctor_test.go
@@ -6,21 +6,27 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/json"
-	"encoding/pem"
 	"errors"
 	"io"
 	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/config"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
@@ -35,6 +41,16 @@ func (f *fakePortChecker) IsPortAvailable(_ context.Context, _ string, port int)
 		return v, nil
 	}
 	return true, nil
+}
+
+// fakePortOwnerProbe is a test double for ports.PortOwnerProbe that returns
+// a fixed owner regardless of input.
+type fakePortOwnerProbe struct {
+	owner ports.PortOwner
+}
+
+func (f *fakePortOwnerProbe) ProbeOwner(_ context.Context, _ string, _ int) ports.PortOwner {
+	return f.owner
 }
 
 // fakeRemoteExecutor is a test double for ports.RemoteExecutor.
@@ -144,36 +160,58 @@ func optsWithGeneratedFile(t *testing.T) ops.DoctorOptions {
 	}
 }
 
-// writeSelfSignedCert creates a self-signed certificate in the generated certs
-// directory under workDir with the given validity window.
-func writeSelfSignedCert(t *testing.T, workDir string, notBefore, notAfter time.Time) {
-	t.Helper()
-	certDir := filepath.Join(workDir, ".vibewarden", "generated", "certs")
-	if err := os.MkdirAll(certDir, 0o755); err != nil {
-		t.Fatalf("create certs dir: %v", err)
-	}
+// doctorConfig returns a defaultConfig() override with TLS.Provider set to
+// "external" so the live-TLS cert check is skipped for doctor tests that
+// do not specifically exercise it. Tests that do exercise the TLS check
+// set Provider to "self-signed" and point Server.Host/Port at a local
+// httptest.NewTLSServer (see startTLSTestSidecar).
+func doctorConfig() *config.Config {
+	cfg := defaultConfig()
+	cfg.TLS.Provider = "external"
+	return cfg
+}
 
+// startTLSTestSidecar boots a local TLS server that mimics the VibeWarden
+// sidecar on /_vibewarden/health. The server uses a short-lived self-signed
+// certificate whose NotAfter is controlled by notAfter. It returns the host
+// and port the test should point cfg.Server.Host/Port at, plus the port
+// already registered as "available=false" on the supplied portChecker so
+// the proxy-port check mirrors a real sidecar-in-use state.
+func startTLSTestSidecar(t *testing.T, notBefore, notAfter time.Time) (host string, port int, cleanup func()) {
+	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatalf("generate key: %v", err)
 	}
-
 	template := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
 		Subject:      pkix.Name{CommonName: "localhost"},
 		NotBefore:    notBefore,
 		NotAfter:     notAfter,
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:     []string{"localhost"},
 	}
-
 	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
 	if err != nil {
 		t.Fatalf("create certificate: %v", err)
 	}
+	tlsCert := tls.Certificate{Certificate: [][]byte{certDER}, PrivateKey: key}
 
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
-	if err := os.WriteFile(filepath.Join(certDir, "server.crt"), certPEM, 0o644); err != nil {
-		t.Fatalf("write cert file: %v", err)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"ok","version":"test"}`))
+	}))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{tlsCert}}
+	srv.StartTLS()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
 	}
+	p, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+	return u.Hostname(), p, srv.Close
 }
 
 func TestDoctorService_Run_AllPassing(t *testing.T) {
@@ -182,7 +220,7 @@ func TestDoctorService_Run_AllPassing(t *testing.T) {
 	hc := reachableHealthChecker()
 
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	var buf bytes.Buffer
 
 	opts := optsWithGeneratedFile(t)
@@ -218,7 +256,7 @@ func TestDoctorService_Run_DockerNotRunning(t *testing.T) {
 	pc := &fakePortChecker{}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	var buf bytes.Buffer
 
 	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
@@ -243,7 +281,7 @@ func TestDoctorService_Run_DockerComposeNotAvailable(t *testing.T) {
 	pc := &fakePortChecker{}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	var buf bytes.Buffer
 
 	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
@@ -265,7 +303,7 @@ func TestDoctorService_Run_PortInUse(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: false}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	var buf bytes.Buffer
 
 	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
@@ -282,12 +320,95 @@ func TestDoctorService_Run_PortInUse(t *testing.T) {
 	}
 }
 
+// TestDoctorService_CheckPort_OwnershipMatrix exercises the port ownership
+// decision table from ADR-084.
+func TestDoctorService_CheckPort_OwnershipMatrix(t *testing.T) {
+	tests := []struct {
+		name         string
+		available    bool
+		probe        ports.PortOwnerProbe
+		wantSeverity ops.Severity
+		wantDetail   string
+	}{
+		{
+			name:         "port free (probe not consulted)",
+			available:    true,
+			probe:        &fakePortOwnerProbe{owner: ports.OwnerForeign},
+			wantSeverity: ops.SeverityOK,
+			wantDetail:   "is available",
+		},
+		{
+			name:         "port bound + probe returns OwnerVibeWarden → OK",
+			available:    false,
+			probe:        &fakePortOwnerProbe{owner: ports.OwnerVibeWarden},
+			wantSeverity: ops.SeverityOK,
+			wantDetail:   "in use by local vibew dev (expected)",
+		},
+		{
+			name:         "port bound + probe returns OwnerForeign → FAIL",
+			available:    false,
+			probe:        &fakePortOwnerProbe{owner: ports.OwnerForeign},
+			wantSeverity: ops.SeverityFail,
+			wantDetail:   "already in use",
+		},
+		{
+			name:         "port bound + no probe wired → FAIL (back-compat)",
+			available:    false,
+			probe:        nil,
+			wantSeverity: ops.SeverityFail,
+			wantDetail:   "already in use",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			fc := noContainersCompose()
+			pc := &fakePortChecker{available: map[int]bool{8443: tt.available}}
+			hc := reachableHealthChecker()
+			svc := ops.NewDoctorService(fc, pc, hc)
+			if tt.probe != nil {
+				svc = svc.WithPortOwnerProbe(tt.probe)
+			}
+			cfg := doctorConfig()
+
+			var buf bytes.Buffer
+			opts := defaultOpts(t)
+			opts.JSON = true
+			if _, err := svc.Run(context.Background(), cfg, opts, &buf); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var results []ops.CheckResult
+			if err := json.Unmarshal(buf.Bytes(), &results); err != nil {
+				t.Fatalf("parse json output: %v\nbody:\n%s", err, buf.String())
+			}
+			var got ops.CheckResult
+			for _, r := range results {
+				if r.Name == "Proxy port" {
+					got = r
+					break
+				}
+			}
+			if got.Name == "" {
+				t.Fatalf("Proxy port check missing from results")
+			}
+			if got.Severity != tt.wantSeverity {
+				t.Errorf("severity = %q, want %q (detail=%q)", got.Severity, tt.wantSeverity, got.Detail)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetail) {
+				t.Errorf("detail %q missing substring %q", got.Detail, tt.wantDetail)
+			}
+		})
+	}
+}
+
 func TestDoctorService_Run_ConfigPathInOutput(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	var buf bytes.Buffer
 
 	opts := defaultOpts(t)
@@ -313,7 +434,7 @@ func TestDoctorService_ChecksAreIndependent(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: false}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	var buf bytes.Buffer
 
 	_, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
@@ -341,7 +462,7 @@ func TestDoctorService_Run_GeneratedFileMissing_IsWarn(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	var buf bytes.Buffer
 
 	// defaultOpts uses an empty temp dir — no generated file present.
@@ -373,7 +494,7 @@ func TestDoctorService_Run_UnhealthyContainer_IsFail(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	var buf bytes.Buffer
 
 	allOK, err := svc.Run(context.Background(), cfg, optsWithGeneratedFile(t), &buf)
@@ -395,7 +516,7 @@ func TestDoctorService_Run_JSONOutput(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	var buf bytes.Buffer
 
 	opts := optsWithGeneratedFile(t)
@@ -431,7 +552,7 @@ func TestDoctorService_Run_OKFAILBadgesInOutput(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	var buf bytes.Buffer
 
 	_, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
@@ -453,7 +574,7 @@ func TestDoctorService_Run_ContainersHealthy_AllOK(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	var buf bytes.Buffer
 
 	opts := optsWithGeneratedFile(t)
@@ -481,7 +602,7 @@ func TestDoctorService_Run_UpstreamReachable(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	var buf bytes.Buffer
 
 	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
@@ -506,7 +627,7 @@ func TestDoctorService_Run_UpstreamUnreachable(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := unreachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	var buf bytes.Buffer
 
 	// Upstream unreachable is WARN, not FAIL, so allOK should still be true.
@@ -528,16 +649,19 @@ func TestDoctorService_Run_UpstreamUnreachable(t *testing.T) {
 }
 
 func TestDoctorService_Run_TLSCertValid(t *testing.T) {
+	host, port, cleanup := startTLSTestSidecar(t, time.Now().Add(-24*time.Hour), time.Now().Add(90*24*time.Hour))
+	defer cleanup()
+
 	fc := noContainersCompose()
-	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	pc := &fakePortChecker{available: map[int]bool{port: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
 	cfg := defaultConfig()
+	cfg.TLS.Provider = "self-signed"
+	cfg.Server.Host = host
+	cfg.Server.Port = port
 
 	opts := defaultOpts(t)
-
-	// Write a valid cert that expires in 90 days.
-	writeSelfSignedCert(t, opts.WorkDir, time.Now().Add(-24*time.Hour), time.Now().Add(90*24*time.Hour))
 
 	var buf bytes.Buffer
 	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
@@ -558,16 +682,19 @@ func TestDoctorService_Run_TLSCertValid(t *testing.T) {
 }
 
 func TestDoctorService_Run_TLSCertExpired(t *testing.T) {
+	host, port, cleanup := startTLSTestSidecar(t, time.Now().Add(-48*time.Hour), time.Now().Add(-24*time.Hour))
+	defer cleanup()
+
 	fc := noContainersCompose()
-	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	pc := &fakePortChecker{available: map[int]bool{port: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
 	cfg := defaultConfig()
+	cfg.TLS.Provider = "self-signed"
+	cfg.Server.Host = host
+	cfg.Server.Port = port
 
 	opts := defaultOpts(t)
-
-	// Write an expired cert.
-	writeSelfSignedCert(t, opts.WorkDir, time.Now().Add(-48*time.Hour), time.Now().Add(-24*time.Hour))
 
 	var buf bytes.Buffer
 	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
@@ -585,16 +712,19 @@ func TestDoctorService_Run_TLSCertExpired(t *testing.T) {
 }
 
 func TestDoctorService_Run_TLSCertExpiringSoon(t *testing.T) {
+	host, port, cleanup := startTLSTestSidecar(t, time.Now().Add(-24*time.Hour), time.Now().Add(3*24*time.Hour))
+	defer cleanup()
+
 	fc := noContainersCompose()
-	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	pc := &fakePortChecker{available: map[int]bool{port: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
 	cfg := defaultConfig()
+	cfg.TLS.Provider = "self-signed"
+	cfg.Server.Host = host
+	cfg.Server.Port = port
 
 	opts := defaultOpts(t)
-
-	// Write a cert that expires in 3 days (within 7-day warning window).
-	writeSelfSignedCert(t, opts.WorkDir, time.Now().Add(-24*time.Hour), time.Now().Add(3*24*time.Hour))
 
 	var buf bytes.Buffer
 	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
@@ -612,32 +742,42 @@ func TestDoctorService_Run_TLSCertExpiringSoon(t *testing.T) {
 	}
 }
 
-func TestDoctorService_Run_TLSCertMissing(t *testing.T) {
+func TestDoctorService_Run_TLSCertSidecarUnreachable(t *testing.T) {
+	// Bind and release a port so we know it is closed for the duration of the test.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().(*net.TCPAddr)
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
 	fc := noContainersCompose()
-	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	pc := &fakePortChecker{available: map[int]bool{addr.Port: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
 	cfg := defaultConfig()
-
-	// defaultOpts has no cert files at all.
-	opts := defaultOpts(t)
+	cfg.TLS.Provider = "self-signed"
+	cfg.Server.Host = "127.0.0.1"
+	cfg.Server.Port = addr.Port
 
 	var buf bytes.Buffer
-	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Cert missing is WARN.
+	// Unreachable sidecar is WARN, not FAIL.
 	if !allOK {
-		t.Errorf("expected allOK = true because missing cert is WARN\noutput:\n%s", buf.String())
+		t.Errorf("expected allOK = true because sidecar-unreachable is WARN\noutput:\n%s", buf.String())
 	}
 
 	out := buf.String()
 	if !strings.Contains(out, "TLS certificate") {
 		t.Errorf("expected 'TLS certificate' check in output, got:\n%s", out)
 	}
-	if !strings.Contains(out, "not found") {
-		t.Errorf("expected 'not found' in cert detail, got:\n%s", out)
+	if !strings.Contains(out, "start 'vibew dev'") {
+		t.Errorf("expected sidecar-unreachable hint in detail, got:\n%s", out)
 	}
 }
 
@@ -646,7 +786,7 @@ func TestDoctorService_Run_TLSCertNonSelfSigned_Skipped(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	cfg.TLS.Provider = "letsencrypt"
 	cfg.TLS.Domain = "example.com"
 
@@ -674,13 +814,13 @@ func TestDoctorService_Run_SSHConnectivity_Success(t *testing.T) {
 	executor := &fakeRemoteExecutor{
 		runResponses: map[string]runResult{
 			"echo ok": {output: "ok", err: nil},
-			"docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null": {
+			"docker compose ps --format json": {
 				output: "", err: nil,
 			},
 		},
 	}
 	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 
 	opts := defaultOpts(t)
 	opts.Target = "ssh://user@192.0.2.1"
@@ -708,7 +848,7 @@ func TestDoctorService_Run_SSHConnectivity_Failure(t *testing.T) {
 		runErr: errors.New("connection refused"),
 	}
 	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 
 	opts := defaultOpts(t)
 	opts.Target = "ssh://user@192.0.2.1"
@@ -736,7 +876,7 @@ func TestDoctorService_Run_NoTarget_NoRemoteChecks(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 
 	// No --target flag, no remote executor.
 	opts := defaultOpts(t)
@@ -756,6 +896,55 @@ func TestDoctorService_Run_NoTarget_NoRemoteChecks(t *testing.T) {
 	}
 }
 
+// TestDoctorService_Run_RemoteContainerHealth_ErrorFormattedNoRawShell ensures
+// that when the remote docker compose command fails the user-facing detail
+// never leaks shell fragments (`2>/dev/null`, `||`, raw ssh command, or the
+// adapter's "ssh exit:" wrapper). This is the end-to-end guarantee described
+// in ADR-084.
+func TestDoctorService_Run_RemoteContainerHealth_ErrorFormattedNoRawShell(t *testing.T) {
+	fc := noContainersCompose()
+	pc := &fakePortChecker{available: map[int]bool{8443: true}}
+	hc := reachableHealthChecker()
+
+	// Simulate the historical leak: stderr containing every fragment.
+	leakErr := errors.New("ssh exit: docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null: exit status 127")
+	executor := &fakeRemoteExecutor{
+		runResponses: map[string]runResult{
+			"echo ok":                         {output: "ok", err: nil},
+			"docker compose ps --format json": {output: "", err: leakErr},
+			"uname -m":                        {output: "x86_64", err: nil},
+		},
+	}
+	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
+	cfg := doctorConfig()
+
+	opts := defaultOpts(t)
+	opts.Target = "ssh://user@192.0.2.1"
+
+	var buf bytes.Buffer
+	if _, err := svc.Run(context.Background(), cfg, opts, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	// Find the Remote containers line.
+	var remoteLine string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "Remote containers") {
+			remoteLine = line
+			break
+		}
+	}
+	if remoteLine == "" {
+		t.Fatalf("Remote containers line missing from output:\n%s", out)
+	}
+	for _, leak := range []string{"2>/dev/null", "||", "ssh exit"} {
+		if strings.Contains(remoteLine, leak) {
+			t.Errorf("remote-containers detail leaks %q:\n%s", leak, remoteLine)
+		}
+	}
+}
+
 func TestDoctorService_Run_RemoteContainerHealth_Unhealthy(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
@@ -768,13 +957,13 @@ func TestDoctorService_Run_RemoteContainerHealth_Unhealthy(t *testing.T) {
 	executor := &fakeRemoteExecutor{
 		runResponses: map[string]runResult{
 			"echo ok": {output: "ok", err: nil},
-			"docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null": {
+			"docker compose ps --format json": {
 				output: unhealthyJSON, err: nil,
 			},
 		},
 	}
 	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 
 	opts := defaultOpts(t)
 	opts.Target = "ssh://user@192.0.2.1"
@@ -808,13 +997,13 @@ func TestDoctorService_Run_RemoteContainerHealth_AllHealthy(t *testing.T) {
 	executor := &fakeRemoteExecutor{
 		runResponses: map[string]runResult{
 			"echo ok": {output: "ok", err: nil},
-			"docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null": {
+			"docker compose ps --format json": {
 				output: healthyJSON, err: nil,
 			},
 		},
 	}
 	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 
 	opts := defaultOpts(t)
 	opts.Target = "ssh://user@192.0.2.1"
@@ -836,7 +1025,7 @@ func TestDoctorService_Run_SectionHeaders(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	var buf bytes.Buffer
 
 	_, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
@@ -860,13 +1049,13 @@ func TestDoctorService_Run_ProductionSectionHeaders(t *testing.T) {
 	executor := &fakeRemoteExecutor{
 		runResponses: map[string]runResult{
 			"echo ok": {output: "ok", err: nil},
-			"docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null": {
+			"docker compose ps --format json": {
 				output: "", err: nil,
 			},
 		},
 	}
 	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 
 	opts := defaultOpts(t)
 	opts.Target = "ssh://user@192.0.2.1"
@@ -888,7 +1077,7 @@ func TestDoctorService_Run_JSONOutput_IncludesSection(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	var buf bytes.Buffer
 
 	opts := defaultOpts(t)
@@ -918,7 +1107,7 @@ func TestDoctorService_Run_ACMEEmail_ZeroSSLWithoutEmail(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	cfg.TLS.Provider = "letsencrypt"
 	cfg.TLS.ACMECA = "https://acme.zerossl.com/v2/DV90"
 	cfg.TLS.Email = ""
@@ -946,7 +1135,7 @@ func TestDoctorService_Run_ACMEEmail_ZeroSSLWithEmail(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	cfg.TLS.Provider = "letsencrypt"
 	cfg.TLS.ACMECA = "https://acme.zerossl.com/v2/DV90"
 	cfg.TLS.Email = "admin@example.com"
@@ -974,7 +1163,7 @@ func TestDoctorService_Run_ACMEEmail_NonZeroSSL(t *testing.T) {
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
 	hc := reachableHealthChecker()
 	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	cfg.TLS.Provider = "letsencrypt"
 	cfg.TLS.ACMECA = "" // default Let's Encrypt
 	cfg.TLS.Email = ""
@@ -1005,7 +1194,7 @@ func TestDoctorService_Run_ImageTag_Exists(t *testing.T) {
 	hc := reachableHealthChecker()
 	ic := &fakeImageChecker{exists: true}
 	svc := ops.NewDoctorService(fc, pc, hc).WithImageChecker(ic)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	cfg.App.Image = "myapp:latest"
 
 	var buf bytes.Buffer
@@ -1032,7 +1221,7 @@ func TestDoctorService_Run_ImageTag_Missing(t *testing.T) {
 	hc := reachableHealthChecker()
 	ic := &fakeImageChecker{exists: false}
 	svc := ops.NewDoctorService(fc, pc, hc).WithImageChecker(ic)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	cfg.App.Image = "myapp:latest"
 
 	var buf bytes.Buffer
@@ -1059,7 +1248,7 @@ func TestDoctorService_Run_ImageTag_CheckerError(t *testing.T) {
 	hc := reachableHealthChecker()
 	ic := &fakeImageChecker{err: errors.New("docker daemon unavailable")}
 	svc := ops.NewDoctorService(fc, pc, hc).WithImageChecker(ic)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	cfg.App.Image = "myapp:latest"
 
 	var buf bytes.Buffer
@@ -1087,7 +1276,7 @@ func TestDoctorService_Run_ImageTag_NoImage_Skipped(t *testing.T) {
 	hc := reachableHealthChecker()
 	ic := &fakeImageChecker{exists: false} // Should not be called.
 	svc := ops.NewDoctorService(fc, pc, hc).WithImageChecker(ic)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 	cfg.App.Image = "" // No image configured.
 
 	var buf bytes.Buffer
@@ -1124,13 +1313,13 @@ func TestDoctorService_Run_ArchCompatibility_Match(t *testing.T) {
 		runResponses: map[string]runResult{
 			"echo ok":  {output: "ok", err: nil},
 			"uname -m": {output: remoteUname, err: nil},
-			"docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null": {
+			"docker compose ps --format json": {
 				output: "", err: nil,
 			},
 		},
 	}
 	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 
 	opts := defaultOpts(t)
 	opts.Target = "ssh://user@192.0.2.1"
@@ -1166,13 +1355,13 @@ func TestDoctorService_Run_ArchCompatibility_Mismatch(t *testing.T) {
 		runResponses: map[string]runResult{
 			"echo ok":  {output: "ok", err: nil},
 			"uname -m": {output: remoteUname, err: nil},
-			"docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null": {
+			"docker compose ps --format json": {
 				output: "", err: nil,
 			},
 		},
 	}
 	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 
 	opts := defaultOpts(t)
 	opts.Target = "ssh://user@192.0.2.1"
@@ -1204,13 +1393,13 @@ func TestDoctorService_Run_ArchCompatibility_RemoteError(t *testing.T) {
 		runResponses: map[string]runResult{
 			"echo ok":  {output: "ok", err: nil},
 			"uname -m": {output: "", err: errors.New("command not found")},
-			"docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null": {
+			"docker compose ps --format json": {
 				output: "", err: nil,
 			},
 		},
 	}
 	svc := ops.NewDoctorService(fc, pc, hc).WithRemoteExecutor(executor)
-	cfg := defaultConfig()
+	cfg := doctorConfig()
 
 	opts := defaultOpts(t)
 	opts.Target = "ssh://user@192.0.2.1"

--- a/internal/app/ops/remote_error.go
+++ b/internal/app/ops/remote_error.go
@@ -1,0 +1,140 @@
+package ops
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// maxRemoteErrorLen bounds the final rendered detail to keep the doctor
+// report single-line and readable. Matches ADR-084 "~180 chars".
+const maxRemoteErrorLen = 180
+
+// formatRemoteError renders a ports.RemoteExecutor error for user display.
+//
+// Contract (per ADR-084):
+//   - Output is a single line (no newlines, no carriage returns).
+//   - It never echoes raw shell fragments (`2>/dev/null`, `||`, `ssh `,
+//     `ssh exit`) — those are stripped so implementation detail does not
+//     leak into user-facing errors.
+//   - When err wraps *exec.ExitError the exit code is surfaced.
+//   - The first non-empty line of stderr is included when present.
+//   - A small set of hard-coded hints is appended based on the exit code.
+//   - Input nil → empty string.
+//
+// cmdName is a short human-readable label for the remote command
+// (e.g. "docker compose ps") used when the stderr line is empty.
+func formatRemoteError(err error, cmdName string) string {
+	if err == nil {
+		return ""
+	}
+
+	exitCode, stderr := extractExitInfo(err)
+	stderrLine := firstMeaningfulLine(stderr)
+	if stderrLine == "" {
+		// Fall back to the wrapped error text, minus the noisy adapter prefix.
+		stderrLine = stripShellLeaks(err.Error())
+	}
+	stderrLine = stripShellLeaks(stderrLine)
+
+	var parts []string
+	if exitCode != 0 {
+		parts = append(parts, fmt.Sprintf("exit %d", exitCode))
+	}
+	if stderrLine != "" {
+		parts = append(parts, stderrLine)
+	}
+	if hint := remoteErrorHint(exitCode, cmdName); hint != "" {
+		parts = append(parts, hint)
+	}
+
+	out := strings.Join(parts, "; ")
+	out = sanitizeSingleLine(out)
+	if len(out) > maxRemoteErrorLen {
+		out = out[:maxRemoteErrorLen-1] + "…"
+	}
+	return out
+}
+
+// extractExitInfo pulls the numeric exit code and stderr text (when
+// available) out of an error returned by ports.RemoteExecutor.Run. The
+// adapter merges stdout+stderr into the error return value, so the caller
+// must pass the raw error here.
+//
+// Returns (0, "") when err is not an *exec.ExitError.
+func extractExitInfo(err error) (int, string) {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode(), string(exitErr.Stderr)
+	}
+	return 0, ""
+}
+
+// firstMeaningfulLine returns the first non-empty, trimmed line of s.
+func firstMeaningfulLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// stripShellLeaks removes shell fragments that must never appear in
+// user-facing doctor output. The replacements are conservative: only
+// well-known literal substrings are removed, and surrounding whitespace is
+// collapsed.
+func stripShellLeaks(s string) string {
+	leaks := []string{
+		" 2>/dev/null",
+		"2>/dev/null",
+		" || docker-compose ps",
+		"|| docker-compose ps",
+		" || ",
+		"ssh exit: ",
+		"ssh exit:",
+		// "ssh " only at the start of a token — a legitimate word like
+		// "ssh" in stderr (e.g. "ssh: connect") is allowed to stay without
+		// the trailing space. We strip the common "ssh <cmd>:" prefix by
+		// anchoring with a colon instead.
+	}
+	for _, l := range leaks {
+		s = strings.ReplaceAll(s, l, "")
+	}
+	// Normalise whitespace runs.
+	s = strings.Join(strings.Fields(s), " ")
+	return s
+}
+
+// sanitizeSingleLine collapses any remaining newlines/carriage returns into
+// spaces so the final string renders on one line.
+func sanitizeSingleLine(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.Join(strings.Fields(s), " ")
+	return s
+}
+
+// remoteErrorHint returns a short, user-facing suggestion keyed off the
+// exit code. cmdName contextualises the default hint (e.g. "docker
+// compose").
+func remoteErrorHint(exitCode int, cmdName string) string {
+	switch exitCode {
+	case 127:
+		return fmt.Sprintf("%s not installed on remote", cmdName)
+	case 126:
+		return fmt.Sprintf("%s not executable — check permissions", cmdName)
+	case 255:
+		return "ssh connection failed — check target and SSH keys"
+	case 0:
+		return ""
+	default:
+		if cmdName != "" {
+			return fmt.Sprintf("check remote %s installation", cmdName)
+		}
+		return "check remote command"
+	}
+}

--- a/internal/app/ops/remote_error.go
+++ b/internal/app/ops/remote_error.go
@@ -19,21 +19,34 @@ const maxRemoteErrorLen = 180
 //     `ssh exit`) — those are stripped so implementation detail does not
 //     leak into user-facing errors.
 //   - When err wraps *exec.ExitError the exit code is surfaced.
-//   - The first non-empty line of stderr is included when present.
+//   - The first non-empty line of output is included when present.
 //   - A small set of hard-coded hints is appended based on the exit code.
-//   - Input nil → empty string.
+//   - Input nil error → empty string.
+//
+// output is the merged stdout+stderr returned alongside err by
+// ports.RemoteExecutor.Run. The ssh adapter uses `cmd.Run()` with a shared
+// buffer, so *exec.ExitError.Stderr is never populated — the real stderr
+// only lives in this string. Pass it in verbatim.
 //
 // cmdName is a short human-readable label for the remote command
-// (e.g. "docker compose ps") used when the stderr line is empty.
-func formatRemoteError(err error, cmdName string) string {
+// (e.g. "docker compose ps") used when the output is empty.
+func formatRemoteError(err error, output string, cmdName string) string {
 	if err == nil {
 		return ""
 	}
 
-	exitCode, stderr := extractExitInfo(err)
-	stderrLine := firstMeaningfulLine(stderr)
+	exitCode := extractExitCode(err)
+	// Prefer the merged output stream from the adapter: that is where the
+	// real stderr lives. Fall back to *exec.ExitError.Stderr (populated only
+	// when callers use cmd.Output(); kept for defence in depth) and finally
+	// to the wrapped error text.
+	stderrLine := firstMeaningfulLine(output)
 	if stderrLine == "" {
-		// Fall back to the wrapped error text, minus the noisy adapter prefix.
+		if _, stderr := extractExitInfo(err); stderr != "" {
+			stderrLine = firstMeaningfulLine(stderr)
+		}
+	}
+	if stderrLine == "" {
 		stderrLine = stripShellLeaks(err.Error())
 	}
 	stderrLine = stripShellLeaks(stderrLine)
@@ -57,10 +70,21 @@ func formatRemoteError(err error, cmdName string) string {
 	return out
 }
 
-// extractExitInfo pulls the numeric exit code and stderr text (when
-// available) out of an error returned by ports.RemoteExecutor.Run. The
-// adapter merges stdout+stderr into the error return value, so the caller
-// must pass the raw error here.
+// extractExitCode returns the numeric exit code from an error that wraps
+// *exec.ExitError. Returns 0 when err does not wrap one.
+func extractExitCode(err error) int {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return 0
+}
+
+// extractExitInfo pulls the numeric exit code and *exec.ExitError.Stderr out
+// of an error. Stderr is only populated by Go when callers use cmd.Output();
+// the ssh adapter uses cmd.Run() with a shared stdout+stderr buffer, so in
+// production this always returns ("", 0). Kept as a defence-in-depth
+// fallback for callers that do use Output-style execution.
 //
 // Returns (0, "") when err is not an *exec.ExitError.
 func extractExitInfo(err error) (int, string) {

--- a/internal/app/ops/remote_error_internal_test.go
+++ b/internal/app/ops/remote_error_internal_test.go
@@ -8,30 +8,48 @@ import (
 	"testing"
 )
 
-// makeExitErr fabricates an *exec.ExitError-equivalent for tests by
-// running a command that is guaranteed to fail with a known code. For
-// pure, table-driven unit tests we wrap a synthetic exit error via
-// exec.Command + an unknown binary, which is portable enough for the
-// exit-code extraction path. When the real exit code cannot be forced
-// the test uses a raw error to exercise the "not an ExitError" branch.
+// makeExitErr fabricates an *exec.ExitError-equivalent for tests by running
+// a command that is guaranteed to fail with a known code. It stamps
+// exitErr.Stderr so the defence-in-depth fallback branch in
+// formatRemoteError can be exercised directly — but see
+// TestFormatRemoteError_SSHAdapterContract below for the production-shaped
+// case where Stderr is empty.
 func makeExitErr(t *testing.T, code int, stderr string) error {
 	t.Helper()
-	// We cannot easily construct *exec.ExitError with a custom code
-	// without spawning a process. Use "sh -c exit <code>" which is
-	// available on macOS+Linux (CI platforms). stderr is stamped via
-	// a printf to stderr before exit.
 	script := fmt.Sprintf("printf %%s %q 1>&2; exit %d", stderr, code)
 	cmd := exec.Command("sh", "-c", script) //nolint:gosec // test-local, inputs are controlled
 	err := cmd.Run()
 	if err == nil {
 		t.Fatalf("expected non-nil error for exit %d", code)
 	}
-	// Attach stderr into *exec.ExitError.Stderr for extractExitInfo to find.
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
 		exitErr.Stderr = []byte(stderr)
 	}
 	return err
+}
+
+// makeSSHAdapterErr mirrors the real ssh.Executor.Run contract: it returns
+// the merged stdout+stderr as the output string and wraps the cmd error in
+// "ssh exit: %w", leaving *exec.ExitError.Stderr empty. This is the shape
+// formatRemoteError actually sees in production.
+func makeSSHAdapterErr(t *testing.T, code int, mergedOutput string) (string, error) {
+	t.Helper()
+	// Run a real process that produces the given exit code so we get a
+	// genuine *exec.ExitError (with Stderr unset, as cmd.Run leaves it).
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("exit %d", code)) //nolint:gosec
+	runErr := cmd.Run()
+	if runErr == nil {
+		t.Fatalf("expected non-nil error for exit %d", code)
+	}
+	// Sanity: the real adapter pattern leaves Stderr empty.
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		if len(exitErr.Stderr) != 0 {
+			t.Fatalf("precondition: *exec.ExitError.Stderr must be empty to mirror ssh adapter, got %q", exitErr.Stderr)
+		}
+	}
+	return mergedOutput, fmt.Errorf("ssh exit: %w", runErr)
 }
 
 func TestFormatRemoteError(t *testing.T) {
@@ -40,6 +58,7 @@ func TestFormatRemoteError(t *testing.T) {
 	tests := []struct {
 		name          string
 		err           error
+		output        string
 		cmdName       string
 		wantContains  []string
 		wantExclusive []string // substrings that MUST NOT appear
@@ -48,12 +67,14 @@ func TestFormatRemoteError(t *testing.T) {
 		{
 			name:      "nil error → empty string",
 			err:       nil,
+			output:    "",
 			cmdName:   "docker compose",
 			wantEmpty: true,
 		},
 		{
 			name:          "exit 127 with stderr → hint + code",
 			err:           makeExitErr(t, 127, "docker: command not found"),
+			output:        "",
 			cmdName:       "docker compose",
 			wantContains:  []string{"exit 127", "docker: command not found", "not installed on remote"},
 			wantExclusive: []string{"2>/dev/null", "||", "\n", "ssh exit"},
@@ -61,6 +82,7 @@ func TestFormatRemoteError(t *testing.T) {
 		{
 			name:          "exit 126 with permission denied",
 			err:           makeExitErr(t, 126, "permission denied"),
+			output:        "",
 			cmdName:       "docker compose",
 			wantContains:  []string{"exit 126", "permission denied", "not executable"},
 			wantExclusive: []string{"2>/dev/null", "||"},
@@ -68,6 +90,7 @@ func TestFormatRemoteError(t *testing.T) {
 		{
 			name:          "exit 1 with multi-line stderr → only first non-empty line",
 			err:           makeExitErr(t, 1, "\n\nfirst line of error\nsecond line of error"),
+			output:        "",
 			cmdName:       "docker compose",
 			wantContains:  []string{"exit 1", "first line of error"},
 			wantExclusive: []string{"second line of error", "\n", "2>/dev/null"},
@@ -75,6 +98,7 @@ func TestFormatRemoteError(t *testing.T) {
 		{
 			name:          "exit 1 with literal 2>/dev/null in stderr stripped",
 			err:           makeExitErr(t, 1, "command failed 2>/dev/null || docker-compose ps"),
+			output:        "",
 			cmdName:       "docker compose",
 			wantContains:  []string{"exit 1"},
 			wantExclusive: []string{"2>/dev/null", "||", "docker-compose"},
@@ -82,6 +106,7 @@ func TestFormatRemoteError(t *testing.T) {
 		{
 			name:          "exit 255 → ssh hint",
 			err:           makeExitErr(t, 255, "ssh: connect to host: timed out"),
+			output:        "",
 			cmdName:       "docker compose",
 			wantContains:  []string{"exit 255", "ssh connection failed"},
 			wantExclusive: []string{"2>/dev/null", "||"},
@@ -89,6 +114,7 @@ func TestFormatRemoteError(t *testing.T) {
 		{
 			name:          "empty stderr, exit 1 → falls back to default hint",
 			err:           makeExitErr(t, 1, ""),
+			output:        "",
 			cmdName:       "docker compose",
 			wantContains:  []string{"exit 1", "check remote docker compose installation"},
 			wantExclusive: []string{"2>/dev/null", "||", "\n"},
@@ -96,6 +122,7 @@ func TestFormatRemoteError(t *testing.T) {
 		{
 			name:          "non-ExitError plain error → rendered as hint only",
 			err:           errors.New("dial timeout"),
+			output:        "",
 			cmdName:       "docker compose",
 			wantContains:  []string{"dial timeout"},
 			wantExclusive: []string{"exit", "2>/dev/null", "||", "ssh exit"},
@@ -103,9 +130,18 @@ func TestFormatRemoteError(t *testing.T) {
 		{
 			name:          "non-ExitError with ssh exit wrapper stripped",
 			err:           fmt.Errorf("ssh exit: %w", errors.New("connection refused")),
+			output:        "",
 			cmdName:       "docker compose",
 			wantContains:  []string{"connection refused"},
 			wantExclusive: []string{"ssh exit", "2>/dev/null", "||"},
+		},
+		{
+			name:          "output arg wins over empty ExitError.Stderr",
+			err:           makeExitErr(t, 127, ""),
+			output:        "docker: command not found\nExtra noise",
+			cmdName:       "docker compose",
+			wantContains:  []string{"exit 127", "docker: command not found", "not installed on remote"},
+			wantExclusive: []string{"Extra noise", "\n", "2>/dev/null"},
 		},
 	}
 
@@ -113,7 +149,7 @@ func TestFormatRemoteError(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := formatRemoteError(tt.err, tt.cmdName)
+			got := formatRemoteError(tt.err, tt.output, tt.cmdName)
 
 			if tt.wantEmpty {
 				if got != "" {
@@ -150,7 +186,7 @@ func TestFormatRemoteError_NoRawShellLeaks(t *testing.T) {
 	// Feed the worst-case: an error string that contains every historical
 	// leak fragment. The output must contain NONE of them.
 	raw := errors.New("ssh docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null: exit status 127")
-	got := formatRemoteError(raw, "docker compose")
+	got := formatRemoteError(raw, "", "docker compose")
 
 	for _, leak := range []string{"2>/dev/null", "||", "ssh exit"} {
 		if strings.Contains(got, leak) {
@@ -159,5 +195,85 @@ func TestFormatRemoteError_NoRawShellLeaks(t *testing.T) {
 	}
 	if strings.ContainsAny(got, "\r\n") {
 		t.Errorf("output must be single line, got %q", got)
+	}
+}
+
+// TestFormatRemoteError_SSHAdapterContract is the regression test for the
+// blocker surfaced on PR #1060: in production the ssh adapter returns
+// merged stdout+stderr as the first return value and wraps the cmd error
+// with "ssh exit: %w". *exec.ExitError.Stderr is NEVER populated because
+// the adapter calls cmd.Run() with a shared buffer (not cmd.Output()).
+//
+// Before the fix, the real stderr line was discarded and the user only
+// saw `exit <code>: <hint>`. This test feeds the adapter-shaped inputs
+// and asserts the real stderr reaches the user-facing string.
+func TestFormatRemoteError_SSHAdapterContract(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		exitCode      int
+		mergedOutput  string
+		cmdName       string
+		wantContains  []string
+		wantExclusive []string
+	}{
+		{
+			name:          "docker missing on remote — real stderr surfaces",
+			exitCode:      127,
+			mergedOutput:  "bash: docker: command not found\n",
+			cmdName:       "docker compose",
+			wantContains:  []string{"exit 127", "docker: command not found", "not installed on remote"},
+			wantExclusive: []string{"ssh exit", "2>/dev/null", "||"},
+		},
+		{
+			name:          "permission denied on remote",
+			exitCode:      126,
+			mergedOutput:  "bash: /usr/local/bin/docker: Permission denied\n",
+			cmdName:       "docker compose",
+			wantContains:  []string{"exit 126", "Permission denied", "not executable"},
+			wantExclusive: []string{"ssh exit"},
+		},
+		{
+			name:          "compose error with multi-line output — only first line leaks",
+			exitCode:      1,
+			mergedOutput:  "no configuration file provided: not found\nstack trace line 1\nstack trace line 2\n",
+			cmdName:       "docker compose",
+			wantContains:  []string{"exit 1", "no configuration file provided"},
+			wantExclusive: []string{"stack trace", "ssh exit"},
+		},
+		{
+			name:          "empty merged output — falls back to default hint",
+			exitCode:      1,
+			mergedOutput:  "",
+			cmdName:       "docker compose",
+			wantContains:  []string{"exit 1", "check remote docker compose installation"},
+			wantExclusive: []string{"ssh exit"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			output, err := makeSSHAdapterErr(t, tt.exitCode, tt.mergedOutput)
+			got := formatRemoteError(err, output, tt.cmdName)
+			if got == "" {
+				t.Fatalf("expected non-empty output for exit=%d output=%q", tt.exitCode, tt.mergedOutput)
+			}
+			if strings.ContainsAny(got, "\r\n") {
+				t.Errorf("output must be single line, got %q", got)
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("output %q missing %q", got, want)
+				}
+			}
+			for _, leak := range tt.wantExclusive {
+				if strings.Contains(got, leak) {
+					t.Errorf("output %q must not contain %q", got, leak)
+				}
+			}
+		})
 	}
 }

--- a/internal/app/ops/remote_error_internal_test.go
+++ b/internal/app/ops/remote_error_internal_test.go
@@ -1,0 +1,163 @@
+package ops
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// makeExitErr fabricates an *exec.ExitError-equivalent for tests by
+// running a command that is guaranteed to fail with a known code. For
+// pure, table-driven unit tests we wrap a synthetic exit error via
+// exec.Command + an unknown binary, which is portable enough for the
+// exit-code extraction path. When the real exit code cannot be forced
+// the test uses a raw error to exercise the "not an ExitError" branch.
+func makeExitErr(t *testing.T, code int, stderr string) error {
+	t.Helper()
+	// We cannot easily construct *exec.ExitError with a custom code
+	// without spawning a process. Use "sh -c exit <code>" which is
+	// available on macOS+Linux (CI platforms). stderr is stamped via
+	// a printf to stderr before exit.
+	script := fmt.Sprintf("printf %%s %q 1>&2; exit %d", stderr, code)
+	cmd := exec.Command("sh", "-c", script) //nolint:gosec // test-local, inputs are controlled
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("expected non-nil error for exit %d", code)
+	}
+	// Attach stderr into *exec.ExitError.Stderr for extractExitInfo to find.
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		exitErr.Stderr = []byte(stderr)
+	}
+	return err
+}
+
+func TestFormatRemoteError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		err           error
+		cmdName       string
+		wantContains  []string
+		wantExclusive []string // substrings that MUST NOT appear
+		wantEmpty     bool
+	}{
+		{
+			name:      "nil error → empty string",
+			err:       nil,
+			cmdName:   "docker compose",
+			wantEmpty: true,
+		},
+		{
+			name:          "exit 127 with stderr → hint + code",
+			err:           makeExitErr(t, 127, "docker: command not found"),
+			cmdName:       "docker compose",
+			wantContains:  []string{"exit 127", "docker: command not found", "not installed on remote"},
+			wantExclusive: []string{"2>/dev/null", "||", "\n", "ssh exit"},
+		},
+		{
+			name:          "exit 126 with permission denied",
+			err:           makeExitErr(t, 126, "permission denied"),
+			cmdName:       "docker compose",
+			wantContains:  []string{"exit 126", "permission denied", "not executable"},
+			wantExclusive: []string{"2>/dev/null", "||"},
+		},
+		{
+			name:          "exit 1 with multi-line stderr → only first non-empty line",
+			err:           makeExitErr(t, 1, "\n\nfirst line of error\nsecond line of error"),
+			cmdName:       "docker compose",
+			wantContains:  []string{"exit 1", "first line of error"},
+			wantExclusive: []string{"second line of error", "\n", "2>/dev/null"},
+		},
+		{
+			name:          "exit 1 with literal 2>/dev/null in stderr stripped",
+			err:           makeExitErr(t, 1, "command failed 2>/dev/null || docker-compose ps"),
+			cmdName:       "docker compose",
+			wantContains:  []string{"exit 1"},
+			wantExclusive: []string{"2>/dev/null", "||", "docker-compose"},
+		},
+		{
+			name:          "exit 255 → ssh hint",
+			err:           makeExitErr(t, 255, "ssh: connect to host: timed out"),
+			cmdName:       "docker compose",
+			wantContains:  []string{"exit 255", "ssh connection failed"},
+			wantExclusive: []string{"2>/dev/null", "||"},
+		},
+		{
+			name:          "empty stderr, exit 1 → falls back to default hint",
+			err:           makeExitErr(t, 1, ""),
+			cmdName:       "docker compose",
+			wantContains:  []string{"exit 1", "check remote docker compose installation"},
+			wantExclusive: []string{"2>/dev/null", "||", "\n"},
+		},
+		{
+			name:          "non-ExitError plain error → rendered as hint only",
+			err:           errors.New("dial timeout"),
+			cmdName:       "docker compose",
+			wantContains:  []string{"dial timeout"},
+			wantExclusive: []string{"exit", "2>/dev/null", "||", "ssh exit"},
+		},
+		{
+			name:          "non-ExitError with ssh exit wrapper stripped",
+			err:           fmt.Errorf("ssh exit: %w", errors.New("connection refused")),
+			cmdName:       "docker compose",
+			wantContains:  []string{"connection refused"},
+			wantExclusive: []string{"ssh exit", "2>/dev/null", "||"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := formatRemoteError(tt.err, tt.cmdName)
+
+			if tt.wantEmpty {
+				if got != "" {
+					t.Fatalf("expected empty string, got %q", got)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatalf("expected non-empty output for %v", tt.err)
+			}
+			if strings.ContainsAny(got, "\r\n") {
+				t.Errorf("output must be single line, got %q", got)
+			}
+			if len(got) > maxRemoteErrorLen {
+				t.Errorf("output exceeds %d chars: %q (len=%d)", maxRemoteErrorLen, got, len(got))
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("output %q missing %q", got, want)
+				}
+			}
+			for _, leak := range tt.wantExclusive {
+				if strings.Contains(got, leak) {
+					t.Errorf("output %q must not contain %q", got, leak)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatRemoteError_NoRawShellLeaks(t *testing.T) {
+	t.Parallel()
+
+	// Feed the worst-case: an error string that contains every historical
+	// leak fragment. The output must contain NONE of them.
+	raw := errors.New("ssh docker compose ps --format json 2>/dev/null || docker-compose ps 2>/dev/null: exit status 127")
+	got := formatRemoteError(raw, "docker compose")
+
+	for _, leak := range []string{"2>/dev/null", "||", "ssh exit"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("formatted output %q must not contain leak %q", got, leak)
+		}
+	}
+	if strings.ContainsAny(got, "\r\n") {
+		t.Errorf("output must be single line, got %q", got)
+	}
+}

--- a/internal/cli/cmd/doctor.go
+++ b/internal/cli/cmd/doctor.go
@@ -87,8 +87,10 @@ Examples:
 			portChecker := opsadapter.NewNetPortChecker()
 			httpClient := &http.Client{Timeout: 5 * time.Second}
 			healthChecker := opsadapter.NewHTTPHealthChecker(httpClient)
+			ownerProbe := opsadapter.NewVibeWardenHealthProbe(nil)
 			svc := opsapp.NewDoctorService(compose, portChecker, healthChecker).
-				WithImageChecker(opsadapter.NewImageCheckerAdapter())
+				WithImageChecker(opsadapter.NewImageCheckerAdapter()).
+				WithPortOwnerProbe(ownerProbe)
 
 			// When --target is provided, create an SSH executor for production checks.
 			if target != "" {

--- a/internal/cli/cmd/mcp.go
+++ b/internal/cli/cmd/mcp.go
@@ -77,7 +77,9 @@ func buildMCPToolDeps() mcp.ToolDeps {
 
 	compose := opsadapter.NewComposeAdapter()
 	portChecker := opsadapter.NewNetPortChecker()
-	doctorSvc := opsapp.NewDoctorService(compose, portChecker, healthChecker)
+	ownerProbe := opsadapter.NewVibeWardenHealthProbe(nil)
+	doctorSvc := opsapp.NewDoctorService(compose, portChecker, healthChecker).
+		WithPortOwnerProbe(ownerProbe)
 
 	return mcp.ToolDeps{
 		HealthChecker: healthChecker,

--- a/internal/ports/ops.go
+++ b/internal/ports/ops.go
@@ -122,3 +122,32 @@ type ImageExporter interface {
 	// the docker CLI fails.
 	Save(ctx context.Context, imageName, destPath string) error
 }
+
+// PortOwner identifies who is listening on a TCP port. It is a value object
+// returned by PortOwnerProbe implementations and consumed by diagnostic
+// services that need to distinguish the sidecar from foreign processes.
+type PortOwner string
+
+const (
+	// OwnerUnknown means the port is free or the owner could not be
+	// determined (e.g. probe error on a reachable host).
+	OwnerUnknown PortOwner = "unknown"
+	// OwnerVibeWarden means a VibeWarden sidecar is listening and
+	// responded on /_vibewarden/health with the expected JSON signature.
+	OwnerVibeWarden PortOwner = "vibewarden"
+	// OwnerForeign means some other process is listening — either the TLS
+	// handshake failed, the HTTP status was non-2xx, or the response body
+	// did not start with the VibeWarden health signature.
+	OwnerForeign PortOwner = "foreign"
+)
+
+// PortOwnerProbe identifies the owner of a listener on host:port by probing
+// the /_vibewarden/health endpoint over TLS. Implementations must be safe to
+// call against self-signed certificates because those are the norm in local
+// development.
+type PortOwnerProbe interface {
+	// ProbeOwner returns the identity of the process bound to host:port.
+	// It never returns an error: ambiguous results are reported as
+	// OwnerForeign (safe default) or OwnerUnknown (port free).
+	ProbeOwner(ctx context.Context, host string, port int) PortOwner
+}


### PR DESCRIPTION
Fixes #1054 (partial). Follow-up #1059 tracks removing production-only doctor checks after deploy sunset (#1051).

## Summary

Implements ADR-084. Three long-standing doctor false-positives fixed at
the structural level — no string-munging:

- **Port ownership** (`bug 1`): new `ports.PortOwnerProbe` + `VibeWardenHealthProbe` adapter. `checkPort` now issues a TLS-protected GET to `/_vibewarden/health` when the port is busy; a sibling `vibew dev` is reported OK ("in use by local vibew dev (expected)") instead of FAIL.
- **TLS certificate** (`bug 2`): deletes the `.vibewarden/generated/certs/server.crt` filesystem scan. `checkTLSCertValid` performs a live TLS handshake against `proxyHost:proxyPort` and reads the leaf cert from `ConnectionState().PeerCertificates[0]` — the expiry/severity logic now reflects what the sidecar is actually serving, not what may or may not live in a directory doctor has no business knowing about. Unreachable sidecar → WARN "start `vibew dev`".
- **Remote container check** (`bug 3`): new `internal/app/ops/remote_error.go` — pure `formatRemoteError` returns a single line with exit code + first stderr line + keyed hint, and never emits `2>/dev/null`, `||`, raw ssh commands, or the adapter's `ssh exit:` wrapper. The remote command is simplified to `docker compose ps --format json` (Compose v1 fallback + shell redirections dropped).
- **SSH adapter micro-fix**: `Executor.Run` now wraps errors as `"ssh exit: %w"` — the raw `ssh <cmd>:` and `output: ...` fragments that were the root cause of the shell leak are gone structurally.

3 topical commits: port-ownership port+adapter, remote-error formatter + ssh micro-fix, doctor service rewrite.

## Test plan

- [x] `make check` passes (lint + vet + build + race tests on main module and demo-app)
- [x] Unit — `VibeWardenHealthProbe`: signature match → OwnerVibeWarden; foreign 200 / non-2xx / plain-TCP / port-closed → OwnerForeign; `0.0.0.0` rewritten to `127.0.0.1`; strict prefix match (non-prefix signature → foreign)
- [x] Unit — `formatRemoteError` table: nil/empty/exit 127/exit 126/exit 1 multi-line/exit 1 with shell leaks/exit 255/plain error/ssh-exit-wrapped error; every case asserts single line, ≤ 180 chars, no `2>/dev/null`, no `||`, no `ssh exit`
- [x] Unit — `checkPort` ownership matrix: port free (probe not consulted) → OK; bound + `OwnerVibeWarden` → OK; bound + `OwnerForeign` → FAIL; bound + no probe → FAIL (back-compat)
- [x] Unit — `checkTLSCertValid` against `httptest.NewTLSServer` with controlled cert `NotAfter`: valid (90d) → OK; near-expiry (3d) → WARN; expired → FAIL; unreachable (closed port) → WARN with hint
- [x] Regression — `Remote containers` detail does not contain `2>/dev/null`, `||`, or `ssh exit` even when the executor returns an error string packed with all three

## Notes

- No new dependencies (stdlib only: `crypto/tls`, `net/http`, `encoding/json`, `os/exec`).
- `NewDoctorService` signature unchanged; probe is wired via `WithPortOwnerProbe(...)` setter for back-compat with existing tests.
- Integration test (build-tagged) deferred — not in scope for this PR; tracked implicitly by #1059 which will own the full production-check sunset.