### PR TITLE
fix(#1078,#1090): TLS state accuracy in vibew status + doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
   releases swallowed compose errors and returned a bare exit code; failures
   now include the full compose stderr in the error message.
 - `vibew add tls` no longer silently regenerates `vibewarden.production.yaml`, wiping commented-out stanzas (WAF block mode, auth, headers). Comments/ordering/whitespace preserved via AST edit. (#1086)
+- **`vibew doctor` no longer reports "expires 0 days" for self-signed certs**
+  (#1078). Self-signed local certificates are now identified and reported as
+  `SelfSignedLocal` instead of triggering a spurious near-expiry warning.
 
 ### Changed
 
@@ -46,6 +49,11 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
   bash deploy.sh'`) was a bug; every doc surface has been realigned.
   The script accepts `user@host[:/remote/path]` and defaults the remote
   path to `~/vibewarden-bundle`.
+- **`vibew status` and `vibew doctor` now report TLS state** (#1090, #1078).
+  The status table and doctor checks surface the live Caddy TLS state:
+  `Obtaining` (ACME in progress), `Obtained` (cert active), `Failing` (ACME
+  failed), or `SelfSignedLocal` (dev self-signed cert). Previously only a
+  binary up/down was shown.
 
 ---
 

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -91,7 +91,10 @@ vibew logs               # pretty-print structured logs
 
 `vibew doctor` checks (in order): config validity, Docker daemon, Docker Compose,
 proxy port availability, generated files, container health, ACME email, image tag
-consistency, upstream reachability, and local TLS cert validity.
+consistency, upstream reachability, and TLS state. The TLS state check reports one
+of four values: `Obtaining` (ACME in progress), `Obtained` (cert active and valid),
+`Failing` (ACME failed), or `SelfSignedLocal` (dev self-signed cert — no expiry
+warning is raised). `vibew status` surfaces the same TLS state in its output table.
 
 ## Writing your Dockerfile
 
@@ -233,7 +236,7 @@ generated compose. VibeWarden never overwrites this file.
 ## Known limitations
 
 - WAF is in `detect` mode by default (logs but does not block). Set `waf.mode: block` in vibewarden.yaml to enforce blocking.
-- `vibew doctor` checks config, Docker, ports, container health, generated files, ACME email, image tag, upstream reachability, and local TLS cert validity.
+- `vibew doctor` checks config, Docker, ports, container health, generated files, ACME email, image tag, upstream reachability, and TLS state (Obtaining/Obtained/Failing/SelfSignedLocal). Self-signed dev certs are identified correctly and do not trigger a spurious expiry warning.
 - Multi-site deployment is new and may have edge cases — report issues if routes or certs behave unexpectedly.
 - `vibew init` does not accept `--tls` or `--domain` flags — run `vibew add tls --domain <your-domain>` after init.
 

--- a/internal/adapters/caddy/tls_state.go
+++ b/internal/adapters/caddy/tls_state.go
@@ -1,0 +1,139 @@
+// Package caddy provides adapters that embed and control the Caddy web
+// server in-process. The TLS state resolver here reports the current TLS
+// state of the sidecar by inspecting Caddy's in-memory configuration and
+// certmagic cache — no HTTP admin-API roundtrip is required.
+package caddy
+
+import (
+	"context"
+	"crypto/x509"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// caddyLocalIssuerCN is the Common Name that Caddy's internal issuer
+// stamps on dev leaf certificates. Seeing this CN is the deterministic
+// signal that we are serving a self-signed dev cert and must not be
+// warned about by expiry heuristics.
+const caddyLocalIssuerCN = "Caddy Local Authority"
+
+// tlsCertExpiryWarnDays mirrors the same constant used by the doctor
+// check — kept private here to avoid a cross-package dependency.
+const tlsCertExpiryWarnDays = 7
+
+// peerCertProvider is the minimal interface the in-process resolver
+// needs to read the current leaf from the certmagic cache. The default
+// implementation walks caddy.ActiveContext() at call time; tests inject
+// a fake to exercise every State variant without a running Caddy.
+type peerCertProvider interface {
+	// LeafCert returns the leaf x509 certificate currently being served
+	// for the configured server. When no leaf is in the cache it returns
+	// (nil, nil). When Caddy is not running in this process it returns
+	// ports.ErrNotInProcess.
+	LeafCert(ctx context.Context) (*x509.Certificate, error)
+}
+
+// defaultPeerCertProvider is the production peerCertProvider. It checks
+// caddy.ActiveContext() for a running Caddy instance and, if present,
+// would read the certmagic cache. Because status and doctor run as
+// separate processes from the sidecar in the common case, this path
+// almost always short-circuits with ErrNotInProcess — which is exactly
+// what the chain resolver relies on to fall through to the handshake
+// adapter.
+type defaultPeerCertProvider struct{}
+
+func (defaultPeerCertProvider) LeafCert(_ context.Context) (*x509.Certificate, error) {
+	ctx := caddy.ActiveContext()
+	if ctx.Context == nil {
+		return nil, ports.ErrNotInProcess
+	}
+	// In-process cert inspection via certmagic is out of scope for v0.17;
+	// the handshake fallback is authoritative for now. Reporting
+	// ErrNotInProcess ensures the chain resolver falls through correctly.
+	return nil, ports.ErrNotInProcess
+}
+
+// InProcessResolver reports TLS state by inspecting Caddy's in-memory
+// state. It is the primary resolver in the chain composed at the
+// composition root.
+//
+// When Caddy is not running in this process (the normal case for
+// `vibew doctor` and `vibew status` CLI subprocesses) Resolve returns
+// ports.ErrNotInProcess so the chain resolver can fall through to the
+// handshake adapter.
+type InProcessResolver struct {
+	cfg      *config.Config
+	provider peerCertProvider
+	now      func() time.Time
+}
+
+// NewInProcessResolver constructs an InProcessResolver bound to
+// the given config. The resolver reads cfg.TLS.Enabled and
+// cfg.TLS.Provider to distinguish Disabled, SelfSignedLocal and
+// ACME-like states.
+func NewInProcessResolver(cfg *config.Config) *InProcessResolver {
+	return &InProcessResolver{
+		cfg:      cfg,
+		provider: defaultPeerCertProvider{},
+		now:      time.Now,
+	}
+}
+
+// withProvider swaps the peerCertProvider for testing. Not part of the
+// public API.
+func (r *InProcessResolver) withProvider(p peerCertProvider) *InProcessResolver {
+	r.provider = p
+	return r
+}
+
+// withNow swaps the clock for testing.
+func (r *InProcessResolver) withNow(now func() time.Time) *InProcessResolver {
+	r.now = now
+	return r
+}
+
+// Resolve implements ports.TLSStateResolver.
+func (r *InProcessResolver) Resolve(ctx context.Context) (tlsdomain.State, error) {
+	if r.cfg == nil || !r.cfg.TLS.Enabled {
+		return tlsdomain.NewDisabled(), nil
+	}
+
+	leaf, err := r.provider.LeafCert(ctx)
+	if err != nil {
+		// ErrNotInProcess is a signal, not a failure — propagate so
+		// the chain can fall through.
+		return tlsdomain.NewUnknown(), err
+	}
+
+	// No leaf in cache yet.
+	if leaf == nil {
+		if r.cfg.TLS.Provider == "self-signed" {
+			// Self-signed but no leaf cached yet — treat as obtaining.
+			return tlsdomain.NewObtaining(), nil
+		}
+		return tlsdomain.NewObtaining(), nil
+	}
+
+	// Self-signed branch is deterministic: issuer CN match → SelfSignedLocal,
+	// NO NotAfter inspection. The internal issuer rotates leaves on a
+	// short TTL and we trust it to do so.
+	if r.cfg.TLS.Provider == "self-signed" && leaf.Issuer.CommonName == caddyLocalIssuerCN {
+		return tlsdomain.NewSelfSignedLocal(), nil
+	}
+
+	// ACME / external branch: inspect expiry.
+	now := r.now()
+	if now.After(leaf.NotAfter) {
+		return tlsdomain.NewExpiringSoon(0, leaf.NotAfter), nil
+	}
+	daysLeft := int(leaf.NotAfter.Sub(now).Hours() / 24)
+	if daysLeft <= tlsCertExpiryWarnDays {
+		return tlsdomain.NewExpiringSoon(daysLeft, leaf.NotAfter), nil
+	}
+	return tlsdomain.NewObtained(leaf.NotAfter), nil
+}

--- a/internal/adapters/caddy/tls_state.go
+++ b/internal/adapters/caddy/tls_state.go
@@ -16,11 +16,9 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
-// caddyLocalIssuerCN is the Common Name that Caddy's internal issuer
-// stamps on dev leaf certificates. Seeing this CN is the deterministic
-// signal that we are serving a self-signed dev cert and must not be
-// warned about by expiry heuristics.
-const caddyLocalIssuerCN = "Caddy Local Authority"
+// caddyLocalIssuerCN aliases the domain constant so the rest of this
+// file can use the short name without an explicit package qualifier.
+const caddyLocalIssuerCN = tlsdomain.CaddyLocalIssuerCN
 
 // tlsCertExpiryWarnDays mirrors the same constant used by the doctor
 // check — kept private here to avoid a cross-package dependency.

--- a/internal/adapters/caddy/tls_state_handshake.go
+++ b/internal/adapters/caddy/tls_state_handshake.go
@@ -1,0 +1,119 @@
+package caddy
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+)
+
+// HandshakeResolver resolves the sidecar's TLS state by performing a
+// live TLS handshake and inspecting the leaf certificate. This is the
+// authoritative resolver when status and doctor run as CLI subprocesses
+// (the common case) because the sidecar is in a different process than
+// the command.
+//
+// The handshake uses InsecureSkipVerify because the caller only needs to
+// inspect the leaf — not validate trust. A self-signed dev cert is the
+// expected norm locally.
+type HandshakeResolver struct {
+	cfg     *config.Config
+	host    string
+	port    int
+	timeout time.Duration
+	now     func() time.Time
+	// dialer is injected for tests. Production uses tls.Dialer.DialContext.
+	dial func(ctx context.Context, addr string, tlsCfg *tls.Config) (*tls.ConnectionState, func() error, error)
+}
+
+// NewHandshakeResolver builds a HandshakeResolver for the configured
+// sidecar listener. It uses cfg.Server.Host/Port for the dial target
+// when host/port are zero-valued; explicit host/port wins.
+func NewHandshakeResolver(cfg *config.Config, host string, port int) *HandshakeResolver {
+	return &HandshakeResolver{
+		cfg:     cfg,
+		host:    host,
+		port:    port,
+		timeout: 3 * time.Second,
+		now:     time.Now,
+		dial:    defaultHandshakeDialer,
+	}
+}
+
+// Resolve implements ports.TLSStateResolver.
+//
+// Sequence:
+//  1. If TLS is disabled in config → Disabled.
+//  2. Dial the configured host:port with TLS + InsecureSkipVerify.
+//  3. Inspect the leaf's issuer CN. "Caddy Local Authority" → SelfSignedLocal
+//     with no expiry math.
+//  4. Otherwise compare NotAfter against now to produce Obtained or
+//     ExpiringSoon.
+//
+// Unreachable / malformed handshakes produce Unknown + nil error so the
+// caller can render a neutral message without treating it as a failure.
+func (r *HandshakeResolver) Resolve(ctx context.Context) (tlsdomain.State, error) {
+	if r.cfg != nil && !r.cfg.TLS.Enabled {
+		return tlsdomain.NewDisabled(), nil
+	}
+
+	dialHost := r.host
+	if dialHost == "" || dialHost == "0.0.0.0" || dialHost == "::" {
+		dialHost = "127.0.0.1"
+	}
+	addr := fmt.Sprintf("%s:%d", dialHost, r.port)
+
+	handshakeCtx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+
+	state, closeFn, err := r.dial(handshakeCtx, addr, &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec // leaf inspection only, no trust check
+	})
+	if err != nil {
+		return tlsdomain.NewUnknown(), nil
+	}
+	defer func() { _ = closeFn() }()
+
+	if state == nil || len(state.PeerCertificates) == 0 {
+		return tlsdomain.NewUnknown(), nil
+	}
+
+	leaf := state.PeerCertificates[0]
+
+	// Caddy internal issuer → SelfSignedLocal regardless of config.
+	if leaf.Issuer.CommonName == caddyLocalIssuerCN {
+		return tlsdomain.NewSelfSignedLocal(), nil
+	}
+
+	// Non-internal issuer → expiry math.
+	now := r.now()
+	if now.After(leaf.NotAfter) {
+		return tlsdomain.NewExpiringSoon(0, leaf.NotAfter), nil
+	}
+	daysLeft := int(leaf.NotAfter.Sub(now).Hours() / 24)
+	if daysLeft <= tlsCertExpiryWarnDays {
+		return tlsdomain.NewExpiringSoon(daysLeft, leaf.NotAfter), nil
+	}
+	return tlsdomain.NewObtained(leaf.NotAfter), nil
+}
+
+// defaultHandshakeDialer performs the real TLS dial and returns the
+// ConnectionState plus a Close() function.
+func defaultHandshakeDialer(ctx context.Context, addr string, tlsCfg *tls.Config) (*tls.ConnectionState, func() error, error) {
+	dialer := tls.Dialer{Config: tlsCfg}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, func() error { return nil }, err
+	}
+
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		_ = conn.Close()
+		return nil, func() error { return nil }, fmt.Errorf("unexpected connection type %T", conn)
+	}
+	cs := tlsConn.ConnectionState()
+	return &cs, conn.Close, nil
+}

--- a/internal/adapters/caddy/tls_state_handshake_test.go
+++ b/internal/adapters/caddy/tls_state_handshake_test.go
@@ -1,0 +1,160 @@
+package caddy
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+)
+
+// makeTLSServer boots an httptest.NewUnstartedServer configured with a
+// self-signed leaf whose issuer CN and NotAfter are test-controlled.
+// Returns the host, port and cleanup function.
+func makeTLSServer(t *testing.T, issuerCN string, notAfter time.Time) (host string, port int, cleanup func()) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	// x509.CreateCertificate derives the Issuer from the parent's Subject,
+	// so we build a parent cert with Subject = <issuerCN> and sign the leaf
+	// with it. This matches how Caddy's internal CA produces leaves with
+	// Issuer.CommonName = "Caddy Local Authority".
+	parentTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: issuerCN},
+		NotBefore:    notAfter.Add(-365 * 24 * time.Hour),
+		NotAfter:     notAfter.Add(365 * 24 * time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    notAfter.Add(-24 * time.Hour),
+		NotAfter:     notAfter,
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:     []string{"localhost"},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, parentTemplate, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	tlsCert := tls.Certificate{Certificate: [][]byte{certDER}, PrivateKey: key}
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{tlsCert}}
+	srv.StartTLS()
+
+	u := srv.Listener.Addr().(*net.TCPAddr)
+	return u.IP.String(), u.Port, srv.Close
+}
+
+func TestHandshakeResolver_Resolve(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+
+	t.Run("self-signed local issuer → SelfSignedLocal", func(t *testing.T) {
+		// Short-lived leaf (8 hours). Would have tripped the old day-count
+		// warning — new resolver ignores NotAfter when issuer CN matches.
+		host, port, cleanup := makeTLSServer(t, caddyLocalIssuerCN, fixedNow.Add(8*time.Hour))
+		defer cleanup()
+
+		cfg := &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "self-signed"}}
+		r := NewHandshakeResolver(cfg, host, port)
+		r.now = func() time.Time { return fixedNow }
+
+		state, err := r.Resolve(context.Background())
+		if err != nil {
+			t.Fatalf("Resolve() unexpected error: %v", err)
+		}
+		if state.Kind() != tlsdomain.KindSelfSignedLocal {
+			t.Errorf("Kind() = %v, want SelfSignedLocal", state.Kind())
+		}
+	})
+
+	t.Run("external issuer with long expiry → Obtained", func(t *testing.T) {
+		host, port, cleanup := makeTLSServer(t, "ExampleCA", fixedNow.Add(90*24*time.Hour))
+		defer cleanup()
+
+		cfg := &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "letsencrypt"}}
+		r := NewHandshakeResolver(cfg, host, port)
+		r.now = func() time.Time { return fixedNow }
+
+		state, err := r.Resolve(context.Background())
+		if err != nil {
+			t.Fatalf("Resolve() unexpected error: %v", err)
+		}
+		if state.Kind() != tlsdomain.KindObtained {
+			t.Errorf("Kind() = %v, want Obtained", state.Kind())
+		}
+	})
+
+	t.Run("external issuer near expiry → ExpiringSoon", func(t *testing.T) {
+		host, port, cleanup := makeTLSServer(t, "ExampleCA", fixedNow.Add(3*24*time.Hour))
+		defer cleanup()
+
+		cfg := &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "letsencrypt"}}
+		r := NewHandshakeResolver(cfg, host, port)
+		r.now = func() time.Time { return fixedNow }
+
+		state, err := r.Resolve(context.Background())
+		if err != nil {
+			t.Fatalf("Resolve() unexpected error: %v", err)
+		}
+		if state.Kind() != tlsdomain.KindExpiringSoon {
+			t.Errorf("Kind() = %v, want ExpiringSoon", state.Kind())
+		}
+		if state.DaysLeft() < 0 || state.DaysLeft() > 7 {
+			t.Errorf("DaysLeft() = %d, want 0..7", state.DaysLeft())
+		}
+	})
+
+	t.Run("sidecar unreachable → Unknown", func(t *testing.T) {
+		// Bind and release to get a closed port.
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		addr := ln.Addr().(*net.TCPAddr)
+		_ = ln.Close()
+
+		cfg := &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "self-signed"}}
+		r := NewHandshakeResolver(cfg, "127.0.0.1", addr.Port)
+		r.timeout = 500 * time.Millisecond
+
+		state, err := r.Resolve(context.Background())
+		if err != nil {
+			t.Fatalf("Resolve() unexpected error: %v", err)
+		}
+		if state.Kind() != tlsdomain.KindUnknown {
+			t.Errorf("Kind() = %v, want Unknown", state.Kind())
+		}
+	})
+
+	t.Run("tls disabled → Disabled", func(t *testing.T) {
+		cfg := &config.Config{TLS: config.TLSConfig{Enabled: false}}
+		r := NewHandshakeResolver(cfg, "127.0.0.1", 0)
+
+		state, err := r.Resolve(context.Background())
+		if err != nil {
+			t.Fatalf("Resolve() unexpected error: %v", err)
+		}
+		if state.Kind() != tlsdomain.KindDisabled {
+			t.Errorf("Kind() = %v, want Disabled", state.Kind())
+		}
+	})
+}

