### PR TITLE
fix(#1086): vibew add preserves hand-written comments in production.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+### Fixed
+
+- `vibew add tls` no longer silently regenerates `vibewarden.production.yaml`, wiping commented-out stanzas (WAF block mode, auth, headers). Comments/ordering/whitespace preserved via AST edit. (#1086)
+
+### Changed
+
+- `vibew add` commands that hit an unparseable YAML file now fail fast with a `vibew validate` remediation hint instead of silently rewriting. (#1086)
+
 ---
 
 ## [v0.16.0] — 2026-04-21

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ Keep prose replies maximally brief without losing technical substance. No pleasa
 - Integration tests for adapters (use `testcontainers-go` — Apache 2.0)
 - Tests live next to the code they test (`foo_test.go`)
 - Minimum coverage target: 80% on `internal/domain/` and `internal/app/`
+- YAML files are edited via node-based upsert (`internal/adapters/yamlmod`); no `yaml.Unmarshal(map[string]any)` → `yaml.Marshal` round-trips in `internal/cli/cmd/add_*.go` or `internal/app/scaffold/`
 
 ---
 

--- a/internal/adapters/yamlmod/toggler.go
+++ b/internal/adapters/yamlmod/toggler.go
@@ -60,25 +60,29 @@ func (t *Toggler) ReadFeatures(_ context.Context, path string) (*scaffold.Featur
 
 // EnableFeature enables the named feature in the file at path. The file is
 // written back atomically (temp file + rename). Returns
-// scaffold.ErrFeatureAlreadyEnabled when the feature is already on.
-func (t *Toggler) EnableFeature(_ context.Context, path string, feature scaffold.Feature, opts scaffold.FeatureOptions) error {
+// scaffold.ErrFeatureAlreadyEnabled when the feature is already on. The
+// returned Diff lists the fields this call added or changed so that the CLI
+// can render a precise summary.
+func (t *Toggler) EnableFeature(_ context.Context, path string, feature scaffold.Feature, opts scaffold.FeatureOptions) (scaffold.Diff, error) {
 	root, err := readNode(path)
 	if err != nil {
-		return err
+		return scaffold.Diff{}, err
 	}
+
+	builder := NewDiffBuilder()
 
 	switch feature {
 	case scaffold.FeatureAuth:
 		if hasKey(root, "auth") || hasKey(root, "kratos") {
-			return fmt.Errorf("add auth: %w", scaffold.ErrFeatureAlreadyEnabled)
+			return scaffold.Diff{}, fmt.Errorf("add auth: %w", scaffold.ErrFeatureAlreadyEnabled)
 		}
-		appendAuthBlock(root)
+		appendAuthBlock(root, builder)
 
 	case scaffold.FeatureRateLimit:
 		if boolField(root, "rate_limit", "enabled") {
-			return fmt.Errorf("add rate-limiting: %w", scaffold.ErrFeatureAlreadyEnabled)
+			return scaffold.Diff{}, fmt.Errorf("add rate-limiting: %w", scaffold.ErrFeatureAlreadyEnabled)
 		}
-		appendRateLimitBlock(root)
+		appendRateLimitBlock(root, builder)
 
 	case scaffold.FeatureTLS:
 		if boolField(root, "tls", "enabled") {
@@ -90,45 +94,48 @@ func (t *Toggler) EnableFeature(_ context.Context, path string, feature scaffold
 				if provider == "" {
 					provider = "letsencrypt"
 				}
-				upsertTLSBlock(root, opts.TLSDomain, provider)
+				upsertTLSBlock(root, builder, opts.TLSDomain, provider)
 			} else {
-				return fmt.Errorf("add tls: %w", scaffold.ErrFeatureAlreadyEnabled)
+				return scaffold.Diff{}, fmt.Errorf("add tls: %w", scaffold.ErrFeatureAlreadyEnabled)
 			}
 		} else {
 			provider := opts.TLSProvider
 			if provider == "" {
 				provider = "letsencrypt"
 			}
-			upsertTLSBlock(root, opts.TLSDomain, provider)
+			upsertTLSBlock(root, builder, opts.TLSDomain, provider)
 		}
 
 	case scaffold.FeatureAdmin:
 		if boolField(root, "admin", "enabled") {
-			return fmt.Errorf("add admin: %w", scaffold.ErrFeatureAlreadyEnabled)
+			return scaffold.Diff{}, fmt.Errorf("add admin: %w", scaffold.ErrFeatureAlreadyEnabled)
 		}
-		upsertAdminBlock(root)
+		upsertAdminBlock(root, builder)
 
 	case scaffold.FeatureMetrics:
 		if boolField(root, "metrics", "enabled") {
-			return fmt.Errorf("add metrics: %w", scaffold.ErrFeatureAlreadyEnabled)
+			return scaffold.Diff{}, fmt.Errorf("add metrics: %w", scaffold.ErrFeatureAlreadyEnabled)
 		}
-		appendMetricsBlock(root)
+		appendMetricsBlock(root, builder)
 
 	case scaffold.FeatureWAF:
 		if boolField(root, "waf", "enabled") {
-			return fmt.Errorf("add waf: %w", scaffold.ErrFeatureAlreadyEnabled)
+			return scaffold.Diff{}, fmt.Errorf("add waf: %w", scaffold.ErrFeatureAlreadyEnabled)
 		}
 		mode := opts.WAFMode
 		if mode == "" {
 			mode = "detect"
 		}
-		upsertWAFBlock(root, mode)
+		upsertWAFBlock(root, builder, mode)
 
 	default:
-		return fmt.Errorf("unknown feature %q", feature)
+		return scaffold.Diff{}, fmt.Errorf("unknown feature %q", feature)
 	}
 
-	return writeNode(path, root)
+	if err := writeNode(path, root); err != nil {
+		return scaffold.Diff{}, err
+	}
+	return builder.Build(path), nil
 }
 
 // --------------------------------------------------------------------------
@@ -244,19 +251,6 @@ func intField(root *yaml.Node, section, field string) int {
 	return n
 }
 
-// setScalar sets or inserts key in root to a scalar value.
-func setScalar(root *yaml.Node, key, value, tag string) {
-	mappingPairs(root, func(k, v *yaml.Node) bool {
-		if k.Value == key {
-			v.Kind = yaml.ScalarNode
-			v.Tag = tag
-			v.Value = value
-			return false
-		}
-		return true
-	})
-}
-
 // appendNode appends a key/value pair to a mapping node.
 func appendNode(m *yaml.Node, key *yaml.Node, value *yaml.Node) {
 	m.Content = append(m.Content, key, value)
@@ -297,12 +291,13 @@ func headComment(n *yaml.Node, comment string) *yaml.Node {
 // --------------------------------------------------------------------------
 
 // appendAuthBlock appends kratos and auth sections to the root mapping.
-func appendAuthBlock(root *yaml.Node) {
+func appendAuthBlock(root *yaml.Node, b *DiffBuilder) {
 	// kratos section
 	kratosVal := mappingNode()
 	appendNode(kratosVal, keyNode("public_url"), scalarNode("http://localhost:4433", "!!str"))
 	appendNode(kratosVal, keyNode("admin_url"), scalarNode("http://localhost:4434", "!!str"))
 	appendNode(root, headComment(keyNode("kratos"), "# Ory Kratos identity server"), kratosVal)
+	recordAdds(b, "kratos", kratosVal)
 
 	// auth section — mode is the single source of truth (ADR-065).
 	authVal := mappingNode()
@@ -312,10 +307,11 @@ func appendAuthBlock(root *yaml.Node) {
 	publicPaths := sequenceNode("/health", "/ready")
 	appendNode(authVal, keyNode("public_paths"), publicPaths)
 	appendNode(root, headComment(keyNode("auth"), "# Authentication (Ory Kratos)"), authVal)
+	recordAdds(b, "auth", authVal)
 }
 
 // appendRateLimitBlock appends a rate_limit section to root.
-func appendRateLimitBlock(root *yaml.Node) {
+func appendRateLimitBlock(root *yaml.Node, b *DiffBuilder) {
 	rl := mappingNode()
 	appendNode(rl, keyNode("enabled"), scalarNode("true", "!!bool"))
 	appendNode(rl, keyNode("trust_proxy_headers"), scalarNode("false", "!!bool"))
@@ -334,21 +330,22 @@ func appendRateLimitBlock(root *yaml.Node) {
 	appendNode(rl, keyNode("exempt_paths"), exemptPaths)
 
 	appendNode(root, headComment(keyNode("rate_limit"), "# Rate limiting"), rl)
+	recordAdds(b, "rate_limit", rl)
 }
 
 // upsertTLSBlock sets tls.enabled = true plus domain/provider in root.
 // If the tls key already exists, its fields are updated; otherwise the section
 // is appended.
-func upsertTLSBlock(root *yaml.Node, domain, provider string) {
+func upsertTLSBlock(root *yaml.Node, b *DiffBuilder, domain, provider string) {
 	existing := findKey(root, "tls")
 	if existing != nil {
 		// Update existing tls section.
-		setScalar(existing, "enabled", "true", "!!bool")
+		setScalarTracked(existing, b, "tls", "enabled", "true", "!!bool")
 		if domain != "" {
-			upsertField(existing, "domain", domain, "!!str")
+			upsertFieldTracked(existing, b, "tls", "domain", domain, "!!str")
 		}
 		if provider != "" {
-			upsertField(existing, "provider", provider, "!!str")
+			upsertFieldTracked(existing, b, "tls", "provider", provider, "!!str")
 		}
 		// storage_path defaults to /root/.local/share/caddy in config.Load
 		// (matches the Docker volume mount). No need to set explicitly.
@@ -361,13 +358,14 @@ func upsertTLSBlock(root *yaml.Node, domain, provider string) {
 	appendNode(tls, keyNode("domain"), scalarNode(domain, "!!str"))
 	appendNode(tls, keyNode("storage_path"), scalarNode("./data/caddy", "!!str"))
 	appendNode(root, headComment(keyNode("tls"), "# TLS configuration"), tls)
+	recordAdds(b, "tls", tls)
 }
 
 // upsertAdminBlock sets admin.enabled = true and appends a token placeholder.
-func upsertAdminBlock(root *yaml.Node) {
+func upsertAdminBlock(root *yaml.Node, b *DiffBuilder) {
 	existing := findKey(root, "admin")
 	if existing != nil {
-		setScalar(existing, "enabled", "true", "!!bool")
+		setScalarTracked(existing, b, "admin", "enabled", "true", "!!bool")
 		return
 	}
 
@@ -375,24 +373,26 @@ func upsertAdminBlock(root *yaml.Node) {
 	appendNode(admin, keyNode("enabled"), scalarNode("true", "!!bool"))
 	appendNode(admin, keyNode("token"), scalarNode("${VIBEWARDEN_ADMIN_TOKEN}", "!!str"))
 	appendNode(root, headComment(keyNode("admin"), "# Admin API"), admin)
+	recordAdds(b, "admin", admin)
 }
 
 // appendMetricsBlock appends a metrics section to root.
-func appendMetricsBlock(root *yaml.Node) {
+func appendMetricsBlock(root *yaml.Node, b *DiffBuilder) {
 	metrics := mappingNode()
 	appendNode(metrics, keyNode("enabled"), scalarNode("true", "!!bool"))
 	appendNode(metrics, keyNode("path"), scalarNode("/metrics", "!!str"))
 	appendNode(root, headComment(keyNode("metrics"), "# Prometheus metrics"), metrics)
+	recordAdds(b, "metrics", metrics)
 }
 
 // upsertWAFBlock sets waf.enabled = true plus mode in root. If the waf key
 // already exists, its fields are updated; otherwise the section is appended.
-func upsertWAFBlock(root *yaml.Node, mode string) {
+func upsertWAFBlock(root *yaml.Node, b *DiffBuilder, mode string) {
 	existing := findKey(root, "waf")
 	if existing != nil {
-		setScalar(existing, "enabled", "true", "!!bool")
+		setScalarTracked(existing, b, "waf", "enabled", "true", "!!bool")
 		if mode != "" {
-			upsertField(existing, "mode", mode, "!!str")
+			upsertFieldTracked(existing, b, "waf", "mode", mode, "!!str")
 		}
 		return
 	}
@@ -409,17 +409,25 @@ func upsertWAFBlock(root *yaml.Node, mode string) {
 	appendNode(waf, keyNode("rules"), rules)
 
 	appendNode(root, headComment(keyNode("waf"), "# Web Application Firewall"), waf)
+	recordAdds(b, "waf", waf)
 }
 
-// upsertField sets key to value in mapping m; if key does not exist it is
-// appended.
-func upsertField(m *yaml.Node, key, value, tag string) {
+// upsertFieldTracked sets key to value in mapping m and records the change
+// on b; if key does not exist, it is appended. The dotted path recorded on b
+// is "prefix.key" (or "key" when prefix is empty).
+// prefix is prepended to the dotted path when non-empty.
+func upsertFieldTracked(m *yaml.Node, b *DiffBuilder, prefix, key, value, tag string) {
 	found := false
 	mappingPairs(m, func(k, v *yaml.Node) bool {
 		if k.Value == key {
+			before := v.Value
 			v.Kind = yaml.ScalarNode
 			v.Tag = tag
 			v.Value = value
+			v.Content = nil
+			if b != nil && before != value {
+				b.RecordChange(dotJoin(prefix, key), before, value)
+			}
 			found = true
 			return false
 		}
@@ -427,5 +435,60 @@ func upsertField(m *yaml.Node, key, value, tag string) {
 	})
 	if !found {
 		appendNode(m, keyNode(key), scalarNode(value, tag))
+		if b != nil {
+			b.RecordAdd(dotJoin(prefix, key), value)
+		}
 	}
+}
+
+// setScalarTracked sets key in mapping m to a scalar value and records the
+// change on b. Unlike upsertFieldTracked it never inserts a missing key.
+func setScalarTracked(m *yaml.Node, b *DiffBuilder, prefix, key, value, tag string) {
+	mappingPairs(m, func(k, v *yaml.Node) bool {
+		if k.Value == key {
+			before := v.Value
+			v.Kind = yaml.ScalarNode
+			v.Tag = tag
+			v.Value = value
+			v.Content = nil
+			if b != nil && before != value {
+				b.RecordChange(dotJoin(prefix, key), before, value)
+			}
+			return false
+		}
+		return true
+	})
+}
+
+// recordAdds walks a freshly-appended subtree and records every leaf as an
+// addition on b. Non-scalar leaves are recorded with their RenderValue.
+func recordAdds(b *DiffBuilder, prefix string, node *yaml.Node) {
+	if b == nil || node == nil {
+		return
+	}
+	switch node.Kind {
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			k := node.Content[i].Value
+			v := node.Content[i+1]
+			path := dotJoin(prefix, k)
+			if v.Kind == yaml.ScalarNode {
+				b.RecordAdd(path, v.Value)
+			} else {
+				recordAdds(b, path, v)
+			}
+		}
+	case yaml.SequenceNode:
+		b.RecordAdd(prefix, RenderValue(node))
+	case yaml.ScalarNode:
+		b.RecordAdd(prefix, node.Value)
+	}
+}
+
+// dotJoin concatenates a dotted path prefix with a key.
+func dotJoin(prefix, key string) string {
+	if prefix == "" {
+		return key
+	}
+	return prefix + "." + key
 }

--- a/internal/adapters/yamlmod/toggler_test.go
+++ b/internal/adapters/yamlmod/toggler_test.go
@@ -330,7 +330,7 @@ func TestToggler_EnableFeature(t *testing.T) {
 				path = filepath.Join(dir, "vibewarden.yaml")
 			}
 
-			err := tog.EnableFeature(ctx, path, tt.feature, tt.opts)
+			_, err := tog.EnableFeature(ctx, path, tt.feature, tt.opts)
 
 			if tt.wantErr {
 				if err == nil {
@@ -374,7 +374,7 @@ func TestToggler_EnableFeature_Idempotent(t *testing.T) {
 
 	original, _ := os.ReadFile(path)
 
-	err := tog.EnableFeature(ctx, path, scaffold.FeatureAuth, scaffold.FeatureOptions{})
+	_, err := tog.EnableFeature(ctx, path, scaffold.FeatureAuth, scaffold.FeatureOptions{})
 	if !errors.Is(err, scaffold.ErrFeatureAlreadyEnabled) {
 		t.Fatalf("expected ErrFeatureAlreadyEnabled, got %v", err)
 	}

--- a/internal/adapters/yamlmod/upsert.go
+++ b/internal/adapters/yamlmod/upsert.go
@@ -1,0 +1,218 @@
+package yamlmod
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/vibewarden/vibewarden/internal/domain/scaffold"
+)
+
+// SeedFactory returns the root mapping node for a brand-new YAML file.
+// It is invoked by UpsertFields only when the target path does not exist.
+// The returned node is the document root (a MappingNode); UpsertFields will
+// then apply the caller's edit closure to it before writing.
+type SeedFactory func() *yaml.Node
+
+// DiffBuilder is passed to the edit closure of UpsertFields and records
+// field-level changes so they can be surfaced to the user. Callers use
+// RecordAdd / RecordChange / RecordRemove as they mutate the YAML node tree.
+//
+// A DiffBuilder is not safe for concurrent use.
+type DiffBuilder struct {
+	added   []scaffold.FieldChange
+	changed []scaffold.FieldChange
+	removed []scaffold.FieldChange
+}
+
+// NewDiffBuilder returns an empty DiffBuilder.
+func NewDiffBuilder() *DiffBuilder { return &DiffBuilder{} }
+
+// RecordAdd records a field addition at the given dotted path with the given
+// rendered after-value.
+func (b *DiffBuilder) RecordAdd(path, after string) {
+	b.added = append(b.added, scaffold.FieldChange{Path: path, After: after})
+}
+
+// RecordChange records a scalar value change at path.
+func (b *DiffBuilder) RecordChange(path, before, after string) {
+	b.changed = append(b.changed, scaffold.FieldChange{Path: path, Before: before, After: after})
+}
+
+// RecordRemove records a field removal at path with the old rendered value.
+func (b *DiffBuilder) RecordRemove(path, before string) {
+	b.removed = append(b.removed, scaffold.FieldChange{Path: path, Before: before})
+}
+
+// Build returns the final Diff for the given file path.
+func (b *DiffBuilder) Build(file string) scaffold.Diff {
+	return scaffold.Diff{
+		File:    file,
+		Added:   b.added,
+		Changed: b.changed,
+		Removed: b.removed,
+	}
+}
+
+// UpsertFields opens path as a yaml.v3 node tree, applies edit on the root
+// mapping, and writes the result back atomically. When path does not exist
+// and seed is non-nil, seed is invoked to produce an initial root mapping
+// before edit runs (so edit always operates on a fully-materialised tree).
+//
+// If path exists but cannot be parsed as YAML, UpsertFields returns a wrapped
+// error ending with "— run `vibew validate` to see details and fix by hand".
+// It never regenerates the file from a template in that case — that would
+// silently destroy the user's edits.
+//
+// The edit closure mutates the node tree in place and records field-level
+// changes on the supplied DiffBuilder. The returned Diff is built from that
+// builder and carries the absolute file path.
+//
+// Comments, key ordering, and blank lines present in the original file are
+// preserved by yaml.v3's node-based marshaller.
+func UpsertFields(
+	path string,
+	seed SeedFactory,
+	edit func(root *yaml.Node, diff *DiffBuilder) error,
+) (scaffold.Diff, error) {
+	builder := NewDiffBuilder()
+
+	data, readErr := os.ReadFile(path) //nolint:gosec // path is a vibewarden.*.yaml resolved from project root
+	var doc yaml.Node
+	var root *yaml.Node
+	switch {
+	case readErr == nil:
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return scaffold.Diff{}, fmt.Errorf(
+				"parsing %s: %w — run `vibew validate` to see details and fix by hand",
+				path, err,
+			)
+		}
+		if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+			root = doc.Content[0]
+		} else {
+			root = mappingNode()
+			doc = yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+		}
+	case errors.Is(readErr, os.ErrNotExist):
+		if seed == nil {
+			root = mappingNode()
+		} else {
+			root = seed()
+			if root == nil {
+				root = mappingNode()
+			}
+		}
+		doc = yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+	default:
+		return scaffold.Diff{}, fmt.Errorf("reading %s: %w", path, readErr)
+	}
+
+	if err := edit(root, builder); err != nil {
+		return scaffold.Diff{}, err
+	}
+
+	if err := writeDoc(path, &doc); err != nil {
+		return scaffold.Diff{}, err
+	}
+
+	return builder.Build(path), nil
+}
+
+// writeDoc marshals doc and writes the result to path atomically. It
+// preserves document-level head and foot comments (which is where yaml.v3
+// attaches trailing commented-out stanzas).
+func writeDoc(path string, doc *yaml.Node) error {
+	data, err := yaml.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("marshaling yaml: %w", err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, permConfig); err != nil {
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+	return nil
+}
+
+// UpsertScalar sets a scalar field at root[section][field] to value (tag).
+// When section is empty, the field is set at the root mapping directly.
+// Missing parent mappings are created. The DiffBuilder records an Add or
+// Change depending on whether the field existed before.
+//
+// The dotted path used for the Diff entry is "section.field" (or "field"
+// when section is empty).
+func UpsertScalar(root *yaml.Node, builder *DiffBuilder, section, field, value, tag string) {
+	target := root
+	dotted := field
+	if section != "" {
+		target = ensureMapping(root, section)
+		dotted = section + "." + field
+	}
+
+	existing := findKey(target, field)
+	if existing == nil {
+		appendNode(target, keyNode(field), scalarNode(value, tag))
+		if builder != nil {
+			builder.RecordAdd(dotted, value)
+		}
+		return
+	}
+
+	before := existing.Value
+	if before == value && existing.Kind == yaml.ScalarNode {
+		return // no-op: same value, no diff entry
+	}
+	existing.Kind = yaml.ScalarNode
+	existing.Tag = tag
+	existing.Value = value
+	existing.Content = nil
+	if builder != nil {
+		builder.RecordChange(dotted, before, value)
+	}
+}
+
+// ensureMapping returns the value node for key at the top level of root,
+// creating an empty mapping (and the key) when it is absent.
+func ensureMapping(root *yaml.Node, key string) *yaml.Node {
+	if v := findKey(root, key); v != nil {
+		if v.Kind != yaml.MappingNode {
+			// Coerce the scalar/sequence into an empty mapping — caller asked
+			// for a nested field, so the parent must be a mapping.
+			v.Kind = yaml.MappingNode
+			v.Tag = "!!map"
+			v.Value = ""
+			v.Content = nil
+		}
+		return v
+	}
+	m := mappingNode()
+	appendNode(root, keyNode(key), m)
+	return m
+}
+
+// RenderValue returns a stable string rendering of n for diff display.
+// It handles scalars (returns Value), mappings/sequences (returns "<map>" /
+// "<seq>"), and nil (returns "").
+func RenderValue(n *yaml.Node) string {
+	if n == nil {
+		return ""
+	}
+	switch n.Kind {
+	case yaml.ScalarNode:
+		return n.Value
+	case yaml.MappingNode:
+		return "<map>"
+	case yaml.SequenceNode:
+		return "<seq>"
+	default:
+		return strings.TrimSpace(n.Value)
+	}
+}

--- a/internal/adapters/yamlmod/upsert_test.go
+++ b/internal/adapters/yamlmod/upsert_test.go
@@ -1,0 +1,233 @@
+package yamlmod_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/vibewarden/vibewarden/internal/adapters/yamlmod"
+)
+
+func TestUpsertFields_PreservesCommentsAndOrdering(t *testing.T) {
+	// Fixture: YAML with head, line, foot comments, blank lines, commented
+	// stanzas, and nested maps. UpsertFields edits a single leaf and must
+	// leave everything else byte-identical.
+	original := `# top-of-file head comment
+# second head line
+server:
+  host: "127.0.0.1"
+  port: 8080        # inline port comment
+
+# WAF is commented out on purpose — do not delete
+# waf:
+#   enabled: true
+#   mode: detect
+
+tls:
+  enabled: true
+  provider: letsencrypt
+  domain: old.example.com
+
+# auth would go here once Kratos is wired up
+# auth:
+#   mode: kratos
+`
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vibewarden.production.yaml")
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+
+	diff, err := yamlmod.UpsertFields(path, nil, func(root *yaml.Node, b *yamlmod.DiffBuilder) error {
+		yamlmod.UpsertScalar(root, b, "tls", "domain", "new.example.com", "!!str")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("UpsertFields: %v", err)
+	}
+
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("reading back: %v", readErr)
+	}
+	out := string(got)
+
+	// Every comment, commented-out stanza, and blank line from the original
+	// must survive.
+	mustContain := []string{
+		"# top-of-file head comment",
+		"# second head line",
+		"# inline port comment",
+		"# WAF is commented out on purpose — do not delete",
+		"# waf:",
+		"#   mode: detect",
+		"# auth would go here once Kratos is wired up",
+		"# auth:",
+		"new.example.com",
+	}
+	for _, m := range mustContain {
+		if !strings.Contains(out, m) {
+			t.Errorf("output lost %q\n\n--- got ---\n%s", m, out)
+		}
+	}
+	if strings.Contains(out, "old.example.com") {
+		t.Errorf("output still contains old.example.com\n\n%s", out)
+	}
+
+	// Diff should record a single Change for tls.domain.
+	if len(diff.Changed) != 1 {
+		t.Fatalf("expected 1 change, got %d: %+v", len(diff.Changed), diff)
+	}
+	c := diff.Changed[0]
+	if c.Path != "tls.domain" || c.Before != "old.example.com" || c.After != "new.example.com" {
+		t.Errorf("unexpected change entry: %+v", c)
+	}
+	if diff.File != path {
+		t.Errorf("Diff.File = %q, want %q", diff.File, path)
+	}
+}
+
+func TestUpsertFields_CreatesFileFromSeed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "brand-new.yaml")
+
+	seed := func() *yaml.Node {
+		// Equivalent to: server: { port: 443 }
+		server := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		server.Content = append(server.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "port"},
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: "443"},
+		)
+		root := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		root.Content = append(root.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "server"},
+			server,
+		)
+		return root
+	}
+
+	diff, err := yamlmod.UpsertFields(path, seed, func(root *yaml.Node, b *yamlmod.DiffBuilder) error {
+		yamlmod.UpsertScalar(root, b, "tls", "domain", "example.com", "!!str")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("UpsertFields: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading back: %v", err)
+	}
+	out := string(got)
+	for _, m := range []string{"server:", "port: 443", "tls:", "domain: example.com"} {
+		if !strings.Contains(out, m) {
+			t.Errorf("output missing %q\n\n%s", m, out)
+		}
+	}
+
+	// tls.domain is an add (tls section wasn't in seed).
+	if len(diff.Added) == 0 {
+		t.Errorf("expected at least one Added entry, got %+v", diff)
+	}
+}
+
+func TestUpsertFields_RefusesOnParseFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.yaml")
+	if err := os.WriteFile(path, []byte("server:\n  port: 8080\n  bad: : :\n"), 0o600); err != nil {
+		t.Fatalf("writing broken fixture: %v", err)
+	}
+
+	_, err := yamlmod.UpsertFields(path, nil, func(root *yaml.Node, b *yamlmod.DiffBuilder) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+	if !strings.Contains(err.Error(), "run `vibew validate`") {
+		t.Errorf("error should point to vibew validate, got: %v", err)
+	}
+}
+
+func TestUpsertFields_ReadErrorIsPropagated(t *testing.T) {
+	// A directory, not a file, causes a non-NotExist read error.
+	dir := t.TempDir()
+	_, err := yamlmod.UpsertFields(dir, nil, func(root *yaml.Node, b *yamlmod.DiffBuilder) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected error when path is a directory")
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected non-NotExist error, got %v", err)
+	}
+}
+
+func TestUpsertFields_EditErrorSkipsWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vibewarden.production.yaml")
+	original := "server:\n  port: 8080\n"
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+
+	wantErr := errors.New("boom")
+	_, err := yamlmod.UpsertFields(path, nil, func(root *yaml.Node, b *yamlmod.DiffBuilder) error {
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected %v, got %v", wantErr, err)
+	}
+
+	got, _ := os.ReadFile(path)
+	if string(got) != original {
+		t.Errorf("file was modified despite edit error:\n%s", got)
+	}
+}
+
+func TestUpsertScalar_AddVsChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.yaml")
+	if err := os.WriteFile(path, []byte("tls:\n  domain: a\n"), 0o600); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+
+	diff, err := yamlmod.UpsertFields(path, nil, func(root *yaml.Node, b *yamlmod.DiffBuilder) error {
+		yamlmod.UpsertScalar(root, b, "tls", "domain", "b", "!!str")        // change
+		yamlmod.UpsertScalar(root, b, "tls", "email", "x@example", "!!str") // add
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("UpsertFields: %v", err)
+	}
+	if len(diff.Changed) != 1 {
+		t.Errorf("expected 1 change, got %+v", diff.Changed)
+	}
+	if len(diff.Added) != 1 {
+		t.Errorf("expected 1 add, got %+v", diff.Added)
+	}
+}
+
+func TestUpsertScalar_NoOpWhenUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.yaml")
+	if err := os.WriteFile(path, []byte("tls:\n  domain: a\n"), 0o600); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+
+	diff, err := yamlmod.UpsertFields(path, nil, func(root *yaml.Node, b *yamlmod.DiffBuilder) error {
+		yamlmod.UpsertScalar(root, b, "tls", "domain", "a", "!!str") // same value
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("UpsertFields: %v", err)
+	}
+	if !diff.IsEmpty() {
+		t.Errorf("expected empty diff, got %+v", diff)
+	}
+}

--- a/internal/app/scaffold/add_feature.go
+++ b/internal/app/scaffold/add_feature.go
@@ -42,6 +42,10 @@ type AddResult struct {
 	// UpdatedConfig is the absolute path of the modified vibewarden.yaml.
 	UpdatedConfig string
 
+	// ConfigDiff lists the fields added/changed/removed in vibewarden.yaml
+	// by the EnableFeature call.
+	ConfigDiff domainscaffold.Diff
+
 	// RegeneratedContextFiles lists agent context files that were regenerated.
 	RegeneratedContextFiles []string
 }
@@ -51,11 +55,12 @@ type AddResult struct {
 func (s *AddFeatureService) AddFeature(ctx context.Context, dir string, opts AddFeatureOptions) (*AddResult, error) {
 	configPath := filepath.Join(dir, vibeWardenYAML)
 
-	if err := s.toggler.EnableFeature(ctx, configPath, opts.Feature, opts.FeatureOptions); err != nil {
+	diff, err := s.toggler.EnableFeature(ctx, configPath, opts.Feature, opts.FeatureOptions)
+	if err != nil {
 		return nil, fmt.Errorf("enabling feature %q: %w", opts.Feature, err)
 	}
 
-	result := &AddResult{UpdatedConfig: configPath}
+	result := &AddResult{UpdatedConfig: configPath, ConfigDiff: diff}
 
 	// Regenerate agent context files when requested.
 	if opts.RegenerateAgentContext {

--- a/internal/app/scaffold/add_feature_test.go
+++ b/internal/app/scaffold/add_feature_test.go
@@ -31,10 +31,10 @@ func (f *fakeToggler) ReadFeatures(_ context.Context, _ string) (*domainscaffold
 	return f.state, nil
 }
 
-func (f *fakeToggler) EnableFeature(_ context.Context, _ string, feature domainscaffold.Feature, opts domainscaffold.FeatureOptions) error {
+func (f *fakeToggler) EnableFeature(_ context.Context, _ string, feature domainscaffold.Feature, opts domainscaffold.FeatureOptions) (domainscaffold.Diff, error) {
 	f.enabledFeature = feature
 	f.enabledOpts = opts
-	return f.enableErr
+	return domainscaffold.Diff{}, f.enableErr
 }
 
 func TestAddFeatureService_AddFeature(t *testing.T) {
@@ -159,5 +159,5 @@ func TestAddFeatureService_AddFeature(t *testing.T) {
 // Compile-time check: fakeToggler satisfies the FeatureToggler interface shape.
 var _ interface {
 	ReadFeatures(context.Context, string) (*domainscaffold.FeatureState, error)
-	EnableFeature(context.Context, string, domainscaffold.Feature, domainscaffold.FeatureOptions) error
+	EnableFeature(context.Context, string, domainscaffold.Feature, domainscaffold.FeatureOptions) (domainscaffold.Diff, error)
 } = (*fakeToggler)(nil)

--- a/internal/cli/cmd/add_helpers.go
+++ b/internal/cli/cmd/add_helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/spf13/cobra"
 
@@ -57,6 +58,7 @@ func runAddFeature(
 	}
 
 	printAddSuccessMessage(cmd, feature, result)
+	PrintAddSummary(cmd.OutOrStdout(), result.ConfigDiff)
 	return nil
 }
 
@@ -74,4 +76,25 @@ func printAddSuccessMessage(cmd *cobra.Command, feature domainscaffold.Feature, 
 	}
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Review vibewarden.yaml and adjust settings as needed.")
+}
+
+// PrintAddSummary writes a human-readable per-file summary of a Diff to w.
+// Called by every `vibew add <feature>` RunE after the underlying edit
+// returns. It is a no-op when diff is empty so already-enabled paths do not
+// print stray headers.
+func PrintAddSummary(w io.Writer, diff domainscaffold.Diff) {
+	if diff.IsEmpty() {
+		return
+	}
+
+	fmt.Fprintf(w, "\nChanges in %s:\n", diff.File)
+	for _, a := range diff.Added {
+		fmt.Fprintf(w, "  + %s: %s\n", a.Path, a.After)
+	}
+	for _, c := range diff.Changed {
+		fmt.Fprintf(w, "  ~ %s: %s -> %s\n", c.Path, c.Before, c.After)
+	}
+	for _, r := range diff.Removed {
+		fmt.Fprintf(w, "  - %s (was: %s)\n", r.Path, r.Before)
+	}
 }

--- a/internal/cli/cmd/add_lint_test.go
+++ b/internal/cli/cmd/add_lint_test.go
@@ -1,0 +1,79 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestAddCommandsHaveNoMapRoundTrips enforces the invariant recorded in
+// CLAUDE.md: every vibew add command that edits a YAML file must do so via
+// the node-based yamlmod facade (which preserves comments and ordering).
+//
+// A map round-trip — yaml.Unmarshal into map[string]any followed by
+// yaml.Marshal — silently destroys comments, blank lines, and key ordering.
+// See issue #1086 for the motivating regression.
+//
+// This test greps every file under internal/cli/cmd/add_*.go and every
+// non-test file under internal/app/scaffold/ for the forbidden pair:
+// yaml.Unmarshal(..., &map[...]...) and yaml.Marshal(map[...]...).
+//
+// When it fires, the fix is to route the edit through
+// yamlmod.UpsertFields or yamlmod.Toggler.EnableFeature.
+func TestAddCommandsHaveNoMapRoundTrips(t *testing.T) {
+	// Repository root — the test package lives four levels down:
+	// <repo>/internal/cli/cmd/add_lint_test.go
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot := filepath.Clean(filepath.Join(wd, "..", "..", ".."))
+
+	targets := []struct {
+		dir  string
+		glob string
+	}{
+		{filepath.Join(repoRoot, "internal", "cli", "cmd"), "add_*.go"},
+		{filepath.Join(repoRoot, "internal", "app", "scaffold"), "add_*.go"},
+	}
+
+	// A file is a violation when it declares (or assigns to) a
+	// map[string]any/interface{} AND calls yaml.Unmarshal AND calls
+	// yaml.Marshal. That combination is the canonical round-trip that
+	// drops comments and ordering.
+	mapDecl := regexp.MustCompile(`map\[string\](?:any|interface\{\})`)
+	unmarshalCall := regexp.MustCompile(`yaml\.Unmarshal\s*\(`)
+	marshalCall := regexp.MustCompile(`yaml\.Marshal\s*\(`)
+
+	var violations []string
+	for _, tgt := range targets {
+		matches, err := filepath.Glob(filepath.Join(tgt.dir, tgt.glob))
+		if err != nil {
+			t.Fatalf("glob %s/%s: %v", tgt.dir, tgt.glob, err)
+		}
+		for _, path := range matches {
+			// Skip this lint test file and any other test file — tests
+			// sometimes use map[string]any for fixtures where comments
+			// do not matter.
+			if strings.HasSuffix(path, "_test.go") {
+				continue
+			}
+			b, err := os.ReadFile(path) //nolint:gosec // path comes from a filepath.Glob rooted at the repo
+			if err != nil {
+				t.Fatalf("reading %s: %v", path, err)
+			}
+			src := string(b)
+			if mapDecl.MatchString(src) && unmarshalCall.MatchString(src) && marshalCall.MatchString(src) {
+				violations = append(violations, path)
+			}
+		}
+	}
+
+	if len(violations) > 0 {
+		t.Fatalf("forbidden yaml map round-trip found — route the edit through internal/adapters/yamlmod instead:\n  %s",
+			strings.Join(violations, "\n  "),
+		)
+	}
+}

--- a/internal/cli/cmd/add_preserves_comments_test.go
+++ b/internal/cli/cmd/add_preserves_comments_test.go
@@ -1,0 +1,166 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// prodWithComments is a hand-edited vibewarden.production.yaml that exercises
+// every comment type the user is likely to add: top-of-file head, inline,
+// blank lines, blocks, and commented-out stanzas.
+const prodWithComments = `# production overrides — DO NOT DELETE COMMENTS BELOW
+# managed by ops team
+server:
+  port: 443          # bind directly to 443
+
+# TLS is managed here, not in vibewarden.yaml
+tls:
+  enabled: true
+  provider: letsencrypt
+  domain: old.example.com
+  # storage_path is intentionally omitted — uses default
+
+# auth is commented out on purpose, Kratos wiring is WIP
+# auth:
+#   mode: kratos
+#   session_cookie_name: ory_kratos_session
+
+# WAF stanza stays commented until block mode is approved
+# waf:
+#   enabled: true
+#   mode: block
+`
+
+// TestAddTLSCmd_PreservesProductionYamlComments is the AC from issue #1086:
+// running `vibew add tls` on a production.yaml that has hand-written
+// comments and commented-out stanzas must leave every comment intact. Only
+// the tls.domain leaf is allowed to change.
+func TestAddTLSCmd_PreservesProductionYamlComments(t *testing.T) {
+	dir := scaffoldTestDir(t, false)
+
+	// Set up base config (TLS already enabled — exercises the "do not touch
+	// vibewarden.yaml" path in add tls).
+	base := "tls:\n  enabled: true\n  provider: self-signed\n"
+	if err := os.WriteFile(filepath.Join(dir, "vibewarden.yaml"), []byte(base), 0o644); err != nil {
+		t.Fatalf("writing vibewarden.yaml: %v", err)
+	}
+
+	prodPath := filepath.Join(dir, "vibewarden.production.yaml")
+	if err := os.WriteFile(prodPath, []byte(prodWithComments), 0o600); err != nil {
+		t.Fatalf("writing production.yaml: %v", err)
+	}
+
+	_, err := runAddCmd(t, dir, "tls", "--domain", "new.example.com")
+	if err != nil {
+		t.Fatalf("add tls: %v", err)
+	}
+
+	got, err := os.ReadFile(prodPath)
+	if err != nil {
+		t.Fatalf("reading back: %v", err)
+	}
+	out := string(got)
+
+	// Every hand-written comment must survive.
+	mustSurvive := []string{
+		"# production overrides — DO NOT DELETE COMMENTS BELOW",
+		"# managed by ops team",
+		"# bind directly to 443",
+		"# TLS is managed here, not in vibewarden.yaml",
+		"# storage_path is intentionally omitted — uses default",
+		"# auth is commented out on purpose, Kratos wiring is WIP",
+		"# auth:",
+		"#   mode: kratos",
+		"# WAF stanza stays commented until block mode is approved",
+		"# waf:",
+		"#   mode: block",
+	}
+	for _, c := range mustSurvive {
+		if !strings.Contains(out, c) {
+			t.Errorf("production.yaml lost comment %q\n\n--- got ---\n%s", c, out)
+		}
+	}
+
+	// Only the domain changed.
+	if !strings.Contains(out, "new.example.com") {
+		t.Errorf("production.yaml missing new domain\n\n%s", out)
+	}
+	if strings.Contains(out, "old.example.com") {
+		t.Errorf("production.yaml still contains old.example.com\n\n%s", out)
+	}
+}
+
+// TestAddTLSCmd_RefusesOnBrokenProductionYaml asserts the "refuse on parse
+// failure" requirement: if production.yaml is malformed, the command fails
+// with a message pointing the user at `vibew validate` and the file is NOT
+// overwritten.
+func TestAddTLSCmd_RefusesOnBrokenProductionYaml(t *testing.T) {
+	dir := scaffoldTestDir(t, false)
+
+	if err := os.WriteFile(filepath.Join(dir, "vibewarden.yaml"), []byte("tls:\n  enabled: true\n  provider: self-signed\n"), 0o644); err != nil {
+		t.Fatalf("writing vibewarden.yaml: %v", err)
+	}
+
+	broken := "server:\n  port: 443\n  bad: : :\n"
+	prodPath := filepath.Join(dir, "vibewarden.production.yaml")
+	if err := os.WriteFile(prodPath, []byte(broken), 0o600); err != nil {
+		t.Fatalf("writing broken production.yaml: %v", err)
+	}
+
+	_, err := runAddCmd(t, dir, "tls", "--domain", "ignored.example.com")
+	if err == nil {
+		t.Fatal("expected error on broken production.yaml, got nil")
+	}
+	if !strings.Contains(err.Error(), "vibew validate") {
+		t.Errorf("error should point to `vibew validate`, got: %v", err)
+	}
+
+	// File must be byte-identical to the broken fixture — no regeneration.
+	got, _ := os.ReadFile(prodPath)
+	if string(got) != broken {
+		t.Errorf("broken production.yaml was silently modified:\n%s", got)
+	}
+}
+
+// TestAddOtherCmds_DoNotTouchProductionYaml asserts that add_waf,
+// add_ratelimit, add_metrics, add_auth, add_admin never read or write
+// vibewarden.production.yaml. This is the "Toggler stays vibewarden.yaml-only"
+// invariant from issue #1086.
+func TestAddOtherCmds_DoNotTouchProductionYaml(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"add auth", []string{"auth"}},
+		{"add rate-limiting", []string{"rate-limiting"}},
+		{"add metrics", []string{"metrics"}},
+		{"add admin", []string{"admin"}},
+		{"add waf", []string{"waf"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := scaffoldTestDir(t, false)
+			if err := os.WriteFile(filepath.Join(dir, "vibewarden.yaml"), []byte(minimalVibeWardenYAML), 0o644); err != nil {
+				t.Fatalf("setup: %v", err)
+			}
+
+			prodPath := filepath.Join(dir, "vibewarden.production.yaml")
+			prodContent := "# prod overrides — hand-edited\nserver:\n  port: 443\n"
+			if err := os.WriteFile(prodPath, []byte(prodContent), 0o600); err != nil {
+				t.Fatalf("writing prod: %v", err)
+			}
+
+			if _, err := runAddCmd(t, dir, tt.args...); err != nil {
+				t.Fatalf("add %v: %v", tt.args, err)
+			}
+
+			got, _ := os.ReadFile(prodPath)
+			if string(got) != prodContent {
+				t.Errorf("production.yaml was modified by %v — it must not touch this file\n\n--- got ---\n%s", tt.args, got)
+			}
+		})
+	}
+}

--- a/internal/cli/cmd/add_tls.go
+++ b/internal/cli/cmd/add_tls.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -102,15 +101,19 @@ Examples:
 
 			// Write the domain and email to vibewarden.production.yaml.
 			prodPath := filepath.Join(projDir, "vibewarden.production.yaml")
-			if err := upsertTLSFieldsInProdConfig(prodPath, domain, email); err != nil {
-				// Non-fatal: the production override file is optional.
-				fmt.Fprintf(cmd.OutOrStdout(), "Note: could not update %s: %v\n", prodPath, err)
-			} else {
-				fmt.Fprintf(cmd.OutOrStdout(), "Domain %q written to %s\n", domain, prodPath)
-				if email != "" {
-					fmt.Fprintf(cmd.OutOrStdout(), "Email %q written to %s\n", email, prodPath)
-				}
+			prodDiff, prodErr := upsertTLSFieldsInProdConfig(prodPath, domain, email)
+			if prodErr != nil {
+				// Parse failure is fatal — we must not silently regenerate
+				// the file and destroy the user's edits. The error already
+				// carries the "run `vibew validate`" remediation.
+				return fmt.Errorf("updating %s: %w", prodPath, prodErr)
 			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Domain %q written to %s\n", domain, prodPath)
+			if email != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "Email %q written to %s\n", email, prodPath)
+			}
+			PrintAddSummary(cmd.OutOrStdout(), prodDiff)
 
 			return nil
 		},
@@ -124,51 +127,52 @@ Examples:
 }
 
 // upsertTLSFieldsInProdConfig reads vibewarden.production.yaml, sets
-// tls.domain and optionally tls.email to the given values, and writes the file
-// back. If the file does not exist, it is created with sensible production
-// defaults.
-func upsertTLSFieldsInProdConfig(path, domain, email string) error {
-	var m map[string]any
-
-	data, err := os.ReadFile(path) //nolint:gosec // path is the vibewarden.production.yaml resolved from project root
-	if err != nil {
-		if os.IsNotExist(err) {
-			// File doesn't exist — create it with sensible production defaults.
-			m = map[string]any{
-				"server": map[string]any{"port": 443},
-				"tls":    map[string]any{"enabled": true, "provider": "letsencrypt"},
+// tls.domain and optionally tls.email to the given values, and writes the
+// file back while preserving comments and ordering. When the file does not
+// exist, it is created with sensible production defaults via
+// productionSeedFactory.
+//
+// If the file exists but cannot be parsed as YAML, this function returns a
+// wrapped error pointing the user at `vibew validate` — it never regenerates
+// the file from scratch, which would silently destroy the user's edits.
+func upsertTLSFieldsInProdConfig(path, domain, email string) (domainscaffold.Diff, error) {
+	return yamlmodadapter.UpsertFields(
+		path,
+		productionSeedFactory,
+		func(root *yaml.Node, b *yamlmodadapter.DiffBuilder) error {
+			yamlmodadapter.UpsertScalar(root, b, "tls", "domain", domain, "!!str")
+			if email != "" {
+				yamlmodadapter.UpsertScalar(root, b, "tls", "email", email, "!!str")
 			}
-		} else {
-			return fmt.Errorf("reading %s: %w", path, err)
-		}
-	} else {
-		if err := yaml.Unmarshal(data, &m); err != nil {
-			return fmt.Errorf("parsing %s: %w", path, err)
-		}
-		if m == nil {
-			m = make(map[string]any)
-		}
-	}
+			return nil
+		},
+	)
+}
 
-	// Ensure tls section exists.
-	tls, ok := m["tls"].(map[string]any)
-	if !ok {
-		tls = make(map[string]any)
-		m["tls"] = tls
-	}
-	tls["domain"] = domain
-	if email != "" {
-		tls["email"] = email
-	}
+// productionSeedFactory returns the seed mapping written to a freshly-created
+// vibewarden.production.yaml. It matches the former map-round-trip defaults:
+// server.port = 443 and tls.enabled = true with provider = letsencrypt.
+func productionSeedFactory() *yaml.Node {
+	server := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	server.Content = append(server.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "port"},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: "443"},
+	)
 
-	out, err := yaml.Marshal(m)
-	if err != nil {
-		return fmt.Errorf("marshalling %s: %w", path, err)
-	}
+	tls := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	tls.Content = append(tls.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "enabled"},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "provider"},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "letsencrypt"},
+	)
 
-	if err := os.WriteFile(path, out, 0o600); err != nil {
-		return fmt.Errorf("writing %s: %w", path, err)
-	}
-
-	return nil
+	root := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	root.Content = append(root.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "server"},
+		server,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "tls"},
+		tls,
+	)
+	return root
 }

--- a/internal/domain/scaffold/features.go
+++ b/internal/domain/scaffold/features.go
@@ -62,6 +62,42 @@ type FeatureState struct {
 	WAFEnabled bool
 }
 
+// FieldChange describes a single key added, changed, or removed by a YAML
+// edit. Before is empty for additions; After is empty for removals. Path is
+// the dotted key path (e.g. "tls.domain").
+type FieldChange struct {
+	// Path is the dotted key path within the edited YAML document.
+	Path string
+
+	// Before is the rendered value prior to the edit, or "" for additions.
+	Before string
+
+	// After is the rendered value after the edit, or "" for removals.
+	After string
+}
+
+// Diff captures the set of fields added, changed, or removed by a single
+// YAML edit. It is used to render a summary to the user after a
+// `vibewarden add <feature>` call.
+type Diff struct {
+	// File is the absolute path of the edited file.
+	File string
+
+	// Added lists fields that did not exist before the edit.
+	Added []FieldChange
+
+	// Changed lists fields whose scalar value was replaced.
+	Changed []FieldChange
+
+	// Removed lists fields that were removed by the edit.
+	Removed []FieldChange
+}
+
+// IsEmpty reports whether the diff captures no changes.
+func (d Diff) IsEmpty() bool {
+	return len(d.Added) == 0 && len(d.Changed) == 0 && len(d.Removed) == 0
+}
+
 // FeatureOptions carries feature-specific options supplied by the user when
 // running `vibewarden add <feature>`. Fields that do not apply to a
 // particular feature are ignored.

--- a/internal/ports/scaffold.go
+++ b/internal/ports/scaffold.go
@@ -35,5 +35,6 @@ type FeatureToggler interface {
 	// EnableFeature enables the named feature in the file at path, applying
 	// opts as feature-specific options. The file is written back atomically.
 	// Returns scaffold.ErrFeatureAlreadyEnabled when the feature is already on.
-	EnableFeature(ctx context.Context, path string, feature scaffold.Feature, opts scaffold.FeatureOptions) error
+	// The returned Diff lists the fields this call added or changed.
+	EnableFeature(ctx context.Context, path string, feature scaffold.Feature, opts scaffold.FeatureOptions) (scaffold.Diff, error)
 }


### PR DESCRIPTION
Closes #1086. Part of v0.17.0.

## Summary

`vibew add tls` used to round-trip `vibewarden.production.yaml` through
`map[string]any`, which silently destroyed user-authored comments, blank
lines, and key ordering every time the command ran. This PR routes the edit
through a new node-based facade so the file survives untouched except for
the fields being updated.

Three logical commits:

1. `feat(#1086): yamlmod.UpsertFields` — node-based edit API, `scaffold.Diff`
   value object, `FeatureToggler.EnableFeature` now returns `(Diff, error)`
2. `fix(#1086): vibew add tls uses UpsertFields` — deletes the map
   round-trip, adds `PrintAddSummary`, refuses on parse failure with a
   "run `vibew validate`" remediation
3. `chore(#1086): lint test` — regex check that forbids re-introducing the
   round-trip pattern anywhere under `internal/cli/cmd/add_*.go` or
   `internal/app/scaffold/add_*.go`

## Invariant enforcement

CLAUDE.md (already on branch) gained the YAML-node-edit invariant. The new
lint test (`add_lint_test.go`) fails CI if any future PR re-adds a
`yaml.Unmarshal → map[string]any → yaml.Marshal` cycle under the add
command tree. Verified against the pre-fix version of `add_tls.go` — the
test fires.

## Test plan

- [x] `make check` — gofmt + golangci-lint + go test -race across main
      module and examples/demo-app
- [x] `upsert_test.go` — fixture with head/inline/block/commented-out
      comments survives byte-for-byte after an `UpsertScalar` edit
- [x] `add_preserves_comments_test.go` — scaffolds a project, hand-edits
      `production.yaml` with WAF + auth commented-out stanzas, runs
      `vibew add tls`, asserts every comment survives. Asserts the other
      five add subcommands never touch `production.yaml`
- [x] `add_preserves_comments_test.go::TestAddTLSCmd_RefusesOnBrokenProductionYaml`
      — malformed file is NOT regenerated, error points to `vibew validate`
- [x] `add_lint_test.go` — forbidden pattern scan passes on HEAD and fails
      on pre-fix `add_tls.go`