### PR TITLE
fix(#1104): middleware log drops → slog.Warn + Prometheus counter

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -428,6 +428,7 @@ The endpoint uses the standard Prometheus text exposition format.
 | `vibewarden_auth_decisions_total` | Counter | `decision` | Auth allow / block decisions |
 | `vibewarden_upstream_errors_total` | Counter | — | Upstream connection failures |
 | `vibewarden_active_connections` | Gauge | — | Currently active connections |
+| `vibewarden_event_log_drops_total` | Counter | `middleware`, `reason` | Count of audit/event-log writes that failed. `middleware` = which middleware dropped (waf, auth, etc.). `reason` = short categorized error class. |
 
 ### Runtime Metrics
 

--- a/internal/adapters/caddy/maintenance_handler.go
+++ b/internal/adapters/caddy/maintenance_handler.go
@@ -72,6 +72,7 @@ func (h *MaintenanceHandler) Provision(_ gocaddy.Context) error {
 			Message: h.Config.Message,
 		},
 		h.eventLogger,
+		nil,
 	)
 	return nil
 }

--- a/internal/adapters/caddy/ratelimit_handler.go
+++ b/internal/adapters/caddy/ratelimit_handler.go
@@ -121,7 +121,7 @@ func (h *RateLimitHandler) Provision(_ gocaddy.Context) error {
 	eventLogger := logadapter.NewSlogEventLogger(os.Stdout)
 	auditLogger := auditadapter.NewJSONWriter(io.Discard)
 
-	h.handler = middleware.RateLimitMiddleware(h.ipLimiter, h.userLimiter, cfg, logger, eventLogger, auditLogger)
+	h.handler = middleware.RateLimitMiddleware(h.ipLimiter, h.userLimiter, cfg, logger, eventLogger, auditLogger, nil)
 
 	return nil
 }

--- a/internal/adapters/caddy/webhook_signature_handler.go
+++ b/internal/adapters/caddy/webhook_signature_handler.go
@@ -109,7 +109,7 @@ func (h *WebhookSignatureHandler) Provision(_ gocaddy.Context) error {
 		})
 	}
 
-	h.handler = middleware.WebhookSignatureMiddleware(rules, eventLogger)
+	h.handler = middleware.WebhookSignatureMiddleware(rules, eventLogger, nil)
 	return nil
 }
 

