### PR TITLE
chore: tighten dev agent prompt — prevent orphan ADR files, ban git add .

### DIFF
--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -13,7 +13,7 @@ hexagonal architecture and DDD patterns.
 
 1. **Read everything first**:
    - `CLAUDE.md` — code style, architecture rules, testing requirements
-   - `DECISIONS.md` — all ADRs, especially the one for this issue
+   - `decisions/README.md` — ADR index. Read the ADR(s) the architect cited for this issue from `decisions/adr-NNN-*.md`. (`DECISIONS.md` at repo root is a PM scratch log; ignore it.)
    - The GitHub issue and all its comments:
      ```bash
      gh issue view <number> --repo vibewarden/vibewarden --comments
@@ -40,32 +40,44 @@ hexagonal architecture and DDD patterns.
 
 5. **Verify**:
    ```bash
-   go build ./...
-   go test ./...
-   go vet ./...
+   make check
    ```
-   Do not open a PR if any of these fail.
+   `make check` is the canonical pre-PR gate (gofmt, goimports, golangci-lint, go test). Do not open a PR if it fails.
 
-6. **Commit** — conventional commits:
+6. **Catch orphan files BEFORE commit** — the architect may have created files (commonly a new ADR under `decisions/adr-NNN-*.md`, or a design note). These will not be picked up by editing tracked files. Run:
    ```bash
-   git add .
+   git status --short | grep '^??'
+   ```
+   For every untracked file that belongs in the PR (especially anything under `decisions/`, `internal/ports/`, `internal/domain/`, or new test fixtures the architect referenced), `git add <path>` it explicitly. **Do NOT use `git add .` or `git add -A`** — those silently grab agent-scratch directories like `.claude/worktrees/`, `.claude/designs/`, `.claude/scheduled_tasks.lock`. Add files by path.
+
+   **ADR orphan check (mandatory if architect wrote any ADR):**
+   ```bash
+   git status --short | grep '^??' | grep -E 'decisions/adr-[0-9]'
+   ```
+   Must return empty AFTER you have added the architect's ADR file. If the architect's note references "ADR-NNN" but the file is missing from the staged set, you have orphaned it — past incident, see #1118 (ADR-090) and #1130 (ADR-092).
+
+   If a new ADR was added, also update `decisions/README.md` index in the correct sort order before committing.
+
+7. **Commit** — conventional commits:
+   ```bash
    git commit -m "feat(#<number>): <description>"
    ```
 
-7. **Push and open PR**:
+8. **Push and open PR**:
    ```bash
    git push origin feat/<issue-number>-<short-slug>
    gh pr create \
      --repo vibewarden/vibewarden \
      --title "feat(#<number>): <description>" \
-     --body "Closes #<number>\n\n## Summary\n<what you built>\n\n## Test plan\n<how to verify>" \
-     --label "status:review"
+     --body "Closes #<number>\n\n## Summary\n<what you built>\n\n## Test plan\n<how to verify>"
    ```
 
-8. **Set issue status**:
+9. **Set status via labels** (not comments):
    ```bash
-   gh issue comment <number> --repo vibewarden/vibewarden --body "Status: READY_FOR_REVIEW\nPR: <pr-url>"
+   gh issue edit <number> --remove-label "status:ready-for-dev" --add-label "status:ready-for-review"
+   gh pr edit <pr-number> --add-label "status:ready-for-review"
    ```
+   Labels are the source of truth for pipeline state. Do not post status comments.
 
 ## Code quality rules
 


### PR DESCRIPTION
## Summary

Tightens `.claude/agents/dev.md` to prevent two patterns that bit us this week.

### 1. Orphan ADR files

Twice in 4 days, an architect-written ADR shipped only on a local working tree:

- **#1118** wrote ADR-090 → never committed → release notes 404'd → recovered in #1124.
- **#1130** wrote ADR-092 → never committed → release notes 404'd → recovered in #1134.

Root cause: dev runs `git add .` from a working dir that missed the new file (architect wrote into `decisions/`, dev was editing in `internal/`).

### 2. `.claude/` agent scratch silently committed via `git add -A`

The PM and architect agents drop scratch into `.claude/worktrees/`, `.claude/designs/`, and `.claude/scheduled_tasks.lock`. A blanket `git add .` from the repo root would sweep them in.

## What changed in `.claude/agents/dev.md`

- Replace `git build/test/vet` chain with `make check` (the canonical pre-PR gate per `feedback_make_check.md` standing rule).
- Add an explicit "catch orphan files BEFORE commit" step with discovery via `git status --short | grep '^??'` and an ADR-specific invariant: `git status --short | grep '^??' | grep -E 'decisions/adr-[0-9]'` MUST return empty after the architect's ADR is staged. References the two incidents so future agents understand the stakes.
- Forbid `git add .` and `git add -A`; require explicit-path adds.
- Replace the old `Status: READY_FOR_REVIEW` comment pattern with `gh issue edit --add-label status:ready-for-review` — labels are the source of truth per CLAUDE.md §Status tracking. Pre-aligns with the upcoming pure-status comment cleanup sweep.
- Fix stale ref: `DECISIONS.md` → `decisions/README.md` (per the standing rule that the index lives at `decisions/README.md` and `DECISIONS.md` is a PM scratch log).

## Test plan

- [x] Diff is contained to `.claude/agents/dev.md`
- [x] Process change only — no code, no tests affected
- [x] `make check` passes (no-op for this PR)

## Out of scope

- Updating the other agent prompts (architect, PM, reviewer, writer). Those have similar issues and will get their own pass; flagging here so future-us doesn't forget.