### PR TITLE
fix(#1077): scaffold placeholder domain avoids LE-blocked example.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,13 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Fixes
 
+- **`vibew init` scaffold no longer suggests `example.com` as the TLS domain**
+  (#1079, closes #1077). The production scaffold placeholder is now
+  `app.yourcompany.com` and calls out that Let's Encrypt rejects RFC-2606
+  reserved names. The `tls.domain is required` validation error for ACME
+  providers was updated to the same guidance. Prevents the confusing
+  `rejectedIdentifier` failure users hit when they copy-pasted the previous
+  placeholder verbatim.
 - **`vibew doctor` no longer flags a running sidecar as a port conflict**
   (#1054, ADR-084). When `vibew dev` is already running on the proxy port,
   doctor probes `/_vibewarden/health` and reports

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ add VibeWarden. Use `vibew add` to enable individual features after the initial 
 | `vibew wrap` | Add VibeWarden sidecar to an existing project |
 | `vibew add auth` | Enable authentication |
 | `vibew add rate-limiting` | Enable rate limiting |
-| `vibew add tls --domain example.com` | Enable TLS |
+| `vibew add tls --domain app.yourcompany.com` | Enable TLS (use a domain you control; Let's Encrypt rejects `example.com`) |
 | `vibew add metrics` | Enable Prometheus metrics |
 | `vibew add admin` | Enable admin API |
 | `vibew generate` | Regenerate `docker-compose.yml` from config |

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -75,7 +75,7 @@ To add a plugin:
 ```bash
 vibew add auth          # enable authentication
 vibew add rate-limiting # enable rate limiting
-vibew add tls --domain example.com
+vibew add tls --domain app.yourcompany.com  # use a real domain you control; Let's Encrypt rejects example.com
 ```
 
 ## Troubleshooting

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -123,7 +123,7 @@ Common flags:
 | `--upstream <port>` | Port your app listens on (default: auto-detected or 3000) |
 | `--auth` | Enable authentication (Ory Kratos) |
 | `--rate-limit` | Enable rate limiting |
-| `--tls --domain example.com` | Enable TLS (requires `--domain`) |
+| `--tls --domain app.yourcompany.com` | Enable TLS (requires `--domain`; use a real domain you control — Let's Encrypt rejects `example.com`) |
 | `--force` | Overwrite existing files |
 
 ### What `wrap` generates
@@ -451,7 +451,7 @@ See the [Observability guide](observability.md) for details.
 ### Enable TLS for production
 
 ```bash
-./vibew add tls --domain myapp.example.com
+./vibew add tls --domain app.yourcompany.com
 ```
 
 This sets `tls.provider: letsencrypt` and `tls.domain` in `vibewarden.yaml` and

--- a/docs/index.md
+++ b/docs/index.md
@@ -142,7 +142,7 @@ On public paths, these headers are present when the visitor has a valid session 
 | `vibew wrap` | Add VibeWarden sidecar to an existing project |
 | `vibew add auth` | Enable authentication |
 | `vibew add rate-limiting` | Enable rate limiting |
-| `vibew add tls --domain example.com` | Enable TLS |
+| `vibew add tls --domain app.yourcompany.com` | Enable TLS (use a domain you control; Let's Encrypt rejects `example.com`) |
 | `vibew add metrics` | Enable Prometheus metrics |
 | `vibew generate` | Regenerate `docker-compose.yml` from config |
 | `vibew dev` | Start local dev environment |

--- a/internal/cli/templates/init-vibewarden.production.yaml.tmpl
+++ b/internal/cli/templates/init-vibewarden.production.yaml.tmpl
@@ -16,7 +16,7 @@ server:
 tls:
   enabled: true
   provider: "letsencrypt"
-  # domain: "example.com"  # REQUIRED -- set your production domain
+  # domain: "app.yourcompany.com"  # REQUIRED -- a domain you control (RFC-reserved example.com will be rejected by Let's Encrypt)
 
 # --- Optional overrides (uncomment as needed) ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1745,7 +1745,8 @@ func (c *Config) Validate() error {
 	if c.TLS.Enabled && acmeProviders[c.TLS.Provider] && c.TLS.Domain == "" {
 		errs = append(errs, fmt.Sprintf(
 			"tls.domain is required when tls.provider is %q — "+
-				"set tls.domain to your domain name (e.g., myapp.example.com)",
+				"set tls.domain to a domain you control and have pointed at this server "+
+				"(Let's Encrypt rejects reserved names like example.com)",
 			c.TLS.Provider,
 		))
 	}


### PR DESCRIPTION
## Summary
- Scaffold template: `# domain: "example.com"` → `# domain: "app.yourcompany.com"` with warning about RFC-reserved names
- Validator error message: now names the Let's Encrypt blocklist issue explicitly
- First-run users following the scaffold won't hit `rejectedIdentifier` ACME errors

Closes #1077. Part of the deploy-is-gone release.

## Test plan
- [x] `make check` passes
- [x] `vibew init` → uncomment domain → validate emits the new error

🤖 Generated with [Claude Code](https://claude.com/claude-code)