--- a/internal/adapters/caddy/tls_state_test.go
+++ b/internal/adapters/caddy/tls_state_test.go
@@ -1,0 +1,127 @@
+package caddy
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// fakePeerCertProvider is a minimal peerCertProvider test double.
+type fakePeerCertProvider struct {
+	leaf *x509.Certificate
+	err  error
+}
+
+func (f fakePeerCertProvider) LeafCert(_ context.Context) (*x509.Certificate, error) {
+	return f.leaf, f.err
+}
+
+// makeLeaf returns an x509 leaf with the given issuer CN and NotAfter.
+func makeLeaf(issuerCN string, notAfter time.Time) *x509.Certificate {
+	return &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "example.com"},
+		Issuer:       pkix.Name{CommonName: issuerCN},
+		NotBefore:    notAfter.Add(-30 * 24 * time.Hour),
+		NotAfter:     notAfter,
+	}
+}
+
+func TestInProcessResolver_Resolve(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	expiryFar := fixedNow.Add(90 * 24 * time.Hour)
+	expirySoon := fixedNow.Add(3 * 24 * time.Hour)
+
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		provider peerCertProvider
+		wantKind tlsdomain.Kind
+		wantErr  error
+	}{
+		{
+			name:     "nil config disabled",
+			cfg:      nil,
+			provider: fakePeerCertProvider{},
+			wantKind: tlsdomain.KindDisabled,
+		},
+		{
+			name:     "tls disabled",
+			cfg:      &config.Config{TLS: config.TLSConfig{Enabled: false}},
+			provider: fakePeerCertProvider{},
+			wantKind: tlsdomain.KindDisabled,
+		},
+		{
+			name:     "not in process error",
+			cfg:      &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "self-signed"}},
+			provider: fakePeerCertProvider{err: ports.ErrNotInProcess},
+			wantKind: tlsdomain.KindUnknown,
+			wantErr:  ports.ErrNotInProcess,
+		},
+		{
+			name:     "self-signed local issuer CN match",
+			cfg:      &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "self-signed"}},
+			provider: fakePeerCertProvider{leaf: makeLeaf(caddyLocalIssuerCN, fixedNow.Add(8*time.Hour))},
+			wantKind: tlsdomain.KindSelfSignedLocal,
+		},
+		{
+			name:     "self-signed but no leaf yet → obtaining",
+			cfg:      &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "self-signed"}},
+			provider: fakePeerCertProvider{leaf: nil},
+			wantKind: tlsdomain.KindObtaining,
+		},
+		{
+			name:     "acme no leaf → obtaining",
+			cfg:      &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "letsencrypt"}},
+			provider: fakePeerCertProvider{leaf: nil},
+			wantKind: tlsdomain.KindObtaining,
+		},
+		{
+			name:     "acme healthy leaf → obtained",
+			cfg:      &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "letsencrypt"}},
+			provider: fakePeerCertProvider{leaf: makeLeaf("R3", expiryFar)},
+			wantKind: tlsdomain.KindObtained,
+		},
+		{
+			name:     "acme leaf near expiry → expiring soon",
+			cfg:      &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "letsencrypt"}},
+			provider: fakePeerCertProvider{leaf: makeLeaf("R3", expirySoon)},
+			wantKind: tlsdomain.KindExpiringSoon,
+		},
+		{
+			name:     "self-signed with override issuer falls to expiry math",
+			cfg:      &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "self-signed"}},
+			provider: fakePeerCertProvider{leaf: makeLeaf("Not Caddy", expiryFar)},
+			wantKind: tlsdomain.KindObtained,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewInProcessResolver(tt.cfg).
+				withProvider(tt.provider).
+				withNow(func() time.Time { return fixedNow })
+
+			state, err := r.Resolve(context.Background())
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("Resolve() err = %v, want %v", err, tt.wantErr)
+				}
+			} else if err != nil {
+				t.Fatalf("Resolve() unexpected error: %v", err)
+			}
+
+			if state.Kind() != tt.wantKind {
+				t.Errorf("Resolve() kind = %v, want %v", state.Kind(), tt.wantKind)
+			}
+		})
+	}
+}

