### PR TITLE
fix(#1099,#1098): ungate ports-purity test, move SharedFuncMap to pure templatefuncs, fix bundle adapter import

### DIFF
--- a/internal/adapters/template/renderer.go
+++ b/internal/adapters/template/renderer.go
@@ -17,6 +17,8 @@ import (
 	"os"
 	"path/filepath"
 	"text/template"
+
+	"github.com/vibewarden/vibewarden/internal/config/templates/funcs"
 )
 
 // File permission constants.
@@ -38,45 +40,6 @@ func NewRenderer(f fs.ReadFileFS) *Renderer {
 	return &Renderer{fs: f}
 }
 
-// SharedFuncMap returns the custom template functions so that callers outside
-// this package (e.g. deploy) can register them on their own templates.
-func SharedFuncMap() template.FuncMap { return funcMap }
-
-// funcMap defines the custom template functions available to all templates.
-var funcMap = template.FuncMap{
-	// mul multiplies two integers and returns the product.
-	// Used in loki-config.yml.tmpl to convert retention days to hours.
-	"mul": func(a, b int) int { return a * b },
-
-	// healthcheckCmd returns a Docker health check command appropriate for
-	// the given language runtime. Images based on Alpine (Go, Kotlin) ship
-	// wget; Python and Node slim images do not but always have their own
-	// runtime available. Falls back to wget for unknown languages.
-	// healthcheckCmd returns a Docker health check command appropriate for
-	// the given language runtime.
-	//
-	// IMPORTANT: the returned string is placed inside a YAML double-quoted
-	// string (["CMD-SHELL", "..."]), so inner double quotes would break
-	// the YAML parse. Python and Node commands use single quotes for their
-	// code argument to avoid this.
-	"healthcheckCmd": func(lang string, port int) string {
-		switch lang {
-		case "python":
-			return fmt.Sprintf(
-				`python -c 'import urllib.request; urllib.request.urlopen("http://127.0.0.1:%d/health")'`,
-				port)
-		case "typescript", "javascript":
-			return fmt.Sprintf(
-				`node -e 'const h=require("http");h.get("http://127.0.0.1:%d/health",r=>{process.exit(r.statusCode===200?0:1)}).on("error",()=>process.exit(1))'`,
-				port)
-		default: // go, kotlin, alpine-based, unknown
-			return fmt.Sprintf(
-				`wget -q --spider http://127.0.0.1:%d/health || exit 1`,
-				port)
-		}
-	},
-}
-
 // Render executes the named template with data and returns the rendered bytes.
 // templateName must be the filename as stored in the FS (e.g. "vibewarden.yaml.tmpl").
 func (r *Renderer) Render(templateName string, data any) ([]byte, error) {
@@ -85,7 +48,7 @@ func (r *Renderer) Render(templateName string, data any) ([]byte, error) {
 		return nil, fmt.Errorf("reading template %q: %w", templateName, err)
 	}
 
-	tmpl, err := template.New(templateName).Funcs(funcMap).Parse(string(src))
+	tmpl, err := template.New(templateName).Funcs(funcs.FuncMap()).Parse(string(src))
 	if err != nil {
 		return nil, fmt.Errorf("parsing template %q: %w", templateName, err)
 	}

--- a/internal/app/bundle/bundle.go
+++ b/internal/app/bundle/bundle.go
@@ -12,9 +12,9 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	templateadapter "github.com/vibewarden/vibewarden/internal/adapters/template"
 	"github.com/vibewarden/vibewarden/internal/config"
 	"github.com/vibewarden/vibewarden/internal/config/templates"
+	"github.com/vibewarden/vibewarden/internal/config/templates/funcs"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
@@ -398,7 +398,7 @@ func renderSidecarCompose(listenPort int) (string, error) {
 		return "", fmt.Errorf("reading sidecar compose template: %w", err)
 	}
 
-	tmpl, err := template.New("sidecar-compose").Funcs(templateadapter.SharedFuncMap()).Parse(string(tmplContent))
+	tmpl, err := template.New("sidecar-compose").Funcs(funcs.FuncMap()).Parse(string(tmplContent))
 	if err != nil {
 		return "", fmt.Errorf("parsing sidecar compose template: %w", err)
 	}
@@ -419,7 +419,7 @@ func renderAppCompose(cfg *config.Config, projectName string) (string, error) {
 		return "", fmt.Errorf("reading app compose template: %w", err)
 	}
 
-	tmpl, err := template.New("app-compose").Funcs(templateadapter.SharedFuncMap()).Parse(string(tmplContent))
+	tmpl, err := template.New("app-compose").Funcs(funcs.FuncMap()).Parse(string(tmplContent))
 	if err != nil {
 		return "", fmt.Errorf("parsing app compose template: %w", err)
 	}

--- a/internal/config/templates/funcs/funcs.go
+++ b/internal/config/templates/funcs/funcs.go
@@ -1,0 +1,53 @@
+// Package funcs provides the shared text/template function map used by all
+// VibeWarden template renderers.
+//
+// These are pure, stateless helpers with no external dependencies beyond stdlib.
+// Both internal/adapters/template and internal/app/bundle import this package
+// as the single source of truth for custom template vocabulary, avoiding any
+// internal/app → internal/adapters dependency.
+package funcs
+
+import (
+	"fmt"
+	"text/template"
+)
+
+// FuncMap returns the custom template.FuncMap available to all VibeWarden
+// templates. The returned map is a new allocation on every call; callers may
+// mutate it freely without affecting other callers.
+func FuncMap() template.FuncMap {
+	return template.FuncMap{
+		"mul":            mul,
+		"healthcheckCmd": healthcheckCmd,
+	}
+}
+
+// mul multiplies two integers and returns the product.
+// Used in loki-config.yml.tmpl to convert retention days to hours.
+func mul(a, b int) int { return a * b }
+
+// healthcheckCmd returns a Docker health check command appropriate for the
+// given language runtime. Images based on Alpine (Go, Kotlin) ship wget;
+// Python and Node slim images do not but always have their own runtime
+// available. Falls back to wget for unknown languages.
+//
+// IMPORTANT: the returned string is placed inside a YAML double-quoted string
+// (["CMD-SHELL", "..."]), so inner double quotes would break the YAML parse.
+// Python and Node commands use single quotes for their code argument to avoid
+// this.
+func healthcheckCmd(lang string, port int) string {
+	switch lang {
+	case "python":
+		return fmt.Sprintf(
+			`python -c 'import urllib.request; urllib.request.urlopen("http://127.0.0.1:%d/health")'`,
+			port)
+	case "typescript", "javascript":
+		return fmt.Sprintf(
+			`node -e 'const h=require("http");h.get("http://127.0.0.1:%d/health",r=>{process.exit(r.statusCode===200?0:1)}).on("error",()=>process.exit(1))'`,
+			port)
+	default: // go, kotlin, alpine-based, unknown
+		return fmt.Sprintf(
+			`wget -q --spider http://127.0.0.1:%d/health || exit 1`,
+			port)
+	}
+}

--- a/internal/config/templates/funcs/funcs_test.go
+++ b/internal/config/templates/funcs/funcs_test.go
@@ -1,0 +1,131 @@
+package funcs_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/config/templates/funcs"
+)
+
+func TestFuncMap_mul(t *testing.T) {
+	fm := funcs.FuncMap()
+	mulFn, ok := fm["mul"]
+	if !ok {
+		t.Fatal("FuncMap() does not contain 'mul'")
+	}
+	fn, ok := mulFn.(func(int, int) int)
+	if !ok {
+		t.Fatalf("FuncMap()['mul'] has unexpected type %T", mulFn)
+	}
+
+	tests := []struct {
+		name string
+		a, b int
+		want int
+	}{
+		{"positive values", 3, 4, 12},
+		{"zero times anything", 0, 5, 0},
+		{"negative multiplier", -2, 6, -12},
+		{"identity", 1, 7, 7},
+		{"retention days to hours (24 days)", 24, 24, 576},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fn(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("mul(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFuncMap_healthcheckCmd(t *testing.T) {
+	fm := funcs.FuncMap()
+	hcFn, ok := fm["healthcheckCmd"]
+	if !ok {
+		t.Fatal("FuncMap() does not contain 'healthcheckCmd'")
+	}
+	fn, ok := hcFn.(func(string, int) string)
+	if !ok {
+		t.Fatalf("FuncMap()['healthcheckCmd'] has unexpected type %T", hcFn)
+	}
+
+	const port = 8080
+
+	tests := []struct {
+		name    string
+		lang    string
+		port    int
+		wantSub string
+		// wantSingleQuotedCode asserts that any code argument in the command
+		// uses single quotes (not outer double quotes) so it is safe to embed
+		// inside a YAML double-quoted ["CMD-SHELL", "..."] string.
+		wantSingleQuotedCode bool
+	}{
+		{
+			name:                 "python uses urllib",
+			lang:                 "python",
+			port:                 port,
+			wantSub:              "urllib.request",
+			wantSingleQuotedCode: true,
+		},
+		{
+			name:                 "typescript uses node",
+			lang:                 "typescript",
+			port:                 port,
+			wantSub:              "node -e",
+			wantSingleQuotedCode: true,
+		},
+		{
+			name:                 "javascript uses node",
+			lang:                 "javascript",
+			port:                 port,
+			wantSub:              "node -e",
+			wantSingleQuotedCode: true,
+		},
+		{
+			name:    "go uses wget",
+			lang:    "go",
+			port:    port,
+			wantSub: "wget",
+		},
+		{
+			name:    "kotlin uses wget",
+			lang:    "kotlin",
+			port:    port,
+			wantSub: "wget",
+		},
+		{
+			name:    "unknown lang falls back to wget",
+			lang:    "rust",
+			port:    port,
+			wantSub: "wget",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fn(tt.lang, tt.port)
+			if !strings.Contains(got, tt.wantSub) {
+				t.Errorf("healthcheckCmd(%q, %d) = %q, want it to contain %q",
+					tt.lang, tt.port, got, tt.wantSub)
+			}
+			// For Python/Node the code argument must be wrapped in single quotes
+			// so the command is safe inside a YAML double-quoted value.
+			if tt.wantSingleQuotedCode && !strings.Contains(got, `'`) {
+				t.Errorf("healthcheckCmd(%q, %d) = %q, expected single-quoted code argument for YAML safety",
+					tt.lang, tt.port, got)
+			}
+		})
+	}
+}
+
+func TestFuncMap_ReturnsNewMapEachCall(t *testing.T) {
+	m1 := funcs.FuncMap()
+	m2 := funcs.FuncMap()
+	m1["extra"] = func() {}
+	if _, found := m2["extra"]; found {
+		t.Error("FuncMap() must return a new map each call; mutation of one affected another")
+	}
+}

--- a/test/architecture/ports_purity_test.go
+++ b/test/architecture/ports_purity_test.go
@@ -1,23 +1,24 @@
-//go:build purity
-// +build purity
-
 // Package architecture_test holds repo-wide architectural-invariant tests.
 //
-// This file guards the hexagonal-architecture invariant locked in
-// ADR-064: internal/ports/ may import stdlib and internal/domain/* only.
-// Imports of internal/config, internal/adapters/*, or internal/app/* would
-// re-introduce the leak that ADR-064 removed.
+// This file guards the hexagonal-architecture invariants locked in ADR-064 and
+// ADR-067. It runs on every `make check` invocation (go test -race ./...) with
+// no build tags required — the ~1.6 s runtime and zero external dependencies
+// (stdlib only) make gating unnecessary.
 //
-// It is behind a build tag because the repository's default make check
-// gate (go build + golangci-lint + go test) does not run this assertion;
-// operators or CI can opt in with `go test -tags=purity ./test/architecture/...`
-// when an extra guardrail is desirable. See ADR-087 for the placement
-// rationale.
-
+// Invariants asserted:
+//
+//  1. internal/ports/ imports only stdlib and internal/domain/* (ADR-064).
+//  2. internal/app/**/*.go (non-test) imports no internal/adapters/* path (ADR-067).
+//  3. internal/mcp/**/*.go (non-test) imports no internal/adapters/* or
+//     internal/app/* path (ADR-067 Decision 2).
 package architecture_test
 
 import (
 	"go/build"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -55,5 +56,88 @@ func TestPortsPackage_OnlyImportsStdlibAndDomain(t *testing.T) {
 			t.Errorf("internal/ports imports %q — only stdlib and %s*** are allowed",
 				imp, allowedInternal)
 		}
+	}
+}
+
+// TestAppPackages_NoAdapterImports asserts that no non-test Go file under
+// internal/app/ imports any path matching internal/adapters/. This encodes
+// the ADR-067 invariant: the app layer must remain adapter-free so that use
+// cases can be tested without infrastructure.
+func TestAppPackages_NoAdapterImports(t *testing.T) {
+	const (
+		moduleRoot  = "github.com/vibewarden/vibewarden/"
+		bannedInfix = moduleRoot + "internal/adapters/"
+		pkgRoot     = "internal/app"
+	)
+
+	assertNoForbiddenImports(t, pkgRoot, []string{bannedInfix})
+}
+
+// TestMCPPackage_NoAdapterOrAppImports asserts that no non-test Go file under
+// internal/mcp/ imports any path matching internal/adapters/ or internal/app/.
+// This encodes ADR-067 Decision 2: the MCP layer defines its own local
+// interface types and must not reach into the app or adapter layers.
+func TestMCPPackage_NoAdapterOrAppImports(t *testing.T) {
+	const (
+		moduleRoot = "github.com/vibewarden/vibewarden/"
+		pkgRoot    = "internal/mcp"
+	)
+
+	banned := []string{
+		moduleRoot + "internal/adapters/",
+		moduleRoot + "internal/app/",
+	}
+
+	assertNoForbiddenImports(t, pkgRoot, banned)
+}
+
+// assertNoForbiddenImports walks pkgRoot (relative to the repo root resolved
+// via go/build), parses every non-test .go file, and fails the test for each
+// import that has any of the forbidden prefixes.
+//
+// pkgRoot is a directory path relative to the module root, not necessarily a
+// Go package itself (e.g. "internal/app" contains sub-packages only).
+func assertNoForbiddenImports(t *testing.T, pkgRoot string, forbidden []string) {
+	t.Helper()
+
+	// Resolve the module root's on-disk path by importing a known package
+	// (internal/ports always exists) and climbing two directories up.
+	sentinel, err := build.Default.Import("github.com/vibewarden/vibewarden/internal/ports", "", build.FindOnly)
+	if err != nil {
+		t.Fatalf("locating module root via internal/ports: %v", err)
+	}
+	// sentinel.Dir is <moduleRoot>/internal/ports — go up two levels.
+	moduleRootDir := filepath.Dir(filepath.Dir(sentinel.Dir))
+	targetDir := filepath.Join(moduleRootDir, filepath.FromSlash(pkgRoot))
+
+	fset := token.NewFileSet()
+
+	err = filepath.WalkDir(targetDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		f, parseErr := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if parseErr != nil {
+			t.Errorf("parsing %s: %v", path, parseErr)
+			return nil
+		}
+
+		for _, imp := range f.Imports {
+			importPath := strings.Trim(imp.Path.Value, `"`)
+			for _, bad := range forbidden {
+				if strings.HasPrefix(importPath, bad) {
+					rel, _ := filepath.Rel(targetDir, path)
+					t.Errorf("%s/%s imports %q — forbidden by ADR-067", pkgRoot, rel, importPath)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", pkgRoot, err)
 	}
 }


### PR DESCRIPTION
Closes #1099
Closes #1098

## Summary

- **New package `internal/config/templates/funcs/`** — pure stdlib-only package exporting `FuncMap() template.FuncMap` containing `mul` and `healthcheckCmd`. This is the single source of truth for VibeWarden template vocabulary; both the adapter and the app layer import it.
- **`internal/adapters/template/renderer.go`** — deleted private `funcMap` var and `SharedFuncMap()` export; `Render()` now calls `funcs.FuncMap()`.
- **`internal/app/bundle/bundle.go`** — removed `templateadapter` import (ADR-067 violation); both `renderSidecarCompose` and `renderAppCompose` now call `funcs.FuncMap()` directly.
- **`test/architecture/ports_purity_test.go`** — dropped `//go:build purity` and `// +build purity` tags so the invariant runs on every `make check` (`go test -race ./...`). Added `TestAppPackages_NoAdapterImports` (ADR-067: `internal/app/**` must not import `internal/adapters/**`) and `TestMCPPackage_NoAdapterOrAppImports` (ADR-067 Decision 2: `internal/mcp/**` must not import `internal/adapters/**` or `internal/app/**`). Both walk non-test `.go` files via `filepath.WalkDir` + `go/parser.ParseFile(parser.ImportsOnly)`.

## Test plan

- `go test ./internal/config/templates/funcs/...` — table-driven tests for `mul` and `healthcheckCmd`.
- `go test ./test/architecture/...` (no flags) — all three invariant tests pass including the two new ones.
- `grep -rn "templateadapter|adapters/template" internal/app/ --include="*.go"` excluding `_test.go` returns empty.
- `make check` is fully green (lint + build + all tests including architecture invariants).