### PR TITLE
chore(#1137): codify artifact policy in CLAUDE.md (no middle-ground artifacts)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ their domain registrar, AWS ACM, etc.
 - **Functional where Go allows**: prefer pure functions, immutable value objects,
   explicit error handling over panics.
 - **No global state**: everything passed via dependency injection.
+- **Artifact policy: real or pure-instruction, never example-shaped.** Every artifact vibew produces is either (a) **real** — validated, kept current, owned by vibew (the merged `vibewarden.yaml` inside the bundle, the deterministic `docker-compose.yml`, the cert files); or (b) **pure instruction** — documented in `AGENTS-VIBEWARDEN.md` or `docs/` as a contract or checklist the agent satisfies (the Dockerfile contract, the deploy recipe). Forbidden: example-shaped middle-ground artifacts that read like real code but rot — placeholder Dockerfiles, commented-out config stanzas, mostly-correct shell scripts. Stale generated content teaches agents the wrong thing; a sharp spec lets them get it right against current reality. Surfaced by the qr-dali deploy retro on v0.17.0.
 
 ### Directory layout
 


### PR DESCRIPTION
## Summary

Adds a single bullet to `CLAUDE.md` §Architecture principles: **Artifact policy: real or pure-instruction, never example-shaped.**

The principle was surfaced by the qr-dali deploy retro on v0.17.0. Saved at `~/notes/vibewarden/retro-0.17.0.md`. The retro flagged five separate friction points (placeholder Dockerfile, commented-out production.yaml stubs, mostly-correct `deploy.sh`, mostly-accurate `vibew status`, decorative `vibew validate`) that all reduce to the same root cause: middle-ground artifacts rot and teach agents the wrong thing.

## Why CLAUDE.md and not an ADR

#1137 originally proposed an ADR. On reflection, this is a **UX/DX policy**, not an architectural decision about code structure. ADRs in this project govern HOW vibew is built (port purity, deploy mechanism, image health policy, Caddy DI). The "no middle-ground artifacts" rule is about WHAT vibew produces for users — that fits alongside the existing CLAUDE.md principles ("always latest stable deps", "no global state", "minimum 80% coverage on domain/app").

CLAUDE.md is also already loaded into every agent's context, whereas an ADR is consulted only when explicitly cited. For a principle that should constrain every future generation/scaffold decision, CLAUDE.md is the more reliable home.

## What this unlocks

This bullet is the citable rationale for the slate of follow-ups under `epic:retro-0.17.0`:

- #1138 — drop `deploy.sh`; bundle README carries the deploy recipe.
- #1139 — stop generating placeholder Dockerfile; tighten contract.
- #1140 — `vibew doctor` / `lint` validates Dockerfile against contract.
- #1141 — image-name resolution truthfulness.
- #1142 — bundle warns on shipping `.credentials` / `.env`.
- #1143 — `vibew status` distinguishes informational from broken state.
- #1144 — `vibew validate` catches real failures or drops.
- #1145 — empty out `vibewarden.production.yaml` commented stubs.
- #1146 — STALE warning content-based, not mtime-based.
- #1147–#1151 — surface trim items.

After merge, those issues' bodies will be edited to anchor on `CLAUDE.md §Architecture principles → Artifact policy` instead of `#1137`.

## Test plan

- [x] `make check` passes (docs-only change; no code touched)
- [x] Diff is one bullet inside the existing `## Architecture principles` list

Closes #1137.