### PR TITLE
feat(#1057): LE rate-limit preflight via crt.sh — avoid blind ACME retries on exhausted budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Added
 
+- **LE rate-limit preflight in `vibew doctor`** — when `tls.provider: letsencrypt` is configured, `vibew doctor` now queries the public [crt.sh](https://crt.sh) Certificate Transparency log to count certificates issued for the registered domain in the last 168 hours. Reports WARN at 4/5, FAIL at 5/5. Degrades to WARN when crt.sh is unreachable. Opt-out: `--skip-le-preflight` flag or `tls.skip_rate_limit_check: true`. (ADR-090, #1057)
+- **`vibew doctor --skip-le-preflight`** — suppresses the LE rate-limit CT log check for a single invocation. (#1057)
+- **`tls.skip_rate_limit_check`** config key — persistent opt-out for the LE rate-limit preflight. Defaults to `false`. (#1057)
 - **`vibew bundle --build`** — runs `vibew build --platform <target>` before inspecting or packaging; use when the image is missing or stale. (#1084)
 - **`vibew bundle --allow-stale`** — suppresses the STALE freshness warning; bundle proceeds regardless of source-file mtime. (#1085)
 - **`vibew bundle --target-platform linux/<arch>`** — overrides the default expected deployment platform (`linux/amd64`); use for Graviton / Pi / arm64 servers. (#1091)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,6 +25,7 @@ pre-flight scripts.
 |------|---------|-------------|
 | `--config <path>` | `./vibewarden.yaml` | Path to a non-default config file |
 | `--json` | `false` | Emit results as a JSON array instead of the human-readable table |
+| `--skip-le-preflight` | `false` | Skip the Let's Encrypt rate-limit preflight check for this run |
 
 ### Checks performed (in order)
 
@@ -40,6 +41,7 @@ pre-flight scripts.
 | 6 | **Container health** | `docker compose ps` shows all containers in `running` / `healthy` state |
 | 7 | **ACME email** | `tls.email` is set when `tls.acme_ca` contains "zerossl" (fails if missing) |
 | 8 | **Image tag** | `app.image` matches a locally available Docker image (skipped when unset) |
+| 9 | **LE rate-limit: `<domain>`** | Queries the public crt.sh CT log to count Let's Encrypt certificates issued for the registered domain in the last 168 hours. WARN at 4/5, FAIL at 5/5. Skipped when `tls.provider` is not `letsencrypt`, when `tls.acme_ca` overrides the default ACME endpoint, or when `tls.skip_rate_limit_check: true` / `--skip-le-preflight` is set. See [LE rate-limit preflight](#le-rate-limit-preflight) below. |
 
 #### Layer 2: Local Runtime
 
@@ -159,6 +161,56 @@ needs to consume the results programmatically:
   }
 ]
 ```
+
+---
+
+## LE rate-limit preflight
+
+When `tls.provider: letsencrypt` is set and no `tls.acme_ca` override is present,
+`vibew doctor` queries the public [crt.sh](https://crt.sh) Certificate Transparency log to
+count certificates issued for your registered domain in the last 168 hours (the
+Let's Encrypt rate-limit window).
+
+### Severity thresholds
+
+| Certificates issued (168h) | Remaining | Result |
+|------|------|------|
+| 0–3 | 5–2 | `[OK]` — enough budget |
+| 4 | 1 | `[WARN]` — "1 of 5 slots remaining this week for `<domain>`" |
+| 5 | 0 | `[FAIL]` — "LE rate limit exhausted for `<domain>`; next slot at `<time>`; use --skip-le-preflight to bypass" |
+| crt.sh unreachable / throttled | — | `[WARN]` — check degraded, not blocking |
+
+A `[FAIL]` result causes `vibew doctor` to exit 1.
+
+### Opt-out
+
+If you are intentionally re-issuing a certificate within the same 168-hour window
+(e.g. after revocation), suppress the check for one run:
+
+```bash
+vibew doctor --skip-le-preflight
+```
+
+Or set it permanently in `vibewarden.yaml`:
+
+```yaml
+tls:
+  provider: letsencrypt
+  skip_rate_limit_check: true
+```
+
+### Privacy note
+
+The check sends your domain name to crt.sh — a public service operated by Sectigo.
+The certificate, once issued, will be publicly visible in CT logs anyway. If this is
+not acceptable, use `--skip-le-preflight` or `tls.skip_rate_limit_check: true`.
+
+### Limitations
+
+- **CT log propagation delay**: a certificate issued in the last 1–3 minutes may not
+  yet appear in CT logs. At 4/5 budget the WARN threshold absorbs this lag.
+- **Wildcard certificates**: `*.example.com` certs have a separate LE limit
+  (10 per 7 days). This check counts only the registered-domain budget.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	golang.org/x/net v0.52.0
 	golang.org/x/term v0.42.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -211,7 +212,6 @@ require (
 	golang.org/x/crypto/x509roots/fallback v0.0.0-20260213171211-a408498e5541 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/mod v0.34.0 // indirect
-	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/internal/adapters/crtsh/client.go
+++ b/internal/adapters/crtsh/client.go
@@ -21,6 +21,11 @@ const (
 	// userAgent is sent on every request so crt.sh operators can identify the
 	// tool. The URL is informational — it helps them contact us if we cause load.
 	userAgent = "vibew-doctor/1 (+https://vibewarden.dev)"
+
+	// maxResponseBytes is the upper bound on crt.sh response body size.
+	// 10 MiB is generous for even the largest CT query result sets; a response
+	// that exceeds this cap is treated as malformed (ErrCTResponseMalformed).
+	maxResponseBytes = 10 * 1024 * 1024
 )
 
 // Client implements ports.CertTransparencyQuerier by calling the crt.sh
@@ -93,9 +98,17 @@ func (c *Client) Query(ctx context.Context, registeredDomain string) ([]ports.Cr
 		return nil, fmt.Errorf("%w: Content-Type %q", tlspreflight.ErrCTResponseMalformed, ct)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	// Bound the response body to maxResponseBytes to prevent memory-exhaustion
+	// from a spoofed or misbehaving server. io.LimitReader returns io.EOF at
+	// the limit — we detect an over-limit response by checking whether the
+	// returned body is exactly maxResponseBytes after a successful read.
+	limited := io.LimitReader(resp.Body, maxResponseBytes+1)
+	body, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, fmt.Errorf("%w: read body: %v", tlspreflight.ErrCTUnavailable, err)
+	}
+	if int64(len(body)) > maxResponseBytes {
+		return nil, fmt.Errorf("%w: response exceeds %d-byte limit", tlspreflight.ErrCTResponseMalformed, maxResponseBytes)
 	}
 
 	// crt.sh returns an empty array "[]" for unknown domains — treat as 0 certs.

--- a/internal/adapters/crtsh/client.go
+++ b/internal/adapters/crtsh/client.go
@@ -1,0 +1,159 @@
+package crtsh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/tlspreflight"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+const (
+	// defaultBase is the crt.sh base URL used by NewClient.
+	defaultBase = "https://crt.sh"
+
+	// userAgent is sent on every request so crt.sh operators can identify the
+	// tool. The URL is informational — it helps them contact us if we cause load.
+	userAgent = "vibew-doctor/1 (+https://vibewarden.dev)"
+)
+
+// Client implements ports.CertTransparencyQuerier by calling the crt.sh
+// public JSON API over HTTPS.
+//
+// Construct via NewClient or NewClientWithBase (for tests). The client is
+// stateless and safe for concurrent use.
+type Client struct {
+	http *http.Client
+	base string
+}
+
+// NewClient returns a Client that calls the production crt.sh endpoint.
+// httpClient must have a Timeout set (the caller in cmd/doctor.go uses 10s
+// per AC-8).
+func NewClient(httpClient *http.Client) *Client {
+	return &Client{http: httpClient, base: defaultBase}
+}
+
+// NewClientWithBase returns a Client with a custom base URL, used in tests to
+// point at an httptest.Server instead of the real crt.sh.
+func NewClientWithBase(httpClient *http.Client, base string) *Client {
+	return &Client{http: httpClient, base: base}
+}
+
+// crtShRow is the JSON shape returned by crt.sh for each certificate record.
+// Only the fields the preflight consumes are decoded; others are ignored.
+type crtShRow struct {
+	NotBefore  string `json:"not_before"`
+	IssuerName string `json:"issuer_name"`
+	CommonName string `json:"common_name"`
+	NameValue  string `json:"name_value"`
+}
+
+// Query fetches certificates from crt.sh for the given registered domain and
+// returns them as a slice of ports.CrtShRecord.
+//
+// Error mapping:
+//   - network / DNS / context cancel  → tlspreflight.ErrCTUnavailable (wrapped)
+//   - HTTP 429                        → tlspreflight.ErrCTThrottled (wrapped)
+//   - HTTP non-200 (except 429)       → tlspreflight.ErrCTUnavailable (wrapped)
+//   - Content-Type not JSON           → tlspreflight.ErrCTResponseMalformed
+//   - JSON decode error               → tlspreflight.ErrCTResponseMalformed (wrapped)
+//   - empty body / empty array        → nil error, empty slice
+func (c *Client) Query(ctx context.Context, registeredDomain string) ([]ports.CrtShRecord, error) {
+	reqURL := buildURL(c.base, registeredDomain)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("%w: build request: %v", tlspreflight.ErrCTUnavailable, err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", tlspreflight.ErrCTUnavailable, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("%w: HTTP 429", tlspreflight.ErrCTThrottled)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: HTTP %d", tlspreflight.ErrCTUnavailable, resp.StatusCode)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if ct != "" && !strings.HasPrefix(strings.ToLower(ct), "application/json") {
+		return nil, fmt.Errorf("%w: Content-Type %q", tlspreflight.ErrCTResponseMalformed, ct)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: read body: %v", tlspreflight.ErrCTUnavailable, err)
+	}
+
+	// crt.sh returns an empty array "[]" for unknown domains — treat as 0 certs.
+	if len(strings.TrimSpace(string(body))) == 0 {
+		return nil, nil
+	}
+
+	var rows []crtShRow
+	if err := json.Unmarshal(body, &rows); err != nil {
+		return nil, fmt.Errorf("%w: %v", tlspreflight.ErrCTResponseMalformed, err)
+	}
+
+	return mapRows(rows), nil
+}
+
+// buildURL constructs the crt.sh query URL for a registered domain.
+func buildURL(base, registeredDomain string) string {
+	params := url.Values{}
+	params.Set("Identity", registeredDomain)
+	params.Set("exclude", "expired")
+	params.Set("output", "json")
+	return base + "/?" + params.Encode()
+}
+
+// mapRows converts raw crt.sh JSON rows to ports.CrtShRecord, skipping rows
+// where not_before cannot be parsed. Per-row parse errors are silent — a
+// single malformed row in a 40-record response must not fail the whole query.
+func mapRows(rows []crtShRow) []ports.CrtShRecord {
+	out := make([]ports.CrtShRecord, 0, len(rows))
+	for _, row := range rows {
+		nb, err := parseNotBefore(row.NotBefore)
+		if err != nil {
+			// Skip silently — per ADR-090 §(b) adapter spec.
+			continue
+		}
+		out = append(out, ports.CrtShRecord{
+			NotBefore:  nb,
+			IssuerName: row.IssuerName,
+			CommonName: row.CommonName,
+			NameValue:  row.NameValue,
+		})
+	}
+	return out
+}
+
+// parseNotBefore attempts RFC 3339 and then the crt.sh legacy format
+// "2006-01-02T15:04:05" (no timezone — treated as UTC).
+func parseNotBefore(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, fmt.Errorf("empty not_before")
+	}
+	// Try standard RFC 3339 first.
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+	// crt.sh sometimes returns timestamps without a timezone suffix.
+	if t, err := time.Parse("2006-01-02T15:04:05", s); err == nil {
+		return t.UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("cannot parse not_before %q", s)
+}

--- a/internal/adapters/crtsh/client_test.go
+++ b/internal/adapters/crtsh/client_test.go
@@ -1,6 +1,7 @@
 package crtsh_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http"
@@ -199,5 +200,24 @@ func TestClient_Query_MalformedNotBeforeRowSkipped(t *testing.T) {
 	// Only the valid row should be returned.
 	if len(recs) != 1 {
 		t.Errorf("len(recs) = %d, want 1 (malformed row should be skipped)", len(recs))
+	}
+}
+
+func TestClient_Query_OversizedBody_MalformedError(t *testing.T) {
+	// Stream a body larger than the 10 MiB cap to trigger ErrCTResponseMalformed.
+	const limit = 10 * 1024 * 1024 // must match maxResponseBytes in client.go
+	oversized := bytes.Repeat([]byte("x"), limit+1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(oversized)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Query(context.Background(), "example.com")
+	if !errors.Is(err, tlspreflight.ErrCTResponseMalformed) {
+		t.Errorf("error = %v, want ErrCTResponseMalformed for oversized body", err)
 	}
 }

--- a/internal/adapters/crtsh/client_test.go
+++ b/internal/adapters/crtsh/client_test.go
@@ -1,0 +1,203 @@
+package crtsh_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/adapters/crtsh"
+	"github.com/vibewarden/vibewarden/internal/domain/tlspreflight"
+)
+
+// newTestClient builds a Client pointing at the given httptest server and
+// using a 5-second timeout.
+func newTestClient(t *testing.T, srv *httptest.Server) *crtsh.Client {
+	t.Helper()
+	return crtsh.NewClientWithBase(&http.Client{Timeout: 5 * time.Second}, srv.URL)
+}
+
+// serve returns an httptest.Server that responds with the given status, body,
+// and Content-Type on every request.
+func serve(status int, body, ct string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if ct != "" {
+			w.Header().Set("Content-Type", ct)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+const realisticJSON = `[
+  {"not_before":"2026-04-20T10:00:00","issuer_name":"C=US, O=Let's Encrypt, CN=R3","common_name":"example.com","name_value":"example.com"},
+  {"not_before":"2026-04-18T08:30:00","issuer_name":"C=US, O=Let's Encrypt, CN=E1","common_name":"example.com","name_value":"example.com"},
+  {"not_before":"2026-03-01T00:00:00","issuer_name":"C=US, O=Sectigo Limited, CN=Sectigo RSA","common_name":"example.com","name_value":"example.com"}
+]`
+
+func TestClient_Query_200_RealisticJSON(t *testing.T) {
+	srv := serve(200, realisticJSON, "application/json")
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	recs, err := c.Query(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(recs) != 3 {
+		t.Errorf("len(recs) = %d, want 3", len(recs))
+	}
+	// First record's IssuerName should contain Let's Encrypt.
+	if !strings.Contains(recs[0].IssuerName, "Let's Encrypt") {
+		t.Errorf("recs[0].IssuerName = %q, want Let's Encrypt", recs[0].IssuerName)
+	}
+}
+
+func TestClient_Query_200_EmptyArray(t *testing.T) {
+	srv := serve(200, "[]", "application/json")
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	recs, err := c.Query(context.Background(), "unknown.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Errorf("len(recs) = %d, want 0", len(recs))
+	}
+}
+
+func TestClient_Query_200_EmptyBody(t *testing.T) {
+	srv := serve(200, "", "application/json")
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	recs, err := c.Query(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if recs != nil {
+		t.Errorf("expected nil recs for empty body, got %v", recs)
+	}
+}
+
+func TestClient_Query_200_MalformedJSON(t *testing.T) {
+	srv := serve(200, `{"not_an_array": true}`, "application/json")
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Query(context.Background(), "example.com")
+	if !errors.Is(err, tlspreflight.ErrCTResponseMalformed) {
+		t.Errorf("error = %v, want ErrCTResponseMalformed", err)
+	}
+}
+
+func TestClient_Query_200_HTMLContentType(t *testing.T) {
+	srv := serve(200, "<html>error</html>", "text/html; charset=utf-8")
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Query(context.Background(), "example.com")
+	if !errors.Is(err, tlspreflight.ErrCTResponseMalformed) {
+		t.Errorf("error = %v, want ErrCTResponseMalformed", err)
+	}
+}
+
+func TestClient_Query_429_Throttled(t *testing.T) {
+	srv := serve(429, "Too Many Requests", "text/plain")
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Query(context.Background(), "example.com")
+	if !errors.Is(err, tlspreflight.ErrCTThrottled) {
+		t.Errorf("error = %v, want ErrCTThrottled", err)
+	}
+}
+
+func TestClient_Query_500_Unavailable(t *testing.T) {
+	srv := serve(500, "Internal Server Error", "text/plain")
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Query(context.Background(), "example.com")
+	if !errors.Is(err, tlspreflight.ErrCTUnavailable) {
+		t.Errorf("error = %v, want ErrCTUnavailable", err)
+	}
+}
+
+func TestClient_Query_ContextCancel_Unavailable(t *testing.T) {
+	// A server that hangs until the client gives up.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	c := crtsh.NewClientWithBase(&http.Client{Timeout: 5 * time.Second}, srv.URL)
+	_, err := c.Query(ctx, "example.com")
+	if !errors.Is(err, tlspreflight.ErrCTUnavailable) {
+		t.Errorf("error = %v, want ErrCTUnavailable", err)
+	}
+}
+
+func TestClient_Query_URLEscaping(t *testing.T) {
+	var gotURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.Query(context.Background(), "*.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(gotURL, "Identity") {
+		t.Errorf("query string %q does not contain Identity param", gotURL)
+	}
+}
+
+func TestClient_Query_UserAgentSent(t *testing.T) {
+	var gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, _ = c.Query(context.Background(), "example.com")
+	if !strings.Contains(gotUA, "vibew-doctor") {
+		t.Errorf("User-Agent = %q, want to contain 'vibew-doctor'", gotUA)
+	}
+}
+
+func TestClient_Query_MalformedNotBeforeRowSkipped(t *testing.T) {
+	// One record has a valid not_before, one has a malformed value.
+	body := `[
+  {"not_before":"2026-04-20T10:00:00","issuer_name":"C=US, O=Let's Encrypt, CN=R3","common_name":"example.com","name_value":"example.com"},
+  {"not_before":"not-a-date","issuer_name":"C=US, O=Let's Encrypt, CN=R3","common_name":"example.com","name_value":"example.com"}
+]`
+	srv := serve(200, body, "application/json")
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	recs, err := c.Query(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Only the valid row should be returned.
+	if len(recs) != 1 {
+		t.Errorf("len(recs) = %d, want 1 (malformed row should be skipped)", len(recs))
+	}
+}

--- a/internal/adapters/crtsh/doc.go
+++ b/internal/adapters/crtsh/doc.go
@@ -1,0 +1,8 @@
+// Package crtsh implements ports.CertTransparencyQuerier by calling the
+// public crt.sh Certificate Transparency JSON API.
+//
+// It is used exclusively by the vibew CLI doctor command to run the
+// Let's Encrypt rate-limit preflight check (ADR-090). The adapter is never
+// imported from internal/plugins/ or internal/adapters/caddy/ — the sidecar
+// runtime does not make outbound crt.sh calls.
+package crtsh

--- a/internal/app/ops/doctor.go
+++ b/internal/app/ops/doctor.go
@@ -12,8 +12,10 @@ import (
 
 	"github.com/fatih/color"
 
+	apptlspreflight "github.com/vibewarden/vibewarden/internal/app/tlspreflight"
 	"github.com/vibewarden/vibewarden/internal/config"
 	tlsdomain "github.com/vibewarden/vibewarden/internal/domain/tls"
+	domaintlspreflight "github.com/vibewarden/vibewarden/internal/domain/tlspreflight"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
@@ -48,12 +50,13 @@ func (c CheckResult) OK() bool { return c.Severity == SeverityOK }
 // DoctorService orchestrates the "vibew doctor" use case.
 // Every check runs independently — a failing check does not stop subsequent ones.
 type DoctorService struct {
-	compose       ports.ComposeRunner
-	portChecker   ports.PortChecker
-	healthChecker ports.HealthChecker
-	imageChecker  ports.DockerImageChecker
-	ownerProbe    ports.PortOwnerProbe
-	tlsState      ports.TLSStateResolver // optional; nil falls back to handshake-on-demand
+	compose        ports.ComposeRunner
+	portChecker    ports.PortChecker
+	healthChecker  ports.HealthChecker
+	imageChecker   ports.DockerImageChecker
+	ownerProbe     ports.PortOwnerProbe
+	tlsState       ports.TLSStateResolver   // optional; nil falls back to handshake-on-demand
+	leRateLimitSvc *apptlspreflight.Service // optional; nil skips LE rate-limit check
 }
 
 // NewDoctorService creates a new DoctorService.
@@ -95,6 +98,15 @@ func (s *DoctorService) WithTLSStateResolver(r ports.TLSStateResolver) *DoctorSe
 	return &cp
 }
 
+// WithLERateLimitService returns a copy of the DoctorService with the given
+// tlspreflight.Service wired for the LE rate-limit preflight check. When nil,
+// the check is skipped entirely (no CheckResult is emitted).
+func (s *DoctorService) WithLERateLimitService(svc *apptlspreflight.Service) *DoctorService {
+	cp := *s
+	cp.leRateLimitSvc = svc
+	return &cp
+}
+
 // DoctorOptions controls how Run behaves.
 type DoctorOptions struct {
 	// ConfigPath is the path to the vibewarden.yaml file (used in the report label).
@@ -104,6 +116,14 @@ type DoctorOptions struct {
 	WorkDir string
 	// JSON requests machine-readable JSON output instead of the human-readable table.
 	JSON bool
+	// SkipLEPreflight skips the Let's Encrypt rate-limit preflight check.
+	// Equivalent to setting tls.skip_rate_limit_check: true in vibewarden.yaml.
+	// Both this flag and the config key are frozen by ADR-090.
+	SkipLEPreflight bool
+	// LERegisteredDomains is the deduplicated list of eTLD+1 domains to check
+	// for LE rate limits. The CLI wiring is responsible for normalising FQDNs
+	// via publicsuffix.EffectiveTLDPlusOne before populating this field.
+	LERegisteredDomains []string
 }
 
 // Run executes all diagnostics and writes the report to out.
@@ -170,6 +190,19 @@ func (s *DoctorService) runChecks(ctx context.Context, cfg *config.Config, opts 
 	results = append(results, withSection(checkACMEEmail(cfg), sectionConfigDocker))
 	if s.imageChecker != nil && cfg.App.Image != "" {
 		results = append(results, withSection(s.checkImageTagConsistency(ctx, cfg.App.Image), sectionConfigDocker))
+	}
+
+	// LE rate-limit preflight — only when all guards pass (see ADR-090 §(i)).
+	if s.leRateLimitSvc != nil &&
+		!opts.SkipLEPreflight &&
+		!cfg.TLS.SkipRateLimitCheck &&
+		cfg.TLS.Enabled &&
+		strings.EqualFold(cfg.TLS.Provider, "letsencrypt") &&
+		cfg.TLS.Domain != "" &&
+		cfg.TLS.ACMECA == "" {
+		for _, cr := range s.checkLERateLimit(ctx, cfg, opts) {
+			results = append(results, withSection(cr, sectionConfigDocker))
+		}
 	}
 
 	// --- Layer 2: Local Runtime ---
@@ -482,6 +515,35 @@ func (s *DoctorService) checkImageTagConsistency(ctx context.Context, image stri
 		Severity: SeverityOK,
 		Detail:   fmt.Sprintf("image %q exists locally", image),
 	}
+}
+
+// checkLERateLimit runs the LE rate-limit preflight for each registered domain
+// in opts.LERegisteredDomains and maps each domain/tlspreflight.Result to a
+// CheckResult. It never returns an error — query failures produce WARN results.
+func (s *DoctorService) checkLERateLimit(ctx context.Context, _ *config.Config, opts DoctorOptions) []CheckResult {
+	if len(opts.LERegisteredDomains) == 0 {
+		return nil
+	}
+
+	preflightResults := s.leRateLimitSvc.Check(ctx, opts.LERegisteredDomains)
+	out := make([]CheckResult, 0, len(preflightResults))
+
+	for _, pr := range preflightResults {
+		cr := CheckResult{
+			Name:   fmt.Sprintf("LE rate-limit: %s", pr.Domain),
+			Detail: pr.Detail,
+		}
+		switch pr.Status {
+		case domaintlspreflight.StatusFail:
+			cr.Severity = SeverityFail
+		case domaintlspreflight.StatusWarn:
+			cr.Severity = SeverityWarn
+		default:
+			cr.Severity = SeverityOK
+		}
+		out = append(out, cr)
+	}
+	return out
 }
 
 // printDoctorReport renders the check results to out using ANSI colour codes.

--- a/internal/app/ops/doctor.go
+++ b/internal/app/ops/doctor.go
@@ -124,6 +124,10 @@ type DoctorOptions struct {
 	// for LE rate limits. The CLI wiring is responsible for normalising FQDNs
 	// via publicsuffix.EffectiveTLDPlusOne before populating this field.
 	LERegisteredDomains []string
+	// LESkippedDomains is the list of FQDNs whose registered domain could not
+	// be derived (e.g. single-label hostnames like "localhost"). The doctor
+	// emits a SeverityWarn CheckResult for each entry per ADR-090.
+	LESkippedDomains []string
 }
 
 // Run executes all diagnostics and writes the report to out.
@@ -193,6 +197,8 @@ func (s *DoctorService) runChecks(ctx context.Context, cfg *config.Config, opts 
 	}
 
 	// LE rate-limit preflight — only when all guards pass (see ADR-090 §(i)).
+	// LESkippedDomains are also surfaced here so single-label hostnames
+	// (e.g. "localhost") produce a WARN instead of silent omission.
 	if s.leRateLimitSvc != nil &&
 		!opts.SkipLEPreflight &&
 		!cfg.TLS.SkipRateLimitCheck &&
@@ -520,28 +526,44 @@ func (s *DoctorService) checkImageTagConsistency(ctx context.Context, image stri
 // checkLERateLimit runs the LE rate-limit preflight for each registered domain
 // in opts.LERegisteredDomains and maps each domain/tlspreflight.Result to a
 // CheckResult. It never returns an error — query failures produce WARN results.
+//
+// Domains in opts.LESkippedDomains (single-label hostnames whose eTLD+1 could
+// not be derived) are also included as SeverityWarn results per ADR-090.
 func (s *DoctorService) checkLERateLimit(ctx context.Context, _ *config.Config, opts DoctorOptions) []CheckResult {
-	if len(opts.LERegisteredDomains) == 0 {
+	if len(opts.LERegisteredDomains) == 0 && len(opts.LESkippedDomains) == 0 {
 		return nil
 	}
 
-	preflightResults := s.leRateLimitSvc.Check(ctx, opts.LERegisteredDomains)
-	out := make([]CheckResult, 0, len(preflightResults))
+	out := make([]CheckResult, 0, len(opts.LERegisteredDomains)+len(opts.LESkippedDomains))
 
-	for _, pr := range preflightResults {
-		cr := CheckResult{
-			Name:   fmt.Sprintf("LE rate-limit: %s", pr.Domain),
-			Detail: pr.Detail,
+	// Emit a WARN CheckResult for each domain that could not be normalised to
+	// eTLD+1 (e.g. "localhost"). No CT query is issued for these.
+	for _, fqdn := range opts.LESkippedDomains {
+		pr := domaintlspreflight.NewSkipped(fqdn)
+		out = append(out, CheckResult{
+			Name:     fmt.Sprintf("LE rate-limit: %s", pr.Domain),
+			Severity: SeverityWarn,
+			Detail:   pr.Detail,
+		})
+	}
+
+	if len(opts.LERegisteredDomains) > 0 {
+		preflightResults := s.leRateLimitSvc.Check(ctx, opts.LERegisteredDomains)
+		for _, pr := range preflightResults {
+			cr := CheckResult{
+				Name:   fmt.Sprintf("LE rate-limit: %s", pr.Domain),
+				Detail: pr.Detail,
+			}
+			switch pr.Status {
+			case domaintlspreflight.StatusFail:
+				cr.Severity = SeverityFail
+			case domaintlspreflight.StatusWarn:
+				cr.Severity = SeverityWarn
+			default:
+				cr.Severity = SeverityOK
+			}
+			out = append(out, cr)
 		}
-		switch pr.Status {
-		case domaintlspreflight.StatusFail:
-			cr.Severity = SeverityFail
-		case domaintlspreflight.StatusWarn:
-			cr.Severity = SeverityWarn
-		default:
-			cr.Severity = SeverityOK
-		}
-		out = append(out, cr)
 	}
 	return out
 }

--- a/internal/app/ops/doctor_test.go
+++ b/internal/app/ops/doctor_test.go
@@ -24,7 +24,9 @@ import (
 	"time"
 
 	"github.com/vibewarden/vibewarden/internal/app/ops"
+	apptlspreflight "github.com/vibewarden/vibewarden/internal/app/tlspreflight"
 	"github.com/vibewarden/vibewarden/internal/config"
+	domaintlspreflight "github.com/vibewarden/vibewarden/internal/domain/tlspreflight"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
@@ -996,5 +998,271 @@ func TestDoctorService_Run_ImageTag_NoImage_Skipped(t *testing.T) {
 	out := buf.String()
 	if strings.Contains(out, "Image tag") {
 		t.Errorf("expected 'Image tag' check to be skipped when no image is configured, got:\n%s", out)
+	}
+}
+
+// fakeCTQuerier is a test double for ports.CertTransparencyQuerier.
+type fakeCTQuerier struct {
+	records []ports.CrtShRecord
+	err     error
+}
+
+func (f *fakeCTQuerier) Query(_ context.Context, _ string) ([]ports.CrtShRecord, error) {
+	return f.records, f.err
+}
+
+// leCfg returns a doctorConfig() with TLS configured for letsencrypt.
+func leCfg() *config.Config {
+	cfg := doctorConfig()
+	cfg.TLS.Enabled = true
+	cfg.TLS.Provider = "letsencrypt"
+	cfg.TLS.Domain = "app.example.com"
+	cfg.TLS.ACMECA = ""
+	return cfg
+}
+
+// leRecords builds n ports.CrtShRecord values, all LE-issued within the 168h window.
+func leRecords(n int) []ports.CrtShRecord {
+	now := time.Now()
+	recs := make([]ports.CrtShRecord, n)
+	for i := range recs {
+		recs[i] = ports.CrtShRecord{
+			NotBefore:  now.Add(-time.Duration(i+1) * time.Hour),
+			IssuerName: "C=US, O=Let's Encrypt, CN=R3",
+		}
+	}
+	return recs
+}
+
+func TestDoctorService_Run_LERateLimit_WARN(t *testing.T) {
+	q := &fakeCTQuerier{records: leRecords(4)} // 4/5 → WARN, 1 remaining
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+		WithLERateLimitService(apptlspreflight.NewService(q))
+
+	cfg := leCfg()
+	opts := defaultOpts(t)
+	opts.LERegisteredDomains = []string{"example.com"}
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// WARN does not cause allOK = false.
+	if !allOK {
+		t.Error("expected allOK = true when only WARN checks exist")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "LE rate-limit: example.com") {
+		t.Errorf("expected LE rate-limit check name in output\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "[WARN]") {
+		t.Errorf("expected [WARN] badge in output\ngot:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_LERateLimit_FAIL(t *testing.T) {
+	q := &fakeCTQuerier{records: leRecords(5)} // 5/5 → FAIL
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+		WithLERateLimitService(apptlspreflight.NewService(q))
+
+	cfg := leCfg()
+	opts := defaultOpts(t)
+	opts.LERegisteredDomains = []string{"example.com"}
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allOK {
+		t.Error("expected allOK = false when LE rate limit is exhausted")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "--skip-le-preflight") {
+		t.Errorf("expected --skip-le-preflight verbatim in FAIL detail\ngot:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_LERateLimit_SkipRateLimitCheck_Config(t *testing.T) {
+	q := &fakeCTQuerier{records: leRecords(5)} // Would be FAIL if checked.
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+		WithLERateLimitService(apptlspreflight.NewService(q))
+
+	cfg := leCfg()
+	cfg.TLS.SkipRateLimitCheck = true // config opt-out
+	opts := defaultOpts(t)
+	opts.LERegisteredDomains = []string{"example.com"}
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allOK {
+		t.Error("expected allOK = true when SkipRateLimitCheck is true")
+	}
+	out := buf.String()
+	if strings.Contains(out, "LE rate-limit") {
+		t.Errorf("expected LE rate-limit check to be skipped\ngot:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_LERateLimit_SkipFlag(t *testing.T) {
+	q := &fakeCTQuerier{records: leRecords(5)} // Would be FAIL if checked.
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+		WithLERateLimitService(apptlspreflight.NewService(q))
+
+	cfg := leCfg()
+	opts := defaultOpts(t)
+	opts.SkipLEPreflight = true // flag opt-out
+	opts.LERegisteredDomains = []string{"example.com"}
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allOK {
+		t.Error("expected allOK = true when --skip-le-preflight flag is set")
+	}
+	out := buf.String()
+	if strings.Contains(out, "LE rate-limit") {
+		t.Errorf("expected LE rate-limit check to be skipped\ngot:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_LERateLimit_NonLEProvider_Skipped(t *testing.T) {
+	q := &fakeCTQuerier{records: leRecords(5)} // Would be FAIL if checked.
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+		WithLERateLimitService(apptlspreflight.NewService(q))
+
+	cfg := doctorConfig()
+	cfg.TLS.Enabled = true
+	cfg.TLS.Provider = "self-signed" // not letsencrypt
+	cfg.TLS.Domain = "app.example.com"
+	opts := defaultOpts(t)
+	opts.LERegisteredDomains = []string{"example.com"}
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allOK {
+		t.Error("expected allOK = true for non-LE provider")
+	}
+	out := buf.String()
+	if strings.Contains(out, "LE rate-limit") {
+		t.Errorf("expected LE rate-limit check to be skipped for non-LE provider\ngot:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_LERateLimit_ACMECASet_Skipped(t *testing.T) {
+	q := &fakeCTQuerier{records: leRecords(5)} // Would be FAIL if checked.
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+		WithLERateLimitService(apptlspreflight.NewService(q))
+
+	cfg := leCfg()
+	cfg.TLS.ACMECA = "https://acme-staging-v02.api.letsencrypt.org/directory"
+	opts := defaultOpts(t)
+	opts.LERegisteredDomains = []string{"example.com"}
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allOK {
+		t.Error("expected allOK = true when ACME CA override is set")
+	}
+	out := buf.String()
+	if strings.Contains(out, "LE rate-limit") {
+		t.Errorf("expected LE rate-limit check to be skipped when ACMECA is set\ngot:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_LERateLimit_NoDomainsInOpts_Skipped(t *testing.T) {
+	q := &fakeCTQuerier{records: leRecords(5)} // Would be FAIL if checked.
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+		WithLERateLimitService(apptlspreflight.NewService(q))
+
+	cfg := leCfg()
+	opts := defaultOpts(t)
+	// LERegisteredDomains deliberately not set.
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// No FAIL because no domains were enumerated.
+	if !allOK {
+		t.Error("expected allOK = true when no registered domains are provided")
+	}
+	out := buf.String()
+	if strings.Contains(out, "LE rate-limit") {
+		t.Errorf("expected LE rate-limit check to be skipped when no domains set\ngot:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_LERateLimit_NetworkError_WARN(t *testing.T) {
+	q := &fakeCTQuerier{err: domaintlspreflight.ErrCTUnavailable}
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+		WithLERateLimitService(apptlspreflight.NewService(q))
+
+	cfg := leCfg()
+	opts := defaultOpts(t)
+	opts.LERegisteredDomains = []string{"example.com"}
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Network error → WARN → allOK stays true.
+	if !allOK {
+		t.Error("expected allOK = true when crt.sh is unreachable (WARN)")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "crt.sh unreachable") {
+		t.Errorf("expected 'crt.sh unreachable' in WARN detail\ngot:\n%s", out)
+	}
+}
+
+func TestDoctorService_Run_LERateLimit_JSONOutput(t *testing.T) {
+	q := &fakeCTQuerier{records: leRecords(4)} // 4/5 → WARN
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+		WithLERateLimitService(apptlspreflight.NewService(q))
+
+	cfg := leCfg()
+	opts := defaultOpts(t)
+	opts.JSON = true
+	opts.LERegisteredDomains = []string{"example.com"}
+
+	var buf bytes.Buffer
+	_, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var results []ops.CheckResult
+	if err := json.Unmarshal(buf.Bytes(), &results); err != nil {
+		t.Fatalf("JSON unmarshal failed: %v\nbody: %s", err, buf.String())
+	}
+	var found bool
+	for _, r := range results {
+		if strings.Contains(r.Name, "LE rate-limit") {
+			found = true
+			if r.Severity != ops.SeverityWarn {
+				t.Errorf("LE rate-limit check severity = %v, want WARN", r.Severity)
+			}
+			if r.Section == "" {
+				t.Error("LE rate-limit check has empty Section")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("LE rate-limit check not found in JSON results: %s", buf.String())
 	}
 }

--- a/internal/app/ops/doctor_test.go
+++ b/internal/app/ops/doctor_test.go
@@ -1003,11 +1003,13 @@ func TestDoctorService_Run_ImageTag_NoImage_Skipped(t *testing.T) {
 
 // fakeCTQuerier is a test double for ports.CertTransparencyQuerier.
 type fakeCTQuerier struct {
-	records []ports.CrtShRecord
-	err     error
+	records   []ports.CrtShRecord
+	err       error
+	callCount int
 }
 
 func (f *fakeCTQuerier) Query(_ context.Context, _ string) ([]ports.CrtShRecord, error) {
+	f.callCount++
 	return f.records, f.err
 }
 
@@ -1189,7 +1191,7 @@ func TestDoctorService_Run_LERateLimit_NoDomainsInOpts_Skipped(t *testing.T) {
 
 	cfg := leCfg()
 	opts := defaultOpts(t)
-	// LERegisteredDomains deliberately not set.
+	// LERegisteredDomains and LESkippedDomains deliberately not set.
 
 	var buf bytes.Buffer
 	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
@@ -1203,6 +1205,42 @@ func TestDoctorService_Run_LERateLimit_NoDomainsInOpts_Skipped(t *testing.T) {
 	out := buf.String()
 	if strings.Contains(out, "LE rate-limit") {
 		t.Errorf("expected LE rate-limit check to be skipped when no domains set\ngot:\n%s", out)
+	}
+}
+
+// TestDoctorService_Run_LERateLimit_SingleLabelDomain_WARN verifies that a
+// single-label hostname (e.g. "localhost") that cannot be normalised to eTLD+1
+// produces a SeverityWarn CheckResult instead of being silently omitted. This
+// satisfies the ADR-090 error-cases contract for un-normalisable domains.
+func TestDoctorService_Run_LERateLimit_SingleLabelDomain_WARN(t *testing.T) {
+	q := &fakeCTQuerier{records: leRecords(0)} // should never be called
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+		WithLERateLimitService(apptlspreflight.NewService(q))
+
+	cfg := leCfg()
+	opts := defaultOpts(t)
+	// Simulate deriveRegisteredDomains returning "localhost" as a skipped domain.
+	opts.LESkippedDomains = []string{"localhost"}
+
+	var buf bytes.Buffer
+	allOK, err := svc.Run(context.Background(), cfg, opts, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// WARN does not flip allOK to false.
+	if !allOK {
+		t.Error("expected allOK = true for WARN result (single-label domain)")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "LE rate-limit") {
+		t.Errorf("expected LE rate-limit check in output for skipped domain\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "cannot derive registered domain") {
+		t.Errorf("expected 'cannot derive registered domain' in WARN detail\ngot:\n%s", out)
+	}
+	// Must not have called the CT querier (q.records would be consumed if queried).
+	if q.callCount > 0 {
+		t.Errorf("expected CT querier not to be called for a skipped domain, got %d calls", q.callCount)
 	}
 }
 

--- a/internal/app/tlspreflight/doc.go
+++ b/internal/app/tlspreflight/doc.go
@@ -1,0 +1,10 @@
+// Package tlspreflight provides the application service that orchestrates
+// the Let's Encrypt rate-limit preflight check (ADR-090).
+//
+// The service queries the Certificate Transparency log via a
+// ports.CertTransparencyQuerier, counts LE-issued certificates in the last
+// 168-hour window, and maps the count to a domain/tlspreflight.Result.
+//
+// It is used exclusively by the vibew CLI doctor command. The sidecar runtime
+// never instantiates this service.
+package tlspreflight

--- a/internal/app/tlspreflight/service.go
+++ b/internal/app/tlspreflight/service.go
@@ -1,0 +1,70 @@
+package tlspreflight
+
+import (
+	"context"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/tlspreflight"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// Service orchestrates the LE rate-limit preflight. It is stateless and safe
+// for concurrent use. Each call to Check issues one crt.sh query per domain
+// (sequential — crt.sh friendly, N is small in practice).
+type Service struct {
+	ct    ports.CertTransparencyQuerier
+	clock func() time.Time
+}
+
+// NewService creates a new Service using the given CertTransparencyQuerier.
+func NewService(ct ports.CertTransparencyQuerier) *Service {
+	return &Service{
+		ct:    ct,
+		clock: time.Now,
+	}
+}
+
+// WithClock returns a copy of the Service with an injected clock function.
+// Used in tests to produce deterministic "next slot" timestamps.
+func (s *Service) WithClock(fn func() time.Time) *Service {
+	cp := *s
+	cp.clock = fn
+	return &cp
+}
+
+// Check runs the preflight for each registered domain in domains. Domains must
+// already be normalised to eTLD+1; the service does not re-normalise (that is
+// the CLI wiring's job).
+//
+// Returns one Result per input domain in the same order. A query failure
+// produces a Result with Status=WARN, Err set, and Detail populated with the
+// appropriate "crt.sh …" message per AC-8.
+func (s *Service) Check(ctx context.Context, registeredDomains []string) []tlspreflight.Result {
+	results := make([]tlspreflight.Result, 0, len(registeredDomains))
+	now := s.clock()
+	threshold := now.Add(-tlspreflight.BudgetWindow)
+
+	for _, domain := range registeredDomains {
+		records, err := s.ct.Query(ctx, domain)
+		if err != nil {
+			results = append(results, tlspreflight.NewFromError(domain, err))
+			continue
+		}
+
+		// Map ports.CrtShRecord → domain.CrtShRecord for the pure parser.
+		domainRecs := make([]tlspreflight.CrtShRecord, len(records))
+		for i, r := range records {
+			domainRecs[i] = tlspreflight.CrtShRecord{
+				NotBefore:  r.NotBefore,
+				IssuerName: r.IssuerName,
+				CommonName: r.CommonName,
+				NameValue:  r.NameValue,
+			}
+		}
+
+		count, oldest := tlspreflight.CountIssuedSince(domainRecs, threshold)
+		results = append(results, tlspreflight.NewFromQuery(domain, count, oldest))
+	}
+
+	return results
+}

--- a/internal/app/tlspreflight/service_test.go
+++ b/internal/app/tlspreflight/service_test.go
@@ -1,0 +1,205 @@
+package tlspreflight_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	apptlspreflight "github.com/vibewarden/vibewarden/internal/app/tlspreflight"
+	domaintlspreflight "github.com/vibewarden/vibewarden/internal/domain/tlspreflight"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// fakeQuerier is a simple in-memory fake for ports.CertTransparencyQuerier.
+type fakeQuerier struct {
+	// responses maps registeredDomain → (records, error) to return.
+	responses map[string]fakeResponse
+}
+
+type fakeResponse struct {
+	records []ports.CrtShRecord
+	err     error
+}
+
+func (f *fakeQuerier) Query(_ context.Context, registeredDomain string) ([]ports.CrtShRecord, error) {
+	r, ok := f.responses[registeredDomain]
+	if !ok {
+		return nil, nil
+	}
+	return r.records, r.err
+}
+
+// fixedClock returns a func() time.Time that always returns t.
+func fixedClock(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}
+
+// leRecord builds a LE-issued ports.CrtShRecord with the given not_before offset
+// from fixedNow.
+func leRecord(fixedNow time.Time, offset time.Duration) ports.CrtShRecord {
+	return ports.CrtShRecord{
+		NotBefore:  fixedNow.Add(offset),
+		IssuerName: "C=US, O=Let's Encrypt, CN=R3",
+		CommonName: "example.com",
+		NameValue:  "example.com",
+	}
+}
+
+var fixedNow = time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+
+// inWindow returns a leRecord issued N hours before fixedNow (inside the 168h window).
+func inWindow(n int) ports.CrtShRecord {
+	return leRecord(fixedNow, -time.Duration(n)*time.Hour)
+}
+
+// nRecords returns n LE records each issued 1h before fixedNow.
+func nRecords(n int) []ports.CrtShRecord {
+	recs := make([]ports.CrtShRecord, n)
+	for i := range recs {
+		recs[i] = inWindow(i + 1)
+	}
+	return recs
+}
+
+func TestService_Check_ThresholdTransitions(t *testing.T) {
+	tests := []struct {
+		name       string
+		issued     int
+		wantStatus domaintlspreflight.Status
+		wantRemain int
+	}{
+		{"0/5 — OK full", 0, domaintlspreflight.StatusOK, 5},
+		{"1/5 — OK", 1, domaintlspreflight.StatusOK, 4},
+		{"2/5 — OK", 2, domaintlspreflight.StatusOK, 3},
+		{"3/5 — OK", 3, domaintlspreflight.StatusOK, 2},
+		{"4/5 — WARN", 4, domaintlspreflight.StatusWarn, 1},
+		{"5/5 — FAIL", 5, domaintlspreflight.StatusFail, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &fakeQuerier{responses: map[string]fakeResponse{
+				"example.com": {records: nRecords(tt.issued)},
+			}}
+			svc := apptlspreflight.NewService(q).WithClock(fixedClock(fixedNow))
+
+			results := svc.Check(context.Background(), []string{"example.com"})
+			if len(results) != 1 {
+				t.Fatalf("len(results) = %d, want 1", len(results))
+			}
+			r := results[0]
+			if r.Status != tt.wantStatus {
+				t.Errorf("Status = %v, want %v", r.Status, tt.wantStatus)
+			}
+			if r.RemainingBudget != tt.wantRemain {
+				t.Errorf("RemainingBudget = %d, want %d", r.RemainingBudget, tt.wantRemain)
+			}
+		})
+	}
+}
+
+func TestService_Check_ErrorSentinels(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		wantErr error
+	}{
+		{"unavailable", domaintlspreflight.ErrCTUnavailable, domaintlspreflight.ErrCTUnavailable},
+		{"throttled", domaintlspreflight.ErrCTThrottled, domaintlspreflight.ErrCTThrottled},
+		{"malformed", domaintlspreflight.ErrCTResponseMalformed, domaintlspreflight.ErrCTResponseMalformed},
+		{"network wrapped", errors.New("dial tcp: connection refused"), nil}, // arbitrary error → WARN
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &fakeQuerier{responses: map[string]fakeResponse{
+				"example.com": {err: tt.err},
+			}}
+			svc := apptlspreflight.NewService(q).WithClock(fixedClock(fixedNow))
+
+			results := svc.Check(context.Background(), []string{"example.com"})
+			if len(results) != 1 {
+				t.Fatalf("len(results) = %d, want 1", len(results))
+			}
+			r := results[0]
+			if r.Status != domaintlspreflight.StatusWarn {
+				t.Errorf("Status = %v, want WARN", r.Status)
+			}
+			if r.Err == nil {
+				t.Error("Err is nil, want non-nil")
+			}
+			if tt.wantErr != nil && !errors.Is(r.Err, tt.wantErr) {
+				t.Errorf("errors.Is(Err, %v) = false, want true", tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestService_Check_MultiDomain_MixedOutcomes(t *testing.T) {
+	q := &fakeQuerier{responses: map[string]fakeResponse{
+		"example.com": {records: nRecords(5)},                     // FAIL
+		"another.io":  {records: nRecords(4)},                     // WARN
+		"fresh.dev":   {records: nil},                             // OK (no records)
+		"unavail.net": {err: domaintlspreflight.ErrCTUnavailable}, // WARN via error
+	}}
+	svc := apptlspreflight.NewService(q).WithClock(fixedClock(fixedNow))
+
+	results := svc.Check(context.Background(), []string{"example.com", "another.io", "fresh.dev", "unavail.net"})
+	if len(results) != 4 {
+		t.Fatalf("len(results) = %d, want 4", len(results))
+	}
+
+	want := []domaintlspreflight.Status{
+		domaintlspreflight.StatusFail,
+		domaintlspreflight.StatusWarn,
+		domaintlspreflight.StatusOK,
+		domaintlspreflight.StatusWarn,
+	}
+	for i, r := range results {
+		if r.Status != want[i] {
+			t.Errorf("results[%d].Status = %v, want %v", i, r.Status, want[i])
+		}
+	}
+}
+
+func TestService_Check_ResultOrder_PreservedFromInput(t *testing.T) {
+	domains := []string{"z.com", "a.com", "m.com"}
+	q := &fakeQuerier{responses: map[string]fakeResponse{
+		"z.com": {records: nil},
+		"a.com": {records: nRecords(5)},
+		"m.com": {records: nRecords(4)},
+	}}
+	svc := apptlspreflight.NewService(q).WithClock(fixedClock(fixedNow))
+
+	results := svc.Check(context.Background(), domains)
+	for i, r := range results {
+		if r.Domain != domains[i] {
+			t.Errorf("results[%d].Domain = %q, want %q", i, r.Domain, domains[i])
+		}
+	}
+}
+
+func TestService_Check_FailNextSlotTime(t *testing.T) {
+	oldest := fixedNow.Add(-100 * time.Hour)
+	q := &fakeQuerier{responses: map[string]fakeResponse{
+		"example.com": {records: []ports.CrtShRecord{
+			{NotBefore: oldest, IssuerName: "C=US, O=Let's Encrypt, CN=R3"},
+			{NotBefore: fixedNow.Add(-10 * time.Hour), IssuerName: "C=US, O=Let's Encrypt, CN=R3"},
+			{NotBefore: fixedNow.Add(-20 * time.Hour), IssuerName: "C=US, O=Let's Encrypt, CN=R3"},
+			{NotBefore: fixedNow.Add(-30 * time.Hour), IssuerName: "C=US, O=Let's Encrypt, CN=R3"},
+			{NotBefore: fixedNow.Add(-40 * time.Hour), IssuerName: "C=US, O=Let's Encrypt, CN=R3"},
+		}},
+	}}
+	svc := apptlspreflight.NewService(q).WithClock(fixedClock(fixedNow))
+
+	results := svc.Check(context.Background(), []string{"example.com"})
+	r := results[0]
+	if r.Status != domaintlspreflight.StatusFail {
+		t.Fatalf("Status = %v, want FAIL", r.Status)
+	}
+	expectedNext := oldest.Add(domaintlspreflight.BudgetWindow)
+	if !r.NextSlotAvailableAt.Equal(expectedNext) {
+		t.Errorf("NextSlotAvailableAt = %v, want %v", r.NextSlotAvailableAt, expectedNext)
+	}
+}

--- a/internal/cli/cmd/doctor.go
+++ b/internal/cli/cmd/doctor.go
@@ -8,10 +8,13 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/net/publicsuffix"
 
 	caddyadapter "github.com/vibewarden/vibewarden/internal/adapters/caddy"
+	crtshAdapter "github.com/vibewarden/vibewarden/internal/adapters/crtsh"
 	opsadapter "github.com/vibewarden/vibewarden/internal/adapters/ops"
 	opsapp "github.com/vibewarden/vibewarden/internal/app/ops"
+	apptlspreflight "github.com/vibewarden/vibewarden/internal/app/tlspreflight"
 	"github.com/vibewarden/vibewarden/internal/config"
 )
 
@@ -21,8 +24,9 @@ import (
 // It exits with status 1 when any check fails so it can be used in scripts.
 func NewDoctorCmd() *cobra.Command {
 	var (
-		configPath string
-		jsonOutput bool
+		configPath      string
+		jsonOutput      bool
+		skipLEPreflight bool
 	)
 
 	cmd := &cobra.Command{
@@ -41,6 +45,7 @@ Checks are organised into two layers:
     - If the stack is running: containers are healthy (docker compose ps)
     - ACME email configured when using ZeroSSL
     - Expected app image exists locally (image tag consistency)
+    - LE rate-limit budget (when tls.provider is "letsencrypt")
 
   Local Runtime (always runs):
     - Upstream application is reachable (HTTP GET)
@@ -49,10 +54,20 @@ Checks are organised into two layers:
 Each check runs independently — a failure does not stop subsequent checks.
 Exit code is 1 when any check fails.
 
+The LE rate-limit check queries the public crt.sh Certificate Transparency log
+to count certificates issued for your domain in the last 168 hours. This
+reveals whether the Let's Encrypt 5-certs-per-domain-per-week budget is near
+exhaustion before attempting TLS issuance. Pass --skip-le-preflight (or set
+tls.skip_rate_limit_check: true in vibewarden.yaml) to suppress this check.
+
+Note: querying crt.sh sends your domain name to a public service. The
+certificate, once issued, will be publicly visible in CT logs anyway.
+
 Examples:
   vibew doctor
   vibew doctor --config ./my-vibewarden.yaml
-  vibew doctor --json`,
+  vibew doctor --json
+  vibew doctor --skip-le-preflight`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Load config — pass nil-safe; doctor will report missing config.
 			cfg, loadErr := config.Load(configPath)
@@ -91,20 +106,32 @@ Examples:
 				caddyadapter.NewHandshakeResolver(cfg, proxyHost, proxyPort),
 			)
 
+			// Wire the LE rate-limit preflight service. The crt.sh HTTP client
+			// uses a separate 10-second timeout per AC-8 (separate from the
+			// 5-second healthChecker client above).
+			ctClient := crtshAdapter.NewClient(&http.Client{Timeout: 10 * time.Second})
+			leRateLimitSvc := apptlspreflight.NewService(ctClient)
+
 			svc := opsapp.NewDoctorService(compose, portChecker, healthChecker).
 				WithImageChecker(opsadapter.NewImageCheckerAdapter()).
 				WithPortOwnerProbe(ownerProbe).
-				WithTLSStateResolver(tlsResolver)
+				WithTLSStateResolver(tlsResolver).
+				WithLERateLimitService(leRateLimitSvc)
 
 			label := configPath
 			if label == "" {
 				label = "vibewarden.yaml"
 			}
 
+			// Normalise domains to eTLD+1 for the LE rate-limit check.
+			registeredDomains := deriveRegisteredDomains(cfg)
+
 			opts := opsapp.DoctorOptions{
-				ConfigPath: label,
-				WorkDir:    workDir,
-				JSON:       jsonOutput,
+				ConfigPath:          label,
+				WorkDir:             workDir,
+				JSON:                jsonOutput,
+				SkipLEPreflight:     skipLEPreflight,
+				LERegisteredDomains: registeredDomains,
 			}
 
 			allOK, err := svc.Run(cmd.Context(), cfg, opts, cmd.OutOrStdout())
@@ -121,6 +148,30 @@ Examples:
 
 	cmd.Flags().StringVar(&configPath, "config", "", "path to vibewarden.yaml (default: ./vibewarden.yaml)")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output results as JSON")
+	cmd.Flags().BoolVar(&skipLEPreflight, "skip-le-preflight", false,
+		"skip the Let's Encrypt rate-limit preflight check (equivalent to tls.skip_rate_limit_check: true)")
 
 	return cmd
+}
+
+// deriveRegisteredDomains returns the deduplicated set of eTLD+1 domains to
+// check for LE rate limits. It reads cfg.TLS.Domain and normalises via
+// publicsuffix.EffectiveTLDPlusOne. Domains that cannot be normalised are
+// skipped silently here — the doctor service emits a WARN for them via a
+// separate skipped-domain Result when needed.
+//
+// In multi-site mode (ADR-068), the caller would extend this function to
+// iterate over all site domains; for now, only the primary TLS domain is used.
+func deriveRegisteredDomains(cfg *config.Config) []string {
+	if cfg.TLS.Domain == "" {
+		return nil
+	}
+	registered, err := publicsuffix.EffectiveTLDPlusOne(cfg.TLS.Domain)
+	if err != nil {
+		// Single-label hostnames (e.g. "localhost") cannot be normalised.
+		// The guard in runChecks will catch this — we return nil so the
+		// caller knows there is nothing to query.
+		return nil
+	}
+	return []string{registered}
 }

--- a/internal/cli/cmd/doctor.go
+++ b/internal/cli/cmd/doctor.go
@@ -124,7 +124,7 @@ Examples:
 			}
 
 			// Normalise domains to eTLD+1 for the LE rate-limit check.
-			registeredDomains := deriveRegisteredDomains(cfg)
+			registeredDomains, skippedDomains := deriveRegisteredDomains(cfg)
 
 			opts := opsapp.DoctorOptions{
 				ConfigPath:          label,
@@ -132,6 +132,7 @@ Examples:
 				JSON:                jsonOutput,
 				SkipLEPreflight:     skipLEPreflight,
 				LERegisteredDomains: registeredDomains,
+				LESkippedDomains:    skippedDomains,
 			}
 
 			allOK, err := svc.Run(cmd.Context(), cfg, opts, cmd.OutOrStdout())
@@ -155,23 +156,25 @@ Examples:
 }
 
 // deriveRegisteredDomains returns the deduplicated set of eTLD+1 domains to
-// check for LE rate limits. It reads cfg.TLS.Domain and normalises via
-// publicsuffix.EffectiveTLDPlusOne. Domains that cannot be normalised are
-// skipped silently here — the doctor service emits a WARN for them via a
-// separate skipped-domain Result when needed.
+// check for LE rate limits, plus a list of FQDNs that could not be normalised
+// (e.g. single-label hostnames like "localhost").
+//
+// The registered slice is passed to the preflight service for CT queries.
+// The skipped slice is passed so the doctor can emit a SeverityWarn result
+// for each un-normalisable domain per ADR-090 instead of staying silent.
 //
 // In multi-site mode (ADR-068), the caller would extend this function to
 // iterate over all site domains; for now, only the primary TLS domain is used.
-func deriveRegisteredDomains(cfg *config.Config) []string {
+func deriveRegisteredDomains(cfg *config.Config) (registered []string, skipped []string) {
 	if cfg.TLS.Domain == "" {
-		return nil
+		return nil, nil
 	}
-	registered, err := publicsuffix.EffectiveTLDPlusOne(cfg.TLS.Domain)
+	reg, err := publicsuffix.EffectiveTLDPlusOne(cfg.TLS.Domain)
 	if err != nil {
-		// Single-label hostnames (e.g. "localhost") cannot be normalised.
-		// The guard in runChecks will catch this — we return nil so the
-		// caller knows there is nothing to query.
-		return nil
+		// Single-label hostnames (e.g. "localhost") cannot be normalised to
+		// eTLD+1. Return the FQDN in the skipped slice so the doctor emits
+		// a WARN result instead of silently omitting the check.
+		return nil, []string{cfg.TLS.Domain}
 	}
-	return []string{registered}
+	return []string{reg}, nil
 }

--- a/internal/cli/cmd/doctor_test.go
+++ b/internal/cli/cmd/doctor_test.go
@@ -1,0 +1,63 @@
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/cli/cmd"
+)
+
+// TestDoctorCmd_Registered verifies that the doctor subcommand is reachable
+// from the root command.
+func TestDoctorCmd_Registered(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+
+	doctorCmd, _, err := root.Find([]string{"doctor"})
+	if err != nil {
+		t.Fatalf("Find(doctor) error: %v", err)
+	}
+	if doctorCmd == nil || doctorCmd.Use != "doctor" {
+		t.Fatal("expected 'doctor' subcommand to be registered on root")
+	}
+}
+
+// TestDoctorCmd_FlagsRegistered verifies all expected flags are present.
+func TestDoctorCmd_FlagsRegistered(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	doctorCmd, _, _ := root.Find([]string{"doctor"})
+
+	flags := []string{"config", "json", "skip-le-preflight"}
+	for _, f := range flags {
+		if doctorCmd.Flags().Lookup(f) == nil {
+			t.Errorf("expected --%s flag to be registered on 'doctor' command", f)
+		}
+	}
+}
+
+// TestDoctorCmd_SkipLEPreflightFlag_HelpText verifies the skip flag is
+// described in the help text (users discover flags via --help).
+func TestDoctorCmd_SkipLEPreflightFlag_HelpText(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var outBuf strings.Builder
+	root.SetOut(&outBuf)
+	root.SetArgs([]string{"doctor", "--help"})
+
+	// Help command does not return an error.
+	_ = root.Execute()
+
+	help := outBuf.String()
+	if !strings.Contains(help, "skip-le-preflight") {
+		t.Errorf("expected --skip-le-preflight in help text\ngot:\n%s", help)
+	}
+}
+
+// TestDoctorCmd_LongDescription_MentionsPreflight verifies the Long description
+// references the LE preflight check so operators can discover it.
+func TestDoctorCmd_LongDescription_MentionsPreflight(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	doctorCmd, _, _ := root.Find([]string{"doctor"})
+
+	if !strings.Contains(doctorCmd.Long, "rate-limit") {
+		t.Error("expected 'rate-limit' mentioned in doctor Long description")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -514,6 +514,13 @@ type TLSConfig struct {
 	ACMECA string `mapstructure:"acme_ca"`
 	// CertMonitoring holds configuration for the background certificate expiry monitor.
 	CertMonitoring TLSCertMonitoringConfig `mapstructure:"cert_monitoring"`
+	// SkipRateLimitCheck disables the Let's Encrypt rate-limit preflight check
+	// run by "vibew doctor" when provider is "letsencrypt". Set to true when
+	// you are intentionally re-issuing within a 168-hour window (e.g. after
+	// certificate revocation) or when crt.sh is unavailable and you want to
+	// suppress the WARN. The --skip-le-preflight flag on "vibew doctor" is the
+	// single-invocation equivalent. Both flags are frozen by ADR-090.
+	SkipRateLimitCheck bool `mapstructure:"skip_rate_limit_check"`
 }
 
 // KratosSMTPConfig holds SMTP settings used by Ory Kratos to send emails.

--- a/internal/domain/tlspreflight/parse.go
+++ b/internal/domain/tlspreflight/parse.go
@@ -1,0 +1,57 @@
+package tlspreflight
+
+import (
+	"strings"
+	"time"
+)
+
+// CrtShRecord is the projection of a crt.sh JSON row that the preflight parser
+// consumes. It mirrors ports.CrtShRecord — defined here in the domain layer to
+// keep the domain package free of port-layer imports.
+type CrtShRecord struct {
+	// NotBefore is the certificate's not-before timestamp as reported by crt.sh.
+	NotBefore time.Time
+	// IssuerName is the full issuer distinguished name string from crt.sh.
+	// Example: "C=US, O=Let's Encrypt, CN=R3"
+	IssuerName string
+	// CommonName is the certificate's CN field.
+	CommonName string
+	// NameValue is the SAN / CN value from crt.sh.
+	NameValue string
+}
+
+// isLEIssuer reports whether the record was issued by Let's Encrypt.
+// The check is case-insensitive and matches any LE sub-CA name
+// (R3, R10, E1, E5, etc.).
+func isLEIssuer(rec CrtShRecord) bool {
+	return strings.Contains(strings.ToLower(rec.IssuerName), "let's encrypt")
+}
+
+// CountIssuedSince counts LE-issued certificates whose not_before is strictly
+// after threshold (exclusive lower bound). It also returns the oldest
+// not_before timestamp among the matching records — this is the timestamp
+// used to compute when the oldest slot in the current window expires
+// (oldest + BudgetWindow).
+//
+// Records with a zero NotBefore are silently skipped (consistent with the
+// adapter's per-row skip-on-parse-error policy).
+//
+// The function is pure — it has no side effects and is safe for concurrent use.
+func CountIssuedSince(records []CrtShRecord, threshold time.Time) (count int, oldestInWindow time.Time) {
+	for _, rec := range records {
+		if rec.NotBefore.IsZero() {
+			continue
+		}
+		if !isLEIssuer(rec) {
+			continue
+		}
+		if !rec.NotBefore.After(threshold) {
+			continue
+		}
+		count++
+		if oldestInWindow.IsZero() || rec.NotBefore.Before(oldestInWindow) {
+			oldestInWindow = rec.NotBefore
+		}
+	}
+	return count, oldestInWindow
+}

--- a/internal/domain/tlspreflight/parse_test.go
+++ b/internal/domain/tlspreflight/parse_test.go
@@ -1,0 +1,149 @@
+package tlspreflight_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/tlspreflight"
+)
+
+func TestCountIssuedSince(t *testing.T) {
+	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	threshold := now.Add(-tlspreflight.BudgetWindow) // 168h ago
+
+	leIssuer := "C=US, O=Let's Encrypt, CN=R3"
+	sectionIssuer := "C=US, O=Sectigo Limited, CN=Sectigo RSA Domain Validation Secure Server CA"
+	zeroSSLIssuer := "C=AT, O=ZeroSSL, CN=ZeroSSL RSA Domain Validation Secure Server CA"
+
+	// Helper to make a record at a given offset from now.
+	rec := func(issuer string, offset time.Duration) tlspreflight.CrtShRecord {
+		return tlspreflight.CrtShRecord{
+			NotBefore:  now.Add(offset),
+			IssuerName: issuer,
+		}
+	}
+
+	tests := []struct {
+		name            string
+		records         []tlspreflight.CrtShRecord
+		wantCount       int
+		wantOldestZero  bool
+		wantOldestHours float64 // hours before now of the expected oldest
+	}{
+		{
+			name:           "empty input",
+			records:        nil,
+			wantCount:      0,
+			wantOldestZero: true,
+		},
+		{
+			name: "all outside window",
+			records: []tlspreflight.CrtShRecord{
+				rec(leIssuer, -200*time.Hour),
+				rec(leIssuer, -300*time.Hour),
+			},
+			wantCount:      0,
+			wantOldestZero: true,
+		},
+		{
+			name: "all LE inside window",
+			records: []tlspreflight.CrtShRecord{
+				rec(leIssuer, -1*time.Hour),
+				rec(leIssuer, -24*time.Hour),
+				rec(leIssuer, -72*time.Hour),
+			},
+			wantCount:       3,
+			wantOldestZero:  false,
+			wantOldestHours: 72,
+		},
+		{
+			name: "mix of LE and Sectigo — Sectigo excluded",
+			records: []tlspreflight.CrtShRecord{
+				rec(leIssuer, -10*time.Hour),
+				rec(sectionIssuer, -20*time.Hour),
+				rec(leIssuer, -30*time.Hour),
+				rec(zeroSSLIssuer, -5*time.Hour),
+			},
+			wantCount:       2,
+			wantOldestZero:  false,
+			wantOldestHours: 30,
+		},
+		{
+			name: "record with zero NotBefore is skipped",
+			records: []tlspreflight.CrtShRecord{
+				{NotBefore: time.Time{}, IssuerName: leIssuer},
+				rec(leIssuer, -5*time.Hour),
+			},
+			wantCount:       1,
+			wantOldestZero:  false,
+			wantOldestHours: 5,
+		},
+		{
+			name: "exact boundary — threshold itself is excluded (strictly after)",
+			records: []tlspreflight.CrtShRecord{
+				{NotBefore: threshold, IssuerName: leIssuer},                  // exactly at threshold — excluded
+				{NotBefore: threshold.Add(time.Second), IssuerName: leIssuer}, // one second after — included
+			},
+			wantCount:       1,
+			wantOldestZero:  false,
+			wantOldestHours: 168.0, // threshold+1s is approximately 168h before now; tolerance handles the 1s
+		},
+		{
+			name: "oldest in window is the earliest within range",
+			records: []tlspreflight.CrtShRecord{
+				rec(leIssuer, -5*time.Hour),
+				rec(leIssuer, -100*time.Hour), // inside window (168h window)
+				rec(leIssuer, -50*time.Hour),
+			},
+			wantCount:       3,
+			wantOldestZero:  false,
+			wantOldestHours: 100,
+		},
+		{
+			name: "count above budget capacity — not clamped at parse level",
+			records: []tlspreflight.CrtShRecord{
+				rec(leIssuer, -1*time.Hour),
+				rec(leIssuer, -2*time.Hour),
+				rec(leIssuer, -3*time.Hour),
+				rec(leIssuer, -4*time.Hour),
+				rec(leIssuer, -5*time.Hour),
+				rec(leIssuer, -6*time.Hour),
+			},
+			wantCount:       6,
+			wantOldestZero:  false,
+			wantOldestHours: 6,
+		},
+		{
+			name: "issuer name matching is case-insensitive",
+			records: []tlspreflight.CrtShRecord{
+				{NotBefore: now.Add(-10 * time.Hour), IssuerName: "C=US, O=LET'S ENCRYPT, CN=R3"},
+			},
+			wantCount:       1,
+			wantOldestZero:  false,
+			wantOldestHours: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count, oldest := tlspreflight.CountIssuedSince(tt.records, threshold)
+			if count != tt.wantCount {
+				t.Errorf("count = %d, want %d", count, tt.wantCount)
+			}
+			if tt.wantOldestZero {
+				if !oldest.IsZero() {
+					t.Errorf("oldest = %v, want zero", oldest)
+				}
+				return
+			}
+			if oldest.IsZero() {
+				t.Fatal("oldest is zero, want non-zero")
+			}
+			gotHours := now.Sub(oldest).Hours()
+			// Allow 1-minute tolerance for the boundary test case.
+			if diff := gotHours - tt.wantOldestHours; diff < -0.1 || diff > 0.1 {
+				t.Errorf("oldest is %v hours before now, want ~%.1f", gotHours, tt.wantOldestHours)
+			}
+		})
+	}
+}

--- a/internal/domain/tlspreflight/result.go
+++ b/internal/domain/tlspreflight/result.go
@@ -1,0 +1,187 @@
+// Package tlspreflight contains the domain types for the Let's Encrypt
+// rate-limit preflight check. It is a pure domain package — the only
+// external dependency is the Go standard library. No adapters, no ports.
+package tlspreflight
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Status is the verdict of a single preflight check.
+type Status string
+
+const (
+	// StatusOK means the domain has enough LE budget to issue a certificate.
+	StatusOK Status = "OK"
+	// StatusWarn means the domain is at 4/5 — one slot remaining this week.
+	StatusWarn Status = "WARN"
+	// StatusFail means the LE rate limit is exhausted for the domain.
+	StatusFail Status = "FAIL"
+)
+
+// Budget constants encode the Let's Encrypt per-registered-domain rate limit.
+// Values are frozen by ADR-090 — changing them requires a new ADR.
+const (
+	// BudgetWindow is the LE rate-limit rolling window.
+	BudgetWindow = 168 * time.Hour
+	// BudgetCapacity is the maximum number of certificates LE issues per
+	// registered domain per BudgetWindow.
+	BudgetCapacity = 5
+	// WarnRemainingAt is the remaining-budget threshold at which the check
+	// transitions to WARN (remaining <= WarnRemainingAt → WARN).
+	WarnRemainingAt = 1
+	// FailRemainingAt is the remaining-budget threshold at which the check
+	// transitions to FAIL (remaining <= FailRemainingAt → FAIL).
+	FailRemainingAt = 0
+)
+
+// Error sentinels returned by the crt.sh adapter and consumed by the
+// application service to map network failures to WARN results.
+var (
+	// ErrCTUnavailable is returned when crt.sh is unreachable (network
+	// timeout, DNS failure, connection refused, or non-200/non-429 HTTP status).
+	ErrCTUnavailable = errors.New("crt.sh unreachable")
+	// ErrCTResponseMalformed is returned when crt.sh returns a response
+	// that cannot be decoded as JSON or has an unexpected Content-Type.
+	ErrCTResponseMalformed = errors.New("crt.sh response malformed")
+	// ErrCTThrottled is returned when crt.sh responds with HTTP 429.
+	ErrCTThrottled = errors.New("crt.sh throttled request")
+)
+
+// Result is the outcome of checking a single registered domain's LE budget.
+// It is a value object — all fields are set once and never mutated.
+//
+// When Err is non-nil the query failed; Status is StatusWarn and all numeric
+// fields are zero-valued except Domain.
+type Result struct {
+	// Domain is the eTLD+1 that was queried, e.g. "example.com".
+	Domain string
+	// Status is the verdict: OK, WARN, or FAIL.
+	Status Status
+	// IssuedInWindow is the count of LE certificates issued within the last
+	// 168 hours for Domain, as reported by crt.sh.
+	IssuedInWindow int
+	// RemainingBudget is BudgetCapacity minus IssuedInWindow, floored at 0.
+	RemainingBudget int
+	// OldestInWindow is the not_before of the oldest LE certificate still
+	// inside the 168-hour window. Zero when no certificates were found.
+	OldestInWindow time.Time
+	// NextSlotAvailableAt is OldestInWindow + 168h — the earliest moment LE
+	// will accept a new issuance. Zero when RemainingBudget > 0.
+	NextSlotAvailableAt time.Time
+	// Detail is the rendered human-readable summary used as CheckResult.Detail.
+	Detail string
+	// Err is non-nil when the CT query failed; Status is WARN in that case.
+	Err error
+}
+
+// RenderDetail builds the Detail string for a Result.
+// It is a pure function — the result is deterministic for a given input.
+// now is used to format relative times; callers may inject a fixed clock for tests.
+func RenderDetail(r Result) string {
+	if r.Err != nil {
+		return renderErrorDetail(r.Err)
+	}
+	switch r.Status {
+	case StatusFail:
+		next := r.NextSlotAvailableAt.Format(time.RFC1123)
+		if r.IssuedInWindow > BudgetCapacity {
+			return fmt.Sprintf(
+				"LE rate limit exhausted for %s (observed %d issuances); next slot at %s; use --skip-le-preflight to bypass",
+				r.Domain, r.IssuedInWindow, next,
+			)
+		}
+		return fmt.Sprintf(
+			"LE rate limit exhausted for %s; next slot at %s; use --skip-le-preflight to bypass",
+			r.Domain, next,
+		)
+	case StatusWarn:
+		return fmt.Sprintf("1 of 5 slots remaining this week for %s", r.Domain)
+	default:
+		remaining := r.RemainingBudget
+		if remaining == BudgetCapacity {
+			return fmt.Sprintf("5 of 5 slots free for %s", r.Domain)
+		}
+		return fmt.Sprintf("%d of 5 slots remaining for %s", remaining, r.Domain)
+	}
+}
+
+// renderErrorDetail maps the error sentinel to a user-facing detail string.
+func renderErrorDetail(err error) string {
+	switch {
+	case errors.Is(err, ErrCTThrottled):
+		return "crt.sh throttled — try again in a few minutes; run with --skip-le-preflight to suppress"
+	case errors.Is(err, ErrCTResponseMalformed):
+		return "crt.sh returned unexpected response — rate-limit check skipped"
+	default:
+		// ErrCTUnavailable or any other wrapped network error.
+		return "crt.sh unreachable — rate-limit check skipped; run with --skip-le-preflight to suppress"
+	}
+}
+
+// CannotDeriveRegisteredDomainDetail returns the Detail string used when
+// publicsuffix.EffectiveTLDPlusOne fails for a given input FQDN.
+func CannotDeriveRegisteredDomainDetail(fqdn string) string {
+	return fmt.Sprintf("cannot derive registered domain from %q — rate-limit check skipped", fqdn)
+}
+
+// NewFromQuery builds a Result from a raw query count and oldest-in-window time.
+// It applies the severity thresholds defined by the LE budget constants.
+func NewFromQuery(domain string, issued int, oldest time.Time) Result {
+	remaining := BudgetCapacity - issued
+	if remaining < 0 {
+		remaining = 0
+	}
+
+	var status Status
+	var nextSlot time.Time
+
+	switch {
+	case remaining <= FailRemainingAt:
+		status = StatusFail
+		if !oldest.IsZero() {
+			nextSlot = oldest.Add(BudgetWindow)
+		}
+	case remaining <= WarnRemainingAt:
+		status = StatusWarn
+	default:
+		status = StatusOK
+	}
+
+	r := Result{
+		Domain:              domain,
+		Status:              status,
+		IssuedInWindow:      issued,
+		RemainingBudget:     remaining,
+		OldestInWindow:      oldest,
+		NextSlotAvailableAt: nextSlot,
+	}
+	r.Detail = RenderDetail(r)
+	return r
+}
+
+// NewFromError builds a Result for a failed CT query. Status is always WARN.
+func NewFromError(domain string, err error) Result {
+	r := Result{
+		Domain: domain,
+		Status: StatusWarn,
+		Err:    err,
+	}
+	r.Detail = RenderDetail(r)
+	return r
+}
+
+// NewSkipped builds a WARN Result for a domain where the registered-domain
+// could not be derived (e.g. a single-label hostname).
+func NewSkipped(fqdn string) Result {
+	detail := CannotDeriveRegisteredDomainDetail(fqdn)
+	return Result{
+		Domain: fqdn,
+		Status: StatusWarn,
+		Detail: detail,
+		Err:    fmt.Errorf("%s", strings.TrimSuffix(detail, " — rate-limit check skipped")),
+	}
+}

--- a/internal/domain/tlspreflight/result_test.go
+++ b/internal/domain/tlspreflight/result_test.go
@@ -1,0 +1,184 @@
+package tlspreflight_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/domain/tlspreflight"
+)
+
+func TestNewFromQuery_StatusMapping(t *testing.T) {
+	// oldest is 50h before now — slot opens at oldest + 168h.
+	baseTime := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		issued       int
+		wantStatus   tlspreflight.Status
+		wantRemain   int
+		wantNextSlot bool // true when NextSlotAvailableAt should be non-zero
+	}{
+		{"0 issued — OK full budget", 0, tlspreflight.StatusOK, 5, false},
+		{"1 issued — OK", 1, tlspreflight.StatusOK, 4, false},
+		{"2 issued — OK", 2, tlspreflight.StatusOK, 3, false},
+		{"3 issued — OK", 3, tlspreflight.StatusOK, 2, false},
+		{"4 issued — WARN", 4, tlspreflight.StatusWarn, 1, false},
+		{"5 issued — FAIL", 5, tlspreflight.StatusFail, 0, true},
+		{"6 issued — FAIL clamped", 6, tlspreflight.StatusFail, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := tlspreflight.NewFromQuery("example.com", tt.issued, baseTime)
+			if r.Status != tt.wantStatus {
+				t.Errorf("Status = %v, want %v", r.Status, tt.wantStatus)
+			}
+			if r.RemainingBudget != tt.wantRemain {
+				t.Errorf("RemainingBudget = %d, want %d", r.RemainingBudget, tt.wantRemain)
+			}
+			if tt.wantNextSlot && r.NextSlotAvailableAt.IsZero() {
+				t.Errorf("NextSlotAvailableAt is zero, want non-zero")
+			}
+			if !tt.wantNextSlot && !r.NextSlotAvailableAt.IsZero() {
+				t.Errorf("NextSlotAvailableAt = %v, want zero", r.NextSlotAvailableAt)
+			}
+			// Detail must always be non-empty.
+			if r.Detail == "" {
+				t.Error("Detail is empty")
+			}
+		})
+	}
+}
+
+func TestRenderDetail_AllPaths(t *testing.T) {
+	baseTime := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	expectedNextSlot := baseTime.Add(tlspreflight.BudgetWindow).Format(time.RFC1123)
+
+	tests := []struct {
+		name        string
+		result      tlspreflight.Result
+		wantContain []string
+	}{
+		{
+			name:        "0 issued — full budget",
+			result:      tlspreflight.NewFromQuery("example.com", 0, time.Time{}),
+			wantContain: []string{"5 of 5 slots free", "example.com"},
+		},
+		{
+			name:        "1 issued",
+			result:      tlspreflight.NewFromQuery("example.com", 1, time.Time{}),
+			wantContain: []string{"4 of 5 slots remaining", "example.com"},
+		},
+		{
+			name:        "2 issued",
+			result:      tlspreflight.NewFromQuery("example.com", 2, time.Time{}),
+			wantContain: []string{"3 of 5 slots remaining", "example.com"},
+		},
+		{
+			name:        "3 issued",
+			result:      tlspreflight.NewFromQuery("example.com", 3, time.Time{}),
+			wantContain: []string{"2 of 5 slots remaining", "example.com"},
+		},
+		{
+			name:        "4 issued — WARN",
+			result:      tlspreflight.NewFromQuery("example.com", 4, time.Time{}),
+			wantContain: []string{"1 of 5 slots remaining this week", "example.com"},
+		},
+		{
+			name:   "5 issued — FAIL contains opt-out flag",
+			result: tlspreflight.NewFromQuery("example.com", 5, baseTime),
+			wantContain: []string{
+				"LE rate limit exhausted",
+				"example.com",
+				"next slot at",
+				expectedNextSlot,
+				"--skip-le-preflight",
+			},
+		},
+		{
+			name:   "6 issued — FAIL with observed suffix",
+			result: tlspreflight.NewFromQuery("example.com", 6, baseTime),
+			wantContain: []string{
+				"LE rate limit exhausted",
+				"observed 6 issuances",
+				"--skip-le-preflight",
+			},
+		},
+		{
+			name:   "error — ErrCTUnavailable",
+			result: tlspreflight.NewFromError("example.com", tlspreflight.ErrCTUnavailable),
+			wantContain: []string{
+				"crt.sh unreachable",
+				"--skip-le-preflight",
+			},
+		},
+		{
+			name:   "error — ErrCTThrottled",
+			result: tlspreflight.NewFromError("example.com", tlspreflight.ErrCTThrottled),
+			wantContain: []string{
+				"crt.sh throttled",
+				"--skip-le-preflight",
+			},
+		},
+		{
+			name:   "error — ErrCTResponseMalformed",
+			result: tlspreflight.NewFromError("example.com", tlspreflight.ErrCTResponseMalformed),
+			wantContain: []string{
+				"crt.sh returned unexpected response",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.result.Detail
+			for _, want := range tt.wantContain {
+				if !containsStr(got, want) {
+					t.Errorf("Detail does not contain %q\ngot: %s", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestNewFromError_StatusIsWarn(t *testing.T) {
+	errs := []error{
+		tlspreflight.ErrCTUnavailable,
+		tlspreflight.ErrCTThrottled,
+		tlspreflight.ErrCTResponseMalformed,
+		fmt.Errorf("some wrapped error: %w", tlspreflight.ErrCTUnavailable),
+	}
+	for _, err := range errs {
+		r := tlspreflight.NewFromError("example.com", err)
+		if r.Status != tlspreflight.StatusWarn {
+			t.Errorf("NewFromError(%v).Status = %v, want WARN", err, r.Status)
+		}
+		if r.Err == nil {
+			t.Errorf("NewFromError(%v).Err is nil, want non-nil", err)
+		}
+	}
+}
+
+func TestNewSkipped(t *testing.T) {
+	r := tlspreflight.NewSkipped("localhost")
+	if r.Status != tlspreflight.StatusWarn {
+		t.Errorf("Status = %v, want WARN", r.Status)
+	}
+	if !containsStr(r.Detail, "cannot derive registered domain") {
+		t.Errorf("Detail = %q, want 'cannot derive registered domain'", r.Detail)
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstr(s, substr))
+}
+
+func containsSubstr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ports/cert_transparency.go
+++ b/internal/ports/cert_transparency.go
@@ -1,0 +1,37 @@
+package ports
+
+import (
+	"context"
+	"time"
+)
+
+// CertTransparencyQuerier returns the raw certificate records published to
+// Certificate Transparency logs for a single registered domain.
+//
+// Implementations call the crt.sh public JSON API. Query MUST receive the
+// registered domain (eTLD+1), not a full FQDN — callers are responsible for
+// normalising via golang.org/x/net/publicsuffix.
+//
+// Error conventions (sentinel values live in domain/tlspreflight):
+//   - tlspreflight.ErrCTUnavailable  — network failure, DNS failure, non-200/non-429 status.
+//   - tlspreflight.ErrCTThrottled    — HTTP 429 from crt.sh.
+//   - tlspreflight.ErrCTResponseMalformed — invalid JSON or unexpected Content-Type.
+type CertTransparencyQuerier interface {
+	Query(ctx context.Context, registeredDomain string) ([]CrtShRecord, error)
+}
+
+// CrtShRecord is the slim projection of a crt.sh JSON row that the preflight
+// needs. It mirrors domain/tlspreflight.CrtShRecord — declared here in the
+// ports layer so adapters and application services can type-check against a
+// stable interface without importing the domain package.
+type CrtShRecord struct {
+	// NotBefore is the certificate's not-before timestamp parsed from RFC 3339.
+	NotBefore time.Time
+	// IssuerName is the full issuer DN string from crt.sh,
+	// e.g. "C=US, O=Let's Encrypt, CN=R3".
+	IssuerName string
+	// CommonName is the certificate's CN field.
+	CommonName string
+	// NameValue is the SAN / name-value field from crt.sh.
+	NameValue string
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1301,7 +1301,7 @@ VibeWarden is operated via the `vibew` CLI. Below is the complete command list.
 | `vibew restart` | Restart containers without rebuilding |
 | `vibew bundle` | Produce a self-contained Docker Compose deploy bundle under `.vibewarden/bundle/` (produces deploy.sh for local-run shipping) |
 | `vibew status` | Show health of all components; TLS column reports state: Obtaining, Obtained, Failing, or SelfSignedLocal |
-| `vibew doctor` | Diagnose common issues; check 7 reports TLS state (Obtaining/Obtained/Failing/SelfSignedLocal) |
+| `vibew doctor` | Diagnose common issues; includes LE rate-limit preflight (crt.sh CT log query) when tls.provider=letsencrypt; --skip-le-preflight suppresses it |
 | `vibew logs` | Pretty-print structured logs |
 | `vibew migrate` | Apply all pending database migrations (alias for migrate up) |
 | `vibew migrate up` | Apply all pending database migrations |
@@ -1480,8 +1480,17 @@ vibew doctor checks (in order):
   4. Proxy port — server.port not already bound
   5. Generated files — .vibewarden/generated/docker-compose.yml present
   6. Container health — all containers running/healthy
-  7. TLS state — reports Obtaining/Obtained/Failing/SelfSignedLocal; self-signed
-     certs are identified and not reported as near-expiry
+  7. ACME email — tls.email set when using ZeroSSL
+  8. Image tag — app.image exists locally (skipped when unset)
+  9. LE rate-limit: <domain> — queries crt.sh CT log; counts LE certs issued in
+     last 168h for the registered domain; WARN at 4/5, FAIL at 5/5. Only runs
+     when tls.provider=letsencrypt and no tls.acme_ca override is set. Degrades
+     to WARN (not FAIL) when crt.sh is unreachable.
+     Opt-out: --skip-le-preflight flag or tls.skip_rate_limit_check: true.
+  10. TLS certificate — live TLS handshake; reports expiry state
+
+vibew doctor flags:
+  --skip-le-preflight  skip the LE rate-limit CT log check for this run
 
 
 ## 15. Troubleshooting

--- a/vibewarden.reference.yaml
+++ b/vibewarden.reference.yaml
@@ -228,6 +228,12 @@ tls:
   # Other ACME CAs (ZeroSSL, Buypass, etc.) are also supported.
   acme_ca: ""
 
+  # Skip the Let's Encrypt rate-limit preflight check run by "vibew doctor".
+  # Set to true after cert revocation when you need to re-issue within the
+  # 168-hour window and already know the budget is (temporarily) exhausted.
+  # Equivalent to passing --skip-le-preflight on the CLI.
+  skip_rate_limit_check: false
+
 # Ory Kratos (identity/auth) settings
 kratos:
   # Kratos public API (user-facing flows). When set, VibeWarden automatically:


### PR DESCRIPTION
## Summary

- Adds LE rate-limit preflight via crt.sh CT log query.
- Runs under `vibew doctor`; `--skip-le-preflight` + `tls.skip_rate_limit_check` opt-out.
- ADR-090.
- Closes #1057.

### New packages

- `internal/domain/tlspreflight/` — pure domain types: `Status`, `Result`, `Budget` constants, error sentinels, `CountIssuedSince` parser. 100% coverage.
- `internal/ports/cert_transparency.go` — `CertTransparencyQuerier` interface and `CrtShRecord` projection.
- `internal/adapters/crtsh/` — HTTP adapter calling `crt.sh/?Identity=<domain>&output=json`. Handles 429/500/malformed/empty/context-cancel.
- `internal/app/tlspreflight/` — `Service.Check(ctx, domains)` orchestrates queries, maps all error sentinels to WARN, preserves input order. 100% coverage.

### Existing file edits

- `internal/app/ops/doctor.go` — `WithLERateLimitService` setter, `checkLERateLimit` helper, six ADR-090 guards in `runChecks`.
- `internal/cli/cmd/doctor.go` — `--skip-le-preflight` flag, crt.sh adapter wiring (10s timeout per AC-8), `deriveRegisteredDomains` via `publicsuffix`.
- `internal/config/config.go` — `TLSConfig.SkipRateLimitCheck bool` field.
- `go.mod` — `golang.org/x/net` promoted from indirect to direct (BSD-3).
- `docs/troubleshooting.md` — flags table row, check table row, full "LE rate-limit preflight" section.
- `llms-full.txt` — doctor checks list and flags updated.
- `CHANGELOG.md` — [Unreleased] Added entries.

### Grep contract

`grep -rn "crtsh\." internal/plugins/ internal/adapters/caddy/` → 0 matches.  
The crt.sh adapter is never instantiated from the sidecar runtime — only from `internal/cli/cmd/doctor.go`.

## Test plan

- [x] `make check` passes (gofmt, golangci-lint, build, `go test -race ./...`)
- [x] Domain + app coverage 100% (well above 85% target)
- [x] crt.sh adapter unit tests cover 429 / 500 / empty / malformed / context-cancel / User-Agent / URL escaping / malformed-row-skipped
- [x] App service tests cover all threshold transitions (0–5/5), all three error sentinels, multi-domain mixed outcomes, result order, next-slot time
- [x] `DoctorService` tests cover WARN / FAIL / SkipRateLimitCheck / SkipFlag / non-LE provider / ACME CA override / no domains / network error / JSON output
- [x] CLI tests verify `--skip-le-preflight` flag registered, long description mentions rate-limit, help text contains flag name