### PR TITLE
docs(#1067): final deploy-reference sweep across user-facing prose

### DIFF
--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -182,9 +182,8 @@ ssh user@host 'cd ~/bundle && bash deploy.sh'
 (same inputs, same bytes), never opens an SSH connection, and never
 touches files outside the output directory.
 
-The removed `vibew deploy` command previously wrapped all four steps over
-SSH in one command. It was retired in ADR-086; running it today prints a
-deprecation message and exits 2.
+There is no all-in-one remote-deploy command. The user owns the transport
+(scp, rsync, CI artifact) and the remote `docker compose up -d`.
 
 Use `app.environment` in vibewarden.yaml for runtime configuration:
 ```yaml

--- a/docs/guide/bundle-to-vps.md
+++ b/docs/guide/bundle-to-vps.md
@@ -125,10 +125,8 @@ actually changed (config, image tag, overlay).
 
 - **Image not loading on the VPS.** Check that the host architecture
   matches the image's target arch. `docker inspect --format='{{.Architecture}}' <image>`
-  on both sides. Cross-arch bundles are not auto-detected by
-  `vibew bundle` — that was a `vibew deploy` feature that did not survive
-  the sunset (ADR-086). Rebuild with `docker buildx build --platform
-  linux/amd64` if needed.
+  on both sides. `vibew bundle` does not auto-detect cross-arch mismatches;
+  rebuild with `docker buildx build --platform linux/amd64` if needed.
 
 - **TLS certificates.** `vibew bundle` emits whatever TLS config the
   merged `vibewarden.yaml` specifies. Let's Encrypt flows run on first
@@ -136,9 +134,8 @@ actually changed (config, image tag, overlay).
   `ssh user@host 'cd ~/bundle && docker compose logs vibewarden | grep -i acme'`.
 
 - **Strict config validation failures before any files are written.**
-  `vibew bundle` calls the same `config.LoadStrict` path as the old
-  `vibew deploy`, so unknown keys abort the command before the bundle
-  directory is touched.
+  `vibew bundle` calls `config.LoadStrict`, so unknown keys abort the
+  command before the bundle directory is touched.
 
 - **Health check failures on the VPS.** `curl -k https://localhost:$PORT/_vibewarden/health`
   over SSH is the canonical probe. The sidecar's own `docker compose

--- a/docs/multi-app.md
+++ b/docs/multi-app.md
@@ -11,9 +11,7 @@ all of them when the project runs locally.
     the initial bundle ship ([ADR-085](../decisions/adr-085-vibew-bundle-cli.md),
     [ADR-086](../decisions/adr-086-sunset-vibew-deploy.md)).
 
-    The removed `vibew deploy` command previously orchestrated multi-site
-    deployments over SSH. That surface was retired in ADR-086; the
-    replacement for multi-site is in-flight under issue #1052 (Helm /
+    The multi-site remote path is in-flight under issue #1052 (Helm /
     Fly.io / k8s targets).
 
     This page documents the **local** multi-app configuration model.
@@ -183,6 +181,5 @@ deploying.
 ## Related
 
 - [Bundle to VPS](guide/bundle-to-vps.md) -- single-site deploy walkthrough
-- [Removed `vibew deploy`](deploy-reference.md) -- breaking-change landing
 - [Configuration](configuration.md) -- `vibewarden.yaml` field reference
 - [ADR-086](../decisions/adr-086-sunset-vibew-deploy.md) -- sunset rationale

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -197,10 +197,9 @@ ssh user@host 'cd ~/bundle && docker compose logs --tail=100 vibewarden'
 ssh user@host 'cd ~/bundle && docker compose restart vibewarden'
 ```
 
-The removed `vibew deploy` command previously did all of this over SSH
-in one step. It was retired in ADR-086 after four retros converged on
-deploy-orchestration as the #1 source of user friction. Running
-`vibew deploy` today prints a deprecation message and exits 2.
+There is no all-in-one remote-deploy command. `vibew bundle` is the only
+supported path to a VPS; the user owns the transport (scp, rsync, CI
+artifact) and the remote `docker compose up -d`.
 
 ## Writing your Dockerfile
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -172,10 +172,10 @@ user then transfers the bundle directory to the VPS and runs
 `docker compose up -d` themselves. No source code is ever sent to the
 production server -- the image must be production-ready.
 
-The removed `vibew deploy` command did all three steps (package, ship,
-start) in one SSH orchestration. That surface was retired in ADR-086 in
-favour of the thin bundle pipeline. Running `vibew deploy` today prints a
-deprecation message and exits 2.
+There is no all-in-one remote-deploy command. `vibew bundle` is the only
+supported path to a VPS; the user owns the transport (scp, rsync, CI
+artifact) and the remote `docker compose up -d`. See CHANGELOG and
+ADR-086 for the rationale.
 
 Use `app.environment` for runtime config (database URLs, API keys, etc.).
 


### PR DESCRIPTION
Closes #1067 (main repo portion). Part of the "vibew deploy is gone" release. Website repo audit is a separate PR.

## Summary

- Swept the main repo for residual `vibew deploy` mentions in user-facing prose.
- Removed retrospective/historical paragraphs from agent-facing surfaces (AGENTS template, llms-full.txt, docs/examples/AGENTS-VIBEWARDEN.md) that still named the removed command. Agents reading these could mistake them for an option that merely prints a deprecation warning and kept trying it.
- Tightened two troubleshooting bullets in `docs/guide/bundle-to-vps.md` (cross-arch, strict validation) to describe current behavior without the retired-command framing.
- Simplified the multi-site deferral banner in `docs/multi-app.md` and dropped the "Removed `vibew deploy`" Related link.

## Retained (legitimate breaking-change signposts)

- `README.md` migration table row.
- `mkdocs.yml` nav label ("Removed vibew deploy").
- `docs/deploy-reference.md` (the historical landing page — that's its job).
- `docs/guide/bundle-to-vps.md` opening framing + ADR-086 See-also.
- CHANGELOG / DECISIONS / ADR (explicitly out of scope per issue #1067).

## Files touched

- `docs/examples/AGENTS-VIBEWARDEN.md`
- `docs/guide/bundle-to-vps.md`
- `docs/multi-app.md`
- `internal/cli/templates/agents/agents-vibewarden.md.tmpl`
- `llms-full.txt`

## Test plan

- [x] `grep -n 'vibew deploy'` across user-facing files returns only the four retained historical signposts listed above.
- [x] `make check` passes locally (golangci-lint + race tests).
- [ ] Reviewer agent approves.
- [ ] Writer agent (PR review mode) approves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)