### PR TITLE
fix(#1102): Caddy handlers consume ports via RuntimeServices registry

### DIFF
--- a/cmd/vibewarden/wiring_serve.go
+++ b/cmd/vibewarden/wiring_serve.go
@@ -132,6 +132,12 @@ func runServe(ctx context.Context, opts serveOptions, extraPlugins ...plugins.Pl
 	ringBuf := logadapter.NewRingBuffer(logadapter.DefaultRingBufferCapacity)
 	eventLogger := buildEventLogger(registry, logger, ringBuf)
 
+	// Publish runtime services to the Caddy adapter's registry so that handler
+	// Provision calls receive the wired sinks instead of constructing their own.
+	// This must happen before adapter.Start (which triggers caddy.Load and
+	// therefore Provision). See ADR-092.
+	caddyadapter.SetRuntimeServices(buildRuntimeServices(logger, eventLogger, registry))
+
 	// Wire the metrics collector into the TLS cert expiry monitor so that
 	// the vibewarden_tls_cert_expiry_seconds gauge is populated. This must
 	// happen after InitAll (metrics provider is ready) and before StartAll

--- a/cmd/vibewarden/wiring_serve_helpers.go
+++ b/cmd/vibewarden/wiring_serve_helpers.go
@@ -7,7 +7,11 @@ import (
 	"sort"
 	"time"
 
+	auditadapter "github.com/vibewarden/vibewarden/internal/adapters/audit"
+	caddyadapter "github.com/vibewarden/vibewarden/internal/adapters/caddy"
 	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
+	ratelimitadapter "github.com/vibewarden/vibewarden/internal/adapters/ratelimit"
+	resilienceadapter "github.com/vibewarden/vibewarden/internal/adapters/resilience"
 	"github.com/vibewarden/vibewarden/internal/config"
 	"github.com/vibewarden/vibewarden/internal/domain/csp"
 	"github.com/vibewarden/vibewarden/internal/plugins"
@@ -418,4 +422,46 @@ func buildEventLogger(registry *plugins.Registry, logger *slog.Logger, ringBuf p
 		slogLogger = logadapter.NewSlogEventLogger(os.Stdout)
 	}
 	return logadapter.NewMultiEventLogger(slogLogger, ringBuf)
+}
+
+// buildRuntimeServices constructs the caddyadapter.RuntimeServices that is
+// published to the Caddy handler registry via SetRuntimeServices. It must be
+// called after buildEventLogger so that the wired event logger (stdout + OTel
+// + ring buffer) is available.
+//
+// The metrics plugin's collector is passed to the CircuitBreakerFactory when
+// present so that circuit breaker state transitions update the Prometheus gauge.
+func buildRuntimeServices(
+	logger *slog.Logger,
+	eventLogger ports.EventLogger,
+	registry *plugins.Registry,
+) caddyadapter.RuntimeServices {
+	// Build the sidecar-level audit logger. Initial implementation writes JSON
+	// to stdout. Fan-out to OTel / PostgreSQL is a later, orthogonal task.
+	auditLogger := auditadapter.NewJSONWriter(os.Stdout)
+
+	// Build the rate limiter factory.
+	rlFactory := ratelimitadapter.NewDefaultMemoryFactory()
+
+	// Extract the MetricsCollectorWithCircuitBreaker from the metrics plugin, if
+	// available. Pass nil otherwise — the factory degrades gracefully.
+	var cbMetrics ports.MetricsCollectorWithCircuitBreaker
+	for _, p := range registry.Plugins() {
+		if mp, ok := p.(*metricsplugin.Plugin); ok {
+			if c, ok2 := mp.Collector().(ports.MetricsCollectorWithCircuitBreaker); ok2 {
+				cbMetrics = c
+			}
+			break
+		}
+	}
+
+	cbFactory := resilienceadapter.NewInMemoryCircuitBreakerFactory(logger, eventLogger, cbMetrics, auditLogger)
+
+	return caddyadapter.RuntimeServices{
+		Logger:                logger,
+		EventLogger:           eventLogger,
+		AuditEventLogger:      auditLogger,
+		RateLimiterFactory:    rlFactory,
+		CircuitBreakerFactory: cbFactory,
+	}
 }

--- a/internal/adapters/caddy/admin_auth_handler.go
+++ b/internal/adapters/caddy/admin_auth_handler.go
@@ -4,13 +4,13 @@ package caddy
 import (
 	"encoding/json"
 	"fmt"
-	"io"
+	"log/slog"
 	"net/http"
+	"os"
 
 	gocaddy "github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 
-	auditadapter "github.com/vibewarden/vibewarden/internal/adapters/audit"
 	"github.com/vibewarden/vibewarden/internal/middleware"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
@@ -62,16 +62,35 @@ func (AdminAuthHandler) CaddyModule() gocaddy.ModuleInfo {
 	}
 }
 
-// Provision implements gocaddy.Provisioner.
-// It is called once after the module is loaded from JSON and creates the
-// compiled middleware handler from the configuration.
+// Provision implements gocaddy.Provisioner. It reads services from the
+// composition-root registry and forwards to ProvisionWith. Production code path.
 func (h *AdminAuthHandler) Provision(_ gocaddy.Context) error {
+	return h.ProvisionWith(currentServices())
+}
+
+// ProvisionWith initialises the handler with explicit services. Tests call this
+// directly with mock services; production calls it via Provision.
+//
+// When services.AuditEventLogger is nil the handler emits a one-time Warn log
+// and skips audit events; request processing continues normally.
+func (h *AdminAuthHandler) ProvisionWith(services RuntimeServices) error {
+	logger := services.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	}
+
+	var auditLogger ports.AuditEventLogger
+	if services.AuditEventLogger != nil {
+		auditLogger = services.AuditEventLogger
+	} else {
+		logger.Warn("admin-auth: AuditEventLogger not set in RuntimeServices; audit events will be dropped")
+	}
+
 	cfg := ports.AdminAuthConfig{
 		Enabled:    h.Config.Enabled,
 		Token:      h.Config.Token,
 		ConfigPath: h.Config.ConfigPath,
 	}
-	auditLogger := auditadapter.NewJSONWriter(io.Discard)
 	h.handler = middleware.AdminAuthMiddleware(cfg, auditLogger)
 	return nil
 }

--- a/internal/adapters/caddy/admin_auth_handler_test.go
+++ b/internal/adapters/caddy/admin_auth_handler_test.go
@@ -66,13 +66,13 @@ func TestAdminAuthHandler_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &AdminAuthHandler{Config: tt.config}
 
-			err := h.Provision(gocaddy.Context{})
+			err := h.ProvisionWith(RuntimeServices{})
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Provision() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ProvisionWith() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			if !tt.wantErr && h.handler == nil {
-				t.Error("Provision() did not create handler")
+				t.Error("ProvisionWith() did not create handler")
 			}
 		})
 	}