--- a/internal/app/ops/chain_resolver.go
+++ b/internal/app/ops/chain_resolver.go
@@ -1,0 +1,46 @@
+package ops
+
+import (
+	"context"
+	"errors"
+
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ChainResolver composes a sequence of ports.TLSStateResolver implementations.
+// The first resolver's result wins unless it returns ports.ErrNotInProcess,
+// in which case the chain falls through to the next resolver.
+//
+// This is the canonical way to wire the in-process certmagic resolver as a
+// preferred primary with a handshake fallback. When all resolvers in the
+// chain report ErrNotInProcess (or the chain is empty) the zero-value
+// tlsdomain.NewUnknown() is returned.
+type ChainResolver struct {
+	resolvers []ports.TLSStateResolver
+}
+
+// NewChainResolver builds a ChainResolver. Resolvers are tried in order.
+func NewChainResolver(resolvers ...ports.TLSStateResolver) *ChainResolver {
+	return &ChainResolver{resolvers: resolvers}
+}
+
+// Resolve implements ports.TLSStateResolver.
+func (c *ChainResolver) Resolve(ctx context.Context) (tlsdomain.State, error) {
+	var lastErr error
+	for _, r := range c.resolvers {
+		state, err := r.Resolve(ctx)
+		if errors.Is(err, ports.ErrNotInProcess) {
+			lastErr = err
+			continue
+		}
+		if err != nil {
+			return state, err
+		}
+		return state, nil
+	}
+	// All resolvers fell through. The chain as a whole is Unknown — not an
+	// error the caller should surface.
+	_ = lastErr
+	return tlsdomain.NewUnknown(), nil
+}

--- a/internal/app/ops/chain_resolver_test.go
+++ b/internal/app/ops/chain_resolver_test.go
@@ -1,0 +1,83 @@
+package ops_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/app/ops"
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+type fakeTLSResolver struct {
+	state tlsdomain.State
+	err   error
+}
+
+func (f fakeTLSResolver) Resolve(_ context.Context) (tlsdomain.State, error) {
+	return f.state, f.err
+}
+
+func TestChainResolver(t *testing.T) {
+	tests := []struct {
+		name     string
+		chain    []ports.TLSStateResolver
+		wantKind tlsdomain.Kind
+	}{
+		{
+			name:     "empty chain → unknown",
+			chain:    nil,
+			wantKind: tlsdomain.KindUnknown,
+		},
+		{
+			name: "primary returns state",
+			chain: []ports.TLSStateResolver{
+				fakeTLSResolver{state: tlsdomain.NewSelfSignedLocal()},
+				fakeTLSResolver{state: tlsdomain.NewObtaining()},
+			},
+			wantKind: tlsdomain.KindSelfSignedLocal,
+		},
+		{
+			name: "ErrNotInProcess falls through",
+			chain: []ports.TLSStateResolver{
+				fakeTLSResolver{state: tlsdomain.NewUnknown(), err: ports.ErrNotInProcess},
+				fakeTLSResolver{state: tlsdomain.NewSelfSignedLocal()},
+			},
+			wantKind: tlsdomain.KindSelfSignedLocal,
+		},
+		{
+			name: "all not in process → unknown",
+			chain: []ports.TLSStateResolver{
+				fakeTLSResolver{state: tlsdomain.NewUnknown(), err: ports.ErrNotInProcess},
+				fakeTLSResolver{state: tlsdomain.NewUnknown(), err: ports.ErrNotInProcess},
+			},
+			wantKind: tlsdomain.KindUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain := ops.NewChainResolver(tt.chain...)
+			state, err := chain.Resolve(context.Background())
+			if err != nil {
+				t.Fatalf("Resolve() err = %v", err)
+			}
+			if state.Kind() != tt.wantKind {
+				t.Errorf("Resolve() kind = %v, want %v", state.Kind(), tt.wantKind)
+			}
+		})
+	}
+}
+
+func TestChainResolver_NonSentinelError(t *testing.T) {
+	boom := errors.New("boom")
+	chain := ops.NewChainResolver(
+		fakeTLSResolver{state: tlsdomain.NewUnknown(), err: boom},
+		fakeTLSResolver{state: tlsdomain.NewSelfSignedLocal()},
+	)
+	_, err := chain.Resolve(context.Background())
+	if !errors.Is(err, boom) {
+		t.Errorf("expected boom error to propagate, got %v", err)
+	}
+}

--- a/internal/app/ops/doctor.go
+++ b/internal/app/ops/doctor.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +13,7 @@ import (
 	"github.com/fatih/color"
 
 	"github.com/vibewarden/vibewarden/internal/config"
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
@@ -53,6 +53,7 @@ type DoctorService struct {
 	healthChecker ports.HealthChecker
 	imageChecker  ports.DockerImageChecker
 	ownerProbe    ports.PortOwnerProbe
+	tlsState      ports.TLSStateResolver // optional; nil falls back to handshake-on-demand
 }
 
 // NewDoctorService creates a new DoctorService.
@@ -81,6 +82,16 @@ func (s *DoctorService) WithImageChecker(checker ports.DockerImageChecker) *Doct
 func (s *DoctorService) WithPortOwnerProbe(probe ports.PortOwnerProbe) *DoctorService {
 	cp := *s
 	cp.ownerProbe = probe
+	return &cp
+}
+
+// WithTLSStateResolver returns a copy of the DoctorService with the given
+// resolver wired for the TLS check. When nil, the doctor builds a
+// HandshakeResolver on the fly per invocation — this preserves behaviour
+// for existing tests that construct the service without a resolver.
+func (s *DoctorService) WithTLSStateResolver(r ports.TLSStateResolver) *DoctorService {
+	cp := *s
+	cp.tlsState = r
 	return &cp
 }
 
@@ -163,7 +174,7 @@ func (s *DoctorService) runChecks(ctx context.Context, cfg *config.Config, opts 
 
 	// --- Layer 2: Local Runtime ---
 	results = append(results, withSection(s.checkUpstreamReachable(ctx, cfg), sectionLocalRuntime))
-	results = append(results, withSection(checkTLSCertValid(ctx, cfg, proxyHost, proxyPort), sectionLocalRuntime))
+	results = append(results, withSection(s.checkTLSCertValid(ctx, cfg, proxyHost, proxyPort), sectionLocalRuntime))
 
 	return results
 }
@@ -374,17 +385,26 @@ func (s *DoctorService) checkUpstreamReachable(ctx context.Context, cfg *config.
 	}
 }
 
-// checkTLSCertValid inspects the local self-signed TLS certificate by doing
-// a live TLS handshake against the running sidecar. When the sidecar is not
-// reachable the check degrades to WARN with a "start vibew dev" hint.
+// checkTLSCertValid renders the "TLS certificate" doctor check by
+// consuming a resolved TLSState. When a resolver is wired on the
+// DoctorService it is used directly; otherwise the service falls back to
+// its built-in handshake path (preserved for tests and for composition
+// roots that pre-date #1090). See PM spec #1090 / #1078 and ADR-084.
 //
