### PR TITLE
docs(#1110): correct init vs wrap scaffolding claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,24 @@ on both x86-64 servers and ARM64 machines (Apple Silicon, AWS Graviton).
 
 ## What `init` / `wrap` generates
 
-Both `vibew init` and `vibew wrap` produce the same project scaffolding:
+Use `vibew init` for a new directory (creates its own git repo). Use `vibew wrap` to add VibeWarden to an existing project in place.
 
-```
-vibewarden.yaml          # Main config — commit this
-vibew                    # CLI binary (installed via install script)
-AGENTS.md                # AI agent context (generic — Claude Code, Cursor, etc.)
-AGENTS-VIBEWARDEN.md     # Tool-agnostic AI agent context (all agents)
-```
+| File | `vibew init` | `vibew wrap` |
+|------|:------------:|:------------:|
+| `vibewarden.yaml` | yes | yes |
+| `vibewarden.production.yaml` | yes | — |
+| `Dockerfile` | yes | — |
+| `.dockerignore` | yes | — |
+| `.gitignore` | yes | yes (created or updated) |
+| `vibew` (macOS/Linux wrapper script) | — | yes |
+| `vibew.ps1` (PowerShell wrapper) | — | yes |
+| `vibew.cmd` (Windows batch wrapper) | — | yes |
+| `AGENTS.md` | yes (created or updated) | yes (created or updated) |
+| `AGENTS-VIBEWARDEN.md` | yes (always overwritten) | yes (always overwritten) |
+| `PROJECT.md` | yes (only with `--describe`) | — |
+| runs `git init` | yes | — |
+
+Wrapper scripts are omitted when `vibew wrap --skip-wrapper` is given.
 
 Running `vibew dev` or `vibew generate` creates runtime files under
 `.vibewarden/generated/` (gitignored):

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -131,10 +131,14 @@ Common flags:
 ```
 vibewarden.yaml          # Main config — commit this
 vibew                    # Wrapper script (macOS/Linux)
-.dockerignore            # Prevents secrets and build artifacts from entering the image
-AGENTS.md                # AI agent context (generic — Claude Code, Cursor, etc.)
-AGENTS-VIBEWARDEN.md     # Tool-agnostic AI agent context (all agents)
+vibew.ps1                # Wrapper script (Windows — PowerShell)
+vibew.cmd                # Wrapper script (Windows — batch/cmd.exe)
+.gitignore               # Created if absent; .vibewarden/ entry appended if missing
+AGENTS.md                # AI agent context (created or updated)
+AGENTS-VIBEWARDEN.md     # VibeWarden-specific instructions for agents (always overwritten)
 ```
+
+Wrapper scripts are omitted when `--skip-wrapper` is given. `vibew wrap` does **not** generate `Dockerfile`, `.dockerignore`, or `vibewarden.production.yaml`.
 
 !!! tip "AI agent context"
     `vibew wrap` generates context files for your AI coding assistant. When you
@@ -172,11 +176,14 @@ Common flags:
   vibewarden.yaml                 # Local dev config (TLS self-signed, port 8443)
   vibewarden.production.yaml      # Production overrides (letsencrypt, port 443)
   Dockerfile                      # Placeholder with examples for common stacks
+  .dockerignore
   .gitignore
   PROJECT.md                      # Project description (only when --describe is given)
-  AGENTS.md                       # AI agent context (tool-agnostic)
-  AGENTS-VIBEWARDEN.md            # VibeWarden-specific instructions for agents
+  AGENTS.md                       # AI agent context (created or updated)
+  AGENTS-VIBEWARDEN.md            # VibeWarden-specific instructions for agents (always overwritten)
 ```
+
+`vibew init` also runs `git init` and creates an initial commit.
 
 !!! note "Environment separation"
     `vibewarden.yaml` is your local dev config. `vibewarden.production.yaml`


### PR DESCRIPTION
Closes #1110

## Summary

- **README.md**: replaced the false "Both `vibew init` and `vibew wrap` produce the same project scaffolding" paragraph and its inaccurate code block with a two-column markdown table listing the correct per-command file set, plus a one-sentence "when to use" lead-in.
- **docs/getting-started.md** "What `wrap` generates": removed `.dockerignore` (not generated by wrap); added `vibew.ps1` and `vibew.cmd` with platform annotations; changed `.gitignore` note to "created or updated"; added a sentence noting what wrap does NOT generate and the `--skip-wrapper` flag.
- **docs/getting-started.md** "What `init` generates": added the missing `.dockerignore` entry; updated AGENTS.md and AGENTS-VIBEWARDEN.md notes to match source behavior (created-or-updated vs always-overwritten); added a sentence noting that `vibew init` also runs `git init`.

File lists verified against `internal/app/scaffold/init_project.go` (`InitProject`) and `internal/app/scaffold/service.go` (`Init` + `renderWrappers` + `ensureGitIgnore`) and `internal/cli/cmd/wrap.go` (`AgentContextService.GenerateAgentContext`). No Go source changes.

## Test plan

- `grep -rn "both.*init.*wrap\|same project scaffolding\|same scaffolding" README.md docs/` returns empty.
- `make check` passes (lint + build + tests all green).