### PR TITLE
docs(#1115): small fixes pass — poll-not-stream, curl flags, down --yes, writer.md doc ref

### DIFF
--- a/.claude/agents/writer.md
+++ b/.claude/agents/writer.md
@@ -111,7 +111,7 @@ documentation affected by the code changes is accurate and consistent.
    - `llms-full.txt` — CLI flags, command examples, config reference
    - `AGENTS-VIBEWARDEN.md` template — boundary rules, known limitations, CLI reference
    - `docs/getting-started.md` — setup steps, command examples
-   - `docs/deploy-to-vps.md` — deploy workflow
+   - `docs/guide/bundle-to-vps.md` — deploy workflow
    - `vibewarden.reference.yaml` — all config fields with defaults
    - `docs/examples/AGENTS-VIBEWARDEN.md` — static example matches template
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Run:     vibew dev
 
 ```bash
 # macOS / Linux
-curl -sS https://vibewarden.dev/install.sh | sh
+curl -fsSL https://vibewarden.dev/install.sh | sh
 
 # New project
 mkdir myapp && cd myapp

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1300,7 +1300,7 @@ VibeWarden is operated via the `vibew` CLI. Below is the complete command list.
 | `vibew dev --verbose` | Start local dev environment and stream docker compose output during startup |
 | `vibew dev --watch` | Watch vibewarden.yaml for changes and auto-regenerate config files + restart the stack (blocks until Ctrl+C) |
 | `vibew dev --observability` | Start Prometheus and Grafana alongside the core stack |
-| `vibew down` | Stop the local dev stack (preserves data volumes; pass `-v` to also remove volumes) |
+| `vibew down` | Stop the local dev stack (preserves data volumes; pass `-v` to also remove volumes; pass `--yes` to skip confirmation prompt in CI/scripts) |
 | `vibew restart` | Restart containers without rebuilding |
 | `vibew bundle` | Produce a self-contained Docker Compose deploy bundle under `.vibewarden/bundle/` (produces deploy.sh for local-run shipping) |
 | `vibew status` | Show health of all components; TLS column reports state: Obtaining, Obtained, Failing, or SelfSignedLocal |
@@ -1642,7 +1642,7 @@ This starts a JSON-RPC 2.0 server on stdio. Tools:
 | `vibewarden_doctor` | Run the full health-check suite |
 | `vibewarden_validate` | Validate a vibewarden.yaml configuration file |
 | `vibewarden_explain` | Explain a configuration in plain language |
-| `vibewarden_watch_events` | Stream live structured log events from the sidecar |
+| `vibewarden_watch_events` | Poll the sidecar admin events endpoint for structured log events |
 | `vibewarden_stream_logs` | Stream raw container logs with client-side filtering (level, since, search) |
 | `vibewarden_schema_describe` | Describe the AI-readable log schema (pure metadata, no sidecar needed) |
 | `vibewarden_propose_action` | Create a configuration-change proposal for human review |


### PR DESCRIPTION
Closes #1115

## Summary

- `llms-full.txt` L1645: `vibewarden_watch_events` description corrected from "Stream live" to "Poll the sidecar admin events endpoint" — matches actual implementation in `internal/mcp/watch_events.go`
- `README.md` L72: `curl -sS` normalized to `curl -fsSL` — consistent with all other install paths
- `llms-full.txt` L1303: `vibew down` row gains `; pass --yes to skip confirmation prompt in CI/scripts`
- `.claude/agents/writer.md` L114: `docs/deploy-to-vps.md` corrected to `docs/guide/bundle-to-vps.md`

## Test plan

- `grep -rn "deploy-to-vps" .claude/agents/ docs/ README.md` — empty (worktrees excluded)
- `grep "curl -sS " README.md` — empty
- `make check` — all checks passed