### PR TITLE
docs(#1108,#1114): llms-full.txt + examples use vibewarden.production.yaml; drop non-existent --config flag

### DIFF
--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -521,7 +521,7 @@ the configured database.
 Apply all pending migrations:
 
 ```bash
-vibew migrate up --config vibewarden.prod.yaml
+vibew migrate up --config vibewarden.production.yaml
 ```
 
 Expected output on success:
@@ -533,13 +533,13 @@ Migrations applied successfully.
 Check current migration version:
 
 ```bash
-vibew migrate status --config vibewarden.prod.yaml
+vibew migrate status --config vibewarden.production.yaml
 ```
 
 Roll back the last migration:
 
 ```bash
-vibew migrate down --config vibewarden.prod.yaml
+vibew migrate down --config vibewarden.production.yaml
 ```
 
 Expected output on success:

--- a/examples/vibewarden.production.yaml
+++ b/examples/vibewarden.production.yaml
@@ -1,11 +1,12 @@
-# vibewarden.prod.yaml — Production configuration example
+# vibewarden.production.yaml — Production configuration example
 #
-# Copy this file to your project root, rename it to vibewarden.prod.yaml (or
-# vibewarden.yaml if you only have one environment), and fill in the values
-# marked with TODO.
+# vibew init generates this file in your project root automatically.
+# vibew add tls --domain <your-domain> keeps it up to date.
+# Do NOT copy or rename vibewarden.yaml manually — vibew bundle merges
+# vibewarden.yaml with vibewarden.production.yaml for you.
 #
-# Generate the Docker Compose stack from this config:
-#   ./vibew generate --config vibewarden.prod.yaml
+# Fill in the values marked with TODO, then run:
+#   vibew bundle
 #
 # See https://vibewarden.dev/docs/configuration for the full reference.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1122,28 +1122,29 @@ Step 4 — Set up project locally:
     # Existing app:
     cd my-existing-app && vibew wrap --upstream 3000
 
-Step 5 — Create vibewarden.prod.yaml by copying the generated vibewarden.yaml
-and modifying it for production. Do NOT write it from scratch:
+Step 5 — Populate vibewarden.production.yaml (generated automatically):
 
-    cp vibewarden.yaml vibewarden.prod.yaml
+`vibew init` creates `vibewarden.production.yaml` in your project root.
+`vibew add tls --domain demo.yourdomain.com` keeps it up to date.
+You do NOT need to copy or rename `vibewarden.yaml` manually.
 
-Then edit vibewarden.prod.yaml to change:
+Edit `vibewarden.production.yaml` to set your production values:
     profile: prod
     tls.provider: letsencrypt
     tls.domain: demo.yourdomain.com
     server.port: 443
 
 For the full set of supported fields, see the authoritative config reference at
-https://vibewarden.dev/vibewarden.reference.yaml. `vibew bundle` merges your
-base `vibewarden.yaml` with your production overrides and strict-validates the
-result before writing the bundle; run it to see exactly what the production
+https://vibewarden.dev/vibewarden.reference.yaml. `vibew bundle` automatically
+merges `vibewarden.yaml` with `vibewarden.production.yaml` and strict-validates
+the result before writing the bundle; run it to see exactly what the production
 config evaluates to.
     waf:
       enabled: true
       mode: block
 
 Step 6 — Produce a deploy bundle locally:
-    vibew bundle --config vibewarden.prod.yaml
+    vibew bundle
     # Writes .vibewarden/bundle/ containing:
     #   image.tar                 — docker-saved app image
     #   docker-compose.yml        — pinned tag, deterministic
@@ -1166,7 +1167,7 @@ Step 8 — Verify (script already probed /_vibewarden/health; double-check anyti
     # OK
 
 Step 9 — Subsequent deploys (after code or config changes):
-    vibew bundle --config vibewarden.prod.yaml
+    vibew bundle
     cd .vibewarden/bundle && ./deploy.sh root@<server-ip>:/opt/myapp
 
 Note: the legacy `vibew deploy` command (one-shot SSH orchestration) was removed
@@ -1189,7 +1190,7 @@ in ADR-086. The bundle pipeline above is the only supported remote workflow.
 
   Full doctor output from the server:
     ssh root@<server-ip> 'docker run --rm \
-      -v /opt/myapp/vibewarden.prod.yaml:/vibewarden.yaml:ro \
+      -v /opt/myapp/vibewarden.production.yaml:/vibewarden.yaml:ro \
       ghcr.io/vibewarden/vibewarden:latest vibew doctor --json'
 
 ### Production Profile


### PR DESCRIPTION
Closes #1108, closes #1114

## Summary

- `llms-full.txt` Section 12 Step 5 rewritten: drop `cp vibewarden.yaml vibewarden.prod.yaml` instruction; document that `vibew init` and `vibew add tls --domain` generate and maintain `vibewarden.production.yaml` automatically.
- `vibew bundle --config vibewarden.prod.yaml` → `vibew bundle` at lines 1146 and 1169.
- Docker run troubleshooting volume mount updated to `vibewarden.production.yaml`.
- `examples/vibewarden.prod.yaml` renamed to `examples/vibewarden.production.yaml` via `git mv`.
- Example file header rewritten: removes stale `vibew generate --config` workflow; documents `vibew bundle` auto-merge workflow.
- `decisions/` ADRs and `DECISIONS.md` left unchanged (historical records).

## Test plan

- `grep -rn 'vibewarden\.prod\.yaml' . --include='*.go' --include='*.md' --include='*.txt' --include='*.yaml' | grep -v decisions/ | grep -v DECISIONS.md | grep -v .claude/worktrees/` — returns zero matches.
- `grep -n -- '--config' llms-full.txt | grep -i bundle` — returns zero matches.
- `make check` passes (all tests green, golangci-lint clean).