### PR TITLE
fix(#1109): replace /_vibewarden/healthz with /_vibewarden/health

### DIFF
--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -444,7 +444,7 @@ Verify Kratos starts and can reach the database:
 
 ```bash
 docker compose logs kratos | grep "Starting"
-curl https://myapp.example.com/_vibewarden/healthz
+curl https://myapp.example.com/_vibewarden/health
 # {"status":"ok"}
 ```
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -156,7 +156,7 @@ services:
     networks:
       - myapp
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:80/_vibewarden/healthz"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:80/_vibewarden/health"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -452,7 +452,7 @@ myapp                  Up (healthy)
 Verify the site is reachable:
 
 ```bash
-curl -I https://myapp.example.com/_vibewarden/healthz
+curl -I https://myapp.example.com/_vibewarden/health
 # HTTP/2 200
 ```
 
@@ -596,7 +596,7 @@ See `docs/observability.md` for the full metrics reference and a local Grafana s
 ### Health check endpoint
 
 ```
-GET /_vibewarden/healthz
+GET /_vibewarden/health
 ```
 
 Returns `200 OK` with `{"status":"ok"}` when VibeWarden is running. Use this for
@@ -651,4 +651,4 @@ startup (subject to Let's Encrypt rate limits — 5 per hour per domain).
 2. Restore `vibewarden.yaml`, Kratos config, and `.env` from version control /
    secrets manager.
 3. Start the stack: `docker compose up -d`.
-4. Verify: `docker compose ps` and `curl https://myapp.example.com/_vibewarden/healthz`.
+4. Verify: `docker compose ps` and `curl https://myapp.example.com/_vibewarden/health`.

--- a/examples/vibewarden.production.yaml
+++ b/examples/vibewarden.production.yaml
@@ -141,7 +141,7 @@ rate_limit:
 
   # Paths excluded from rate limiting (e.g. Prometheus scrape endpoint).
   exempt_paths:
-    - /_vibewarden/healthz
+    - /_vibewarden/health
 
 # -------------------------------------------------------------------------
 # Web Application Firewall

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1180,7 +1180,7 @@ in ADR-086. The bundle pipeline above is the only supported remote workflow.
 
   Port 80 blocked (ACME fails):
     Check Hetzner firewall rules: allow TCP 80 inbound from 0.0.0.0/0.
-    curl -v http://demo.yourdomain.com/_vibewarden/healthz
+    curl -v http://demo.yourdomain.com/_vibewarden/health
 
   Let's Encrypt rate limit (>5 failures/hour):
     Wait 1 hour. Use tls.provider: self-signed to test the rest of the stack.


### PR DESCRIPTION
Closes #1109

## Summary

- 7 occurrences of `/_vibewarden/healthz` replaced with `/_vibewarden/health` across 4 files
- `docs/production-deployment.md` (4 occurrences): Docker Compose healthcheck + 3 curl examples
- `docs/postgres.md` (1 occurrence): verify curl example
- `llms-full.txt` (1 occurrence): troubleshooting curl example
- `examples/vibewarden.production.yaml` (1 occurrence): `exempt_paths` entry

## Test plan

- `grep -rn "_vibewarden/healthz" docs/ llms-full.txt examples/` returns zero results
- `make check` passes (all checks pass locally)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>