--- a/internal/adapters/egress/proxy.go
+++ b/internal/adapters/egress/proxy.go
@@ -260,7 +260,7 @@ func (p *Proxy) Start() error {
 	// blocked prior to any upstream contact.
 	var handler http.Handler = mux
 	if len(p.cfg.PromptInjectionRoutes) > 0 {
-		handler = middleware.PromptInjectionMiddleware(p.cfg.PromptInjectionRoutes, p.logger, p.cfg.EventLogger)(mux)
+		handler = middleware.PromptInjectionMiddleware(p.cfg.PromptInjectionRoutes, p.logger, p.cfg.EventLogger, nil)(mux)
 	}
 
 	p.server = &http.Server{

--- a/internal/adapters/metrics/noop.go
+++ b/internal/adapters/metrics/noop.go
@@ -56,3 +56,6 @@ func (NoOpMetricsCollector) IncEgressErrorTotal(_ string) {}
 
 // SetTLSCertExpirySeconds implements ports.MetricsCollector and does nothing.
 func (NoOpMetricsCollector) SetTLSCertExpirySeconds(_ string, _ float64) {}
+
+// IncEventLogDrop implements ports.EventLogDropCounter and does nothing.
+func (NoOpMetricsCollector) IncEventLogDrop(_, _ string) {}

--- a/internal/adapters/metrics/otel.go
+++ b/internal/adapters/metrics/otel.go
@@ -31,6 +31,7 @@ type OTelAdapter struct {
 	egressDuration            ports.Float64Histogram
 	egressErrorsTotal         ports.Int64Counter
 	tlsCertExpirySeconds      ports.Int64UpDownCounter
+	eventLogDrops             ports.Int64Counter
 	currentConns              atomic.Int64
 	currentCBState            atomic.Int64
 	currentUpstreamHealthy    atomic.Int64
@@ -156,6 +157,13 @@ func NewOTelAdapter(provider ports.OTelProvider, pathPatterns []string) (*OTelAd
 		return nil, err
 	}
 
+	eventLogDrops, err := meter.Int64Counter("vibewarden_event_log_drops_total",
+		ports.WithDescription("Total number of audit/event-log emissions dropped by middleware because the logger sink returned an error."),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &OTelAdapter{
 		requestsTotal:        requestsTotal,
 		requestDuration:      requestDuration,
@@ -172,6 +180,7 @@ func NewOTelAdapter(provider ports.OTelProvider, pathPatterns []string) (*OTelAd
 		egressDuration:       egressDuration,
 		egressErrorsTotal:    egressErrorsTotal,
 		tlsCertExpirySeconds: tlsCertExpirySeconds,
+		eventLogDrops:        eventLogDrops,
 		pathMatcher:          NewPathMatcher(pathPatterns),
 		handler:              provider.Handler(),
 	}, nil
@@ -322,4 +331,13 @@ func (a *OTelAdapter) SetTLSCertExpirySeconds(domain string, seconds float64) {
 			ports.Attribute{Key: "domain", Value: domain},
 		)
 	}
+}
+
+// IncEventLogDrop implements ports.EventLogDropCounter.
+// Increments vibewarden_event_log_drops_total{middleware, reason}.
+func (a *OTelAdapter) IncEventLogDrop(middleware, reason string) {
+	a.eventLogDrops.Add(context.Background(), 1,
+		ports.Attribute{Key: "middleware", Value: middleware},
+		ports.Attribute{Key: "reason", Value: reason},
+	)
 }

--- a/internal/middleware/admin_auth.go
+++ b/internal/middleware/admin_auth.go
@@ -65,13 +65,13 @@ func AdminAuthMiddleware(cfg ports.AdminAuthConfig, auditLogger ports.AuditEvent
 			// Validate the X-Admin-Key header.
 			provided := r.Header.Get(adminKeyHeader)
 			if !secureEqual(provided, cfg.Token) {
-				emitAuditAuthFailure(r, auditLogger, "", "missing or invalid admin key")
+				emitAuditAuthFailure(r, auditLogger, nil, "", "missing or invalid admin key")
 				w.Header().Set("WWW-Authenticate", `Bearer realm="vibewarden-admin"`)
 				WriteErrorResponse(w, r, http.StatusUnauthorized, "unauthorized", "missing or invalid admin key")
 				return
 			}
 
-			emitAuditAuthSuccess(r, auditLogger, "", "")
+			emitAuditAuthSuccess(r, auditLogger, nil, "", "")
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/internal/middleware/api_key.go
+++ b/internal/middleware/api_key.go
@@ -52,6 +52,7 @@ func APIKeyMiddleware(
 	cfg ports.APIKeyConfig,
 	eventLogger ports.EventLogger,
 	auditLogger ports.AuditEventLogger,
+	drops ports.EventLogDropCounter,
 ) func(http.Handler) http.Handler {
 	header := cfg.Header
 	if header == "" {
@@ -62,16 +63,16 @@ func APIKeyMiddleware(
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			rawKey := r.Header.Get(header)
 			if rawKey == "" {
-				emitAPIKeyFailed(r, eventLogger, "missing api key")
-				emitAuditAPIKeyFailure(r, auditLogger, "", "missing api key")
+				emitAPIKeyFailed(r, eventLogger, drops, "missing api key")
+				emitAuditAPIKeyFailure(r, auditLogger, drops, "", "missing api key")
 				WriteErrorResponse(w, r, http.StatusUnauthorized, "unauthorized", "API key required")
 				return
 			}
 
 			apiKey, err := validator.Validate(r.Context(), rawKey)
 			if err != nil {
-				emitAPIKeyFailed(r, eventLogger, "invalid or inactive api key")
-				emitAuditAPIKeyFailure(r, auditLogger, "", "invalid or inactive api key")
+				emitAPIKeyFailed(r, eventLogger, drops, "invalid or inactive api key")
+				emitAuditAPIKeyFailure(r, auditLogger, drops, "", "invalid or inactive api key")
 				WriteErrorResponse(w, r, http.StatusUnauthorized, "unauthorized", "invalid or inactive API key")
 				return
 			}
@@ -80,15 +81,15 @@ func APIKeyMiddleware(
 			// that the key holds all required scopes. No matching rule = allow.
 			if rule, ok := auth.MatchingScopeRule(cfg.ScopeRules, r.Method, r.URL.Path); ok {
 				if !rule.SatisfiedBy(apiKey.Scopes) {
-					emitAPIKeyForbidden(r, eventLogger, apiKey, rule.RequiredScopes)
-					emitAuditAPIKeyForbidden(r, auditLogger, apiKey, rule.RequiredScopes)
+					emitAPIKeyForbidden(r, eventLogger, drops, apiKey, rule.RequiredScopes)
+					emitAuditAPIKeyForbidden(r, auditLogger, drops, apiKey, rule.RequiredScopes)
 					WriteErrorResponse(w, r, http.StatusForbidden, "forbidden", "insufficient scopes")
 					return
 				}
 			}
 
-			emitAPIKeySuccess(r, eventLogger, apiKey)
-			emitAuditAPIKeySuccess(r, auditLogger, apiKey)
+			emitAPIKeySuccess(r, eventLogger, drops, apiKey)
+			emitAuditAPIKeySuccess(r, auditLogger, drops, apiKey)
 			ctx := contextWithAPIKey(r.Context(), apiKey)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
@@ -110,10 +111,7 @@ func contextWithAPIKey(ctx context.Context, k *auth.APIKey) context.Context {
 
 // emitAPIKeySuccess logs an auth.api_key.success event via the EventLogger port.
 // If eventLogger is nil the call is a no-op.
-func emitAPIKeySuccess(r *http.Request, eventLogger ports.EventLogger, key *auth.APIKey) {
-	if eventLogger == nil {
-		return
-	}
+func emitAPIKeySuccess(r *http.Request, eventLogger ports.EventLogger, drops ports.EventLogDropCounter, key *auth.APIKey) {
 	scopes := make([]string, len(key.Scopes))
 	for i, s := range key.Scopes {
 		scopes[i] = string(s)
@@ -124,32 +122,24 @@ func emitAPIKeySuccess(r *http.Request, eventLogger ports.EventLogger, key *auth
 		KeyName: key.Name,
 		Scopes:  scopes,
 	})
-	// Best-effort: ignore logging errors so request processing is never blocked.
-	_ = eventLogger.Log(r.Context(), ev)
+	logEvent(r.Context(), eventLogger, drops, "api_key", ev)
 }
 
 // emitAPIKeyFailed logs an auth.api_key.failed event via the EventLogger port.
 // If eventLogger is nil the call is a no-op.
-func emitAPIKeyFailed(r *http.Request, eventLogger ports.EventLogger, reason string) {
-	if eventLogger == nil {
-		return
-	}
+func emitAPIKeyFailed(r *http.Request, eventLogger ports.EventLogger, drops ports.EventLogDropCounter, reason string) {
 	ev := events.NewAPIKeyFailed(events.APIKeyFailedParams{
 		Method: r.Method,
 		Path:   r.URL.Path,
 		Reason: reason,
 	})
-	// Best-effort: ignore logging errors so request processing is never blocked.
-	_ = eventLogger.Log(r.Context(), ev)
+	logEvent(r.Context(), eventLogger, drops, "api_key", ev)
 }
 
 // emitAPIKeyForbidden logs an auth.api_key.forbidden event via the EventLogger
 // port when a valid key lacks the required scopes for the requested path+method.
 // If eventLogger is nil the call is a no-op.
-func emitAPIKeyForbidden(r *http.Request, eventLogger ports.EventLogger, key *auth.APIKey, requiredScopes []string) {
-	if eventLogger == nil {
-		return
-	}
+func emitAPIKeyForbidden(r *http.Request, eventLogger ports.EventLogger, drops ports.EventLogDropCounter, key *auth.APIKey, requiredScopes []string) {
 	keyScopes := make([]string, len(key.Scopes))
 	for i, s := range key.Scopes {
 		keyScopes[i] = string(s)
@@ -161,16 +151,12 @@ func emitAPIKeyForbidden(r *http.Request, eventLogger ports.EventLogger, key *au
 		KeyScopes:      keyScopes,
 		RequiredScopes: requiredScopes,
 	})
-	// Best-effort: ignore logging errors so request processing is never blocked.
-	_ = eventLogger.Log(r.Context(), ev)
+	logEvent(r.Context(), eventLogger, drops, "api_key", ev)
 }
 
 // emitAuditAPIKeySuccess emits an audit.auth.api_key.success event via the
 // AuditEventLogger port. If auditLogger is nil the call is a no-op.
-func emitAuditAPIKeySuccess(r *http.Request, auditLogger ports.AuditEventLogger, key *auth.APIKey) {
-	if auditLogger == nil {
-		return
-	}
+func emitAuditAPIKeySuccess(r *http.Request, auditLogger ports.AuditEventLogger, drops ports.EventLogDropCounter, key *auth.APIKey) {
 	scopes := make([]string, len(key.Scopes))
 	for i, s := range key.Scopes {
 		scopes[i] = string(s)
@@ -192,16 +178,12 @@ func emitAuditAPIKeySuccess(r *http.Request, auditLogger ports.AuditEventLogger,
 	if err != nil {
 		return
 	}
-	// Best-effort: ignore logging errors so request processing is never blocked.
-	_ = auditLogger.Log(r.Context(), ev)
+	logAudit(r.Context(), auditLogger, drops, "api_key", ev)
 }
 
 // emitAuditAPIKeyFailure emits an audit.auth.api_key.failure event via the
 // AuditEventLogger port. If auditLogger is nil the call is a no-op.
-func emitAuditAPIKeyFailure(r *http.Request, auditLogger ports.AuditEventLogger, keyName, reason string) {
-	if auditLogger == nil {
-		return
-	}
+func emitAuditAPIKeyFailure(r *http.Request, auditLogger ports.AuditEventLogger, drops ports.EventLogDropCounter, keyName, reason string) {
 	ev, err := audit.NewAuditEvent(
 		audit.EventTypeAuthAPIKeyFailure,
 		audit.Actor{
@@ -219,17 +201,13 @@ func emitAuditAPIKeyFailure(r *http.Request, auditLogger ports.AuditEventLogger,
 	if err != nil {
 		return
 	}
-	// Best-effort: ignore logging errors so request processing is never blocked.
-	_ = auditLogger.Log(r.Context(), ev)
+	logAudit(r.Context(), auditLogger, drops, "api_key", ev)
 }
 
 // emitAuditAPIKeyForbidden emits an audit.auth.api_key.forbidden event via the
 // AuditEventLogger port when a valid key lacks the required scopes.
 // If auditLogger is nil the call is a no-op.
-func emitAuditAPIKeyForbidden(r *http.Request, auditLogger ports.AuditEventLogger, key *auth.APIKey, requiredScopes []string) {
-	if auditLogger == nil {
-		return
-	}
+func emitAuditAPIKeyForbidden(r *http.Request, auditLogger ports.AuditEventLogger, drops ports.EventLogDropCounter, key *auth.APIKey, requiredScopes []string) {
 	keyScopes := make([]string, len(key.Scopes))
 	for i, s := range key.Scopes {
 		keyScopes[i] = string(s)
@@ -252,6 +230,5 @@ func emitAuditAPIKeyForbidden(r *http.Request, auditLogger ports.AuditEventLogge
 	if err != nil {
 		return
 	}
-	// Best-effort: ignore logging errors so request processing is never blocked.
-	_ = auditLogger.Log(r.Context(), ev)
+	logAudit(r.Context(), auditLogger, drops, "api_key", ev)
 }

--- a/internal/middleware/api_key_test.go
+++ b/internal/middleware/api_key_test.go
@@ -46,7 +46,7 @@ func TestAPIKeyMiddleware_MissingHeader(t *testing.T) {
 	validator := &fakeAPIKeyValidator{keys: map[string]*auth.APIKey{}}
 	cfg := ports.APIKeyConfig{Header: "X-API-Key"}
 
-	mw := APIKeyMiddleware(validator, cfg, nil, nil)
+	mw := APIKeyMiddleware(validator, cfg, nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -71,7 +71,7 @@ func TestAPIKeyMiddleware_InvalidKey(t *testing.T) {
 	validator := &fakeAPIKeyValidator{keys: map[string]*auth.APIKey{}}
 	cfg := ports.APIKeyConfig{Header: "X-API-Key"}
 
-	mw := APIKeyMiddleware(validator, cfg, nil, nil)
+	mw := APIKeyMiddleware(validator, cfg, nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -97,7 +97,7 @@ func TestAPIKeyMiddleware_ValidKey(t *testing.T) {
 
 	var nextCtx context.Context
 	nextCalled := false
-	mw := APIKeyMiddleware(validator, cfg, nil, nil)
+	mw := APIKeyMiddleware(validator, cfg, nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		nextCalled = true
 		nextCtx = r.Context()
@@ -135,7 +135,7 @@ func TestAPIKeyMiddleware_CustomHeader(t *testing.T) {
 	cfg := ports.APIKeyConfig{Header: "Authorization"}
 
 	nextCalled := false
-	mw := APIKeyMiddleware(validator, cfg, nil, nil)
+	mw := APIKeyMiddleware(validator, cfg, nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		nextCalled = true
 		w.WriteHeader(http.StatusOK)
@@ -180,7 +180,7 @@ func TestAPIKeyMiddleware_DefaultHeader(t *testing.T) {
 	cfg := ports.APIKeyConfig{}
 
 	nextCalled := false
-	mw := APIKeyMiddleware(validator, cfg, nil, nil)
+	mw := APIKeyMiddleware(validator, cfg, nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		nextCalled = true
 		w.WriteHeader(http.StatusOK)
@@ -200,7 +200,7 @@ func TestAPIKeyMiddleware_401IsJSON(t *testing.T) {
 	validator := &fakeAPIKeyValidator{keys: map[string]*auth.APIKey{}}
 	cfg := ports.APIKeyConfig{}
 
-	mw := APIKeyMiddleware(validator, cfg, nil, nil)
+	mw := APIKeyMiddleware(validator, cfg, nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -235,7 +235,7 @@ func TestAPIKeyMiddleware_EmitsSuccessEvent(t *testing.T) {
 	cfg := ports.APIKeyConfig{}
 	spy := &fakeEventLogger{}
 
-	mw := APIKeyMiddleware(validator, cfg, spy, nil)
+	mw := APIKeyMiddleware(validator, cfg, spy, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -262,7 +262,7 @@ func TestAPIKeyMiddleware_EmitsFailedEventOnMissingKey(t *testing.T) {
 	cfg := ports.APIKeyConfig{}
 	spy := &fakeEventLogger{}
 
-	mw := APIKeyMiddleware(validator, cfg, spy, nil)
+	mw := APIKeyMiddleware(validator, cfg, spy, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -285,7 +285,7 @@ func TestAPIKeyMiddleware_EmitsFailedEventOnInvalidKey(t *testing.T) {
 	cfg := ports.APIKeyConfig{}
 	spy := &fakeEventLogger{}
 
-	mw := APIKeyMiddleware(validator, cfg, spy, nil)
+	mw := APIKeyMiddleware(validator, cfg, spy, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -308,7 +308,7 @@ func TestAPIKeyMiddleware_NilEventLoggerDoesNotPanic(t *testing.T) {
 	validator := &fakeAPIKeyValidator{keys: map[string]*auth.APIKey{}}
 	cfg := ports.APIKeyConfig{}
 
-	mw := APIKeyMiddleware(validator, cfg, nil, nil)
+	mw := APIKeyMiddleware(validator, cfg, nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -345,7 +345,7 @@ func TestAPIKeyMiddleware_KeyScopesInContext(t *testing.T) {
 	cfg := ports.APIKeyConfig{}
 
 	var gotKey *auth.APIKey
-	mw := APIKeyMiddleware(validator, cfg, nil, nil)
+	mw := APIKeyMiddleware(validator, cfg, nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotKey, _ = APIKeyFromContext(r.Context())
 		w.WriteHeader(http.StatusOK)
@@ -404,7 +404,7 @@ func TestAPIKeyMiddleware_ScopeEnforcement_AllowsWhenScopeSatisfied(t *testing.T
 	cfg := ports.APIKeyConfig{ScopeRules: scopeRules()}
 
 	nextCalled := false
-	mw := APIKeyMiddleware(validator, cfg, nil, nil)
+	mw := APIKeyMiddleware(validator, cfg, nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		nextCalled = true
 		w.WriteHeader(http.StatusOK)
@@ -436,7 +436,7 @@ func TestAPIKeyMiddleware_ScopeEnforcement_Returns403WhenScopeMissing(t *testing
 	cfg := ports.APIKeyConfig{ScopeRules: scopeRules()}
 
 	nextCalled := false
-	mw := APIKeyMiddleware(validator, cfg, nil, nil)
+	mw := APIKeyMiddleware(validator, cfg, nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		nextCalled = true
 		w.WriteHeader(http.StatusOK)
@@ -469,7 +469,7 @@ func TestAPIKeyMiddleware_ScopeEnforcement_NoMatchingRuleAllows(t *testing.T) {
 	cfg := ports.APIKeyConfig{ScopeRules: scopeRules()}
 
 	nextCalled := false
-	mw := APIKeyMiddleware(validator, cfg, nil, nil)
+	mw := APIKeyMiddleware(validator, cfg, nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		nextCalled = true
 		w.WriteHeader(http.StatusOK)
@@ -503,7 +503,7 @@ func TestAPIKeyMiddleware_ScopeEnforcement_EmptyRulesAllowsAll(t *testing.T) {
 	cfg := ports.APIKeyConfig{ScopeRules: nil}
 
 	nextCalled := false
-	mw := APIKeyMiddleware(validator, cfg, nil, nil)
+	mw := APIKeyMiddleware(validator, cfg, nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		nextCalled = true
 		w.WriteHeader(http.StatusOK)
@@ -535,7 +535,7 @@ func TestAPIKeyMiddleware_ScopeEnforcement_EmitsForbiddenEvent(t *testing.T) {
 	cfg := ports.APIKeyConfig{ScopeRules: scopeRules()}
 	spy := &fakeEventLogger{}
 
-	mw := APIKeyMiddleware(validator, cfg, spy, nil)
+	mw := APIKeyMiddleware(validator, cfg, spy, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -569,7 +569,7 @@ func TestAPIKeyMiddleware_ScopeEnforcement_403IsJSON(t *testing.T) {
 	}
 	cfg := ports.APIKeyConfig{ScopeRules: scopeRules()}
 
-	mw := APIKeyMiddleware(validator, cfg, nil, nil)
+	mw := APIKeyMiddleware(validator, cfg, nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -631,7 +631,7 @@ func TestAPIKeyMiddleware_ScopeEnforcement_AdminPathRequiresAdminScope(t *testin
 			}
 			cfg := ports.APIKeyConfig{ScopeRules: scopeRules()}
 
-			mw := APIKeyMiddleware(validator, cfg, nil, nil)
+			mw := APIKeyMiddleware(validator, cfg, nil, nil, nil)
 			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			})

--- a/internal/middleware/audit_test.go
+++ b/internal/middleware/audit_test.go
@@ -64,7 +64,7 @@ func TestAuthMiddleware_EmitsAuditAuthSuccessEvent(t *testing.T) {
 	}
 	auditSpy := &fakeAuditEventLogger{}
 
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, auditSpy)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, auditSpy, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -106,7 +106,7 @@ func TestAuthMiddleware_EmitsAuditAuthFailureOnMissingCookie(t *testing.T) {
 	}
 	auditSpy := &fakeAuditEventLogger{}
 
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, auditSpy)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, auditSpy, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -141,7 +141,7 @@ func TestAuthMiddleware_EmitsAuditAuthFailureOnInvalidSession(t *testing.T) {
 	}
 	auditSpy := &fakeAuditEventLogger{}
 
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, auditSpy)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, auditSpy, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -167,7 +167,7 @@ func TestAuthMiddleware_NilAuditLoggerDoesNotPanic(t *testing.T) {
 	}
 
 	// nil auditLogger must not cause a panic.
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -273,7 +273,7 @@ func TestAPIKeyMiddleware_EmitsAuditSuccessEvent(t *testing.T) {
 	cfg := ports.APIKeyConfig{}
 	auditSpy := &fakeAuditEventLogger{}
 
-	mw := APIKeyMiddleware(validator, cfg, nil, auditSpy)
+	mw := APIKeyMiddleware(validator, cfg, nil, auditSpy, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -306,7 +306,7 @@ func TestAPIKeyMiddleware_EmitsAuditFailureOnMissingKey(t *testing.T) {
 	cfg := ports.APIKeyConfig{}
 	auditSpy := &fakeAuditEventLogger{}
 
-	mw := APIKeyMiddleware(validator, cfg, nil, auditSpy)
+	mw := APIKeyMiddleware(validator, cfg, nil, auditSpy, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -335,7 +335,7 @@ func TestAPIKeyMiddleware_EmitsAuditFailureOnInvalidKey(t *testing.T) {
 	cfg := ports.APIKeyConfig{}
 	auditSpy := &fakeAuditEventLogger{}
 
-	mw := APIKeyMiddleware(validator, cfg, nil, auditSpy)
+	mw := APIKeyMiddleware(validator, cfg, nil, auditSpy, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -363,7 +363,7 @@ func TestAPIKeyMiddleware_EmitsAuditForbiddenEvent(t *testing.T) {
 	cfg := ports.APIKeyConfig{ScopeRules: scopeRules()}
 	auditSpy := &fakeAuditEventLogger{}
 
-	mw := APIKeyMiddleware(validator, cfg, nil, auditSpy)
+	mw := APIKeyMiddleware(validator, cfg, nil, auditSpy, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -396,7 +396,7 @@ func TestAPIKeyMiddleware_NilAuditLoggerDoesNotPanic(t *testing.T) {
 	validator := &fakeAPIKeyValidator{keys: map[string]*auth.APIKey{}}
 	cfg := ports.APIKeyConfig{}
 
-	mw := APIKeyMiddleware(validator, cfg, nil, nil)
+	mw := APIKeyMiddleware(validator, cfg, nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -420,7 +420,7 @@ func TestRateLimitMiddleware_EmitsAuditRateLimitHitEvent(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), newTestLogger(), nil, auditSpy)
+	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), newTestLogger(), nil, auditSpy, nil)
 	handler := mw(next)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/data", nil)
@@ -460,7 +460,7 @@ func TestRateLimitMiddleware_EmitsAuditRateLimitHitOnUserLimit(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), newTestLogger(), nil, auditSpy)
+	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), newTestLogger(), nil, auditSpy, nil)
 	handler := mw(next)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/data", nil)
@@ -488,7 +488,7 @@ func TestRateLimitMiddleware_NilAuditLoggerDoesNotPanic(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), newTestLogger(), nil, nil)
+	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), newTestLogger(), nil, nil, nil)
 	handler := mw(next)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/data", nil)

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -53,6 +53,7 @@ func AuthMiddleware(
 	logger *slog.Logger,
 	eventLogger ports.EventLogger,
 	auditLogger ports.AuditEventLogger,
+	drops ports.EventLogDropCounter,
 ) func(http.Handler) http.Handler {
 	loginURL := cfg.LoginURL
 	if loginURL == "" {
@@ -99,25 +100,25 @@ func AuthMiddleware(
 					// Kratos is reachable but credentials are absent or invalid.
 					// If we were previously unhealthy, record the recovery.
 					if unavailableState.CompareAndSwap(1, 0) {
-						emitKratosRecovered(r, eventLogger, providerURL)
+						emitKratosRecovered(r, eventLogger, drops, providerURL)
 					}
-					emitAuthFailed(r, eventLogger, result.Message, "")
-					emitAuditAuthFailure(r, auditLogger, "", result.Message)
+					emitAuthFailed(r, eventLogger, drops, result.Message, "")
+					emitAuditAuthFailure(r, auditLogger, drops, "", result.Message)
 					http.Redirect(w, r, loginURL, http.StatusFound)
 
 				case "provider_unavailable":
 					// Emit availability event only on transition to unavailable.
 					if unavailableState.CompareAndSwap(0, 1) {
-						emitKratosUnavailable(r, eventLogger, providerURL, result.Message)
+						emitKratosUnavailable(r, eventLogger, drops, providerURL, result.Message)
 					}
-					emitAuthFailed(r, eventLogger, "auth provider unavailable", result.Message)
-					emitAuditAuthFailure(r, auditLogger, "", "auth provider unavailable")
+					emitAuthFailed(r, eventLogger, drops, "auth provider unavailable", result.Message)
+					emitAuditAuthFailure(r, auditLogger, drops, "", "auth provider unavailable")
 					WriteErrorResponse(w, r, http.StatusServiceUnavailable, "auth_provider_unavailable", "authentication service is temporarily unavailable")
 
 				default:
 					// Unknown failure — fail closed.
-					emitAuthFailed(r, eventLogger, "unexpected auth error", result.Message)
-					emitAuditAuthFailure(r, auditLogger, "", "unexpected auth error")
+					emitAuthFailed(r, eventLogger, drops, "unexpected auth error", result.Message)
+					emitAuditAuthFailure(r, auditLogger, drops, "", "unexpected auth error")
 					WriteErrorResponse(w, r, http.StatusServiceUnavailable, "auth_provider_unavailable", "authentication service is temporarily unavailable")
 				}
 				return
@@ -125,12 +126,12 @@ func AuthMiddleware(
 
 			// Authentication succeeded — record recovery if we were previously unhealthy.
 			if unavailableState.CompareAndSwap(1, 0) {
-				emitKratosRecovered(r, eventLogger, providerURL)
+				emitKratosRecovered(r, eventLogger, drops, providerURL)
 			}
 
 			// Step 7: Valid identity — store in context and proceed.
-			emitAuthSuccessIdentity(r, eventLogger, result.Identity)
-			emitAuditAuthSuccess(r, auditLogger, result.Identity.ID(), result.Identity.Email())
+			emitAuthSuccessIdentity(r, eventLogger, drops, result.Identity)
+			emitAuditAuthSuccess(r, auditLogger, drops, result.Identity.ID(), result.Identity.Email())
 			ctx := contextWithIdentity(r.Context(), result.Identity)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
@@ -150,10 +151,7 @@ func stripXUserHeaders(r *http.Request) {
 // emitAuthSuccessIdentity logs an auth.success event via the EventLogger port
 // using the domain Identity value object.
 // If eventLogger is nil the call is a no-op.
-func emitAuthSuccessIdentity(r *http.Request, eventLogger ports.EventLogger, ident identity.Identity) {
-	if eventLogger == nil {
-		return
-	}
+func emitAuthSuccessIdentity(r *http.Request, eventLogger ports.EventLogger, drops ports.EventLogDropCounter, ident identity.Identity) {
 	ev := events.NewAuthSuccess(events.AuthSuccessParams{
 		Method:     r.Method,
 		Path:       r.URL.Path,
@@ -161,58 +159,44 @@ func emitAuthSuccessIdentity(r *http.Request, eventLogger ports.EventLogger, ide
 		IdentityID: ident.ID(),
 		Email:      ident.Email(),
 	})
-	// Best-effort: ignore logging errors so request processing is never blocked.
-	_ = eventLogger.Log(r.Context(), ev)
+	logEvent(r.Context(), eventLogger, drops, "auth", ev)
 }
 
 // emitAuthFailed logs an auth.failed event via the EventLogger port.
 // If eventLogger is nil the call is a no-op.
-func emitAuthFailed(r *http.Request, eventLogger ports.EventLogger, reason, detail string) {
-	if eventLogger == nil {
-		return
-	}
+func emitAuthFailed(r *http.Request, eventLogger ports.EventLogger, drops ports.EventLogDropCounter, reason, detail string) {
 	ev := events.NewAuthFailed(events.AuthFailedParams{
 		Method: r.Method,
 		Path:   r.URL.Path,
 		Reason: reason,
 		Detail: detail,
 	})
-	// Best-effort: ignore logging errors so request processing is never blocked.
-	_ = eventLogger.Log(r.Context(), ev)
+	logEvent(r.Context(), eventLogger, drops, "auth", ev)
 }
 
 // emitKratosUnavailable logs an auth.provider_unavailable event.
 // If eventLogger is nil the call is a no-op.
-func emitKratosUnavailable(r *http.Request, eventLogger ports.EventLogger, providerURL, errMsg string) {
-	if eventLogger == nil {
-		return
-	}
+func emitKratosUnavailable(r *http.Request, eventLogger ports.EventLogger, drops ports.EventLogDropCounter, providerURL, errMsg string) {
 	ev := events.NewAuthProviderUnavailable(events.AuthProviderUnavailableParams{
 		ProviderURL:  providerURL,
 		Error:        errMsg,
 		AffectedPath: r.URL.Path,
 	})
-	_ = eventLogger.Log(r.Context(), ev)
+	logEvent(r.Context(), eventLogger, drops, "auth", ev)
 }
 
 // emitKratosRecovered logs an auth.provider_recovered event.
 // If eventLogger is nil the call is a no-op.
-func emitKratosRecovered(r *http.Request, eventLogger ports.EventLogger, providerURL string) {
-	if eventLogger == nil {
-		return
-	}
+func emitKratosRecovered(r *http.Request, eventLogger ports.EventLogger, drops ports.EventLogDropCounter, providerURL string) {
 	ev := events.NewAuthProviderRecovered(events.AuthProviderRecoveredParams{
 		ProviderURL: providerURL,
 	})
-	_ = eventLogger.Log(r.Context(), ev)
+	logEvent(r.Context(), eventLogger, drops, "auth", ev)
 }
 
 // emitAuditAuthSuccess emits an audit.auth.success event via the AuditEventLogger port.
 // If auditLogger is nil the call is a no-op.
-func emitAuditAuthSuccess(r *http.Request, auditLogger ports.AuditEventLogger, userID, email string) {
-	if auditLogger == nil {
-		return
-	}
+func emitAuditAuthSuccess(r *http.Request, auditLogger ports.AuditEventLogger, drops ports.EventLogDropCounter, userID, email string) {
 	ev, err := audit.NewAuditEvent(
 		audit.EventTypeAuthSuccess,
 		audit.Actor{
@@ -230,16 +214,12 @@ func emitAuditAuthSuccess(r *http.Request, auditLogger ports.AuditEventLogger, u
 	if err != nil {
 		return
 	}
-	// Best-effort: ignore logging errors so request processing is never blocked.
-	_ = auditLogger.Log(r.Context(), ev)
+	logAudit(r.Context(), auditLogger, drops, "auth", ev)
 }
 
 // emitAuditAuthFailure emits an audit.auth.failure event via the AuditEventLogger port.
 // If auditLogger is nil the call is a no-op.
-func emitAuditAuthFailure(r *http.Request, auditLogger ports.AuditEventLogger, userID, reason string) {
-	if auditLogger == nil {
-		return
-	}
+func emitAuditAuthFailure(r *http.Request, auditLogger ports.AuditEventLogger, drops ports.EventLogDropCounter, userID, reason string) {
 	ev, err := audit.NewAuditEvent(
 		audit.EventTypeAuthFailure,
 		audit.Actor{
@@ -257,6 +237,5 @@ func emitAuditAuthFailure(r *http.Request, auditLogger ports.AuditEventLogger, u
 	if err != nil {
 		return
 	}
-	// Best-effort: ignore logging errors so request processing is never blocked.
-	_ = auditLogger.Log(r.Context(), ev)
+	logAudit(r.Context(), auditLogger, drops, "auth", ev)
 }

--- a/internal/middleware/auth_graceful_test.go
+++ b/internal/middleware/auth_graceful_test.go
@@ -26,7 +26,7 @@ func TestAuthMiddleware_KratosUnavailable_EmitsAvailabilityEvent(t *testing.T) {
 	}
 	spy := &fakeEventLogger{}
 
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), spy, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), spy, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -78,7 +78,7 @@ func TestAuthMiddleware_KratosRecovery_EmitsRecoveredEvent(t *testing.T) {
 	}
 	spy := &fakeEventLogger{}
 
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), spy, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), spy, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -115,7 +115,7 @@ func TestAuthMiddleware_KratosRecovery_NoDoubleRecoveryEvent(t *testing.T) {
 		LoginURL:          "/login",
 	}
 	spy := &fakeEventLogger{}
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), spy, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), spy, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 
 	// Fail once to set unavailable state.
@@ -157,7 +157,7 @@ func TestAuthMiddleware_AvailabilityEvent_PayloadContainsProviderURL(t *testing.
 		KratosPublicURL:   wantURL,
 	}
 	spy := &fakeEventLogger{}
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), spy, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), spy, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 
 	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
@@ -192,7 +192,7 @@ func TestAuthMiddleware_KratosUnavailable_Returns503(t *testing.T) {
 		LoginURL:            "/login",
 		OnKratosUnavailable: ports.KratosUnavailable503,
 	}
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 
 	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)

--- a/internal/middleware/auth_integration_test.go
+++ b/internal/middleware/auth_integration_test.go
@@ -44,7 +44,7 @@ func TestAuthMiddleware_Integration_UnauthenticatedRedirect(t *testing.T) {
 		LoginURL:          "/self-service/login/browser",
 	}
 
-	handler := AuthMiddleware(provider, cfg, slog.Default(), nil, nil)(
+	handler := AuthMiddleware(provider, cfg, slog.Default(), nil, nil, nil)(
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),
@@ -80,7 +80,7 @@ func TestAuthMiddleware_Integration_PublicPathBypass(t *testing.T) {
 	}
 
 	nextCalled := false
-	handler := AuthMiddleware(alwaysErr, cfg, slog.Default(), nil, nil)(
+	handler := AuthMiddleware(alwaysErr, cfg, slog.Default(), nil, nil, nil)(
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 			w.WriteHeader(http.StatusOK)
@@ -125,7 +125,7 @@ func TestAuthMiddleware_Integration_AuthProviderUnavailable(t *testing.T) {
 		SessionCookieName: "ory_kratos_session",
 	}
 
-	handler := AuthMiddleware(provider, cfg, slog.Default(), nil, nil)(
+	handler := AuthMiddleware(provider, cfg, slog.Default(), nil, nil, nil)(
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),
@@ -154,7 +154,7 @@ func TestAuthMiddleware_Integration_ValidSessionAllowsRequest(t *testing.T) {
 	}
 
 	nextCalled := false
-	handler := AuthMiddleware(provider, cfg, slog.Default(), nil, nil)(
+	handler := AuthMiddleware(provider, cfg, slog.Default(), nil, nil, nil)(
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			nextCalled = true
 			w.WriteHeader(http.StatusOK)
@@ -194,7 +194,7 @@ func TestAuthMiddleware_Integration_KratosFlowPathsArePublic(t *testing.T) {
 		PublicPaths:       kratosFlowPaths,
 	}
 
-	handler := AuthMiddleware(alwaysErr, cfg, slog.Default(), nil, nil)(
+	handler := AuthMiddleware(alwaysErr, cfg, slog.Default(), nil, nil, nil)(
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -77,7 +77,7 @@ func TestAuthMiddleware_UnauthenticatedRequest(t *testing.T) {
 		LoginURL:          "/login",
 	}
 
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -112,7 +112,7 @@ func TestAuthMiddleware_AuthenticatedRequest(t *testing.T) {
 	nextCalled := false
 	var nextCtx context.Context
 
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		nextCalled = true
 		nextCtx = r.Context()
@@ -163,7 +163,7 @@ func TestAuthMiddleware_PublicPathBypass(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			nextCalled := false
-			mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil)
+			mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil, nil)
 			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				nextCalled = true
 				w.WriteHeader(http.StatusOK)
@@ -209,7 +209,7 @@ func TestAuthMiddleware_GlobPatternMatching(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			nextCalled := false
-			mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil)
+			mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil, nil)
 			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				nextCalled = true
 				w.WriteHeader(http.StatusOK)
@@ -242,7 +242,7 @@ func TestAuthMiddleware_ProviderUnavailable(t *testing.T) {
 		LoginURL:          "/login",
 	}
 
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -272,7 +272,7 @@ func TestAuthMiddleware_XUserHeadersStripped(t *testing.T) {
 	}
 
 	var receivedHeaders http.Header
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedHeaders = r.Header.Clone()
 		w.WriteHeader(http.StatusOK)
@@ -316,7 +316,7 @@ func TestAuthMiddleware_XUserHeadersStrippedOnPublicPath(t *testing.T) {
 	}
 
 	var receivedHeaders http.Header
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedHeaders = r.Header.Clone()
 		w.WriteHeader(http.StatusOK)
@@ -356,7 +356,7 @@ func TestAuthMiddleware_VibewardenPrefixAlwaysPublic(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			nextCalled := false
-			mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil)
+			mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil, nil)
 			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				nextCalled = true
 				w.WriteHeader(http.StatusOK)
@@ -389,7 +389,7 @@ func TestAuthMiddleware_DefaultCookieNameAndLoginURL(t *testing.T) {
 		Enabled: true,
 	}
 
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil, nil)
 	nextCalled := false
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		nextCalled = true
@@ -438,7 +438,7 @@ func TestAuthMiddleware_InvalidSessionRedirects(t *testing.T) {
 				LoginURL:          "/login",
 			}
 
-			mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil)
+			mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil, nil)
 			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			})
@@ -470,7 +470,7 @@ func TestAuthMiddleware_EmitsAuthSuccessEvent(t *testing.T) {
 	}
 	spy := &fakeEventLogger{}
 
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), spy, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), spy, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -509,7 +509,7 @@ func TestAuthMiddleware_EmitsAuthFailedEvent(t *testing.T) {
 	}
 	spy := &fakeEventLogger{}
 
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), spy, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), spy, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -541,7 +541,7 @@ func TestAuthMiddleware_NilEventLoggerDoesNotPanic(t *testing.T) {
 		LoginURL:          "/login",
 	}
 
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -563,7 +563,7 @@ func TestAuthMiddleware_503IsJSON(t *testing.T) {
 		LoginURL:          "/login",
 	}
 
-	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil)
+	mw := AuthMiddleware(provider, cfg, newTestLogger(), nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})

--- a/internal/middleware/kratos_flow.go
+++ b/internal/middleware/kratos_flow.go
@@ -26,11 +26,11 @@ var kratosFlowPathPrefixes = []string{
 //
 // The eventLogger receives structured events following the VibeWarden schema.
 // If eventLogger is nil, event logging is skipped silently.
-func KratosFlowLoggingMiddleware(logger *slog.Logger, eventLogger ports.EventLogger) func(http.Handler) http.Handler {
+func KratosFlowLoggingMiddleware(logger *slog.Logger, eventLogger ports.EventLogger, drops ports.EventLogDropCounter) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if isKratosFlowPath(r.URL.Path) {
-				emitKratosFlowEvent(r, eventLogger)
+				emitKratosFlowEvent(r, eventLogger, drops)
 			}
 			next.ServeHTTP(w, r)
 		})
@@ -50,14 +50,10 @@ func isKratosFlowPath(requestPath string) bool {
 
 // emitKratosFlowEvent emits the proxy.kratos_flow structured event via the
 // EventLogger port. If eventLogger is nil the call is a no-op.
-func emitKratosFlowEvent(r *http.Request, eventLogger ports.EventLogger) {
-	if eventLogger == nil {
-		return
-	}
+func emitKratosFlowEvent(r *http.Request, eventLogger ports.EventLogger, drops ports.EventLogDropCounter) {
 	ev := events.NewProxyKratosFlow(events.ProxyKratosFlowParams{
 		Method: r.Method,
 		Path:   r.URL.Path,
 	})
-	// Best-effort: ignore logging errors so request processing is never blocked.
-	_ = eventLogger.Log(r.Context(), ev)
+	logEvent(r.Context(), eventLogger, drops, "kratos_flow", ev)
 }

--- a/internal/middleware/kratos_flow_test.go
+++ b/internal/middleware/kratos_flow_test.go
@@ -105,7 +105,7 @@ func TestKratosFlowLoggingMiddleware_CallsNext(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := KratosFlowLoggingMiddleware(logger, nil)(next)
+	mw := KratosFlowLoggingMiddleware(logger, nil, nil)(next)
 
 	req := httptest.NewRequest(http.MethodGet, "/self-service/login/browser", nil)
 	rec := httptest.NewRecorder()
@@ -128,7 +128,7 @@ func TestKratosFlowLoggingMiddleware_NonKratosPathCallsNext(t *testing.T) {
 		w.WriteHeader(http.StatusTeapot)
 	})
 
-	mw := KratosFlowLoggingMiddleware(logger, nil)(next)
+	mw := KratosFlowLoggingMiddleware(logger, nil, nil)(next)
 
 	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
 	rec := httptest.NewRecorder()
@@ -149,7 +149,7 @@ func TestKratosFlowLoggingMiddleware_EmitsEventForKratosPath(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := KratosFlowLoggingMiddleware(slog.Default(), spy)(next)
+	mw := KratosFlowLoggingMiddleware(slog.Default(), spy, nil)(next)
 
 	req := httptest.NewRequest(http.MethodGet, "/self-service/login/browser", nil)
 	rec := httptest.NewRecorder()
@@ -176,7 +176,7 @@ func TestKratosFlowLoggingMiddleware_DoesNotEmitEventForNonKratosPath(t *testing
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := KratosFlowLoggingMiddleware(slog.Default(), spy)(next)
+	mw := KratosFlowLoggingMiddleware(slog.Default(), spy, nil)(next)
 
 	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
 	rec := httptest.NewRecorder()
@@ -193,7 +193,7 @@ func TestKratosFlowLoggingMiddleware_NilEventLoggerDoesNotPanic(t *testing.T) {
 	})
 
 	// Must not panic with nil eventLogger.
-	mw := KratosFlowLoggingMiddleware(slog.Default(), nil)(next)
+	mw := KratosFlowLoggingMiddleware(slog.Default(), nil, nil)(next)
 
 	req := httptest.NewRequest(http.MethodGet, "/self-service/login/browser", nil)
 	rec := httptest.NewRecorder()

--- a/internal/middleware/logdrop.go
+++ b/internal/middleware/logdrop.go
@@ -1,0 +1,75 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/vibewarden/vibewarden/internal/domain/audit"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// logEvent is a fire-and-forget wrapper around ports.EventLogger.Log.
+// On error it emits slog.WarnContext and increments
+// vibewarden_event_log_drops_total via mc.
+//
+// Callers must not halt request handling on failure; this function always
+// returns void. Both logger and mc may be nil — nil logger is a silent no-op,
+// nil mc means the counter is skipped but the slog.Warn still fires.
+func logEvent(ctx context.Context, logger ports.EventLogger, mc ports.EventLogDropCounter, middleware string, ev events.Event) {
+	if logger == nil {
+		return
+	}
+	if err := logger.Log(ctx, ev); err != nil {
+		reason := errorReason(err)
+		slog.WarnContext(ctx, "event log drop",
+			slog.String("middleware", middleware),
+			slog.String("event_type", ev.EventType),
+			slog.String("reason", reason),
+			slog.Any("err", err),
+		)
+		if mc != nil {
+			mc.IncEventLogDrop(middleware, reason)
+		}
+	}
+}
+
+// logAudit is the AuditEventLogger counterpart of logEvent.
+// On error it emits slog.WarnContext and increments
+// vibewarden_event_log_drops_total via mc.
+//
+// Callers must not halt request handling on failure; this function always
+// returns void. Both logger and mc may be nil — nil logger is a silent no-op,
+// nil mc means the counter is skipped but the slog.Warn still fires.
+func logAudit(ctx context.Context, logger ports.AuditEventLogger, mc ports.EventLogDropCounter, middleware string, ev audit.AuditEvent) {
+	if logger == nil {
+		return
+	}
+	if err := logger.Log(ctx, ev); err != nil {
+		reason := errorReason(err)
+		slog.WarnContext(ctx, "event log drop",
+			slog.String("middleware", middleware),
+			slog.String("event_type", string(ev.EventType)),
+			slog.String("reason", reason),
+			slog.Any("err", err),
+		)
+		if mc != nil {
+			mc.IncEventLogDrop(middleware, reason)
+		}
+	}
+}
+
+// errorReason returns a low-cardinality label string classifying err for use
+// as a Prometheus label value. It never calls err.Error() to prevent
+// unbounded label cardinality.
+func errorReason(err error) string {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "deadline_exceeded"
+	default:
+		return "other"
+	}
+}

--- a/internal/middleware/logdrop_test.go
+++ b/internal/middleware/logdrop_test.go
@@ -1,0 +1,360 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/domain/audit"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// errEventLogger is a ports.EventLogger fake that returns a configurable error.
+type errEventLogger struct {
+	err error
+}
+
+func (f *errEventLogger) Log(_ context.Context, _ events.Event) error {
+	return f.err
+}
+
+// errAuditEventLogger is a ports.AuditEventLogger fake that returns a configurable error.
+type errAuditEventLogger struct {
+	err error
+}
+
+func (f *errAuditEventLogger) Log(_ context.Context, _ audit.AuditEvent) error {
+	return f.err
+}
+
+// fakeDropCounter records calls to IncEventLogDrop.
+type fakeDropCounter struct {
+	calls []dropCall
+}
+
+type dropCall struct {
+	middleware string
+	reason     string
+}
+
+func (f *fakeDropCounter) IncEventLogDrop(middleware, reason string) {
+	f.calls = append(f.calls, dropCall{middleware, reason})
+}
+
+// Compile-time checks.
+var _ ports.EventLogger = (*errEventLogger)(nil)
+var _ ports.AuditEventLogger = (*errAuditEventLogger)(nil)
+var _ ports.EventLogDropCounter = (*fakeDropCounter)(nil)
+
+// installTestLogger replaces the global slog default with one writing JSON to
+// buf. The original logger is restored via t.Cleanup.
+func installTestLogger(t *testing.T, buf *bytes.Buffer) {
+	t.Helper()
+	orig := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+}
+
+// mustUnmarshalWarn parses the JSON from buf and returns the first "WARN" log
+// entry found, or nil if none.
+func mustUnmarshalWarn(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	dec := json.NewDecoder(buf)
+	for dec.More() {
+		var m map[string]any
+		if err := dec.Decode(&m); err != nil {
+			t.Fatalf("failed to decode log JSON: %v", err)
+		}
+		if m["level"] == "WARN" {
+			return m
+		}
+	}
+	return nil
+}
+
+// testEvent creates a minimal events.Event with the given EventType.
+func testEvent(eventType string) events.Event {
+	return events.Event{
+		SchemaVersion: "v1",
+		EventType:     eventType,
+	}
+}
+
+// testAuditEvent creates a minimal audit.AuditEvent.
+func testAuditEvent(t *testing.T) audit.AuditEvent {
+	t.Helper()
+	ev, err := audit.NewAuditEvent(
+		audit.EventTypeAuthSuccess,
+		audit.Actor{IP: "127.0.0.1"},
+		audit.Target{Path: "/test"},
+		audit.OutcomeSuccess,
+		"",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("testAuditEvent: %v", err)
+	}
+	return ev
+}
+
+func TestLogEvent(t *testing.T) {
+	tests := []struct {
+		name            string
+		loggerErr       error
+		mc              *fakeDropCounter
+		wantWarn        bool
+		wantCounterCall bool
+		wantReason      string
+	}{
+		{
+			name:            "happy path — no error, no warn",
+			loggerErr:       nil,
+			mc:              &fakeDropCounter{},
+			wantWarn:        false,
+			wantCounterCall: false,
+		},
+		{
+			name:            "generic error — warn + counter with reason other",
+			loggerErr:       errors.New("boom"),
+			mc:              &fakeDropCounter{},
+			wantWarn:        true,
+			wantCounterCall: true,
+			wantReason:      "other",
+		},
+		{
+			name:            "context.Canceled — warn + counter with reason canceled",
+			loggerErr:       context.Canceled,
+			mc:              &fakeDropCounter{},
+			wantWarn:        true,
+			wantCounterCall: true,
+			wantReason:      "canceled",
+		},
+		{
+			name:            "context.DeadlineExceeded — warn + counter with reason deadline_exceeded",
+			loggerErr:       context.DeadlineExceeded,
+			mc:              &fakeDropCounter{},
+			wantWarn:        true,
+			wantCounterCall: true,
+			wantReason:      "deadline_exceeded",
+		},
+		{
+			name:            "nil logger — silent no-op",
+			loggerErr:       nil,
+			mc:              &fakeDropCounter{},
+			wantWarn:        false,
+			wantCounterCall: false,
+		},
+		{
+			name:            "nil mc — warn fires, counter skipped",
+			loggerErr:       errors.New("boom"),
+			mc:              nil,
+			wantWarn:        true,
+			wantCounterCall: false,
+			wantReason:      "other",
+		},
+	}
+
+	const mw = "test"
+	const evType = "auth.success"
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			installTestLogger(t, &buf)
+
+			var logger ports.EventLogger
+			if tt.name != "nil logger — silent no-op" {
+				logger = &errEventLogger{err: tt.loggerErr}
+			}
+
+			var mc ports.EventLogDropCounter
+			if tt.mc != nil {
+				mc = tt.mc
+			}
+
+			logEvent(context.Background(), logger, mc, mw, testEvent(evType))
+
+			entry := mustUnmarshalWarn(t, &buf)
+			if tt.wantWarn && entry == nil {
+				t.Fatal("expected slog WARN entry, got none")
+			}
+			if !tt.wantWarn && entry != nil {
+				t.Fatalf("unexpected slog WARN entry: %v", entry)
+			}
+			if tt.wantWarn {
+				if got := entry["middleware"]; got != mw {
+					t.Errorf("middleware = %q, want %q", got, mw)
+				}
+				if got := entry["event_type"]; got != evType {
+					t.Errorf("event_type = %q, want %q", got, evType)
+				}
+				if got := entry["reason"]; got != tt.wantReason {
+					t.Errorf("reason = %q, want %q", got, tt.wantReason)
+				}
+			}
+
+			if tt.mc != nil {
+				if tt.wantCounterCall && len(tt.mc.calls) == 0 {
+					t.Fatal("expected counter call, got none")
+				}
+				if !tt.wantCounterCall && len(tt.mc.calls) != 0 {
+					t.Fatalf("unexpected counter calls: %v", tt.mc.calls)
+				}
+				if tt.wantCounterCall {
+					got := tt.mc.calls[0]
+					if got.middleware != mw {
+						t.Errorf("counter middleware = %q, want %q", got.middleware, mw)
+					}
+					if got.reason != tt.wantReason {
+						t.Errorf("counter reason = %q, want %q", got.reason, tt.wantReason)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestLogAudit(t *testing.T) {
+	tests := []struct {
+		name            string
+		loggerErr       error
+		mc              *fakeDropCounter
+		nilLogger       bool
+		wantWarn        bool
+		wantCounterCall bool
+		wantReason      string
+	}{
+		{
+			name:            "happy path — no error, no warn",
+			loggerErr:       nil,
+			mc:              &fakeDropCounter{},
+			wantWarn:        false,
+			wantCounterCall: false,
+		},
+		{
+			name:            "generic error — warn + counter with reason other",
+			loggerErr:       errors.New("boom"),
+			mc:              &fakeDropCounter{},
+			wantWarn:        true,
+			wantCounterCall: true,
+			wantReason:      "other",
+		},
+		{
+			name:            "context.Canceled — warn + counter with reason canceled",
+			loggerErr:       context.Canceled,
+			mc:              &fakeDropCounter{},
+			wantWarn:        true,
+			wantCounterCall: true,
+			wantReason:      "canceled",
+		},
+		{
+			name:            "context.DeadlineExceeded — warn + counter with reason deadline_exceeded",
+			loggerErr:       context.DeadlineExceeded,
+			mc:              &fakeDropCounter{},
+			wantWarn:        true,
+			wantCounterCall: true,
+			wantReason:      "deadline_exceeded",
+		},
+		{
+			name:            "nil logger — silent no-op",
+			nilLogger:       true,
+			mc:              &fakeDropCounter{},
+			wantWarn:        false,
+			wantCounterCall: false,
+		},
+		{
+			name:            "nil mc — warn fires, counter skipped",
+			loggerErr:       errors.New("boom"),
+			mc:              nil,
+			wantWarn:        true,
+			wantCounterCall: false,
+			wantReason:      "other",
+		},
+	}
+
+	const mw = "test"
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			installTestLogger(t, &buf)
+
+			var logger ports.AuditEventLogger
+			if !tt.nilLogger {
+				logger = &errAuditEventLogger{err: tt.loggerErr}
+			}
+
+			var mc ports.EventLogDropCounter
+			if tt.mc != nil {
+				mc = tt.mc
+			}
+
+			logAudit(context.Background(), logger, mc, mw, testAuditEvent(t))
+
+			entry := mustUnmarshalWarn(t, &buf)
+			if tt.wantWarn && entry == nil {
+				t.Fatal("expected slog WARN entry, got none")
+			}
+			if !tt.wantWarn && entry != nil {
+				t.Fatalf("unexpected slog WARN entry: %v", entry)
+			}
+			if tt.wantWarn {
+				if got := entry["middleware"]; got != mw {
+					t.Errorf("middleware = %q, want %q", got, mw)
+				}
+				if got := entry["event_type"]; got != string(audit.EventTypeAuthSuccess) {
+					t.Errorf("event_type = %q, want %q", got, string(audit.EventTypeAuthSuccess))
+				}
+				if got := entry["reason"]; got != tt.wantReason {
+					t.Errorf("reason = %q, want %q", got, tt.wantReason)
+				}
+			}
+
+			if tt.mc != nil {
+				if tt.wantCounterCall && len(tt.mc.calls) == 0 {
+					t.Fatal("expected counter call, got none")
+				}
+				if !tt.wantCounterCall && len(tt.mc.calls) != 0 {
+					t.Fatalf("unexpected counter calls: %v", tt.mc.calls)
+				}
+				if tt.wantCounterCall {
+					got := tt.mc.calls[0]
+					if got.middleware != mw {
+						t.Errorf("counter middleware = %q, want %q", got.middleware, mw)
+					}
+					if got.reason != tt.wantReason {
+						t.Errorf("counter reason = %q, want %q", got.reason, tt.wantReason)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestErrorReason(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"context.Canceled", context.Canceled, "canceled"},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, "deadline_exceeded"},
+		{"wrapped Canceled", errors.Join(context.Canceled, errors.New("wrap")), "canceled"},
+		{"wrapped DeadlineExceeded", errors.Join(context.DeadlineExceeded, errors.New("wrap")), "deadline_exceeded"},
+		{"generic error", errors.New("boom"), "other"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := errorReason(tt.err)
+			if got != tt.want {
+				t.Errorf("errorReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/middleware/maintenance.go
+++ b/internal/middleware/maintenance.go
@@ -33,7 +33,7 @@ type MaintenanceConfig struct {
 // The JSON response body is:
 //
 //	{"error":"maintenance","status":503,"message":"<configured message>"}
-func MaintenanceMiddleware(cfg MaintenanceConfig, eventLogger ports.EventLogger) func(next http.Handler) http.Handler {
+func MaintenanceMiddleware(cfg MaintenanceConfig, eventLogger ports.EventLogger, drops ports.EventLogDropCounter) func(next http.Handler) http.Handler {
 	message := cfg.Message
 	if message == "" {
 		message = "Service is under maintenance"
@@ -53,23 +53,20 @@ func MaintenanceMiddleware(cfg MaintenanceConfig, eventLogger ports.EventLogger)
 				return
 			}
 
-			emitMaintenanceBlocked(r, eventLogger, message)
+			emitMaintenanceBlocked(r, eventLogger, drops, message)
 			WriteErrorResponse(w, r, http.StatusServiceUnavailable, "maintenance", message)
 		})
 	}
 }
 
 // emitMaintenanceBlocked emits a maintenance.request_blocked structured event.
-// If eventLogger is nil the call is a no-op. Errors are discarded so that
-// logging failures never affect request handling.
-func emitMaintenanceBlocked(r *http.Request, eventLogger ports.EventLogger, message string) {
-	if eventLogger == nil {
-		return
-	}
+// If eventLogger is nil the call is a no-op. On error it emits slog.Warn and
+// increments the drops counter.
+func emitMaintenanceBlocked(r *http.Request, eventLogger ports.EventLogger, drops ports.EventLogDropCounter, message string) {
 	ev := events.NewMaintenanceRequestBlocked(events.MaintenanceRequestBlockedParams{
 		Path:    r.URL.Path,
 		Method:  r.Method,
 		Message: message,
 	})
-	_ = eventLogger.Log(r.Context(), ev)
+	logEvent(r.Context(), eventLogger, drops, "maintenance", ev)
 }

--- a/internal/middleware/maintenance_test.go
+++ b/internal/middleware/maintenance_test.go
@@ -35,7 +35,7 @@ func nextHandler(called *bool) http.Handler {
 func TestMaintenanceMiddleware_disabled(t *testing.T) {
 	cfg := MaintenanceConfig{Enabled: false, Message: "irrelevant"}
 	logger := &maintenanceFakeEventLogger{}
-	mw := MaintenanceMiddleware(cfg, logger)
+	mw := MaintenanceMiddleware(cfg, logger, nil)
 
 	called := false
 	handler := mw(nextHandler(&called))
@@ -86,7 +86,7 @@ func TestMaintenanceMiddleware_enabled_blocks_regular_paths(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := MaintenanceConfig{Enabled: true, Message: tt.message}
 			logger := &maintenanceFakeEventLogger{}
-			mw := MaintenanceMiddleware(cfg, logger)
+			mw := MaintenanceMiddleware(cfg, logger, nil)
 
 			called := false
 			handler := mw(nextHandler(&called))
@@ -145,7 +145,7 @@ func TestMaintenanceMiddleware_enabled_skips_vibewarden_paths(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := MaintenanceConfig{Enabled: true, Message: "down for maintenance"}
 			logger := &maintenanceFakeEventLogger{}
-			mw := MaintenanceMiddleware(cfg, logger)
+			mw := MaintenanceMiddleware(cfg, logger, nil)
 
 			called := false
 			handler := mw(nextHandler(&called))
@@ -169,7 +169,7 @@ func TestMaintenanceMiddleware_enabled_skips_vibewarden_paths(t *testing.T) {
 
 func TestMaintenanceMiddleware_defaultMessage(t *testing.T) {
 	cfg := MaintenanceConfig{Enabled: true, Message: ""}
-	mw := MaintenanceMiddleware(cfg, nil)
+	mw := MaintenanceMiddleware(cfg, nil, nil)
 
 	called := false
 	handler := mw(nextHandler(&called))
@@ -193,7 +193,7 @@ func TestMaintenanceMiddleware_defaultMessage(t *testing.T) {
 
 func TestMaintenanceMiddleware_nilEventLoggerDoesNotPanic(t *testing.T) {
 	cfg := MaintenanceConfig{Enabled: true, Message: "maintenance"}
-	mw := MaintenanceMiddleware(cfg, nil) // nil logger must not panic
+	mw := MaintenanceMiddleware(cfg, nil, nil) // nil logger must not panic
 
 	called := false
 	handler := mw(nextHandler(&called))

--- a/internal/middleware/prompt_injection.go
+++ b/internal/middleware/prompt_injection.go
@@ -91,6 +91,7 @@ func PromptInjectionMiddleware(
 	routes []PromptInjectionRouteConfig,
 	logger *slog.Logger,
 	eventLogger ports.EventLogger,
+	drops ports.EventLogDropCounter,
 ) func(http.Handler) http.Handler {
 	// Filter to only enabled routes to avoid repeated checks at request time.
 	enabled := make([]PromptInjectionRouteConfig, 0, len(routes))
@@ -190,9 +191,7 @@ func PromptInjectionMiddleware(
 						slog.String("method", r.Method),
 						slog.String("url", targetURL),
 					)
-					if eventLogger != nil {
-						_ = eventLogger.Log(r.Context(), events.NewLLMPromptInjectionBlocked(params))
-					}
+					logEvent(r.Context(), eventLogger, drops, "prompt_injection", events.NewLLMPromptInjectionBlocked(params))
 					WriteErrorResponse(w, r, http.StatusBadRequest, "prompt_injection_blocked",
 						fmt.Sprintf("request blocked: prompt injection detected by pattern %q in %s",
 							patternName, frag.path))
@@ -207,9 +206,7 @@ func PromptInjectionMiddleware(
 					slog.String("method", r.Method),
 					slog.String("url", targetURL),
 				)
-				if eventLogger != nil {
-					_ = eventLogger.Log(r.Context(), events.NewLLMPromptInjectionDetected(params))
-				}
+				logEvent(r.Context(), eventLogger, drops, "prompt_injection", events.NewLLMPromptInjectionDetected(params))
 				// Do not break — continue scanning all fragments in detect mode.
 			}
 

--- a/internal/middleware/prompt_injection_test.go
+++ b/internal/middleware/prompt_injection_test.go
@@ -44,7 +44,7 @@ func buildRoute(t *testing.T, name, pattern string, action middleware.PromptInje
 }
 
 func TestPromptInjectionMiddleware_NoRoutes(t *testing.T) {
-	mw := middleware.PromptInjectionMiddleware(nil, slog.Default(), nil)
+	mw := middleware.PromptInjectionMiddleware(nil, slog.Default(), nil, nil)
 	handler := mw(okPromptHandler)
 
 	body := `{"prompt":"ignore previous instructions"}`
@@ -62,7 +62,7 @@ func TestPromptInjectionMiddleware_NoRoutes(t *testing.T) {
 
 func TestPromptInjectionMiddleware_NoBody(t *testing.T) {
 	route := buildRoute(t, "openai", "https://api.openai.com/**", middleware.PromptInjectionActionBlock, nil)
-	mw := middleware.PromptInjectionMiddleware([]middleware.PromptInjectionRouteConfig{route}, slog.Default(), nil)
+	mw := middleware.PromptInjectionMiddleware([]middleware.PromptInjectionRouteConfig{route}, slog.Default(), nil, nil)
 	handler := mw(okPromptHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -83,6 +83,7 @@ func TestPromptInjectionMiddleware_Block(t *testing.T) {
 		[]middleware.PromptInjectionRouteConfig{route},
 		slog.Default(),
 		logger,
+		nil,
 	)
 	handler := mw(okPromptHandler)
 
@@ -112,6 +113,7 @@ func TestPromptInjectionMiddleware_Detect(t *testing.T) {
 		[]middleware.PromptInjectionRouteConfig{route},
 		slog.Default(),
 		logger,
+		nil,
 	)
 	handler := mw(okPromptHandler)
 
@@ -141,6 +143,7 @@ func TestPromptInjectionMiddleware_CleanRequest(t *testing.T) {
 		[]middleware.PromptInjectionRouteConfig{route},
 		slog.Default(),
 		logger,
+		nil,
 	)
 	handler := mw(okPromptHandler)
 
@@ -206,6 +209,7 @@ func TestPromptInjectionMiddleware_ContentPaths(t *testing.T) {
 				[]middleware.PromptInjectionRouteConfig{route},
 				slog.Default(),
 				nil,
+				nil,
 			)
 			handler := mw(okPromptHandler)
 
@@ -241,6 +245,7 @@ func TestPromptInjectionMiddleware_BodyRestored(t *testing.T) {
 		[]middleware.PromptInjectionRouteConfig{route},
 		slog.Default(),
 		nil,
+		nil,
 	)
 	handler := mw(downstream)
 
@@ -262,6 +267,7 @@ func TestPromptInjectionMiddleware_UnmatchedRoute(t *testing.T) {
 		[]middleware.PromptInjectionRouteConfig{route},
 		slog.Default(),
 		logger,
+		nil,
 	)
 	handler := mw(okPromptHandler)
 
@@ -335,6 +341,7 @@ func TestPromptInjectionMiddleware_NonJSONBody(t *testing.T) {
 		[]middleware.PromptInjectionRouteConfig{route},
 		slog.Default(),
 		logger,
+		nil,
 	)
 	handler := mw(okPromptHandler)
 
@@ -365,6 +372,7 @@ func TestPromptInjectionMiddleware_DefaultActionBlock(t *testing.T) {
 		[]middleware.PromptInjectionRouteConfig{route},
 		slog.Default(),
 		nil,
+		nil,
 	)
 	handler := mw(okPromptHandler)
 
@@ -386,6 +394,7 @@ func TestPromptInjectionMiddleware_BlockResponseFormat(t *testing.T) {
 	mw := middleware.PromptInjectionMiddleware(
 		[]middleware.PromptInjectionRouteConfig{route},
 		slog.Default(),
+		nil,
 		nil,
 	)
 	handler := mw(okPromptHandler)

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -43,6 +43,7 @@ func RateLimitMiddleware(
 	logger *slog.Logger,
 	eventLogger ports.EventLogger,
 	auditLogger ports.AuditEventLogger,
+	drops ports.EventLogDropCounter,
 ) func(http.Handler) http.Handler {
 	matcher, err := NewExemptPathMatcher(cfg.ExemptPaths)
 	if err != nil {
@@ -68,7 +69,7 @@ func RateLimitMiddleware(
 			// requests into a shared "" bucket, undermining per-IP limits.
 			clientIP := ExtractClientIP(r, cfg.TrustProxyHeaders)
 			if clientIP == "" {
-				emitRateLimitUnidentified(r, eventLogger)
+				emitRateLimitUnidentified(r, eventLogger, drops)
 				WriteErrorResponse(w, r, http.StatusForbidden, "forbidden", "client IP could not be determined")
 				return
 			}
@@ -76,8 +77,8 @@ func RateLimitMiddleware(
 			// Step 3: Per-IP rate limit check.
 			ipResult := ipLimiter.Allow(r.Context(), clientIP)
 			if !ipResult.Allowed {
-				emitRateLimitHit(r, eventLogger, "ip", clientIP, "", ipResult)
-				emitAuditRateLimitHit(r, auditLogger, "ip", clientIP, ipResult)
+				emitRateLimitHit(r, eventLogger, drops, "ip", clientIP, "", ipResult)
+				emitAuditRateLimitHit(r, auditLogger, drops, "ip", clientIP, ipResult)
 				writeRateLimitResponse(w, r, ipResult)
 				return
 			}
@@ -87,8 +88,8 @@ func RateLimitMiddleware(
 			if userID != "" {
 				userResult := userLimiter.Allow(r.Context(), userID)
 				if !userResult.Allowed {
-					emitRateLimitHit(r, eventLogger, "user", userID, clientIP, userResult)
-					emitAuditRateLimitHit(r, auditLogger, "user", clientIP, userResult)
+					emitRateLimitHit(r, eventLogger, drops, "user", userID, clientIP, userResult)
+					emitAuditRateLimitHit(r, auditLogger, drops, "user", clientIP, userResult)
 					writeRateLimitResponse(w, r, userResult)
 					return
 				}
@@ -121,14 +122,12 @@ func retryAfterSeconds(d time.Duration) int {
 func emitRateLimitHit(
 	r *http.Request,
 	eventLogger ports.EventLogger,
+	drops ports.EventLogDropCounter,
 	limitType string,
 	identifier string,
 	clientIP string,
 	result ports.RateLimitResult,
 ) {
-	if eventLogger == nil {
-		return
-	}
 	ev := events.NewRateLimitHit(events.RateLimitHitParams{
 		LimitType:         limitType,
 		Identifier:        identifier,
@@ -139,22 +138,17 @@ func emitRateLimitHit(
 		Method:            r.Method,
 		ClientIP:          clientIP,
 	})
-	// Best-effort: ignore logging errors so request processing is never blocked.
-	_ = eventLogger.Log(r.Context(), ev)
+	logEvent(r.Context(), eventLogger, drops, "ratelimit", ev)
 }
 
 // emitRateLimitUnidentified emits a rate_limit.unidentified_client event via
 // the EventLogger port. If eventLogger is nil the call is a no-op.
-func emitRateLimitUnidentified(r *http.Request, eventLogger ports.EventLogger) {
-	if eventLogger == nil {
-		return
-	}
+func emitRateLimitUnidentified(r *http.Request, eventLogger ports.EventLogger, drops ports.EventLogDropCounter) {
 	ev := events.NewRateLimitUnidentified(events.RateLimitUnidentifiedParams{
 		Path:   r.URL.Path,
 		Method: r.Method,
 	})
-	// Best-effort: ignore logging errors so request processing is never blocked.
-	_ = eventLogger.Log(r.Context(), ev)
+	logEvent(r.Context(), eventLogger, drops, "ratelimit", ev)
 }
 
 // emitAuditRateLimitHit emits an audit.rate_limit.hit event via the
@@ -162,13 +156,11 @@ func emitRateLimitUnidentified(r *http.Request, eventLogger ports.EventLogger) {
 func emitAuditRateLimitHit(
 	r *http.Request,
 	auditLogger ports.AuditEventLogger,
+	drops ports.EventLogDropCounter,
 	limitType string,
 	clientIP string,
 	result ports.RateLimitResult,
 ) {
-	if auditLogger == nil {
-		return
-	}
 	ev, err := audit.NewAuditEvent(
 		audit.EventTypeRateLimitHit,
 		audit.Actor{IP: clientIP},
@@ -184,6 +176,5 @@ func emitAuditRateLimitHit(
 	if err != nil {
 		return
 	}
-	// Best-effort: ignore logging errors so request processing is never blocked.
-	_ = auditLogger.Log(r.Context(), ev)
+	logAudit(r.Context(), auditLogger, drops, "ratelimit", ev)
 }

--- a/internal/middleware/ratelimit_integration_test.go
+++ b/internal/middleware/ratelimit_integration_test.go
@@ -38,7 +38,7 @@ func buildRateLimitHandler(
 	cfg.PerIP = ipRule
 	cfg.PerUser = userRule
 
-	handler = RateLimitMiddleware(ipLimiter, userLimiter, cfg, slog.Default(), nil, nil)
+	handler = RateLimitMiddleware(ipLimiter, userLimiter, cfg, slog.Default(), nil, nil, nil)
 	return handler, ipLimiter, userLimiter
 }
 
@@ -480,7 +480,7 @@ func TestRateLimitMiddleware_Integration_LimitersAreCloseable(t *testing.T) {
 		PerUser:           userRule,
 	}
 
-	mw := RateLimitMiddleware(ipLimiter, userLimiter, cfg, slog.Default(), nil, nil)
+	mw := RateLimitMiddleware(ipLimiter, userLimiter, cfg, slog.Default(), nil, nil, nil)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -93,7 +93,7 @@ func TestRateLimitMiddleware_RequestWithinLimit(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), logger, nil, nil)
+	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), logger, nil, nil, nil)
 	handler := mw(next)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/data", nil)
@@ -121,7 +121,7 @@ func TestRateLimitMiddleware_IPLimitExceeded(t *testing.T) {
 		nextCalled = true
 	})
 
-	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), newTestLogger(), spy, nil)
+	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), newTestLogger(), spy, nil, nil)
 	handler := mw(next)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/data", nil)
@@ -173,7 +173,7 @@ func TestRateLimitMiddleware_UserLimitExceeded(t *testing.T) {
 		nextCalled = true
 	})
 
-	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), newTestLogger(), spy, nil)
+	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), newTestLogger(), spy, nil, nil)
 	handler := mw(next)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/data", nil)
@@ -222,7 +222,7 @@ func TestRateLimitMiddleware_UnauthenticatedSkipsUserLimiter(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), logger, nil, nil)
+	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), logger, nil, nil, nil)
 	handler := mw(next)
 
 	// No X-User-Id header — unauthenticated request.
@@ -252,7 +252,7 @@ func TestRateLimitMiddleware_ExemptPath(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), logger, nil, nil)
+	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), logger, nil, nil, nil)
 	handler := mw(next)
 
 	// /_vibewarden/* is always exempt.
@@ -290,7 +290,7 @@ func TestRateLimitMiddleware_CustomExemptPath(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := RateLimitMiddleware(ipLimiter, userLimiter, cfg, logger, nil, nil)
+	mw := RateLimitMiddleware(ipLimiter, userLimiter, cfg, logger, nil, nil, nil)
 	handler := mw(next)
 
 	r := httptest.NewRequest(http.MethodGet, "/public/logo.png", nil)
@@ -313,7 +313,7 @@ func TestRateLimitMiddleware_429ContentType(t *testing.T) {
 	logger := newTestLogger()
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), logger, nil, nil)
+	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), logger, nil, nil, nil)
 	handler := mw(next)
 
 	r := httptest.NewRequest(http.MethodGet, "/api", nil)
@@ -341,7 +341,7 @@ func TestRateLimitMiddleware_TrustProxyHeader(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := RateLimitMiddleware(ipLimiter, userLimiter, cfg, logger, nil, nil)
+	mw := RateLimitMiddleware(ipLimiter, userLimiter, cfg, logger, nil, nil, nil)
 	handler := mw(next)
 
 	r := httptest.NewRequest(http.MethodGet, "/api", nil)
@@ -378,7 +378,7 @@ func TestRateLimitMiddleware_RetryAfterRoundsUp(t *testing.T) {
 			logger := newTestLogger()
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-			mw := RateLimitMiddleware(ipLimiter, allowAll(), defaultCfg(), logger, nil, nil)
+			mw := RateLimitMiddleware(ipLimiter, allowAll(), defaultCfg(), logger, nil, nil, nil)
 			handler := mw(next)
 
 			r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -411,7 +411,7 @@ func TestRateLimitMiddleware_StructuredLogEvent(t *testing.T) {
 	spy := &fakeEventLogger{}
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	mw := RateLimitMiddleware(ipLimiter, allowAll(), defaultCfg(), newTestLogger(), spy, nil)
+	mw := RateLimitMiddleware(ipLimiter, allowAll(), defaultCfg(), newTestLogger(), spy, nil, nil)
 	handler := mw(next)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/resource", nil)
@@ -452,7 +452,7 @@ func TestRateLimitMiddleware_EmptyClientIP_Returns403(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), newTestLogger(), spy, nil)
+	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), newTestLogger(), spy, nil, nil)
 	handler := mw(next)
 
 	// RemoteAddr with no port causes net.SplitHostPort to fail, which makes
@@ -491,7 +491,7 @@ func TestRateLimitMiddleware_AuthenticatedBothLimitsChecked(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), logger, nil, nil)
+	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), logger, nil, nil, nil)
 	handler := mw(next)
 
 	r := httptest.NewRequest(http.MethodGet, "/api/data", nil)
@@ -519,7 +519,7 @@ func TestRateLimitMiddleware_429IncludesRequestID(t *testing.T) {
 	// When tracing is disabled, a 429 response must include a request_id field.
 	ipLimiter := denyWithRetry(time.Second, 10, 20)
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	mw := RateLimitMiddleware(ipLimiter, allowAll(), defaultCfg(), newTestLogger(), nil, nil)
+	mw := RateLimitMiddleware(ipLimiter, allowAll(), defaultCfg(), newTestLogger(), nil, nil, nil)
 	handler := mw(next)
 
 	r := httptest.NewRequest(http.MethodGet, "/api", nil)
@@ -550,7 +550,7 @@ func TestRateLimitMiddleware_403ForbiddenIsJSON(t *testing.T) {
 	ipLimiter := allowAll()
 	userLimiter := allowAll()
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), newTestLogger(), nil, nil)
+	mw := RateLimitMiddleware(ipLimiter, userLimiter, defaultCfg(), newTestLogger(), nil, nil, nil)
 	handler := mw(next)
 
 	// RemoteAddr with no port causes ExtractClientIP to return "".

--- a/internal/middleware/response_validation.go
+++ b/internal/middleware/response_validation.go
@@ -75,6 +75,7 @@ func LLMResponseValidationMiddleware(
 	routes []LLMResponseValidationRouteConfig,
 	logger *slog.Logger,
 	eventLogger ports.EventLogger,
+	drops ports.EventLogDropCounter,
 ) func(http.Handler) http.Handler {
 	// Filter to only enabled routes to avoid repeated checks at request time.
 	enabled := make([]LLMResponseValidationRouteConfig, 0, len(routes))
@@ -145,13 +146,13 @@ func LLMResponseValidationMiddleware(
 					slog.String("error", valErr.Error()),
 				)
 				if matched.Action == LLMResponseValidationActionBlock {
-					emitLLMResponseInvalid(r, eventLogger, matched, targetURL, buf.status, ct, traceID,
+					emitLLMResponseInvalid(r, eventLogger, drops, matched, targetURL, buf.status, ct, traceID,
 						[]string{fmt.Sprintf("response body is not valid JSON: %s", valErr)})
 					WriteErrorResponse(w, r, http.StatusBadGateway, "llm_response_invalid",
 						"upstream response failed schema validation: body is not valid JSON")
 					return
 				}
-				emitLLMResponseInvalid(r, eventLogger, matched, targetURL, buf.status, ct, traceID,
+				emitLLMResponseInvalid(r, eventLogger, drops, matched, targetURL, buf.status, ct, traceID,
 					[]string{fmt.Sprintf("response body is not valid JSON: %s", valErr)})
 				copyBufferedResponse(w, buf)
 				return
@@ -163,7 +164,7 @@ func LLMResponseValidationMiddleware(
 					slog.String("url", targetURL),
 					slog.Int("violations", len(violations)),
 				)
-				emitLLMResponseInvalid(r, eventLogger, matched, targetURL, buf.status, ct, traceID, violations)
+				emitLLMResponseInvalid(r, eventLogger, drops, matched, targetURL, buf.status, ct, traceID, violations)
 
 				if matched.Action == LLMResponseValidationActionBlock {
 					WriteErrorResponse(w, r, http.StatusBadGateway, "llm_response_invalid",
@@ -239,10 +240,11 @@ func isJSONContentType(ct string) bool {
 }
 
 // emitLLMResponseInvalid emits an llm.response_invalid structured event when an
-// event logger is configured.
+// event logger is configured. On error it emits slog.Warn and increments drops.
 func emitLLMResponseInvalid(
 	r *http.Request,
 	eventLogger ports.EventLogger,
+	drops ports.EventLogDropCounter,
 	matched *LLMResponseValidationRouteConfig,
 	targetURL string,
 	statusCode int,
@@ -250,9 +252,6 @@ func emitLLMResponseInvalid(
 	traceID string,
 	violations []string,
 ) {
-	if eventLogger == nil {
-		return
-	}
 	ev := events.NewLLMResponseInvalid(events.LLMResponseInvalidParams{
 		Route:       matched.RouteName,
 		Method:      r.Method,
@@ -263,7 +262,7 @@ func emitLLMResponseInvalid(
 		Violations:  violations,
 		TraceID:     traceID,
 	})
-	_ = eventLogger.Log(r.Context(), ev)
+	logEvent(r.Context(), eventLogger, drops, "response_validation", ev)
 }
 
 // LLMResponseValidationRouteInput carries the per-route configuration fields

--- a/internal/middleware/response_validation_test.go
+++ b/internal/middleware/response_validation_test.go
@@ -123,7 +123,7 @@ func invokeMiddleware(
 	eventLogger ports.EventLogger,
 ) *httptest.ResponseRecorder {
 	t.Helper()
-	mw := middleware.LLMResponseValidationMiddleware(routes, slog.Default(), eventLogger)
+	mw := middleware.LLMResponseValidationMiddleware(routes, slog.Default(), eventLogger, nil)
 	handler := mw(upstream)
 
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(`{"prompt":"hello"}`)))
@@ -143,7 +143,7 @@ func TestLLMResponseValidation_NoRoutes(t *testing.T) {
 	upstream := upstreamHandler(http.StatusOK, "application/json",
 		`{"model":"gpt-4"}`) // would fail schema
 
-	mw := middleware.LLMResponseValidationMiddleware(nil, slog.Default(), nil)
+	mw := middleware.LLMResponseValidationMiddleware(nil, slog.Default(), nil, nil)
 	handler := mw(upstream)
 
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -409,7 +409,7 @@ func TestLLMResponseValidation_NoTargetURL(t *testing.T) {
 	routes := newMiddlewareRoutes("openai", "https://api.openai.com/**",
 		buildValidator(t), middleware.LLMResponseValidationActionBlock)
 
-	mw := middleware.LLMResponseValidationMiddleware(routes, slog.Default(), nil)
+	mw := middleware.LLMResponseValidationMiddleware(routes, slog.Default(), nil, nil)
 	handler := mw(upstream)
 
 	// Request without X-Egress-URL and not using /_egress/ path.

--- a/internal/middleware/waf.go
+++ b/internal/middleware/waf.go
@@ -76,6 +76,14 @@ func WAFMiddleware(
 
 	modeStr := string(mode)
 
+	// Extract the EventLogDropCounter from mc if it satisfies the interface.
+	// OTelAdapter and NoOpMetricsCollector both implement it; other collectors
+	// transparently fall back to nil (counter skipped, slog.Warn still fires).
+	var drops ports.EventLogDropCounter
+	if d, ok := mc.(ports.EventLogDropCounter); ok {
+		drops = d
+	}
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Bypass exempt paths.
@@ -106,7 +114,7 @@ func WAFMiddleware(
 
 				if mode == WAFModeBlock {
 					// Emit audit event before writing the response.
-					emitWAFAuditEvent(r, auditLogger, audit.EventTypeWAFBlocked, d, modeStr)
+					emitWAFAuditEvent(r, auditLogger, drops, audit.EventTypeWAFBlocked, d, modeStr)
 
 					logger.Warn("waf: request blocked",
 						slog.String("rule", d.Rule().Name()),
@@ -124,7 +132,7 @@ func WAFMiddleware(
 				}
 
 				// Detect mode: log and continue.
-				emitWAFAuditEvent(r, auditLogger, audit.EventTypeWAFDetection, d, modeStr)
+				emitWAFAuditEvent(r, auditLogger, drops, audit.EventTypeWAFDetection, d, modeStr)
 
 				logger.Warn("waf: attack detected (detect mode — request allowed)",
 					slog.String("rule", d.Rule().Name()),
@@ -150,19 +158,15 @@ func wafDetail(d waf.Detection) string {
 }
 
 // emitWAFAuditEvent records a WAF audit event if auditLogger is non-nil.
-// Best-effort: errors are silently discarded so request processing is never
-// interrupted by audit logging failures.
+// On error it emits slog.Warn and increments the drops counter (if non-nil).
 func emitWAFAuditEvent(
 	r *http.Request,
 	auditLogger ports.AuditEventLogger,
+	drops ports.EventLogDropCounter,
 	eventType audit.EventType,
 	d waf.Detection,
 	mode string,
 ) {
-	if auditLogger == nil {
-		return
-	}
-
 	outcome := audit.OutcomeFailure
 	if eventType == audit.EventTypeWAFDetection {
 		// In detect mode the request proceeds — outcome is informational.
@@ -189,8 +193,7 @@ func emitWAFAuditEvent(
 	if err != nil {
 		return
 	}
-	// Best-effort.
-	_ = auditLogger.Log(r.Context(), ev)
+	logAudit(r.Context(), auditLogger, drops, "waf", ev)
 }
 
 // extractClientIPOrEmpty returns the client IP from RemoteAddr, stripping the

--- a/internal/middleware/webhook_signature.go
+++ b/internal/middleware/webhook_signature.go
@@ -38,6 +38,7 @@ type WebhookSignatureRule struct {
 func WebhookSignatureMiddleware(
 	rules []WebhookSignatureRule,
 	eventLogger ports.EventLogger,
+	drops ports.EventLogDropCounter,
 ) func(http.Handler) http.Handler {
 	index := make(map[string]domainwebhook.VerifyConfig, len(rules))
 	for _, r := range rules {
@@ -56,7 +57,7 @@ func WebhookSignatureMiddleware(
 			// restore it for the upstream handler.
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				emitWebhookInvalid(r, eventLogger, cfg.Provider, "failed to read request body")
+				emitWebhookInvalid(r, eventLogger, drops, cfg.Provider, "failed to read request body")
 				WriteErrorResponse(w, r, http.StatusUnauthorized, "unauthorized", "could not read request body")
 				return
 			}
@@ -82,12 +83,12 @@ func WebhookSignatureMiddleware(
 			verifyErr := domainwebhook.Verify(cfg, r.Header, body, fullURL, formParams)
 			if verifyErr != nil {
 				reason := classifyError(verifyErr)
-				emitWebhookInvalid(r, eventLogger, cfg.Provider, reason)
+				emitWebhookInvalid(r, eventLogger, drops, cfg.Provider, reason)
 				WriteErrorResponse(w, r, http.StatusUnauthorized, "unauthorized", "webhook signature verification failed")
 				return
 			}
 
-			emitWebhookValid(r, eventLogger, cfg.Provider)
+			emitWebhookValid(r, eventLogger, drops, cfg.Provider)
 			next.ServeHTTP(w, r)
 		})
 	}
@@ -124,25 +125,19 @@ func classifyError(err error) string {
 
 // emitWebhookValid emits a webhook.signature_valid event.
 // If eventLogger is nil the call is a no-op.
-func emitWebhookValid(r *http.Request, eventLogger ports.EventLogger, provider domainwebhook.Provider) {
-	if eventLogger == nil {
-		return
-	}
+func emitWebhookValid(r *http.Request, eventLogger ports.EventLogger, drops ports.EventLogDropCounter, provider domainwebhook.Provider) {
 	ev := events.NewWebhookSignatureValid(events.WebhookSignatureValidParams{
 		Path:     r.URL.Path,
 		Method:   r.Method,
 		Provider: string(provider),
 		ClientIP: ExtractClientIP(r, true),
 	})
-	_ = eventLogger.Log(r.Context(), ev)
+	logEvent(r.Context(), eventLogger, drops, "webhook_signature", ev)
 }
 
 // emitWebhookInvalid emits a webhook.signature_invalid event.
 // If eventLogger is nil the call is a no-op.
-func emitWebhookInvalid(r *http.Request, eventLogger ports.EventLogger, provider domainwebhook.Provider, reason string) {
-	if eventLogger == nil {
-		return
-	}
+func emitWebhookInvalid(r *http.Request, eventLogger ports.EventLogger, drops ports.EventLogDropCounter, provider domainwebhook.Provider, reason string) {
 	ev := events.NewWebhookSignatureInvalid(events.WebhookSignatureInvalidParams{
 		Path:     r.URL.Path,
 		Method:   r.Method,
@@ -150,5 +145,5 @@ func emitWebhookInvalid(r *http.Request, eventLogger ports.EventLogger, provider
 		Reason:   reason,
 		ClientIP: ExtractClientIP(r, true),
 	})
-	_ = eventLogger.Log(r.Context(), ev)
+	logEvent(r.Context(), eventLogger, drops, "webhook_signature", ev)
 }

--- a/internal/middleware/webhook_signature_test.go
+++ b/internal/middleware/webhook_signature_test.go
@@ -94,7 +94,7 @@ func TestWebhookSignatureMiddleware(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := &fakeEventLogger{}
 
-			handler := middleware.WebhookSignatureMiddleware(rules, logger)(
+			handler := middleware.WebhookSignatureMiddleware(rules, logger, nil)(
 				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					w.WriteHeader(http.StatusOK)
 				}),
@@ -146,7 +146,7 @@ func TestWebhookSignatureMiddlewareBodyRestored(t *testing.T) {
 	}
 
 	var gotBody []byte
-	handler := middleware.WebhookSignatureMiddleware(rules, nil)(
+	handler := middleware.WebhookSignatureMiddleware(rules, nil, nil)(
 		http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 			buf := new(bytes.Buffer)
 			buf.ReadFrom(r.Body) //nolint:errcheck
@@ -181,7 +181,7 @@ func TestWebhookSignatureMiddlewareNilEventLogger(t *testing.T) {
 		},
 	}
 
-	handler := middleware.WebhookSignatureMiddleware(rules, nil)(
+	handler := middleware.WebhookSignatureMiddleware(rules, nil, nil)(
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),

--- a/internal/plugins/egress/plugin.go
+++ b/internal/plugins/egress/plugin.go
@@ -173,7 +173,7 @@ func (p *Plugin) Init(ctx context.Context) error {
 // Returns a no-op passthrough middleware when no routes have prompt injection
 // enabled.
 func (p *Plugin) PromptInjectionMiddleware() func(http.Handler) http.Handler {
-	return middleware.PromptInjectionMiddleware(p.promptInjectionRoutes, p.logger, p.eventLogger)
+	return middleware.PromptInjectionMiddleware(p.promptInjectionRoutes, p.logger, p.eventLogger, nil)
 }
 
 // LLMResponseValidationMiddleware returns the LLM response schema validation
@@ -187,7 +187,7 @@ func (p *Plugin) PromptInjectionMiddleware() func(http.Handler) http.Handler {
 // Returns a no-op passthrough middleware when no routes have LLM response
 // validation enabled.
 func (p *Plugin) LLMResponseValidationMiddleware() func(http.Handler) http.Handler {
-	return middleware.LLMResponseValidationMiddleware(p.llmResponseRoutes, p.logger, p.eventLogger)
+	return middleware.LLMResponseValidationMiddleware(p.llmResponseRoutes, p.logger, p.eventLogger, nil)
 }
 
 // Addr returns the TCP address the egress proxy is listening on.

--- a/internal/ports/event_log_drop.go
+++ b/internal/ports/event_log_drop.go
@@ -1,0 +1,17 @@
+// Package ports defines the interfaces (ports) for VibeWarden's hexagonal architecture.
+package ports
+
+// EventLogDropCounter is the narrow outbound port used by the middleware
+// log-drop helper. Adapters that emit drop metrics implement this interface;
+// a nil value is a valid no-op at call sites.
+//
+// IncEventLogDrop increments the vibewarden_event_log_drops_total counter for
+// the given middleware and reason labels.
+//
+// The middleware label is a fixed short string identifying the middleware
+// (e.g. "auth", "waf", "ratelimit"). The reason label is a low-cardinality
+// class derived from the error (e.g. "canceled", "deadline_exceeded", "other").
+// Raw error strings must never be used as label values.
+type EventLogDropCounter interface {
+	IncEventLogDrop(middleware, reason string)
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1015,6 +1015,16 @@ to prevent high-cardinality labels:
       - "/users/:id"
       - "/api/v1/items/:item_id/comments/:comment_id"
 
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `vibewarden_requests_total` | Counter | `method`, `status_code`, `path_pattern` | Total HTTP requests handled |
+| `vibewarden_request_duration_seconds` | Histogram | `method`, `path_pattern` | Request latency distribution |
+| `vibewarden_rate_limit_hits_total` | Counter | `limit_type` | Number of rate limit triggers |
+| `vibewarden_auth_decisions_total` | Counter | `decision` | Auth allow / block decisions |
+| `vibewarden_upstream_errors_total` | Counter | — | Upstream connection failures |
+| `vibewarden_active_connections` | Gauge | — | Currently active connections |
+| `vibewarden_event_log_drops_total` | Counter | `middleware`, `reason` | Audit/event-log writes that failed silently; use to alert on log-pipeline degradation. |
+
 ### OTLP Export
 
 Push metrics and logs to any OTLP-compatible backend (Grafana Cloud, Datadog,

--- a/test/benchmarks/proxy_bench_test.go
+++ b/test/benchmarks/proxy_bench_test.go
@@ -157,7 +157,7 @@ func BenchmarkProxy_WithRateLimiting(b *testing.B) {
 	cfg := defaultRateLimitCfg()
 
 	handler := middleware.RateLimitMiddleware(
-		ipLimiter, userLimiter, cfg, logger, nil, nil,
+		ipLimiter, userLimiter, cfg, logger, nil, nil, nil,
 	)(upstreamHandler)
 
 	b.ReportAllocs()
@@ -212,7 +212,7 @@ func BenchmarkProxy_AllMiddleware(b *testing.B) {
 
 	// Build the chain from innermost to outermost.
 	wafMW := middleware.WAFMiddleware(rs, defaultWAFCfg(), logger, noopMetrics{}, nil)
-	rateMW := middleware.RateLimitMiddleware(ipLimiter, userLimiter, defaultRateLimitCfg(), logger, nil, nil)
+	rateMW := middleware.RateLimitMiddleware(ipLimiter, userLimiter, defaultRateLimitCfg(), logger, nil, nil, nil)
 	secMW := middleware.SecurityHeaders(defaultSecurityCfg())
 
 	handler := secMW(rateMW(wafMW(upstreamHandler)))


### PR DESCRIPTION
Closes #1104

## Summary

- New port EventLogDropCounter (internal/ports/event_log_drop.go)
- logEvent/logAudit helpers (internal/middleware/logdrop.go) replace 23 silent drop sites
- vibewarden_event_log_drops_total{middleware,reason} counter on OTelAdapter
- NoOpMetricsCollector implements IncEventLogDrop as no-op
- All 10 middleware files updated; new nilable drops param (nil-safe)

## Test plan

- make check passes (golangci-lint + race + all tests)
- grep confirms zero silent drop sites remain in internal/middleware/