### PR TITLE
fix(#1076): vibew init error for positional args — point at cwd convention

### DIFF
--- a/internal/cli/cmd/init.go
+++ b/internal/cli/cmd/init.go
@@ -85,7 +85,7 @@ func NewInitCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: "Scaffold a new VibeWarden project in the current directory",
+		Short: "Scaffold a new VibeWarden project in the current directory (name derived from dirname; same convention as vibew wrap)",
 		Long: `Scaffold a new project with VibeWarden security pre-configured.
 
 The command scaffolds into the current working directory, creating:
@@ -113,7 +113,12 @@ Examples:
   vibew init --describe "a task management API"
   vibew init --non-interactive
   vibew init --force`,
-		Args: cobra.NoArgs,
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return nil
+			}
+			return fmt.Errorf("vibew init takes no arguments.\nRun it from inside the project directory (name is derived from dirname).\nUse --name to override the derived name, or --help for all flags.") //nolint:revive,staticcheck // user-facing CLI error: intentional capitalisation, newlines, and trailing period
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			interactive := !nonInteractive && IsTTY(os.Stdin)
 

--- a/internal/cli/cmd/init_test.go
+++ b/internal/cli/cmd/init_test.go
@@ -680,6 +680,43 @@ func TestInitCmd_NonInteractiveFlag_NoTTYWithFlag(t *testing.T) {
 	}
 }
 
+// TestInitCmd_PositionalArgsError verifies that passing any positional argument
+// to vibew init returns the prescribed actionable error message that explains
+// the cwd-derivation convention, instead of cobra's generic unknown-command
+// message.
+func TestInitCmd_PositionalArgsError(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"single positional", []string{"init", "my-project"}},
+		{"multiple positionals", []string{"init", "a", "b"}},
+		{"positional after flag", []string{"init", "--name", "foo", "x"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := cmd.NewRootCmd("test")
+			var errOut bytes.Buffer
+			root.SetErr(&errOut)
+			root.SetArgs(tt.args)
+
+			err := root.Execute()
+			if err == nil {
+				t.Fatal("expected non-nil error, got nil")
+			}
+
+			stderr := errOut.String()
+			if !strings.Contains(stderr, "takes no arguments") {
+				t.Errorf("stderr missing 'takes no arguments'; got:\n%s", stderr)
+			}
+			if !strings.Contains(stderr, "name is derived from dirname") {
+				t.Errorf("stderr missing 'name is derived from dirname'; got:\n%s", stderr)
+			}
+		})
+	}
+}
+
 // TestInitCmd_NoNameFlag_NoNameInConfig verifies that when --name is not set,
 // vibewarden.yaml does not contain a top-level name: field.
 //


### PR DESCRIPTION
Closes #1076

## Summary

- Replaces `cobra.NoArgs` in `internal/cli/cmd/init.go` with a custom `cobra.PositionalArgs` validator that emits the prescribed actionable error when any positional argument is passed, instead of cobra's generic "unknown command" message.
- Updates the `Short` description to state the dirname-derivation convention (visible in `vibew --help` listing).
- Adds `TestInitCmd_PositionalArgsError` table-driven test in `internal/cli/cmd/init_test.go` covering: single positional arg, multiple positional args, positional after `--name` flag — all assert non-nil error and that stderr contains both `takes no arguments` and `name is derived from dirname`.

## Test plan

- `go test ./internal/cli/cmd/... -run TestInitCmd_PositionalArgsError -v` — all 3 subtests pass.
- `make check` — lint, build, full test suite all pass.
- Manual: `vibew init myproject` prints the prescribed three-line error; `vibew init` with no args still succeeds from a valid directory.