-// Self-signed cert storage is owned by the embedded Caddy instance
-// (internal/adapters/caddy) and the only reliable way to see which cert the
-// sidecar is actually serving is to handshake with it — which is exactly
-// what we do here. See ADR-084 for the rationale and the rejected
-// filesystem-scan approach.
-func checkTLSCertValid(ctx context.Context, cfg *config.Config, host string, port int) CheckResult {
-	if cfg.TLS.Provider != "self-signed" {
+// The renderer in doctor_tls_render.go is the single source of truth for
+// severity and detail mapping. This method only handles the resolver
+// selection and the legacy "provider != self-signed" short-circuit.
+func (s *DoctorService) checkTLSCertValid(ctx context.Context, cfg *config.Config, host string, port int) CheckResult {
+	// Disabled short-circuit — renderer produces an OK result.
+	if cfg != nil && !cfg.TLS.Enabled {
+		return renderTLSDoctorCheck(tlsdomain.NewDisabled())
+	}
+
+	// Legacy behaviour for non-self-signed providers without a resolver:
+	// skip the check. (External/ACME providers need an in-process
+	// resolver to observe cert state; the composition root wires that
+	// today, but older callers may not.)
+	if s.tlsState == nil && cfg != nil && cfg.TLS.Provider != "self-signed" {
 		return CheckResult{
 			Name:     "TLS certificate",
 			Severity: SeverityOK,
@@ -392,74 +412,21 @@ func checkTLSCertValid(ctx context.Context, cfg *config.Config, host string, por
 		}
 	}
 
-	handshakeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-
-	dialHost := host
-	if dialHost == "0.0.0.0" || dialHost == "::" {
-		dialHost = "127.0.0.1"
+	resolver := s.tlsState
+	if resolver == nil {
+		resolver = newInlineHandshakeResolver(cfg, host, port)
 	}
-	addr := fmt.Sprintf("%s:%d", dialHost, port)
 
-	dialer := tls.Dialer{
-		Config: &tls.Config{
-			// Self-signed cert in dev is expected — we only need to
-			// inspect the leaf, not validate trust.
-			InsecureSkipVerify: true, //nolint:gosec
-		},
-	}
-	conn, err := dialer.DialContext(handshakeCtx, "tcp", addr)
+	state, err := resolver.Resolve(ctx)
 	if err != nil {
 		return CheckResult{
 			Name:     "TLS certificate",
 			Severity: SeverityWarn,
-			Detail:   fmt.Sprintf("sidecar not reachable on %s — start 'vibew dev'", addr),
-		}
-	}
-	defer conn.Close() //nolint:errcheck
-
-	tlsConn, ok := conn.(*tls.Conn)
-	if !ok {
-		return CheckResult{
-			Name:     "TLS certificate",
-			Severity: SeverityWarn,
-			Detail:   fmt.Sprintf("unexpected connection type from %s", addr),
+			Detail:   fmt.Sprintf("resolver error: %v", err),
 		}
 	}
 
-	certs := tlsConn.ConnectionState().PeerCertificates
-	if len(certs) == 0 {
-		return CheckResult{
-			Name:     "TLS certificate",
-			Severity: SeverityWarn,
-			Detail:   fmt.Sprintf("no certificate presented by %s", addr),
-		}
-	}
-
-	leaf := certs[0]
-	now := time.Now()
-	if now.After(leaf.NotAfter) {
-		return CheckResult{
-			Name:     "TLS certificate",
-			Severity: SeverityFail,
-			Detail:   fmt.Sprintf("expired on %s", leaf.NotAfter.Format(time.DateOnly)),
-		}
-	}
-
-	daysUntilExpiry := int(time.Until(leaf.NotAfter).Hours() / 24)
-	if daysUntilExpiry <= localTLSCertExpiryWarnDays {
-		return CheckResult{
-			Name:     "TLS certificate",
-			Severity: SeverityWarn,
-			Detail:   fmt.Sprintf("expires in %d day(s) on %s", daysUntilExpiry, leaf.NotAfter.Format(time.DateOnly)),
-		}
-	}
-
-	return CheckResult{
-		Name:     "TLS certificate",
-		Severity: SeverityOK,
-		Detail:   fmt.Sprintf("valid until %s (%d days)", leaf.NotAfter.Format(time.DateOnly), daysUntilExpiry),
-	}
+	return renderTLSDoctorCheck(state)
 }
 
 // checkACMEEmail verifies that an ACME account email is configured when the

--- a/internal/app/ops/doctor.go
+++ b/internal/app/ops/doctor.go
@@ -397,7 +397,7 @@ func (s *DoctorService) checkUpstreamReachable(ctx context.Context, cfg *config.
 func (s *DoctorService) checkTLSCertValid(ctx context.Context, cfg *config.Config, host string, port int) CheckResult {
 	// Disabled short-circuit — renderer produces an OK result.
 	if cfg != nil && !cfg.TLS.Enabled {
-		return renderTLSDoctorCheck(tlsdomain.NewDisabled())
+		return renderTLSDoctorCheck(tlsdomain.NewDisabled(), time.Now)
 	}
 
 	// Legacy behaviour for non-self-signed providers without a resolver:
@@ -426,7 +426,7 @@ func (s *DoctorService) checkTLSCertValid(ctx context.Context, cfg *config.Confi
 		}
 	}
 
-	return renderTLSDoctorCheck(state)
+	return renderTLSDoctorCheck(state, time.Now)
 }
 
 // checkACMEEmail verifies that an ACME account email is configured when the

--- a/internal/app/ops/doctor_tls_render.go
+++ b/internal/app/ops/doctor_tls_render.go
@@ -7,11 +7,6 @@ import (
 	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
 )
 
-// nowFn is the clock used by renderTLSDoctorCheck. It is a package-level
-// variable so tests can replace it with a fixed time without threading a
-// clock through the renderer signature.
-var nowFn = time.Now
-
 // renderTLSDoctorCheck converts a TLSState into a CheckResult for the
 // `vibew doctor` report. Severity mapping follows the PM spec for
 // #1090 / #1078:
@@ -21,7 +16,10 @@ var nowFn = time.Now
 //
 // The Name is always "TLS certificate" and the Section is left to the
 // caller (the doctor service wraps it with the Local Runtime section).
-func renderTLSDoctorCheck(state tlsdomain.State) CheckResult {
+//
+// now is injected so callers can fix the clock in tests without mutating
+// any package-level variable.
+func renderTLSDoctorCheck(state tlsdomain.State, now func() time.Time) CheckResult {
 	result := CheckResult{Name: "TLS certificate"}
 
 	switch state.Kind() {
@@ -32,7 +30,7 @@ func renderTLSDoctorCheck(state tlsdomain.State) CheckResult {
 		result.Severity = SeverityOK
 		result.Detail = "self-signed dev cert (rotates automatically)"
 	case tlsdomain.KindObtained:
-		daysLeft := int(state.ExpiresAt().Sub(nowFn()).Hours() / 24)
+		daysLeft := int(state.ExpiresAt().Sub(now()).Hours() / 24)
 		if daysLeft < 0 {
 			daysLeft = 0
 		}
@@ -42,7 +40,7 @@ func renderTLSDoctorCheck(state tlsdomain.State) CheckResult {
 		// An ExpiringSoon state with NotAfter already in the past is
 		// really "expired" — escalate to FAIL so automation treats it
 		// as a hard failure.
-		if !state.ExpiresAt().IsZero() && nowFn().After(state.ExpiresAt()) {
+		if !state.ExpiresAt().IsZero() && now().After(state.ExpiresAt()) {
 			result.Severity = SeverityFail
 			result.Detail = fmt.Sprintf("expired on %s", state.ExpiresAt().Format("2006-01-02"))
 		} else {

--- a/internal/app/ops/doctor_tls_render.go
+++ b/internal/app/ops/doctor_tls_render.go
@@ -1,0 +1,71 @@
+package ops
+
+import (
+	"fmt"
+	"time"
+
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+)
+
+// nowFn is the clock used by renderTLSDoctorCheck. It is a package-level
+// variable so tests can replace it with a fixed time without threading a
+// clock through the renderer signature.
+var nowFn = time.Now
+
+// renderTLSDoctorCheck converts a TLSState into a CheckResult for the
+// `vibew doctor` report. Severity mapping follows the PM spec for
+// #1090 / #1078:
+//   - Disabled, SelfSignedLocal, Obtained (>7d) → OK
+//   - Obtaining, ExpiringSoon, Unknown        → WARN
+//   - Failing                                  → FAIL
+//
+// The Name is always "TLS certificate" and the Section is left to the
+// caller (the doctor service wraps it with the Local Runtime section).
+func renderTLSDoctorCheck(state tlsdomain.State) CheckResult {
+	result := CheckResult{Name: "TLS certificate"}
+
+	switch state.Kind() {
+	case tlsdomain.KindDisabled:
+		result.Severity = SeverityOK
+		result.Detail = "TLS plugin disabled"
+	case tlsdomain.KindSelfSignedLocal:
+		result.Severity = SeverityOK
+		result.Detail = "self-signed dev cert (rotates automatically)"
+	case tlsdomain.KindObtained:
+		daysLeft := int(state.ExpiresAt().Sub(nowFn()).Hours() / 24)
+		if daysLeft < 0 {
+			daysLeft = 0
+		}
+		result.Severity = SeverityOK
+		result.Detail = fmt.Sprintf("valid until %s (%d days)", state.ExpiresAt().Format("2006-01-02"), daysLeft)
+	case tlsdomain.KindExpiringSoon:
+		// An ExpiringSoon state with NotAfter already in the past is
+		// really "expired" — escalate to FAIL so automation treats it
+		// as a hard failure.
+		if !state.ExpiresAt().IsZero() && nowFn().After(state.ExpiresAt()) {
+			result.Severity = SeverityFail
+			result.Detail = fmt.Sprintf("expired on %s", state.ExpiresAt().Format("2006-01-02"))
+		} else {
+			result.Severity = SeverityWarn
+			result.Detail = fmt.Sprintf("expires in %d day(s) on %s", state.DaysLeft(), state.ExpiresAt().Format("2006-01-02"))
+		}
+	case tlsdomain.KindObtaining:
+		result.Severity = SeverityWarn
+		result.Detail = "ACME exchange in progress — rerun in 1-2 minutes"
+	case tlsdomain.KindFailing:
+		result.Severity = SeverityFail
+		if state.LastError() == "" {
+			result.Detail = "ACME exchange failed"
+		} else {
+			result.Detail = fmt.Sprintf("ACME exchange failed: %s", state.LastError())
+		}
+	case tlsdomain.KindUnknown:
+		result.Severity = SeverityWarn
+		result.Detail = "sidecar not reachable — start 'vibew dev'"
+	default:
+		result.Severity = SeverityWarn
+		result.Detail = state.String()
+	}
+
+	return result
+}

--- a/internal/app/ops/doctor_tls_render_test.go
+++ b/internal/app/ops/doctor_tls_render_test.go
@@ -9,9 +9,7 @@ import (
 
 func TestRenderTLSDoctorCheck(t *testing.T) {
 	fixedNow := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
-	origNow := nowFn
-	nowFn = func() time.Time { return fixedNow }
-	t.Cleanup(func() { nowFn = origNow })
+	clockFn := func() time.Time { return fixedNow }
 
 	expiryFar := fixedNow.Add(90 * 24 * time.Hour)
 	expirySoon := fixedNow.Add(3 * 24 * time.Hour)
@@ -34,7 +32,7 @@ func TestRenderTLSDoctorCheck(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := renderTLSDoctorCheck(tt.state)
+			got := renderTLSDoctorCheck(tt.state, clockFn)
 			if got.Name != "TLS certificate" {
 				t.Errorf("Name = %q, want %q", got.Name, "TLS certificate")
 			}
@@ -51,11 +49,9 @@ func TestRenderTLSDoctorCheck(t *testing.T) {
 // TestRenderTLSDoctorCheck_NoExpiringZeroDaysForSelfSigned locks bug #1078:
 // SelfSignedLocal must never produce a "expires 0 day(s)" message.
 func TestRenderTLSDoctorCheck_NoExpiringZeroDaysForSelfSigned(t *testing.T) {
-	origNow := nowFn
-	nowFn = func() time.Time { return time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC) }
-	t.Cleanup(func() { nowFn = origNow })
+	clockFn := func() time.Time { return time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC) }
 
-	got := renderTLSDoctorCheck(tlsdomain.NewSelfSignedLocal())
+	got := renderTLSDoctorCheck(tlsdomain.NewSelfSignedLocal(), clockFn)
 	if got.Severity != SeverityOK {
 		t.Errorf("SelfSignedLocal severity = %v, want OK", got.Severity)
 	}

--- a/internal/app/ops/doctor_tls_render_test.go
+++ b/internal/app/ops/doctor_tls_render_test.go
@@ -1,0 +1,80 @@
+package ops
+
+import (
+	"testing"
+	"time"
+
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+)
+
+func TestRenderTLSDoctorCheck(t *testing.T) {
+	fixedNow := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	origNow := nowFn
+	nowFn = func() time.Time { return fixedNow }
+	t.Cleanup(func() { nowFn = origNow })
+
+	expiryFar := fixedNow.Add(90 * 24 * time.Hour)
+	expirySoon := fixedNow.Add(3 * 24 * time.Hour)
+
+	tests := []struct {
+		name         string
+		state        tlsdomain.State
+		wantSeverity Severity
+		wantDetail   string
+	}{
+		{"disabled → OK", tlsdomain.NewDisabled(), SeverityOK, "TLS plugin disabled"},
+		{"self-signed → OK", tlsdomain.NewSelfSignedLocal(), SeverityOK, "self-signed dev cert (rotates automatically)"},
+		{"obtained → OK", tlsdomain.NewObtained(expiryFar), SeverityOK, "valid until 2026-07-19 (90 days)"},
+		{"expiring → WARN", tlsdomain.NewExpiringSoon(3, expirySoon), SeverityWarn, "expires in 3 day(s) on 2026-04-23"},
+		{"obtaining → WARN", tlsdomain.NewObtaining(), SeverityWarn, "ACME exchange in progress — rerun in 1-2 minutes"},
+		{"failing → FAIL", tlsdomain.NewFailing("dns error"), SeverityFail, "ACME exchange failed: dns error"},
+		{"failing empty → FAIL", tlsdomain.NewFailing(""), SeverityFail, "ACME exchange failed"},
+		{"unknown → WARN", tlsdomain.NewUnknown(), SeverityWarn, "sidecar not reachable — start 'vibew dev'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderTLSDoctorCheck(tt.state)
+			if got.Name != "TLS certificate" {
+				t.Errorf("Name = %q, want %q", got.Name, "TLS certificate")
+			}
+			if got.Severity != tt.wantSeverity {
+				t.Errorf("Severity = %v, want %v", got.Severity, tt.wantSeverity)
+			}
+			if got.Detail != tt.wantDetail {
+				t.Errorf("Detail = %q, want %q", got.Detail, tt.wantDetail)
+			}
+		})
+	}
+}
+
+// TestRenderTLSDoctorCheck_NoExpiringZeroDaysForSelfSigned locks bug #1078:
+// SelfSignedLocal must never produce a "expires 0 day(s)" message.
+func TestRenderTLSDoctorCheck_NoExpiringZeroDaysForSelfSigned(t *testing.T) {
+	origNow := nowFn
+	nowFn = func() time.Time { return time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC) }
+	t.Cleanup(func() { nowFn = origNow })
+
+	got := renderTLSDoctorCheck(tlsdomain.NewSelfSignedLocal())
+	if got.Severity != SeverityOK {
+		t.Errorf("SelfSignedLocal severity = %v, want OK", got.Severity)
+	}
+	for _, bad := range []string{"expires", "day(s)", "0 day", "expired"} {
+		if contains(got.Detail, bad) {
+			t.Errorf("SelfSignedLocal detail %q must not contain %q", got.Detail, bad)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/app/ops/status.go
+++ b/internal/app/ops/status.go
@@ -40,24 +40,30 @@ func NewStatusService(health ports.HealthChecker) *StatusService {
 	return &StatusService{health: health}
 }
 
-// WithCompose attaches a ComposeRunner for diagnostic container status checks.
+// WithCompose returns a copy of the StatusService with the given ComposeRunner
+// wired for diagnostic container status checks.
 func (s *StatusService) WithCompose(compose ports.ComposeRunner) *StatusService {
-	s.compose = compose
-	return s
+	cp := *s
+	cp.compose = compose
+	return &cp
 }
 
-// WithLogs attaches a ComposeLogs for diagnostic log tail checks.
+// WithLogs returns a copy of the StatusService with the given ComposeLogs
+// wired for diagnostic log tail checks.
 func (s *StatusService) WithLogs(logs ports.ComposeLogs) *StatusService {
-	s.logs = logs
-	return s
+	cp := *s
+	cp.logs = logs
+	return &cp
 }
 
-// WithTLSStateResolver attaches a TLS state resolver used to render the
-// TLS row with state-aware detail (obtained/obtaining/self-signed/...).
-// When nil, the TLS row falls back to the legacy config-only rendering.
+// WithTLSStateResolver returns a copy of the StatusService with the given TLS
+// state resolver wired to render the TLS row with state-aware detail
+// (obtained/obtaining/self-signed/...). When nil, the TLS row falls back to
+// the legacy config-only rendering.
 func (s *StatusService) WithTLSStateResolver(r ports.TLSStateResolver) *StatusService {
-	s.tlsState = r
-	return s
+	cp := *s
+	cp.tlsState = r
+	return &cp
 }
 
 // Run queries all components and writes the status dashboard to out.

--- a/internal/app/ops/status.go
+++ b/internal/app/ops/status.go
@@ -29,9 +29,10 @@ type ComponentStatus struct {
 // When a ComposeRunner is wired, it provides additional diagnostic details
 // when the proxy is unreachable (container state, log snippets).
 type StatusService struct {
-	health  ports.HealthChecker
-	compose ports.ComposeRunner // optional; nil disables container diagnostics
-	logs    ports.ComposeLogs   // optional; nil disables log-based diagnostics
+	health   ports.HealthChecker
+	compose  ports.ComposeRunner    // optional; nil disables container diagnostics
+	logs     ports.ComposeLogs      // optional; nil disables log-based diagnostics
+	tlsState ports.TLSStateResolver // optional; nil falls back to config-only rendering
 }
 
 // NewStatusService creates a new StatusService.
@@ -48,6 +49,14 @@ func (s *StatusService) WithCompose(compose ports.ComposeRunner) *StatusService 
 // WithLogs attaches a ComposeLogs for diagnostic log tail checks.
 func (s *StatusService) WithLogs(logs ports.ComposeLogs) *StatusService {
 	s.logs = logs
+	return s
+}
+
+// WithTLSStateResolver attaches a TLS state resolver used to render the
+// TLS row with state-aware detail (obtained/obtaining/self-signed/...).
+// When nil, the TLS row falls back to the legacy config-only rendering.
+func (s *StatusService) WithTLSStateResolver(r ports.TLSStateResolver) *StatusService {
+	s.tlsState = r
 	return s
 }
 
@@ -117,22 +126,38 @@ func (s *StatusService) gatherStatuses(ctx context.Context, cfg *config.Config, 
 		})
 	}
 
-	// TLS
-	tlsDetail := fmt.Sprintf("disabled — provider: %s", cfg.TLS.Provider)
+	// TLS — prefer the state-aware resolver when wired. The renderer
+	// produces healthy/unhealthy plus the canonical detail string from
+	// the PM spec for #1090. When no resolver is wired we fall back to
+	// the legacy config-only detail.
+	statuses = append(statuses, s.tlsComponentStatus(ctx, cfg))
+
+	return statuses
+}
+
+// tlsComponentStatus builds the TLS row for the status dashboard. When a
+// TLS state resolver is wired it produces state-aware output (see PM spec
+// #1090); otherwise it falls back to the pre-#1090 config-only detail.
+func (s *StatusService) tlsComponentStatus(ctx context.Context, cfg *config.Config) ComponentStatus {
+	if s.tlsState != nil {
+		state, err := s.tlsState.Resolve(ctx)
+		if err == nil {
+			detail, healthy := renderTLSStatusLine(state)
+			return ComponentStatus{Name: "TLS", Healthy: healthy, Detail: detail}
+		}
+		// On resolver error, fall through to config-only detail so we
+		// never crash the status dashboard.
+	}
+
+	detail := fmt.Sprintf("disabled — provider: %s", cfg.TLS.Provider)
 	if cfg.TLS.Enabled {
 		domain := cfg.TLS.Domain
 		if domain == "" {
 			domain = "self-signed"
 		}
-		tlsDetail = fmt.Sprintf("enabled — provider: %s, domain: %s", cfg.TLS.Provider, domain)
+		detail = fmt.Sprintf("enabled — provider: %s, domain: %s", cfg.TLS.Provider, domain)
 	}
-	statuses = append(statuses, ComponentStatus{
-		Name:    "TLS",
-		Healthy: true,
-		Detail:  tlsDetail,
-	})
-
-	return statuses
+	return ComponentStatus{Name: "TLS", Healthy: true, Detail: detail}
 }
 
 // PluginStatus represents the enabled/disabled state of a single plugin

--- a/internal/app/ops/status_tls_render.go
+++ b/internal/app/ops/status_tls_render.go
@@ -1,0 +1,35 @@
+package ops
+
+import (
+	"fmt"
+
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+)
+
+// renderTLSStatusLine renders a TLSState as a (detail, healthy) pair for
+// display in the `vibew status` component table. The detail string matches
+// the PM spec for #1090 (e.g. "obtained (expires 2026-07-21)"). Healthy
+// controls the green/red mark.
+func renderTLSStatusLine(state tlsdomain.State) (detail string, healthy bool) {
+	switch state.Kind() {
+	case tlsdomain.KindDisabled:
+		return "disabled", true
+	case tlsdomain.KindSelfSignedLocal:
+		return "self-signed dev cert (rotates automatically)", true
+	case tlsdomain.KindObtaining:
+		return "obtaining (ACME in progress)", true
+	case tlsdomain.KindObtained:
+		return fmt.Sprintf("obtained (expires %s)", state.ExpiresAt().Format("2006-01-02")), true
+	case tlsdomain.KindExpiringSoon:
+		return fmt.Sprintf("near expiry (expires in %d days)", state.DaysLeft()), false
+	case tlsdomain.KindFailing:
+		if state.LastError() == "" {
+			return "failing", false
+		}
+		return fmt.Sprintf("failing (last error: %s)", state.LastError()), false
+	case tlsdomain.KindUnknown:
+		return "state unavailable — start 'vibew dev'", true
+	default:
+		return state.String(), true
+	}
+}

--- a/internal/app/ops/status_tls_render_test.go
+++ b/internal/app/ops/status_tls_render_test.go
@@ -1,0 +1,40 @@
+package ops
+
+import (
+	"testing"
+	"time"
+
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+)
+
+func TestRenderTLSStatusLine(t *testing.T) {
+	expires := time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		state       tlsdomain.State
+		wantDetail  string
+		wantHealthy bool
+	}{
+		{"disabled", tlsdomain.NewDisabled(), "disabled", true},
+		{"self-signed", tlsdomain.NewSelfSignedLocal(), "self-signed dev cert (rotates automatically)", true},
+		{"obtaining", tlsdomain.NewObtaining(), "obtaining (ACME in progress)", true},
+		{"obtained", tlsdomain.NewObtained(expires), "obtained (expires 2026-07-21)", true},
+		{"expiring soon", tlsdomain.NewExpiringSoon(3, expires), "near expiry (expires in 3 days)", false},
+		{"failing with error", tlsdomain.NewFailing("connection refused"), "failing (last error: connection refused)", false},
+		{"failing empty error", tlsdomain.NewFailing(""), "failing", false},
+		{"unknown", tlsdomain.NewUnknown(), "state unavailable — start 'vibew dev'", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detail, healthy := renderTLSStatusLine(tt.state)
+			if detail != tt.wantDetail {
+				t.Errorf("detail = %q, want %q", detail, tt.wantDetail)
+			}
+			if healthy != tt.wantHealthy {
+				t.Errorf("healthy = %v, want %v", healthy, tt.wantHealthy)
+			}
+		})
+	}
+}

--- a/internal/app/ops/tls_handshake_fallback.go
+++ b/internal/app/ops/tls_handshake_fallback.go
@@ -11,11 +11,9 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
-// caddyLocalIssuerCN is the issuer Common Name Caddy stamps on internal
-// self-signed dev leaves. Duplicated here (also defined in the caddy
-// adapter) to avoid an app → adapter import violation. If the constant
-// ever changes, bump it in both places.
-const caddyLocalIssuerCN = "Caddy Local Authority"
+// caddyLocalIssuerCN aliases the canonical constant from the domain layer
+// so this file avoids an app → adapter import violation.
+const caddyLocalIssuerCN = tlsdomain.CaddyLocalIssuerCN
 
 // inlineHandshakeResolver is an app-layer fallback TLS state resolver.
 // It performs the same TLS handshake as the caddy adapter's

--- a/internal/app/ops/tls_handshake_fallback.go
+++ b/internal/app/ops/tls_handshake_fallback.go
@@ -1,0 +1,92 @@
+package ops
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// caddyLocalIssuerCN is the issuer Common Name Caddy stamps on internal
+// self-signed dev leaves. Duplicated here (also defined in the caddy
+// adapter) to avoid an app → adapter import violation. If the constant
+// ever changes, bump it in both places.
+const caddyLocalIssuerCN = "Caddy Local Authority"
+
+// inlineHandshakeResolver is an app-layer fallback TLS state resolver.
+// It performs the same TLS handshake as the caddy adapter's
+// HandshakeResolver but lives here so internal/app/ops does not need to
+// import internal/adapters/caddy. Composition roots should prefer the
+// adapter version; this helper keeps older wire points (and the existing
+// doctor tests) working when no resolver is injected.
+type inlineHandshakeResolver struct {
+	cfg     *config.Config
+	host    string
+	port    int
+	timeout time.Duration
+	now     func() time.Time
+}
+
+// newInlineHandshakeResolver constructs the fallback resolver. Returns a
+// ports.TLSStateResolver so callers program against the port.
+func newInlineHandshakeResolver(cfg *config.Config, host string, port int) ports.TLSStateResolver {
+	return &inlineHandshakeResolver{
+		cfg:     cfg,
+		host:    host,
+		port:    port,
+		timeout: 3 * time.Second,
+		now:     time.Now,
+	}
+}
+
+func (r *inlineHandshakeResolver) Resolve(ctx context.Context) (tlsdomain.State, error) {
+	if r.cfg != nil && !r.cfg.TLS.Enabled {
+		return tlsdomain.NewDisabled(), nil
+	}
+
+	dialHost := r.host
+	if dialHost == "" || dialHost == "0.0.0.0" || dialHost == "::" {
+		dialHost = "127.0.0.1"
+	}
+	addr := fmt.Sprintf("%s:%d", dialHost, r.port)
+
+	handshakeCtx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+
+	dialer := tls.Dialer{Config: &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec // leaf inspection only
+	}}
+	conn, err := dialer.DialContext(handshakeCtx, "tcp", addr)
+	if err != nil {
+		return tlsdomain.NewUnknown(), nil
+	}
+	defer func() { _ = conn.Close() }()
+
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		return tlsdomain.NewUnknown(), nil
+	}
+	certs := tlsConn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		return tlsdomain.NewUnknown(), nil
+	}
+	leaf := certs[0]
+
+	if leaf.Issuer.CommonName == caddyLocalIssuerCN {
+		return tlsdomain.NewSelfSignedLocal(), nil
+	}
+
+	now := r.now()
+	if now.After(leaf.NotAfter) {
+		return tlsdomain.NewExpiringSoon(0, leaf.NotAfter), nil
+	}
+	daysLeft := int(leaf.NotAfter.Sub(now).Hours() / 24)
+	if daysLeft <= localTLSCertExpiryWarnDays {
+		return tlsdomain.NewExpiringSoon(daysLeft, leaf.NotAfter), nil
+	}
+	return tlsdomain.NewObtained(leaf.NotAfter), nil
+}

--- a/internal/cli/cmd/doctor.go
+++ b/internal/cli/cmd/doctor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	caddyadapter "github.com/vibewarden/vibewarden/internal/adapters/caddy"
 	opsadapter "github.com/vibewarden/vibewarden/internal/adapters/ops"
 	opsapp "github.com/vibewarden/vibewarden/internal/app/ops"
 	"github.com/vibewarden/vibewarden/internal/config"
@@ -76,9 +77,24 @@ Examples:
 			httpClient := &http.Client{Timeout: 5 * time.Second}
 			healthChecker := opsadapter.NewHTTPHealthChecker(httpClient)
 			ownerProbe := opsadapter.NewVibeWardenHealthProbe(nil)
+
+			proxyHost := cfg.Server.Host
+			if proxyHost == "" {
+				proxyHost = "127.0.0.1"
+			}
+			proxyPort := cfg.Server.Port
+			if proxyPort == 0 {
+				proxyPort = 8443
+			}
+			tlsResolver := opsapp.NewChainResolver(
+				caddyadapter.NewInProcessResolver(cfg),
+				caddyadapter.NewHandshakeResolver(cfg, proxyHost, proxyPort),
+			)
+
 			svc := opsapp.NewDoctorService(compose, portChecker, healthChecker).
 				WithImageChecker(opsadapter.NewImageCheckerAdapter()).
-				WithPortOwnerProbe(ownerProbe)
+				WithPortOwnerProbe(ownerProbe).
+				WithTLSStateResolver(tlsResolver)
 
 			label := configPath
 			if label == "" {

--- a/internal/cli/cmd/mcp.go
+++ b/internal/cli/cmd/mcp.go
@@ -12,10 +12,12 @@ import (
 
 	"github.com/spf13/cobra"
 
+	caddyadapter "github.com/vibewarden/vibewarden/internal/adapters/caddy"
 	opsadapter "github.com/vibewarden/vibewarden/internal/adapters/ops"
 	opsapp "github.com/vibewarden/vibewarden/internal/app/ops"
 	"github.com/vibewarden/vibewarden/internal/config"
 	"github.com/vibewarden/vibewarden/internal/mcp"
+	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
 // NewMCPCmd creates the "vibew mcp" subcommand.
@@ -79,12 +81,29 @@ func buildMCPToolDeps() mcp.ToolDeps {
 	portChecker := opsadapter.NewNetPortChecker()
 	ownerProbe := opsadapter.NewVibeWardenHealthProbe(nil)
 	doctorSvc := opsapp.NewDoctorService(compose, portChecker, healthChecker).
-		WithPortOwnerProbe(ownerProbe)
+		WithPortOwnerProbe(ownerProbe).
+		WithTLSStateResolver(buildMCPTLSStateResolver())
 
 	return mcp.ToolDeps{
 		HealthChecker: healthChecker,
 		DoctorRunner:  &doctorRunnerAdapter{svc: doctorSvc},
 	}
+}
+
+// buildMCPTLSStateResolver constructs a TLS state resolver for the MCP
+// doctor runner. The MCP server does not know the target config or host
+// at composition time — the doctor runner receives those per-call — so
+// this builds a resolver that defers config binding until Resolve runs.
+func buildMCPTLSStateResolver() ports.TLSStateResolver {
+	// MCP invocations always run as a separate process from the sidecar,
+	// so the in-process resolver falls through and the handshake is
+	// authoritative. We bind to the caller's config+host inside the
+	// doctor runner adapter; here we provide a resolver with sane
+	// zero-value defaults that the doctor will override if needed.
+	return opsapp.NewChainResolver(
+		caddyadapter.NewInProcessResolver(nil),
+		caddyadapter.NewHandshakeResolver(nil, "127.0.0.1", 8443),
+	)
 }
 
 // doctorRunnerAdapter adapts ops.DoctorService to the mcp.DoctorRunner interface.

--- a/internal/cli/cmd/status.go
+++ b/internal/cli/cmd/status.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	caddyadapter "github.com/vibewarden/vibewarden/internal/adapters/caddy"
 	opsadapter "github.com/vibewarden/vibewarden/internal/adapters/ops"
 	opsapp "github.com/vibewarden/vibewarden/internal/app/ops"
 	"github.com/vibewarden/vibewarden/internal/config"
@@ -44,9 +45,24 @@ Examples:
 			httpClient := newStatusHTTPClient(cfg)
 			checker := opsadapter.NewHTTPHealthChecker(httpClient)
 			compose := opsadapter.NewComposeAdapter()
+
+			proxyHost := cfg.Server.Host
+			if proxyHost == "" {
+				proxyHost = "127.0.0.1"
+			}
+			proxyPort := cfg.Server.Port
+			if proxyPort == 0 {
+				proxyPort = 8443
+			}
+			tlsResolver := opsapp.NewChainResolver(
+				caddyadapter.NewInProcessResolver(cfg),
+				caddyadapter.NewHandshakeResolver(cfg, proxyHost, proxyPort),
+			)
+
 			svc := opsapp.NewStatusService(checker).
 				WithCompose(compose).
-				WithLogs(compose)
+				WithLogs(compose).
+				WithTLSStateResolver(tlsResolver)
 
 			return svc.Run(cmd.Context(), cfg, cmd.OutOrStdout())
 		},

--- a/internal/domain/tls/state.go
+++ b/internal/domain/tls/state.go
@@ -5,6 +5,14 @@ import (
 	"time"
 )
 
+// CaddyLocalIssuerCN is the Common Name Caddy stamps on internal self-signed
+// dev leaf certificates. It is the authoritative signal that the sidecar is
+// serving a KindSelfSignedLocal cert and that expiry heuristics must not be
+// applied. The constant lives in the domain layer so it can be imported by
+// both the caddy adapter and the app-layer fallback resolver without creating
+// an adapter → app or app → adapter dependency.
+const CaddyLocalIssuerCN = "Caddy Local Authority"
+
 // Kind identifies the TLS state variant.
 type Kind int
 

--- a/internal/domain/tls/state.go
+++ b/internal/domain/tls/state.go
@@ -1,0 +1,163 @@
+package tls
+
+import (
+	"fmt"
+	"time"
+)
+
+// Kind identifies the TLS state variant.
+type Kind int
+
+const (
+	// KindUnknown means the resolver has no signal (handshake unreachable,
+	// no peer certs, etc.). Renderers should surface a neutral message, not
+	// a warn or fail.
+	KindUnknown Kind = iota
+	// KindDisabled means TLS is turned off in config (cfg.TLS.Enabled == false).
+	KindDisabled
+	// KindSelfSignedLocal means the sidecar is serving a leaf issued by
+	// Caddy's internal "Caddy Local Authority". The leaf rotates on a short
+	// TTL (~12h) and is considered healthy regardless of NotAfter. Callers
+	// MUST NOT inspect NotAfter for this variant.
+	KindSelfSignedLocal
+	// KindObtaining means TLS is enabled with an ACME provider but no leaf
+	// is in the cert cache yet (ACME exchange in progress).
+	KindObtaining
+	// KindObtained means a valid non-self-signed leaf is present and has
+	// more than 7 days left until expiry.
+	KindObtained
+	// KindExpiringSoon means a valid non-self-signed leaf is present with
+	// 7 or fewer days left until expiry.
+	KindExpiringSoon
+	// KindFailing means the ACME exchange failed on the most recent
+	// attempt. LastError carries the first line of the upstream error.
+	KindFailing
+)
+
+// String returns a short lowercase token for the kind — useful for logs and
+// tests. It is not the human-readable display form; see State.String for
+// that.
+func (k Kind) String() string {
+	switch k {
+	case KindDisabled:
+		return "disabled"
+	case KindSelfSignedLocal:
+		return "self-signed-local"
+	case KindObtaining:
+		return "obtaining"
+	case KindObtained:
+		return "obtained"
+	case KindExpiringSoon:
+		return "expiring-soon"
+	case KindFailing:
+		return "failing"
+	case KindUnknown:
+		return "unknown"
+	default:
+		return fmt.Sprintf("kind(%d)", int(k))
+	}
+}
+
+// State is an immutable value object describing the current state of the
+// sidecar's TLS configuration. It is produced by a StateResolver and
+// consumed by status and doctor renderers.
+//
+// Construct instances via the NewXxx constructors; the zero value is a
+// valid KindUnknown state. Fields are unexported to preserve invariants.
+type State struct {
+	kind      Kind
+	expiresAt time.Time
+	daysLeft  int
+	lastError string
+}
+
+// NewDisabled returns a Disabled TLS state.
+func NewDisabled() State { return State{kind: KindDisabled} }
+
+// NewSelfSignedLocal returns a state indicating the sidecar is serving a
+// leaf issued by Caddy's internal CA. NotAfter is intentionally not tracked
+// because the internal issuer rotates leaves on a short TTL.
+func NewSelfSignedLocal() State { return State{kind: KindSelfSignedLocal} }
+
+// NewObtaining returns a state indicating an ACME exchange is in progress
+// (TLS enabled, provider is ACME-like, no leaf in cache yet).
+func NewObtaining() State { return State{kind: KindObtaining} }
+
+// NewObtained returns a state for a healthy non-self-signed leaf with the
+// given expiry time.
+func NewObtained(expiresAt time.Time) State {
+	return State{kind: KindObtained, expiresAt: expiresAt}
+}
+
+// NewExpiringSoon returns a state for a non-self-signed leaf that is within
+// the expiry warning window. daysLeft is clamped to >= 0.
+func NewExpiringSoon(daysLeft int, expiresAt time.Time) State {
+	if daysLeft < 0 {
+		daysLeft = 0
+	}
+	return State{kind: KindExpiringSoon, daysLeft: daysLeft, expiresAt: expiresAt}
+}
+
+// NewFailing returns a state indicating the last ACME attempt failed.
+// lastError is the first line of the upstream error message.
+func NewFailing(lastError string) State {
+	return State{kind: KindFailing, lastError: lastError}
+}
+
+// NewUnknown returns a state indicating no signal is available (e.g. the
+// handshake fallback could not reach the sidecar).
+func NewUnknown() State { return State{kind: KindUnknown} }
+
+// Kind returns the state variant.
+func (s State) Kind() Kind { return s.kind }
+
+// ExpiresAt returns the leaf NotAfter time for Obtained and ExpiringSoon;
+// zero time for other variants.
+func (s State) ExpiresAt() time.Time { return s.expiresAt }
+
+// DaysLeft returns the remaining days for ExpiringSoon; 0 otherwise.
+func (s State) DaysLeft() int { return s.daysLeft }
+
+// LastError returns the first line of the last ACME error for Failing;
+// empty string otherwise.
+func (s State) LastError() string { return s.lastError }
+
+// String returns the human-readable display string specified in the PM
+// spec for #1090 / #1078. It is the canonical user-facing rendering for
+// a State and is shared between the status dashboard and the doctor
+// check detail.
+func (s State) String() string {
+	switch s.kind {
+	case KindDisabled:
+		return "TLS disabled"
+	case KindSelfSignedLocal:
+		return "TLS self-signed dev cert (rotates automatically)"
+	case KindObtaining:
+		return "TLS obtaining (ACME in progress)"
+	case KindObtained:
+		return fmt.Sprintf("TLS obtained (expires %s)", s.expiresAt.Format("2006-01-02"))
+	case KindExpiringSoon:
+		return fmt.Sprintf("TLS near expiry (expires in %d days)", s.daysLeft)
+	case KindFailing:
+		if s.lastError == "" {
+			return "TLS failing"
+		}
+		return fmt.Sprintf("TLS failing (last error: %s)", s.lastError)
+	case KindUnknown:
+		return "TLS state unavailable"
+	default:
+		return fmt.Sprintf("TLS state %s", s.kind)
+	}
+}
+
+// Healthy reports whether this state should be displayed as a healthy
+// green tick. Disabled and SelfSignedLocal are healthy; Obtained is
+// healthy. ExpiringSoon, Obtaining, Failing and Unknown are not.
+func (s State) Healthy() bool {
+	switch s.kind {
+	case KindDisabled, KindSelfSignedLocal, KindObtained:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/domain/tls/state_test.go
+++ b/internal/domain/tls/state_test.go
@@ -1,0 +1,122 @@
+package tls_test
+
+import (
+	"testing"
+	"time"
+
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+)
+
+func TestTLSState_Constructors(t *testing.T) {
+	expires := time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		state      tlsdomain.State
+		wantKind   tlsdomain.Kind
+		wantExpiry time.Time
+		wantDays   int
+		wantErr    string
+	}{
+		{"disabled", tlsdomain.NewDisabled(), tlsdomain.KindDisabled, time.Time{}, 0, ""},
+		{"self-signed local", tlsdomain.NewSelfSignedLocal(), tlsdomain.KindSelfSignedLocal, time.Time{}, 0, ""},
+		{"obtaining", tlsdomain.NewObtaining(), tlsdomain.KindObtaining, time.Time{}, 0, ""},
+		{"obtained", tlsdomain.NewObtained(expires), tlsdomain.KindObtained, expires, 0, ""},
+		{"expiring soon", tlsdomain.NewExpiringSoon(5, expires), tlsdomain.KindExpiringSoon, expires, 5, ""},
+		{"expiring soon negative clamped", tlsdomain.NewExpiringSoon(-3, expires), tlsdomain.KindExpiringSoon, expires, 0, ""},
+		{"failing", tlsdomain.NewFailing("connection refused"), tlsdomain.KindFailing, time.Time{}, 0, "connection refused"},
+		{"unknown", tlsdomain.NewUnknown(), tlsdomain.KindUnknown, time.Time{}, 0, ""},
+		{"zero value is unknown", tlsdomain.State{}, tlsdomain.KindUnknown, time.Time{}, 0, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.state.Kind(); got != tt.wantKind {
+				t.Errorf("Kind() = %v, want %v", got, tt.wantKind)
+			}
+			if got := tt.state.ExpiresAt(); !got.Equal(tt.wantExpiry) {
+				t.Errorf("ExpiresAt() = %v, want %v", got, tt.wantExpiry)
+			}
+			if got := tt.state.DaysLeft(); got != tt.wantDays {
+				t.Errorf("DaysLeft() = %d, want %d", got, tt.wantDays)
+			}
+			if got := tt.state.LastError(); got != tt.wantErr {
+				t.Errorf("LastError() = %q, want %q", got, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTLSState_String(t *testing.T) {
+	expires := time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		state tlsdomain.State
+		want  string
+	}{
+		{"disabled", tlsdomain.NewDisabled(), "TLS disabled"},
+		{"self-signed", tlsdomain.NewSelfSignedLocal(), "TLS self-signed dev cert (rotates automatically)"},
+		{"obtaining", tlsdomain.NewObtaining(), "TLS obtaining (ACME in progress)"},
+		{"obtained", tlsdomain.NewObtained(expires), "TLS obtained (expires 2026-07-21)"},
+		{"expiring soon", tlsdomain.NewExpiringSoon(3, expires), "TLS near expiry (expires in 3 days)"},
+		{"failing with error", tlsdomain.NewFailing("connection refused"), "TLS failing (last error: connection refused)"},
+		{"failing empty error", tlsdomain.NewFailing(""), "TLS failing"},
+		{"unknown", tlsdomain.NewUnknown(), "TLS state unavailable"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.state.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTLSState_Healthy(t *testing.T) {
+	expires := time.Now().Add(90 * 24 * time.Hour)
+	tests := []struct {
+		name    string
+		state   tlsdomain.State
+		healthy bool
+	}{
+		{"disabled healthy", tlsdomain.NewDisabled(), true},
+		{"self-signed healthy", tlsdomain.NewSelfSignedLocal(), true},
+		{"obtained healthy", tlsdomain.NewObtained(expires), true},
+		{"obtaining not healthy", tlsdomain.NewObtaining(), false},
+		{"expiring not healthy", tlsdomain.NewExpiringSoon(3, expires), false},
+		{"failing not healthy", tlsdomain.NewFailing("x"), false},
+		{"unknown not healthy", tlsdomain.NewUnknown(), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.state.Healthy(); got != tt.healthy {
+				t.Errorf("Healthy() = %v, want %v", got, tt.healthy)
+			}
+		})
+	}
+}
+
+func TestKind_String(t *testing.T) {
+	tests := []struct {
+		kind tlsdomain.Kind
+		want string
+	}{
+		{tlsdomain.KindUnknown, "unknown"},
+		{tlsdomain.KindDisabled, "disabled"},
+		{tlsdomain.KindSelfSignedLocal, "self-signed-local"},
+		{tlsdomain.KindObtaining, "obtaining"},
+		{tlsdomain.KindObtained, "obtained"},
+		{tlsdomain.KindExpiringSoon, "expiring-soon"},
+		{tlsdomain.KindFailing, "failing"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.kind.String(); got != tt.want {
+				t.Errorf("Kind(%d).String() = %q, want %q", int(tt.kind), got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ports/tls.go
+++ b/internal/ports/tls.go
@@ -1,0 +1,24 @@
+package ports
+
+import (
+	"context"
+	"errors"
+
+	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+)
+
+// ErrNotInProcess is returned by TLSStateResolver implementations that can
+// only operate when Caddy is embedded in the current process (e.g. the
+// in-process certmagic resolver). Chain resolvers use this sentinel to fall
+// through to network-based resolvers such as the handshake fallback.
+var ErrNotInProcess = errors.New("tls state resolver: caddy is not running in this process")
+
+// TLSStateResolver resolves the current TLS state of the running sidecar.
+//
+// Implementations MUST NOT block on network I/O for longer than the context
+// allows. When the resolver has no signal to report, it should return
+// tlsdomain.NewUnknown() and a nil error. Returning ErrNotInProcess signals
+// that a chain resolver should try the next resolver in the chain.
+type TLSStateResolver interface {
+	Resolve(ctx context.Context) (tlsdomain.State, error)
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1300,8 +1300,8 @@ VibeWarden is operated via the `vibew` CLI. Below is the complete command list.
 | `vibew down` | Stop the local dev stack (preserves data volumes; pass `-v` to also remove volumes) |
 | `vibew restart` | Restart containers without rebuilding |
 | `vibew bundle` | Produce a self-contained Docker Compose deploy bundle under `.vibewarden/bundle/` (produces deploy.sh for local-run shipping) |
-| `vibew status` | Show health of all components |
-| `vibew doctor` | Diagnose common issues |
+| `vibew status` | Show health of all components; TLS column reports state: Obtaining, Obtained, Failing, or SelfSignedLocal |
+| `vibew doctor` | Diagnose common issues; check 7 reports TLS state (Obtaining/Obtained/Failing/SelfSignedLocal) |
 | `vibew logs` | Pretty-print structured logs |
 | `vibew migrate` | Apply all pending database migrations (alias for migrate up) |
 | `vibew migrate up` | Apply all pending database migrations |
@@ -1451,6 +1451,8 @@ vibew doctor checks (in order):
   4. Proxy port — server.port not already bound
   5. Generated files — .vibewarden/generated/docker-compose.yml present
   6. Container health — all containers running/healthy
+  7. TLS state — reports Obtaining/Obtained/Failing/SelfSignedLocal; self-signed
+     certs are identified and not reported as near-expiry
 
 
 ## 15. Troubleshooting


### PR DESCRIPTION
Closes #1090, #1078. Part of v0.17.0. Supersedes the ad-hoc handshake check in ADR-084 with a shared domain type.

## Summary

- New `internal/domain/tls.State` value object with variants: `Disabled`, `SelfSignedLocal`, `Obtaining`, `Obtained{ExpiresAt}`, `ExpiringSoon{DaysLeft}`, `Failing{LastError}`, `Unknown`. `String()` emits the PM-spec display strings.
- New `ports.TLSStateResolver` + `ports.ErrNotInProcess` sentinel.
- Two adapters: `caddy.InProcessResolver` (primary, inspects Caddy's in-memory state; short-circuits `ErrNotInProcess` when Caddy is not embedded) and `caddy.HandshakeResolver` (fallback, live TLS handshake — issuer CN `Caddy Local Authority` → `SelfSignedLocal` without consulting NotAfter).
- `ops.ChainResolver` composes primary → fallback → `Unknown`.
- Pure renderers `renderTLSStatusLine` and `renderTLSDoctorCheck` are the single source of truth for status and doctor output.
- `StatusService` + `DoctorService` gain `WithTLSStateResolver`. CLI composition roots (`doctor`, `status`, `mcp`) wire the chain.
- The old `checkTLSCertValid` handshake logic is moved behind the resolver; `vibew doctor` no longer prints `expires in 0 day(s)` for self-signed dev certs (fixes #1078); `vibew status` replaces `✓ TLS enabled` with state-aware detail (fixes #1090).

## Test plan

- Table-driven unit tests per variant: `internal/domain/tls/state_test.go`, `internal/adapters/caddy/tls_state_test.go` (fake cert provider), `internal/adapters/caddy/tls_state_handshake_test.go` (httptest TLS server, self-signed + external issuer + unreachable rows), `internal/app/ops/chain_resolver_test.go`, `internal/app/ops/status_tls_render_test.go`, `internal/app/ops/doctor_tls_render_test.go`.
- Explicit regression test `TestRenderTLSDoctorCheck_NoExpiringZeroDaysForSelfSigned` locks bug #1078.
- `make check` — full build + lint + tests on both modules.