### PR TITLE
fix(#1065): integration tests — add --non-interactive flag and repair skip/flag bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Added
 
+- `vibew init --non-interactive` flag — skips interactive prompts even when stdin is a TTY; primarily for CI / agent scripting. (#1065)
 - **`vibew bundle` command** — generates Docker Compose deployment
   artifacts (`docker-compose.yml`, `vibewarden.yaml`, `.env`, `sample.env`,
   `deploy.sh`, `README.md`, `image.tar`) into `.vibewarden/bundle/` with

--- a/internal/cli/cmd/init.go
+++ b/internal/cli/cmd/init.go
@@ -56,6 +56,16 @@ func promptString(w *os.File, r *bufio.Reader, prompt, defaultVal string) (strin
 // This matches `vibew wrap`'s convention: cd into the directory first,
 // then run the command. No subdirectory creation.
 //
+// Interactivity is auto-detected via IsTTY(os.Stdin): when stdin is a
+// terminal the command may prompt for optional fields (e.g. --describe).
+// The --non-interactive flag provides an explicit, agent-discoverable
+// escape hatch: it forces non-interactive behaviour even when stdin IS a
+// TTY. The flag is preferred by AI agents, CI runners, and test harnesses
+// because it is visible in `vibew init --help` output and is unambiguous
+// across shells and PTY allocators (some CI environments allocate a TTY).
+// When stdin is not a TTY the flag is a no-op — non-interactive is already
+// the effective mode.
+//
 // Usage:
 //
 //	mkdir myapp && cd myapp
@@ -63,13 +73,15 @@ func promptString(w *os.File, r *bufio.Reader, prompt, defaultVal string) (strin
 //	vibew init --port 8080
 //	vibew init --name myapp
 //	vibew init --describe "a task management API"
+//	vibew init --non-interactive --port 3000
 func NewInitCmd() *cobra.Command {
 	var (
-		port     int
-		force    bool
-		version  string
-		describe string
-		name     string
+		port           int
+		force          bool
+		version        string
+		describe       string
+		name           string
+		nonInteractive bool
 	)
 
 	cmd := &cobra.Command{
@@ -101,10 +113,11 @@ Examples:
   vibew init --port 8080
   vibew init --name my-custom-project
   vibew init --describe "a task management API"
+  vibew init --non-interactive
   vibew init --force`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			interactive := IsTTY(os.Stdin)
+			interactive := !nonInteractive && IsTTY(os.Stdin)
 
 			stdinReader := bufio.NewReader(os.Stdin)
 
@@ -161,6 +174,7 @@ Examples:
 	cmd.Flags().StringVar(&version, "version", "", "VibeWarden version to pin in .vibewarden-version (default: latest)")
 	cmd.Flags().StringVar(&describe, "describe", "", "one-line description of what the project builds; written to PROJECT.md and injected into agent files")
 	cmd.Flags().StringVar(&name, "name", "", "project name for Docker Compose project naming and deploy directories (default: current directory name)")
+	cmd.Flags().BoolVar(&nonInteractive, "non-interactive", false, "skip all interactive prompts and use defaults (implied when stdin is not a TTY)")
 
 	return cmd
 }

--- a/internal/cli/cmd/init_test.go
+++ b/internal/cli/cmd/init_test.go
@@ -541,6 +541,145 @@ func TestInitCmd_NameFlag_WritesNameToConfig(t *testing.T) {
 	}
 }
 
+// TestInitCmd_NonInteractiveFlag_RegisteredAndDescribed verifies that
+// `--non-interactive` is a registered flag on `vibew init` and that it
+// appears in `--help` output. This is the agent-discoverability guarantee
+// that motivated introducing the flag (issue #1065).
+func TestInitCmd_NonInteractiveFlag_RegisteredAndDescribed(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	initCmd, _, err := root.Find([]string{"init"})
+	if err != nil {
+		t.Fatalf("Find(init) error: %v", err)
+	}
+	if initCmd.Flags().Lookup("non-interactive") == nil {
+		t.Fatal("expected --non-interactive flag on init command")
+	}
+
+	root.SetArgs([]string{"init", "--help"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+
+	_ = root.Execute()
+	helpOutput := out.String()
+	if !strings.Contains(helpOutput, "--non-interactive") {
+		t.Errorf("--non-interactive flag must appear in help output:\n%s", helpOutput)
+	}
+}
+
+// TestInitCmd_NonInteractiveFlag_SkipsPromptsWithTTY verifies that
+// passing `--non-interactive` bypasses the description prompt even when
+// stdin IS a TTY. Regression guard for #1065.
+//
+// The test sets IsTTY to true and deliberately does NOT wire a stdin
+// pipe: if the flag is ignored, the scaffolder blocks forever reading
+// from an empty os.Stdin (or a real terminal). Success is measured by
+// the init command completing without blocking and PROJECT.md not being
+// created (empty description).
+func TestInitCmd_NonInteractiveFlag_SkipsPromptsWithTTY(t *testing.T) {
+	parent := scaffoldTestDir(t, false)
+	projectDir := filepath.Join(parent, "noninteractiveapp")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	// Override IsTTY to claim interactive — the flag must still win.
+	origIsTTY := cmd.IsTTY
+	cmd.IsTTY = func(*os.File) bool { return true }
+	t.Cleanup(func() { cmd.IsTTY = origIsTTY })
+
+	root := cmd.NewRootCmd("test")
+	root.SetOut(&bytes.Buffer{})
+	root.SetArgs([]string{"init", "--non-interactive"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("init --non-interactive failed: %v", err)
+	}
+
+	// vibewarden.yaml should exist — the scaffold ran to completion
+	// without waiting for input.
+	if _, err := os.Stat(filepath.Join(projectDir, "vibewarden.yaml")); err != nil {
+		t.Errorf("expected vibewarden.yaml after non-interactive init: %v", err)
+	}
+	// PROJECT.md must NOT exist — no description was provided and the
+	// prompt was skipped.
+	if _, err := os.Stat(filepath.Join(projectDir, "PROJECT.md")); err == nil {
+		t.Error("PROJECT.md must not exist when --non-interactive skips the describe prompt")
+	}
+}
+
+// TestInitCmd_NonInteractiveFlag_NoTTYStillSkips is a regression guard for
+// the pre-existing no-TTY auto-detection path: even with the flag absent,
+// when IsTTY reports false, no prompt should fire.
+func TestInitCmd_NonInteractiveFlag_NoTTYStillSkips(t *testing.T) {
+	parent := scaffoldTestDir(t, false)
+	projectDir := filepath.Join(parent, "nottyapp")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	// IsTTY already returns false via TestMain; assert init completes.
+	root := cmd.NewRootCmd("test")
+	root.SetOut(&bytes.Buffer{})
+	root.SetArgs([]string{"init"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("init (no TTY, no flag) failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(projectDir, "vibewarden.yaml")); err != nil {
+		t.Errorf("expected vibewarden.yaml after non-TTY init: %v", err)
+	}
+}
+
+// TestInitCmd_NonInteractiveFlag_NoTTYWithFlag verifies the combination is
+// a no-op — stdin is already non-TTY, so the flag changes nothing.
+func TestInitCmd_NonInteractiveFlag_NoTTYWithFlag(t *testing.T) {
+	parent := scaffoldTestDir(t, false)
+	projectDir := filepath.Join(parent, "nottyflagapp")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	root := cmd.NewRootCmd("test")
+	root.SetOut(&bytes.Buffer{})
+	root.SetArgs([]string{"init", "--non-interactive"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("init --non-interactive (no TTY) failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(projectDir, "vibewarden.yaml")); err != nil {
+		t.Errorf("expected vibewarden.yaml: %v", err)
+	}
+}
+
 // TestInitCmd_NoNameFlag_NoNameInConfig verifies that when --name is not set,
 // vibewarden.yaml does not contain a top-level name: field.
 //

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -123,6 +123,7 @@ support `--tls` or `--domain` — use `vibew add tls` after init for TLS.
 - `--describe` -- one-line project description (written to PROJECT.md and agent files)
 - `--version` -- VibeWarden version to pin in .vibewarden-version (default: latest)
 - `--force` -- overwrite existing files
+- `--non-interactive` -- skip interactive prompts even when stdin is a TTY (CI / agent scripting)
 
 ### wrap flags
 

--- a/test/integration/bundle_test.go
+++ b/test/integration/bundle_test.go
@@ -51,7 +51,7 @@ func TestBundle_CLI_UpAndHealthy(t *testing.T) {
 	if err := os.MkdirAll(projectDir, 0o750); err != nil {
 		t.Fatalf("mkdir project: %v", err)
 	}
-	if err := runCmd(ctx, projectDir, "vibew", "init", "--non-interactive", "--upstream", "3000"); err != nil {
+	if err := runCmd(ctx, projectDir, "vibew", "init", "--non-interactive", "--port", "3000"); err != nil {
 		t.Fatalf("vibew init: %v", err)
 	}
 

--- a/test/integration/multisite_test.go
+++ b/test/integration/multisite_test.go
@@ -9,7 +9,9 @@
 //
 // Prerequisites:
 //   - Docker daemon running
-//   - vibewarden:local-test image built (make integration does this automatically)
+//   - vibewarden:local-test image built (make integration does this
+//     automatically). The test auto-skips with an actionable message when
+//     the image is not present locally.
 //
 // Run:
 //
@@ -23,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -65,6 +68,17 @@ const (
 func TestMultiSite(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
+	}
+
+	// Fast-fail probes: skip cleanly when docker is missing or the
+	// sidecar image has not been built. Mirrors bundle_test.go.
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not on PATH; skipping multi-site integration test")
+	}
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer probeCancel()
+	if err := exec.CommandContext(probeCtx, "docker", "image", "inspect", sidecarImage).Run(); err != nil {
+		t.Skipf("%s image not found; run 'make integration' to build it", sidecarImage)
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Fixes #1065

## Summary

Three surgical fixes per the architect design on #1065:

1. **`vibew init --non-interactive`** — new explicit boolean flag that forces
   non-interactive behavior even when stdin IS a TTY. Visible in `--help`,
   so AI agents and CI harnesses can discover it without guessing. Auto-detection
   via `IsTTY(os.Stdin)` remains the default; the flag is a no-op when stdin
   is not a TTY.
2. **`test/integration/bundle_test.go`** — the CLI call used the non-existent
   `--upstream` flag; corrected to `--port 3000` (the actual flag name on
   `vibew init`). The `--non-interactive` token stays — valid after fix 1.
3. **`test/integration/multisite_test.go`** — pre-flight probe for docker
   and the `vibewarden:local-test` image. Skips cleanly with an actionable
   remediation message when the image is not built, mirroring the existing
   skip pattern in `bundle_test.go`.

No new ADR, no new dependencies, no rename of `--port`.

## Test plan

- [x] `make check` passes (build + vet + golangci-lint + race tests)
- [x] Four new unit tests in `internal/cli/cmd/init_test.go`:
      flag registered & in `--help`; flag + TTY skips prompt; no-TTY without
      flag skips prompt; no-TTY with flag is a no-op.
- [x] `go test -tags=integration -run TestMultiSite -race ./test/integration/...`
      skips cleanly with message `vibewarden:local-test image not found; run 'make integration' to build it` when the image is absent.
- [x] `go test -tags=integration -run TestBundle_CLI_UpAndHealthy -race ./test/integration/...`
      compiles. End-to-end run requires a freshly-built `vibew` binary on PATH
      (the default `/usr/local/bin/vibew` may be stale; run `go install ./cmd/vibewarden` first).