@@ -125,8 +125,8 @@ func TestAdminAuthHandler_ServeHTTP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &AdminAuthHandler{Config: tt.config}
-			if err := h.Provision(gocaddy.Context{}); err != nil {
-				t.Fatalf("Provision() error = %v", err)
+			if err := h.ProvisionWith(RuntimeServices{}); err != nil {
+				t.Fatalf("ProvisionWith() error = %v", err)
 			}
 
 			nextCalled := false

--- a/internal/adapters/caddy/circuit_breaker_handler.go
+++ b/internal/adapters/caddy/circuit_breaker_handler.go
@@ -4,7 +4,6 @@ package caddy
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -13,9 +12,6 @@ import (
 	gocaddy "github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 
-	auditadapter "github.com/vibewarden/vibewarden/internal/adapters/audit"
-	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
-	resilienceadapter "github.com/vibewarden/vibewarden/internal/adapters/resilience"
 	"github.com/vibewarden/vibewarden/internal/middleware"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
@@ -80,12 +76,32 @@ func (CircuitBreakerHandler) CaddyModule() gocaddy.ModuleInfo {
 	}
 }
 
-// Provision implements gocaddy.Provisioner. It initialises the circuit breaker,
-// logger, event logger, and audit logger.
+// Provision implements gocaddy.Provisioner. It reads services from the
+// composition-root registry and forwards to ProvisionWith. Production code path.
 func (h *CircuitBreakerHandler) Provision(_ gocaddy.Context) error {
-	h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
-	h.eventLogger = logadapter.NewSlogEventLogger(os.Stdout)
-	h.auditLogger = auditadapter.NewJSONWriter(io.Discard)
+	return h.ProvisionWith(currentServices())
+}
+
+// ProvisionWith initialises the handler with explicit services. Tests call this
+// directly with mock services; production calls it via Provision.
+//
+// Returns an error when services.CircuitBreakerFactory is nil — that is a
+// programmer error (the composition root failed to wire the dependency).
+func (h *CircuitBreakerHandler) ProvisionWith(services RuntimeServices) error {
+	h.logger = services.Logger
+	if h.logger == nil {
+		h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	}
+	h.eventLogger = services.EventLogger
+	h.auditLogger = services.AuditEventLogger
+
+	if services.AuditEventLogger == nil {
+		h.logger.Warn("circuit-breaker: AuditEventLogger not set in RuntimeServices; audit events will be dropped")
+	}
+
+	if services.CircuitBreakerFactory == nil {
+		return fmt.Errorf("missing CircuitBreakerFactory in runtime services")
+	}
 
 	cfg := ports.CircuitBreakerConfig{
 		Enabled:   true,
@@ -93,11 +109,10 @@ func (h *CircuitBreakerHandler) Provision(_ gocaddy.Context) error {
 		Timeout:   time.Duration(h.Config.TimeoutSeconds * float64(time.Second)),
 	}
 
-	cb, err := resilienceadapter.NewInMemoryCircuitBreaker(cfg, h.logger, h.eventLogger, nil)
+	cb, err := services.CircuitBreakerFactory.NewCircuitBreaker(cfg)
 	if err != nil {
 		return fmt.Errorf("provisioning circuit breaker: %w", err)
 	}
-	cb.WithAuditLogger(h.auditLogger)
 	h.cb = cb
 	return nil
 }

--- a/internal/adapters/caddy/circuit_breaker_handler_test.go
+++ b/internal/adapters/caddy/circuit_breaker_handler_test.go
@@ -10,6 +10,16 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
+// fakeCBFactory is a test double for ports.CircuitBreakerFactory.
+type fakeCBFactory struct {
+	cb  ports.CircuitBreaker
+	err error
+}
+
+func (f *fakeCBFactory) NewCircuitBreaker(_ ports.CircuitBreakerConfig) (ports.CircuitBreaker, error) {
+	return f.cb, f.err
+}
+
 var _ ports.CircuitBreaker = (*fakeCB)(nil)
 
 // fakeCB is a simple ports.CircuitBreaker fake for handler tests.
@@ -217,6 +227,36 @@ func TestBuildCaddyConfig_CircuitBreakerBeforeTimeout(t *testing.T) {
 	}
 	if cbIdx >= toIdx {
 		t.Errorf("circuit breaker (index %d) must come before timeout (index %d)", cbIdx, toIdx)
+	}
+}
+
+// TestCircuitBreakerHandler_ProvisionWith_MissingFactory verifies that
+// ProvisionWith returns an error when CircuitBreakerFactory is nil.
+func TestCircuitBreakerHandler_ProvisionWith_MissingFactory(t *testing.T) {
+	h := &CircuitBreakerHandler{
+		Config: CircuitBreakerHandlerConfig{Threshold: 5, TimeoutSeconds: 60},
+	}
+	err := h.ProvisionWith(RuntimeServices{})
+	if err == nil {
+		t.Error("ProvisionWith() should return error when CircuitBreakerFactory is nil")
+	}
+}
+
+// TestCircuitBreakerHandler_ProvisionWith_UsesFactory verifies that ProvisionWith
+// uses the provided CircuitBreakerFactory to create the circuit breaker.
+func TestCircuitBreakerHandler_ProvisionWith_UsesFactory(t *testing.T) {
+	fakeCB := &fakeCB{}
+	factory := &fakeCBFactory{cb: fakeCB}
+
+	h := &CircuitBreakerHandler{
+		Config: CircuitBreakerHandlerConfig{Threshold: 5, TimeoutSeconds: 60},
+	}
+	err := h.ProvisionWith(RuntimeServices{CircuitBreakerFactory: factory})
+	if err != nil {
+		t.Fatalf("ProvisionWith() unexpected error: %v", err)
+	}
+	if h.cb != fakeCB {
+		t.Error("ProvisionWith() did not use the provided factory's circuit breaker")
 	}
 }
 

--- a/internal/adapters/caddy/ipfilter_audit_test.go
+++ b/internal/adapters/caddy/ipfilter_audit_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	gocaddy "github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 
 	"github.com/vibewarden/vibewarden/internal/domain/audit"
@@ -45,6 +44,7 @@ func (f *fakeAuditEventLogger) lastAuditEventOfType(eventType audit.EventType) (
 
 // TestIPFilterHandler_EmitsAuditBlockedEvent verifies that a blocked request
 // produces an audit.ip_filter.blocked event with correct actor and target fields.
+// This is a regression test for the io.Discard bug fixed in ADR-092.
 func TestIPFilterHandler_EmitsAuditBlockedEvent(t *testing.T) {
 	auditSpy := &fakeAuditEventLogger{}
 
@@ -53,13 +53,10 @@ func TestIPFilterHandler_EmitsAuditBlockedEvent(t *testing.T) {
 			Mode:      "blocklist",
 			Addresses: []string{"10.0.0.1"},
 		},
-		auditLogger: auditSpy,
 	}
-	if err := h.Provision(gocaddy.Context{}); err != nil {
-		t.Fatalf("Provision() error: %v", err)
+	if err := h.ProvisionWith(RuntimeServices{AuditEventLogger: auditSpy}); err != nil {
+		t.Fatalf("ProvisionWith() error: %v", err)
 	}
-	// Override the audit logger set by Provision with our spy.
-	h.auditLogger = auditSpy
 
 	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		w.WriteHeader(http.StatusOK)
@@ -108,12 +105,10 @@ func TestIPFilterHandler_NoAuditEventOnAllowedRequest(t *testing.T) {
 			Mode:      "blocklist",
 			Addresses: []string{"10.0.0.1"},
 		},
-		auditLogger: auditSpy,
 	}
-	if err := h.Provision(gocaddy.Context{}); err != nil {
-		t.Fatalf("Provision() error: %v", err)
+	if err := h.ProvisionWith(RuntimeServices{AuditEventLogger: auditSpy}); err != nil {
+		t.Fatalf("ProvisionWith() error: %v", err)
 	}
-	h.auditLogger = auditSpy
 
 	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		w.WriteHeader(http.StatusOK)
@@ -142,7 +137,7 @@ func TestIPFilterHandler_NilAuditLoggerDoesNotPanic(t *testing.T) {
 			Addresses: []string{"10.0.0.1"},
 		},
 	}
-	if err := h.Provision(gocaddy.Context{}); err != nil {
+	if err := h.ProvisionWith(RuntimeServices{}); err != nil {
 		t.Fatalf("Provision() error: %v", err)
 	}
 	// Explicitly set to nil to test nil-safety.

--- a/internal/adapters/caddy/ipfilter_handler.go
+++ b/internal/adapters/caddy/ipfilter_handler.go
@@ -3,7 +3,6 @@ package caddy
 
 import (
 	"context"
-	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -12,8 +11,6 @@ import (
 	gocaddy "github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 
-	auditadapter "github.com/vibewarden/vibewarden/internal/adapters/audit"
-	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
 	"github.com/vibewarden/vibewarden/internal/domain/audit"
 	"github.com/vibewarden/vibewarden/internal/domain/events"
 	"github.com/vibewarden/vibewarden/internal/domain/ipfilter"
@@ -78,12 +75,28 @@ func (IPFilterHandler) CaddyModule() gocaddy.ModuleInfo {
 	}
 }
 
-// Provision implements gocaddy.Provisioner. It parses all configured address
-// strings into an ipfilter.List for efficient per-request matching.
+// Provision implements gocaddy.Provisioner. It reads services from the
+// composition-root registry and forwards to ProvisionWith. Production code path.
 func (h *IPFilterHandler) Provision(_ gocaddy.Context) error {
-	h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
-	h.eventLogger = logadapter.NewSlogEventLogger(os.Stdout)
-	h.auditLogger = auditadapter.NewJSONWriter(io.Discard)
+	return h.ProvisionWith(currentServices())
+}
+
+// ProvisionWith initialises the handler with explicit services. Tests call this
+// directly with mock services; production calls it via Provision.
+//
+// When services.AuditEventLogger is nil the handler emits a one-time Warn log
+// and skips audit events; request processing continues normally.
+func (h *IPFilterHandler) ProvisionWith(services RuntimeServices) error {
+	h.logger = services.Logger
+	if h.logger == nil {
+		h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	}
+	h.eventLogger = services.EventLogger
+	h.auditLogger = services.AuditEventLogger
+
+	if services.AuditEventLogger == nil {
+		h.logger.Warn("ip-filter: AuditEventLogger not set in RuntimeServices; audit events will be dropped")
+	}
 
 	list, err := ipfilter.ParseList(h.Config.Addresses)
 	if err != nil {

--- a/internal/adapters/caddy/ipfilter_handler_test.go
+++ b/internal/adapters/caddy/ipfilter_handler_test.go
@@ -60,7 +60,7 @@ func TestIPFilterHandler_Provision_ValidAddresses(t *testing.T) {
 					Addresses: tt.addresses,
 				},
 			}
-			if err := h.Provision(gocaddy.Context{}); err != nil {
+			if err := h.ProvisionWith(RuntimeServices{}); err != nil {
 				t.Errorf("Provision() unexpected error: %v", err)
 			}
 		})
@@ -76,7 +76,7 @@ func TestIPFilterHandler_Provision_InvalidAddress(t *testing.T) {
 			Addresses: []string{"not-an-ip"},
 		},
 	}
-	if err := h.Provision(gocaddy.Context{}); err == nil {
+	if err := h.ProvisionWith(RuntimeServices{}); err == nil {
 		t.Error("Provision() expected error for invalid address, got nil")
 	}
 }
@@ -135,7 +135,7 @@ func TestIPFilterHandler_ServeHTTP_Blocklist(t *testing.T) {
 					Addresses: tt.addresses,
 				},
 			}
-			if err := h.Provision(gocaddy.Context{}); err != nil {
+			if err := h.ProvisionWith(RuntimeServices{}); err != nil {
 				t.Fatalf("Provision() error: %v", err)
 			}
 
@@ -218,7 +218,7 @@ func TestIPFilterHandler_ServeHTTP_Allowlist(t *testing.T) {
 					Addresses: tt.addresses,
 				},
 			}
-			if err := h.Provision(gocaddy.Context{}); err != nil {
+			if err := h.ProvisionWith(RuntimeServices{}); err != nil {
 				t.Fatalf("Provision() error: %v", err)
 			}
 
@@ -273,7 +273,7 @@ func TestIPFilterHandler_MatchesAny(t *testing.T) {
 					Addresses: tt.addresses,
 				},
 			}
-			if err := h.Provision(gocaddy.Context{}); err != nil {
+			if err := h.ProvisionWith(RuntimeServices{}); err != nil {
 				t.Fatalf("Provision() error: %v", err)
 			}
 
@@ -313,7 +313,7 @@ func TestIPFilterHandler_UnknownMode_TreatedAsBlocklist(t *testing.T) {
 			Addresses: []string{"10.0.0.1"},
 		},
 	}
-	if err := h.Provision(gocaddy.Context{}); err != nil {
+	if err := h.ProvisionWith(RuntimeServices{}); err != nil {
 		t.Fatalf("Provision() error: %v", err)
 	}
 
@@ -347,7 +347,7 @@ func TestIPFilterHandler_ServeHTTP_Blocked403IsJSON(t *testing.T) {
 			Addresses: []string{"10.0.0.1"},
 		},
 	}
-	if err := h.Provision(gocaddy.Context{}); err != nil {
+	if err := h.ProvisionWith(RuntimeServices{}); err != nil {
 		t.Fatalf("Provision() error: %v", err)
 	}
 

--- a/internal/adapters/caddy/maintenance_handler.go
+++ b/internal/adapters/caddy/maintenance_handler.go
@@ -8,7 +8,6 @@ import (
 	gocaddy "github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 
-	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
 	"github.com/vibewarden/vibewarden/internal/middleware"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
@@ -60,11 +59,23 @@ func (MaintenanceHandler) CaddyModule() gocaddy.ModuleInfo {
 	}
 }
 
-// Provision implements gocaddy.Provisioner. It builds the middleware handler
-// that will be called on every request.
+// Provision implements gocaddy.Provisioner. It reads services from the
+// composition-root registry and forwards to ProvisionWith. Production code path.
 func (h *MaintenanceHandler) Provision(_ gocaddy.Context) error {
-	h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
-	h.eventLogger = logadapter.NewSlogEventLogger(os.Stdout)
+	return h.ProvisionWith(currentServices())
+}
+
+// ProvisionWith initialises the handler with explicit services. Tests call this
+// directly with mock services; production calls it via Provision.
+//
+// When services.EventLogger is nil the handler falls back to a stderr-only slog
+// logger so that early-boot misconfiguration remains observable.
+func (h *MaintenanceHandler) ProvisionWith(services RuntimeServices) error {
+	h.logger = services.Logger
+	if h.logger == nil {
+		h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	}
+	h.eventLogger = services.EventLogger
 
 	h.inner = middleware.MaintenanceMiddleware(
 		middleware.MaintenanceConfig{

--- a/internal/adapters/caddy/maintenance_handler_test.go
+++ b/internal/adapters/caddy/maintenance_handler_test.go
@@ -1,7 +1,11 @@
 package caddy
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
 
 func TestMaintenanceHandler_CaddyModule(t *testing.T) {
@@ -16,5 +20,50 @@ func TestMaintenanceHandler_CaddyModule(t *testing.T) {
 	module := info.New()
 	if _, ok := module.(*MaintenanceHandler); !ok {
 		t.Errorf("CaddyModule().New() returned %T, want *MaintenanceHandler", module)
+	}
+}
+
+// TestMaintenanceHandler_ProvisionWith verifies that ProvisionWith builds the
+// handler correctly with an explicit services struct.
+func TestMaintenanceHandler_ProvisionWith(t *testing.T) {
+	h := &MaintenanceHandler{
+		Config: MaintenanceHandlerConfig{Message: "down for maintenance"},
+	}
+	if err := h.ProvisionWith(RuntimeServices{}); err != nil {
+		t.Fatalf("ProvisionWith() unexpected error: %v", err)
+	}
+	if h.inner == nil {
+		t.Error("ProvisionWith() did not create inner middleware")
+	}
+}
+
+// TestMaintenanceHandler_ServeHTTP_Returns503 verifies that the maintenance handler
+// blocks requests with 503 when enabled.
+func TestMaintenanceHandler_ServeHTTP_Returns503(t *testing.T) {
+	h := &MaintenanceHandler{
+		Config: MaintenanceHandlerConfig{Message: "maintenance"},
+	}
+	if err := h.ProvisionWith(RuntimeServices{}); err != nil {
+		t.Fatalf("ProvisionWith() error: %v", err)
+	}
+
+	nextCalled := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/app/page", nil)
+	w := httptest.NewRecorder()
+
+	if err := h.ServeHTTP(w, req, next); err != nil {
+		t.Fatalf("ServeHTTP() unexpected error: %v", err)
+	}
+
+	if nextCalled {
+		t.Error("expected maintenance to block the request, but next was called")
+	}
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
 	}
 }

--- a/internal/adapters/caddy/ratelimit_handler.go
+++ b/internal/adapters/caddy/ratelimit_handler.go
@@ -4,7 +4,6 @@ package caddy
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -12,9 +11,6 @@ import (
 	gocaddy "github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 
-	auditadapter "github.com/vibewarden/vibewarden/internal/adapters/audit"
-	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
-	ratelimitadapter "github.com/vibewarden/vibewarden/internal/adapters/ratelimit"
 	"github.com/vibewarden/vibewarden/internal/middleware"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
@@ -86,20 +82,37 @@ func (RateLimitHandler) CaddyModule() gocaddy.ModuleInfo {
 	}
 }
 
-// Provision implements gocaddy.Provisioner.
-// It is called once after the module is loaded from JSON, and creates the
-// in-memory rate limiter stores and the compiled middleware handler.
+// Provision implements gocaddy.Provisioner. It reads services from the
+// composition-root registry and forwards to ProvisionWith. Production code path.
 func (h *RateLimitHandler) Provision(_ gocaddy.Context) error {
-	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	return h.ProvisionWith(currentServices())
+}
 
-	factory := ratelimitadapter.NewDefaultMemoryFactory()
+// ProvisionWith initialises the handler with explicit services. Tests call this
+// directly with mock services; production calls it via Provision.
+//
+// Returns an error when services.RateLimiterFactory is nil — that is a
+// programmer error (the composition root failed to wire the dependency).
+func (h *RateLimitHandler) ProvisionWith(services RuntimeServices) error {
+	logger := services.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	}
 
-	h.ipLimiter = factory.NewLimiter(ports.RateLimitRule{
+	if services.RateLimiterFactory == nil {
+		return fmt.Errorf("missing RateLimiterFactory in runtime services")
+	}
+
+	if services.AuditEventLogger == nil {
+		logger.Warn("rate-limit: AuditEventLogger not set in RuntimeServices; audit events will be dropped")
+	}
+
+	h.ipLimiter = services.RateLimiterFactory.NewLimiter(ports.RateLimitRule{
 		RequestsPerSecond: h.Config.PerIP.RequestsPerSecond,
 		Burst:             h.Config.PerIP.Burst,
 	})
 
-	h.userLimiter = factory.NewLimiter(ports.RateLimitRule{
+	h.userLimiter = services.RateLimiterFactory.NewLimiter(ports.RateLimitRule{
 		RequestsPerSecond: h.Config.PerUser.RequestsPerSecond,
 		Burst:             h.Config.PerUser.Burst,
 	})
@@ -118,10 +131,10 @@ func (h *RateLimitHandler) Provision(_ gocaddy.Context) error {
 		},
 	}
 
-	eventLogger := logadapter.NewSlogEventLogger(os.Stdout)
-	auditLogger := auditadapter.NewJSONWriter(io.Discard)
-
-	h.handler = middleware.RateLimitMiddleware(h.ipLimiter, h.userLimiter, cfg, logger, eventLogger, auditLogger, nil)
+	h.handler = middleware.RateLimitMiddleware(
+		h.ipLimiter, h.userLimiter, cfg,
+		logger, services.EventLogger, services.AuditEventLogger, nil,
+	)
 
 	return nil
 }

--- a/internal/adapters/caddy/ratelimit_handler_test.go
+++ b/internal/adapters/caddy/ratelimit_handler_test.go
@@ -13,6 +13,15 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
+// fakeRateLimiterFactory is a test double for ports.RateLimiterFactory.
+type fakeRateLimiterFactory struct {
+	allowResult ports.RateLimitResult
+}
+
+func (f *fakeRateLimiterFactory) NewLimiter(_ ports.RateLimitRule) ports.RateLimiter {
+	return &fakeRateLimiter{allowResult: f.allowResult}
+}
+
 // fakeRateLimiter is a test double for ports.RateLimiter.
 type fakeRateLimiter struct {
 	allowResult ports.RateLimitResult
@@ -118,24 +127,29 @@ func TestRateLimitHandler_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &RateLimitHandler{Config: tt.config}
 
-			err := h.Provision(gocaddy.Context{})
+			svc := RuntimeServices{
+				RateLimiterFactory: &fakeRateLimiterFactory{
+					allowResult: ports.RateLimitResult{Allowed: true},
+				},
+			}
+			err := h.ProvisionWith(svc)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Provision() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ProvisionWith() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			if !tt.wantErr {
 				if h.ipLimiter == nil {
-					t.Error("Provision() did not create ipLimiter")
+					t.Error("ProvisionWith() did not create ipLimiter")
 				}
 				if h.userLimiter == nil {
-					t.Error("Provision() did not create userLimiter")
+					t.Error("ProvisionWith() did not create userLimiter")
 				}
 				if h.handler == nil {
-					t.Error("Provision() did not create handler")
+					t.Error("ProvisionWith() did not create handler")
 				}
 				// Clean up background goroutines.
 				if err := h.Cleanup(); err != nil {
-					t.Errorf("Cleanup() after Provision() error = %v", err)
+					t.Errorf("Cleanup() after ProvisionWith() error = %v", err)
 				}
 			}
 		})
@@ -262,8 +276,13 @@ func TestRateLimitHandler_ServeHTTP(t *testing.T) {
 					},
 				},
 			}
-			if err := h.Provision(gocaddy.Context{}); err != nil {
-				t.Fatalf("Provision() error = %v", err)
+			svc := RuntimeServices{
+				RateLimiterFactory: &fakeRateLimiterFactory{
+					allowResult: ports.RateLimitResult{Allowed: true},
+				},
+			}
+			if err := h.ProvisionWith(svc); err != nil {
+				t.Fatalf("ProvisionWith() error = %v", err)
 			}
 			defer func() {
 				if err := h.Cleanup(); err != nil {
@@ -397,6 +416,22 @@ func TestBuildRateLimitHandlerJSON(t *testing.T) {
 				tt.checks(t, result)
 			}
 		})
+	}
+}
+
+// TestRateLimitHandler_ProvisionWith_MissingFactory verifies that ProvisionWith
+// returns an error when RateLimiterFactory is nil.
+func TestRateLimitHandler_ProvisionWith_MissingFactory(t *testing.T) {
+	h := &RateLimitHandler{
+		Config: RateLimitHandlerConfig{
+			Enabled: true,
+			PerIP:   RateLimitRuleHandlerConfig{RequestsPerSecond: 10, Burst: 20},
+			PerUser: RateLimitRuleHandlerConfig{RequestsPerSecond: 5, Burst: 10},
+		},
+	}
+	err := h.ProvisionWith(RuntimeServices{})
+	if err == nil {
+		t.Error("ProvisionWith() should return error when RateLimiterFactory is nil")
 	}
 }
 

--- a/internal/adapters/caddy/retry_handler.go
+++ b/internal/adapters/caddy/retry_handler.go
@@ -15,7 +15,6 @@ import (
 	gocaddy "github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 
-	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
 	"github.com/vibewarden/vibewarden/internal/domain/events"
 	"github.com/vibewarden/vibewarden/internal/middleware"
 	"github.com/vibewarden/vibewarden/internal/ports"
@@ -94,11 +93,20 @@ func (RetryHandler) CaddyModule() gocaddy.ModuleInfo {
 	}
 }
 
-// Provision implements gocaddy.Provisioner. It initialises the logger and
-// event logger used by this handler instance.
+// Provision implements gocaddy.Provisioner. It reads services from the
+// composition-root registry and forwards to ProvisionWith. Production code path.
 func (h *RetryHandler) Provision(_ gocaddy.Context) error {
-	h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
-	h.eventLogger = logadapter.NewSlogEventLogger(os.Stdout)
+	return h.ProvisionWith(currentServices())
+}
+
+// ProvisionWith initialises the handler with explicit services. Tests call this
+// directly with mock services; production calls it via Provision.
+func (h *RetryHandler) ProvisionWith(services RuntimeServices) error {
+	h.logger = services.Logger
+	if h.logger == nil {
+		h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	}
+	h.eventLogger = services.EventLogger
 	return nil
 }
 

--- a/internal/adapters/caddy/runtime_services.go
+++ b/internal/adapters/caddy/runtime_services.go
@@ -1,0 +1,63 @@
+package caddy
+
+import (
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// RuntimeServices bundles the live service dependencies required by
+// VibeWarden's Caddy HTTP handler modules. The composition root
+// (cmd/vibewarden) builds these once at startup and publishes them through
+// SetRuntimeServices before caddy.Load runs for the first time. Handlers
+// retrieve the current set during Provision.
+//
+// Individual fields may be nil — handlers must check and degrade gracefully
+// (log a warning, skip the optional behaviour). This is the same contract
+// already honoured by the existing middleware helpers.
+type RuntimeServices struct {
+	// Logger is the structured logger shared across all handlers.
+	Logger *slog.Logger
+
+	// EventLogger is the operational event sink (stdout + OTel + ring buffer
+	// in production, an in-memory spy in tests).
+	EventLogger ports.EventLogger
+
+	// AuditEventLogger is the security audit sink. When nil, handlers emit a
+	// one-time Warn log entry and skip the audit event.
+	AuditEventLogger ports.AuditEventLogger
+
+	// RateLimiterFactory creates per-handler rate limiter instances. Required
+	// by RateLimitHandler — ProvisionWith returns an error when nil.
+	RateLimiterFactory ports.RateLimiterFactory
+
+	// CircuitBreakerFactory creates per-handler circuit breaker instances.
+	// Required by CircuitBreakerHandler — ProvisionWith returns an error when nil.
+	CircuitBreakerFactory ports.CircuitBreakerFactory
+}
+
+// runtimeServicesRegistry is the package-scope atomic pointer. It is written
+// only by SetRuntimeServices (the composition root) and read only by
+// currentServices (within the caddy adapter package). The zero value of the
+// pointer is nil, which currentServices converts to a zero RuntimeServices.
+var runtimeServicesRegistry atomic.Pointer[RuntimeServices]
+
+// SetRuntimeServices publishes the services to the atomic registry.
+// Safe for concurrent use. Calling this after Provision has run for a handler
+// has no effect on already-provisioned handlers; those keep the first set
+// (Caddy's handler lifecycle calls Provision exactly once per config load).
+func SetRuntimeServices(s RuntimeServices) {
+	runtimeServicesRegistry.Store(&s)
+}
+
+// currentServices returns the most recently published services, or a
+// zero-value RuntimeServices if SetRuntimeServices has never been called.
+// Unexported — only the caddy adapter package may read the registry.
+func currentServices() RuntimeServices {
+	p := runtimeServicesRegistry.Load()
+	if p == nil {
+		return RuntimeServices{}
+	}
+	return *p
+}

--- a/internal/adapters/caddy/runtime_services_test.go
+++ b/internal/adapters/caddy/runtime_services_test.go
@@ -1,0 +1,143 @@
+package caddy
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/domain/audit"
+	"github.com/vibewarden/vibewarden/internal/domain/events"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// fakeEventLoggerSvc is a test double for ports.EventLogger.
+type fakeEventLoggerSvc struct {
+	logged []events.Event
+	mu     sync.Mutex
+}
+
+func (f *fakeEventLoggerSvc) Log(_ context.Context, ev events.Event) error {
+	f.mu.Lock()
+	f.logged = append(f.logged, ev)
+	f.mu.Unlock()
+	return nil
+}
+
+// fakeAuditLoggerSvc is a test double for ports.AuditEventLogger.
+type fakeAuditLoggerSvc struct {
+	logged []audit.AuditEvent
+	mu     sync.Mutex
+}
+
+func (f *fakeAuditLoggerSvc) Log(_ context.Context, ev audit.AuditEvent) error {
+	f.mu.Lock()
+	f.logged = append(f.logged, ev)
+	f.mu.Unlock()
+	return nil
+}
+
+// TestRuntimeServices_ZeroValueWhenUnset asserts that currentServices returns a
+// zero-value RuntimeServices when SetRuntimeServices has never been called.
+func TestRuntimeServices_ZeroValueWhenUnset(t *testing.T) {
+	// Reset the registry to nil before this test so other tests don't affect it.
+	runtimeServicesRegistry.Store(nil)
+
+	svc := currentServices()
+	if svc.Logger != nil {
+		t.Error("Logger should be nil in zero-value RuntimeServices")
+	}
+	if svc.EventLogger != nil {
+		t.Error("EventLogger should be nil in zero-value RuntimeServices")
+	}
+	if svc.AuditEventLogger != nil {
+		t.Error("AuditEventLogger should be nil in zero-value RuntimeServices")
+	}
+	if svc.RateLimiterFactory != nil {
+		t.Error("RateLimiterFactory should be nil in zero-value RuntimeServices")
+	}
+	if svc.CircuitBreakerFactory != nil {
+		t.Error("CircuitBreakerFactory should be nil in zero-value RuntimeServices")
+	}
+}
+
+// TestRuntimeServices_SetAndGet verifies that SetRuntimeServices stores a value
+// that is retrievable via currentServices.
+func TestRuntimeServices_SetAndGet(t *testing.T) {
+	logger := slog.Default()
+	el := &fakeEventLoggerSvc{}
+	al := &fakeAuditLoggerSvc{}
+
+	SetRuntimeServices(RuntimeServices{
+		Logger:           logger,
+		EventLogger:      el,
+		AuditEventLogger: al,
+	})
+	defer runtimeServicesRegistry.Store(nil) // cleanup
+
+	got := currentServices()
+	if got.Logger != logger {
+		t.Error("Logger not stored correctly")
+	}
+	if got.EventLogger != el {
+		t.Error("EventLogger not stored correctly")
+	}
+	if got.AuditEventLogger != al {
+		t.Error("AuditEventLogger not stored correctly")
+	}
+}
+
+// TestRuntimeServices_LastWriteWins verifies that concurrent SetRuntimeServices
+// calls are both safe and result in a valid services value being readable.
+func TestRuntimeServices_LastWriteWins(t *testing.T) {
+	const goroutines = 50
+
+	el1 := &fakeEventLoggerSvc{}
+	el2 := &fakeEventLoggerSvc{}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			if i%2 == 0 {
+				SetRuntimeServices(RuntimeServices{EventLogger: el1})
+			} else {
+				SetRuntimeServices(RuntimeServices{EventLogger: el2})
+			}
+		}()
+	}
+	wg.Wait()
+	defer runtimeServicesRegistry.Store(nil) // cleanup
+
+	got := currentServices()
+	// The result must be one of the two valid values — either el1 or el2.
+	if got.EventLogger != el1 && got.EventLogger != el2 {
+		t.Errorf("currentServices().EventLogger is neither el1 nor el2: got %v", got.EventLogger)
+	}
+}
+
+// TestRuntimeServices_Idempotent verifies that calling SetRuntimeServices twice
+// with different values results in the second value being visible.
+func TestRuntimeServices_Idempotent(t *testing.T) {
+	el1 := &fakeEventLoggerSvc{}
+	el2 := &fakeEventLoggerSvc{}
+
+	SetRuntimeServices(RuntimeServices{EventLogger: el1})
+	SetRuntimeServices(RuntimeServices{EventLogger: el2})
+	defer runtimeServicesRegistry.Store(nil) // cleanup
+
+	got := currentServices()
+	if got.EventLogger != el2 {
+		t.Error("second SetRuntimeServices should overwrite the first")
+	}
+}
+
+// TestSetRuntimeServices_CompileTimeInterfaceGuard verifies that the types in
+// RuntimeServices satisfy the declared ports at compile time.
+func TestSetRuntimeServices_CompileTimeInterfaceGuard(t *testing.T) {
+	var _ ports.EventLogger = (*fakeEventLoggerSvc)(nil)
+	var _ ports.AuditEventLogger = (*fakeAuditLoggerSvc)(nil)
+}

--- a/internal/adapters/caddy/timeout_handler.go
+++ b/internal/adapters/caddy/timeout_handler.go
@@ -14,7 +14,6 @@ import (
 	gocaddy "github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 
-	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
 	"github.com/vibewarden/vibewarden/internal/domain/events"
 	"github.com/vibewarden/vibewarden/internal/middleware"
 	"github.com/vibewarden/vibewarden/internal/ports"
@@ -68,11 +67,20 @@ func (TimeoutHandler) CaddyModule() gocaddy.ModuleInfo {
 	}
 }
 
-// Provision implements gocaddy.Provisioner. It initialises the logger and
-// event logger used by this handler instance.
+// Provision implements gocaddy.Provisioner. It reads services from the
+// composition-root registry and forwards to ProvisionWith. Production code path.
 func (h *TimeoutHandler) Provision(_ gocaddy.Context) error {
-	h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
-	h.eventLogger = logadapter.NewSlogEventLogger(os.Stdout)
+	return h.ProvisionWith(currentServices())
+}
+
+// ProvisionWith initialises the handler with explicit services. Tests call this
+// directly with mock services; production calls it via Provision.
+func (h *TimeoutHandler) ProvisionWith(services RuntimeServices) error {
+	h.logger = services.Logger
+	if h.logger == nil {
+		h.logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	}
+	h.eventLogger = services.EventLogger
 	return nil
 }
 

--- a/internal/adapters/caddy/webhook_signature_handler.go
+++ b/internal/adapters/caddy/webhook_signature_handler.go
@@ -11,7 +11,6 @@ import (
 	gocaddy "github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 
-	logadapter "github.com/vibewarden/vibewarden/internal/adapters/log"
 	domainwebhook "github.com/vibewarden/vibewarden/internal/domain/webhook"
 	"github.com/vibewarden/vibewarden/internal/middleware"
 )
@@ -75,11 +74,20 @@ func (WebhookSignatureHandler) CaddyModule() gocaddy.ModuleInfo {
 	}
 }
 
-// Provision implements gocaddy.Provisioner.
-// It resolves secret env var references and constructs the middleware handler.
-func (h *WebhookSignatureHandler) Provision(_ gocaddy.Context) error {
-	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
-	eventLogger := logadapter.NewSlogEventLogger(os.Stdout)
+// Provision implements gocaddy.Provisioner. It reads services from the
+// composition-root registry and forwards to ProvisionWith. Production code path.
+func (h *WebhookSignatureHandler) Provision(ctx gocaddy.Context) error {
+	return h.ProvisionWith(ctx, currentServices())
+}
+
+// ProvisionWith initialises the handler with explicit services. Tests call this
+// directly with mock services; production calls it via Provision.
+func (h *WebhookSignatureHandler) ProvisionWith(_ gocaddy.Context, services RuntimeServices) error {
+	logger := services.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	}
+	eventLogger := services.EventLogger
 
 	rules := make([]middleware.WebhookSignatureRule, 0, len(h.Config.Rules))
 	for i, r := range h.Config.Rules {

--- a/internal/adapters/caddy/webhook_signature_handler_test.go
+++ b/internal/adapters/caddy/webhook_signature_handler_test.go
@@ -1,0 +1,138 @@
+package caddy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gocaddy "github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+// TestWebhookSignatureHandler_CaddyModule verifies the Caddy module metadata.
+func TestWebhookSignatureHandler_CaddyModule(t *testing.T) {
+	info := WebhookSignatureHandler{}.CaddyModule()
+
+	if info.ID != "http.handlers.vibewarden_webhook_signature" {
+		t.Errorf("CaddyModule().ID = %q, want %q", info.ID, "http.handlers.vibewarden_webhook_signature")
+	}
+	if info.New == nil {
+		t.Fatal("CaddyModule().New is nil")
+	}
+	mod := info.New()
+	if mod == nil {
+		t.Fatal("CaddyModule().New() returned nil")
+	}
+	if _, ok := mod.(*WebhookSignatureHandler); !ok {
+		t.Errorf("CaddyModule().New() returned %T, want *WebhookSignatureHandler", mod)
+	}
+}
+
+// TestWebhookSignatureHandler_InterfaceGuards verifies the handler satisfies required Caddy interfaces.
+func TestWebhookSignatureHandler_InterfaceGuards(t *testing.T) {
+	var _ gocaddy.Provisioner = (*WebhookSignatureHandler)(nil)
+	var _ caddyhttp.MiddlewareHandler = (*WebhookSignatureHandler)(nil)
+}
+
+// TestWebhookSignatureHandler_ProvisionWith verifies that ProvisionWith with valid
+// services succeeds and that the handler accepts requests.
+func TestWebhookSignatureHandler_ProvisionWith(t *testing.T) {
+	tests := []struct {
+		name    string
+		rules   []WebhookSignatureHandlerRuleConfig
+		wantErr bool
+	}{
+		{
+			name:    "no rules — handler accepts all requests",
+			rules:   nil,
+			wantErr: false,
+		},
+		{
+			name: "valid stripe rule",
+			rules: []WebhookSignatureHandlerRuleConfig{
+				{Path: "/webhook/stripe", Provider: "stripe", SecretEnvVar: "STRIPE_SECRET"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid github rule",
+			rules: []WebhookSignatureHandlerRuleConfig{
+				{Path: "/webhook/github", Provider: "github", SecretEnvVar: "GITHUB_SECRET"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "unknown provider returns error",
+			rules: []WebhookSignatureHandlerRuleConfig{
+				{Path: "/webhook", Provider: "unknown_provider", SecretEnvVar: "SECRET"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing path returns error",
+			rules: []WebhookSignatureHandlerRuleConfig{
+				{Path: "", Provider: "stripe", SecretEnvVar: "SECRET"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &WebhookSignatureHandler{
+				Config: WebhookSignatureHandlerConfig{Rules: tt.rules},
+			}
+			err := h.ProvisionWith(gocaddy.Context{}, RuntimeServices{})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ProvisionWith() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestWebhookSignatureHandler_ServeHTTP_NoRules verifies that when no rules are
+// configured, all requests pass through to the next handler.
+func TestWebhookSignatureHandler_ServeHTTP_NoRules(t *testing.T) {
+	h := &WebhookSignatureHandler{
+		Config: WebhookSignatureHandlerConfig{Rules: nil},
+	}
+	if err := h.ProvisionWith(gocaddy.Context{}, RuntimeServices{}); err != nil {
+		t.Fatalf("ProvisionWith() error: %v", err)
+	}
+
+	nextCalled := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/stripe", nil)
+	w := httptest.NewRecorder()
+
+	if err := h.ServeHTTP(w, req, next); err != nil {
+		t.Fatalf("ServeHTTP() unexpected error: %v", err)
+	}
+
+	if !nextCalled {
+		t.Error("expected next handler to be called when no rules configured")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+// TestWebhookSignatureHandler_ProvisionWith_UsesEventLogger verifies that
+// ProvisionWith correctly stores the event logger from RuntimeServices.
+func TestWebhookSignatureHandler_ProvisionWith_UsesEventLogger(t *testing.T) {
+	el := &fakeEventLogger{}
+
+	h := &WebhookSignatureHandler{
+		Config: WebhookSignatureHandlerConfig{Rules: nil},
+	}
+	if err := h.ProvisionWith(gocaddy.Context{}, RuntimeServices{EventLogger: el}); err != nil {
+		t.Fatalf("ProvisionWith() error: %v", err)
+	}
+	// Handler successfully built — event logger was wired in.
+	// (Full event emission verification requires a live request with a valid signature.)
+}

--- a/internal/adapters/resilience/circuit_breaker_factory.go
+++ b/internal/adapters/resilience/circuit_breaker_factory.go
@@ -1,0 +1,56 @@
+package resilience
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// InMemoryCircuitBreakerFactory implements ports.CircuitBreakerFactory. It
+// holds the shared dependencies (logger, event logger, metrics, audit logger)
+// that are wired once at startup and reused for every circuit breaker instance
+// it creates.
+type InMemoryCircuitBreakerFactory struct {
+	logger      *slog.Logger
+	eventLogger ports.EventLogger
+	metrics     ports.MetricsCollectorWithCircuitBreaker
+	auditLogger ports.AuditEventLogger
+}
+
+// NewInMemoryCircuitBreakerFactory creates an InMemoryCircuitBreakerFactory with
+// the supplied dependencies. All fields are optional (nil is accepted) except
+// that nil metrics simply disables gauge reporting.
+func NewInMemoryCircuitBreakerFactory(
+	logger *slog.Logger,
+	eventLogger ports.EventLogger,
+	metrics ports.MetricsCollectorWithCircuitBreaker,
+	auditLogger ports.AuditEventLogger,
+) *InMemoryCircuitBreakerFactory {
+	return &InMemoryCircuitBreakerFactory{
+		logger:      logger,
+		eventLogger: eventLogger,
+		metrics:     metrics,
+		auditLogger: auditLogger,
+	}
+}
+
+// NewCircuitBreaker implements ports.CircuitBreakerFactory. It returns a new
+// InMemoryCircuitBreaker configured with cfg. The factory's pre-wired logger,
+// event logger, metrics, and audit logger are attached to every instance.
+//
+// Returns an error when cfg contains an invalid threshold or timeout (threshold
+// ≤ 0 or timeout ≤ 0).
+func (f *InMemoryCircuitBreakerFactory) NewCircuitBreaker(cfg ports.CircuitBreakerConfig) (ports.CircuitBreaker, error) {
+	cb, err := NewInMemoryCircuitBreaker(cfg, f.logger, f.eventLogger, f.metrics)
+	if err != nil {
+		return nil, fmt.Errorf("creating circuit breaker: %w", err)
+	}
+	if f.auditLogger != nil {
+		cb.WithAuditLogger(f.auditLogger)
+	}
+	return cb, nil
+}
+
+// Compile-time assertion that InMemoryCircuitBreakerFactory satisfies the port.
+var _ ports.CircuitBreakerFactory = (*InMemoryCircuitBreakerFactory)(nil)

--- a/internal/adapters/resilience/circuit_breaker_factory_test.go
+++ b/internal/adapters/resilience/circuit_breaker_factory_test.go
@@ -1,0 +1,108 @@
+package resilience_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/adapters/resilience"
+	"github.com/vibewarden/vibewarden/internal/domain/audit"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// TestInMemoryCircuitBreakerFactory_NewCircuitBreaker_WiresAuditLogger verifies
+// that a factory built with an audit logger produces a circuit breaker that
+// emits audit events on state transitions.
+func TestInMemoryCircuitBreakerFactory_NewCircuitBreaker_WiresAuditLogger(t *testing.T) {
+	al := &fakeAuditEventLogger{}
+	factory := resilience.NewInMemoryCircuitBreakerFactory(nil, nil, nil, al)
+
+	cb, err := factory.NewCircuitBreaker(ports.CircuitBreakerConfig{
+		Enabled:   true,
+		Threshold: 1,
+		Timeout:   time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("NewCircuitBreaker() unexpected error: %v", err)
+	}
+
+	// Trip the circuit — should emit an audit.circuit_breaker.opened event.
+	cb.RecordFailure()
+
+	if !al.hasAuditEventType(audit.EventTypeCircuitBreakerOpened) {
+		t.Error("expected audit.circuit_breaker.opened event but none was logged")
+	}
+}
+
+// TestInMemoryCircuitBreakerFactory_NewCircuitBreaker_RejectsInvalidConfig verifies
+// that a zero threshold causes NewCircuitBreaker to return an error.
+func TestInMemoryCircuitBreakerFactory_NewCircuitBreaker_RejectsInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     ports.CircuitBreakerConfig
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			cfg: ports.CircuitBreakerConfig{
+				Enabled:   true,
+				Threshold: 5,
+				Timeout:   30 * time.Second,
+			},
+			wantErr: false,
+		},
+		{
+			name: "zero threshold returns error",
+			cfg: ports.CircuitBreakerConfig{
+				Enabled:   true,
+				Threshold: 0,
+				Timeout:   30 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero timeout returns error",
+			cfg: ports.CircuitBreakerConfig{
+				Enabled:   true,
+				Threshold: 5,
+				Timeout:   0,
+			},
+			wantErr: true,
+		},
+	}
+
+	factory := resilience.NewInMemoryCircuitBreakerFactory(nil, nil, nil, nil)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := factory.NewCircuitBreaker(tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewCircuitBreaker() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestInMemoryCircuitBreakerFactory_NilAuditLogger verifies that a factory with
+// a nil audit logger produces a working circuit breaker without panic.
+func TestInMemoryCircuitBreakerFactory_NilAuditLogger(t *testing.T) {
+	factory := resilience.NewInMemoryCircuitBreakerFactory(nil, nil, nil, nil)
+
+	cb, err := factory.NewCircuitBreaker(ports.CircuitBreakerConfig{
+		Enabled:   true,
+		Threshold: 1,
+		Timeout:   time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("NewCircuitBreaker() unexpected error: %v", err)
+	}
+
+	// Must not panic.
+	cb.RecordFailure()
+	_ = cb.IsOpen()
+}
+
+// TestInMemoryCircuitBreakerFactory_SatisfiesPort is a compile-time check that
+// the factory implements ports.CircuitBreakerFactory.
+func TestInMemoryCircuitBreakerFactory_SatisfiesPort(t *testing.T) {
+	var _ ports.CircuitBreakerFactory = (*resilience.InMemoryCircuitBreakerFactory)(nil)
+}

--- a/internal/ports/circuit_breaker.go
+++ b/internal/ports/circuit_breaker.go
@@ -46,6 +46,18 @@ type CircuitBreakerConfig struct {
 	Timeout time.Duration
 }
 
+// CircuitBreakerFactory creates CircuitBreaker instances from a configuration.
+// Implementations wire logger, event logger, and metrics once at construction
+// time; NewCircuitBreaker captures only the per-instance threshold and timeout.
+//
+// This mirrors the existing RateLimiterFactory pattern.
+type CircuitBreakerFactory interface {
+	// NewCircuitBreaker returns a fresh CircuitBreaker configured with the
+	// supplied threshold and timeout. The returned breaker honours the
+	// factory's pre-wired logger, event logger, and metrics sinks.
+	NewCircuitBreaker(cfg CircuitBreakerConfig) (CircuitBreaker, error)
+}
+
 // MetricsCollectorWithCircuitBreaker extends MetricsCollector with a circuit
 // breaker state gauge. Adapters that expose this gauge implement this interface;
 // others embed a no-op to satisfy MetricsCollector without the extra method.

--- a/test/architecture/ports_purity_test.go
+++ b/test/architecture/ports_purity_test.go
@@ -91,6 +91,57 @@ func TestMCPPackage_NoAdapterOrAppImports(t *testing.T) {
 	assertNoForbiddenImports(t, pkgRoot, banned)
 }
 
+// TestCaddyAdapter_NoPeerAdapterImports asserts that no non-test Go file under
+// internal/adapters/caddy/ imports any peer adapter package (i.e. any path
+// matching internal/adapters/ other than internal/adapters/caddy itself).
+//
+// This guards the ADR-092 invariant: Caddy handler modules must receive their
+// dependencies via RuntimeServices, not by directly constructing sibling adapters.
+func TestCaddyAdapter_NoPeerAdapterImports(t *testing.T) {
+	const (
+		moduleRoot  = "github.com/vibewarden/vibewarden/"
+		pkgRoot     = "internal/adapters/caddy"
+		caddyPkg    = moduleRoot + "internal/adapters/caddy"
+		adapterBase = moduleRoot + "internal/adapters/"
+	)
+
+	sentinel, err := build.Default.Import("github.com/vibewarden/vibewarden/internal/ports", "", build.FindOnly)
+	if err != nil {
+		t.Fatalf("locating module root via internal/ports: %v", err)
+	}
+	moduleRootDir := filepath.Dir(filepath.Dir(sentinel.Dir))
+	targetDir := filepath.Join(moduleRootDir, filepath.FromSlash(pkgRoot))
+
+	fset := token.NewFileSet()
+
+	walkErr := filepath.WalkDir(targetDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		f, parseErr := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if parseErr != nil {
+			t.Errorf("parsing %s: %v", path, parseErr)
+			return nil
+		}
+
+		for _, imp := range f.Imports {
+			importPath := strings.Trim(imp.Path.Value, `"`)
+			if strings.HasPrefix(importPath, adapterBase) && !strings.HasPrefix(importPath, caddyPkg) {
+				rel, _ := filepath.Rel(targetDir, path)
+				t.Errorf("%s/%s imports peer adapter %q — forbidden by ADR-092", pkgRoot, rel, importPath)
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walking %s: %v", pkgRoot, walkErr)
+	}
+}
+
 // assertNoForbiddenImports walks pkgRoot (relative to the repo root resolved
 // via go/build), parses every non-test .go file, and fails the test for each
 // import that has any of the forbidden prefixes.


### PR DESCRIPTION
Closes #1102

## Summary

- **New port**: `ports.CircuitBreakerFactory` appended to `internal/ports/circuit_breaker.go` — mirrors the existing `RateLimiterFactory` pattern.
- **New adapter**: `InMemoryCircuitBreakerFactory` in `internal/adapters/resilience/circuit_breaker_factory.go` implementing the new port.
- **New registry**: `RuntimeServices` struct + `atomic.Pointer` registry in `internal/adapters/caddy/runtime_services.go` with exported `SetRuntimeServices` setter and unexported `currentServices()` accessor.
- **8 handlers refactored**: `admin_auth`, `maintenance`, `ratelimit`, `retry`, `webhook_signature`, `timeout`, `circuit_breaker`, `ipfilter` — each gains `ProvisionWith(RuntimeServices)` that tests call directly; `Provision` forwards via `currentServices()`.
- **Composition root wired**: `cmd/vibewarden/wiring_serve_helpers.go` gains `buildRuntimeServices` building an audit JSON writer (stdout), `RateLimiterFactory`, and `CircuitBreakerFactory`; `wiring_serve.go` calls `SetRuntimeServices` before `adapter.Start`.
- **Bug fixed**: audit events from `AdminAuthHandler`, `RateLimitHandler`, `CircuitBreakerHandler`, `IPFilterHandler` previously written to `io.Discard` now reach the operator's stdout JSON sink.
- **Architecture test**: `TestCaddyAdapter_NoPeerAdapterImports` in `test/architecture/ports_purity_test.go` enforces the ADR-092 invariant going forward.

## Test plan

- `make check` passes locally (golangci-lint 0 issues, all tests green including `-race`).
- `grep -rn "internal/adapters/(audit|log|ratelimit|resilience)" internal/adapters/caddy/ | grep -v _test.go` returns empty.
- New regression tests in `ipfilter_audit_test.go`, `circuit_breaker_handler_test.go`, `ratelimit_handler_test.go` verify events reach the wired spy sink (not io.Discard).
- `TestCaddyAdapter_NoPeerAdapterImports` catches any future peer-adapter imports in caddy handler production files.