### PR TITLE
docs(#1112,#1113): add vibew dev --watch/--observability to CLI table, drop redundant generate step from examples

### DIFF
--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -15,13 +15,7 @@ Step 1 — move into this directory:
 cd examples/nextjs
 ```
 
-Step 2 — generate the runtime stack from `vibewarden.yaml`:
-
-```bash
-vibew generate
-```
-
-Step 3 — start everything:
+Step 2 — start everything (runs `vibew generate` internally, then starts the stack):
 
 ```bash
 vibew dev
@@ -81,9 +75,8 @@ auth:
     - /api/public
 ```
 
-Then run `vibew generate` again. Requests to `/api/protected` without a valid
-JWT will receive a `401 Unauthorized` response from VibeWarden before reaching
-the Next.js app.
+Requests to `/api/protected` without a valid JWT will receive a `401 Unauthorized`
+response from VibeWarden before reaching the Next.js app.
 
 ## Development without VibeWarden
 

--- a/examples/node-express/README.md
+++ b/examples/node-express/README.md
@@ -15,13 +15,7 @@ Step 1 — move into this directory:
 cd examples/node-express
 ```
 
-Step 2 — generate the runtime stack from `vibewarden.yaml`:
-
-```bash
-vibew generate
-```
-
-Step 3 — start everything:
+Step 2 — start everything (runs `vibew generate` internally, then starts the stack):
 
 ```bash
 vibew dev
@@ -79,9 +73,8 @@ auth:
     - /public
 ```
 
-Then run `vibew generate` again. Requests to `/protected` without a valid JWT
-will receive a `401 Unauthorized` response from VibeWarden before reaching the
-Express app.
+Requests to `/protected` without a valid JWT will receive a `401 Unauthorized`
+response from VibeWarden before reaching the Express app.
 
 ## Development without VibeWarden
 

--- a/examples/python-flask/README.md
+++ b/examples/python-flask/README.md
@@ -15,13 +15,7 @@ Step 1 — move into this directory:
 cd examples/python-flask
 ```
 
-Step 2 — generate the runtime stack from `vibewarden.yaml`:
-
-```bash
-vibew generate
-```
-
-Step 3 — start everything:
+Step 2 — start everything (runs `vibew generate` internally, then starts the stack):
 
 ```bash
 vibew dev
@@ -79,9 +73,8 @@ auth:
     - /public
 ```
 
-Then run `vibew generate` again. Requests to `/protected` without a valid JWT
-will receive a `401 Unauthorized` response from VibeWarden before reaching the
-Flask app.
+Requests to `/protected` without a valid JWT will receive a `401 Unauthorized`
+response from VibeWarden before reaching the Flask app.
 
 ## Development without VibeWarden
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1298,6 +1298,8 @@ VibeWarden is operated via the `vibew` CLI. Below is the complete command list.
 | `vibew build` | Build the Docker image for the app |
 | `vibew dev` | Start local dev environment |
 | `vibew dev --verbose` | Start local dev environment and stream docker compose output during startup |
+| `vibew dev --watch` | Watch vibewarden.yaml for changes and auto-regenerate config files + restart the stack (blocks until Ctrl+C) |
+| `vibew dev --observability` | Start Prometheus and Grafana alongside the core stack |
 | `vibew down` | Stop the local dev stack (preserves data volumes; pass `-v` to also remove volumes) |
 | `vibew restart` | Restart containers without rebuilding |
 | `vibew bundle` | Produce a self-contained Docker Compose deploy bundle under `.vibewarden/bundle/` (produces deploy.sh for local-run shipping) |


### PR DESCRIPTION
Closes #1112, closes #1113

## Summary

- Added `vibew dev --watch` and `vibew dev --observability` rows to the CLI table in `llms-full.txt`, immediately after the `vibew dev --verbose` row
- Removed the redundant `vibew generate` step from the Quick start in `examples/node-express/README.md`, `examples/python-flask/README.md`, and `examples/nextjs/README.md`; `vibew dev` is now the single start command (with a note that it runs generate internally)
- Removed the misleading "Then run `vibew generate` again." sentence from the JWT auth sections of those same three READMEs
- `examples/spring-boot/README.md` left untouched — already correct

## Test plan

- `make check` passes (lint, build, all tests green)
- Confirm `llms-full.txt` has the two new flag rows immediately after `vibew dev --verbose`
- Confirm the three example READMEs show a two-step Quick start with no stray `vibew generate` mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)