### PR TITLE
fix(#1141): bundle uses cwd-basename when name: unset; --build agrees on the tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`vibew bundle` no longer ignores the cwd-basename fallback for project name** (#1141, [ADR-093](decisions/adr-093-bundle-image-name-cwd-basename-fallback.md)). With no `name:` field set, `vibew bundle` and `vibew bundle --build` now both look for `<dirname>-app:latest`, matching the documented behavior. Previously `vibew bundle` resolved the image tag via `cfg.ComposeProjectName()` which silently fell through to the literal `"vibewarden"` when `ProjectRoot` was not populated by the loader, while `vibew bundle --build` correctly derived the cwd-basename — two different names from the same input. `deriveProjectName` is now the single project-name authority inside `runBundle`; its result is fed to both the image-tag default and the `--build` step.
+
 ### Changed
 
 - **`vibew init` no longer generates a placeholder `Dockerfile` or `.dockerignore`** (#1139). `AGENTS-VIBEWARDEN.md` now carries a Dockerfile contract checklist; agents and users write their own Dockerfile against that contract. Migration: existing projects that already have a Dockerfile are unaffected. New projects must write a Dockerfile after `vibew init` — see `AGENTS-VIBEWARDEN.md` §Dockerfile contract.

--- a/decisions/adr-093-bundle-image-name-cwd-basename-fallback.md
+++ b/decisions/adr-093-bundle-image-name-cwd-basename-fallback.md
@@ -1,0 +1,257 @@
+# ADR-093: bundle image-name resolution — cwd-basename fallback unified across `vibew bundle` and `--build`
+
+**Date**: 2026-04-23
+**Issue**: #1141
+**Status**: Accepted
+
+## Context
+
+`vibew bundle` and `vibew bundle --build` walk different project-name
+derivation chains when neither `name:` nor `app.image:` is set in
+`vibewarden.yaml`:
+
+- **`runBundle`** computes the image tag default at `bundle.go:192` as
+  `cfg.ComposeProjectName() + "-app:latest"`. `ComposeProjectName()` chains
+  `Name → App.Image → ProjectRoot → "vibewarden"`. `LoadRaw` (the loader used
+  by `vibew bundle`) never populates `ProjectRoot`, so step 3 silently fails
+  and the chain returns the literal `"vibewarden"`. Result: `imageTag =
+  "vibewarden-app:latest"`.
+
+- **`BuildService.resolveImageTag`** (in `internal/app/ops/build.go`) has a
+  defensive guard: when `ComposeProjectName()` returns `"vibewarden"` it
+  falls through to `filepath.Base(workDir)`. Result: `--build` builds
+  `qr-dali-app:latest`.
+
+Two derivation chains produce two different names from the same input,
+breaking ADR-089's "single source of truth" invariant.
+
+PM (#1141) selected **Option A — fix the derivation chain** so both code
+paths use cwd-basename fallback. Option B (mandatory `name:`) is rejected.
+
+PM placed **out of scope**: setting `cfg.ProjectRoot` inside `LoadRaw`. This
+constrains the architect to fix the bug at the **leaf** (pipe a single
+derived name into both call sites) rather than at the source (mutate the
+load path).
+
+`deriveProjectName` already resolves the correct cwd-basename fallback via
+`bundleapp.ProjectNameFromConfig(absConfig)` and is run through
+`sanitiseProjectName`. Its result is currently only used for
+`BundleOptions.ProjectName`, not for `imageTag` or `BuildService`. The fix
+is to make `deriveProjectName` the single source of truth for the project
+name within `runBundle` and feed it to every downstream consumer.
+
+## Decision
+
+`deriveProjectName(cfg, absConfig)` becomes the **single project-name
+authority** inside `runBundle`. Its result is used to:
+
+1. compute the default `imageTag` (`"<projectName>-app:latest"`) when
+   `--image-tag` is not supplied; and
+2. drive the `--build` step so `BuildService` resolves the same tag.
+
+`BuildService` gains an optional explicit `ImageTag` (or `ProjectName`)
+input on `BuildOptions` so the caller can pin the tag without re-running
+the chain inside `resolveImageTag`. When `ImageTag` is set on
+`BuildOptions`, `resolveImageTag` returns it verbatim. Otherwise the
+existing chain runs (preserving behavior for `vibew build` invoked
+standalone, where `runBundle` is not on the call stack).
+
+### Domain model changes
+
+None. This is a use-case-layer fix.
+
+### Ports (interfaces)
+
+No new ports. `ports.DockerBuilder` and `ports.DockerShellProber` are
+unchanged.
+
+### Adapters
+
+No adapter changes.
+
+### Application service
+
+`internal/app/ops/build.go::BuildService.Run` currently calls
+`resolveImageTag(cfg, workDir)`. Change:
+
+- Add `ImageTag string` field to `BuildOptions` (godoc: "Pre-resolved image
+  tag. When non-empty, BuildService skips its own derivation and uses this
+  tag verbatim. Callers that have already resolved the project name (e.g.
+  `vibew bundle --build`) pass it here so the build step matches the
+  bundle's image lookup. When empty, the existing config/workdir chain
+  runs.").
+- In `Run`, prefer `opts.ImageTag` when non-empty; otherwise call
+  `resolveImageTag(cfg, workDir)` as today.
+
+`runBundle` (`internal/cli/cmd/bundle.go`) changes:
+
+- Compute `projectName := deriveProjectName(cfg, absConfig)` (already done
+  at line 190 — keep it).
+- Replace lines 191–193 with:
+  ```go
+  if imageTag == "" {
+      imageTag = projectName + "-app:latest"
+  }
+  ```
+  This drops the `cfg.ComposeProjectName()` call entirely from the bundle
+  path. `deriveProjectName` already chains `Name → App.Image →
+  ProjectNameFromConfig` and sanitises every step.
+- In the `if build {}` block (lines 200–211) pass `ImageTag: imageTag` on
+  the `BuildOptions` struct so the build step uses the same tag.
+
+### File layout
+
+No new files. Edits only:
+
+- `/Users/tibtof/workspace/vibewarden/internal/app/ops/build.go`
+  - Add `ImageTag string` to `BuildOptions`.
+  - Branch in `Run` to prefer `opts.ImageTag`.
+  - Update godoc on `resolveImageTag` to note that callers with a
+    pre-resolved tag should set `BuildOptions.ImageTag`.
+- `/Users/tibtof/workspace/vibewarden/internal/cli/cmd/bundle.go`
+  - Use `projectName` (already computed) to build the default `imageTag`.
+  - Set `BuildOptions.ImageTag = imageTag` in the `--build` branch.
+- `/Users/tibtof/workspace/vibewarden/internal/app/ops/build_test.go` (or
+  equivalent existing test file) — extend tests for the new
+  `ImageTag` short-circuit.
+- `/Users/tibtof/workspace/vibewarden/internal/cli/cmd/bundle_test.go` (or
+  the existing `internal/app/bundle/` tests) — table-driven case for
+  `imageTag` resolution covering `name:` set, `app.image:` set, and
+  cwd-basename fallback.
+- `/Users/tibtof/workspace/vibewarden/internal/config/templates/agents-vibewarden.md.tmpl`
+- `/Users/tibtof/workspace/vibewarden/docs/examples/AGENTS-VIBEWARDEN.md`
+  - Correct fallback description: `name:` field → `app.image:` strip → cwd
+    directory basename. State `name:` is optional in the common case.
+- `/Users/tibtof/workspace/vibewarden/CHANGELOG.md`
+  - `[Unreleased] ### Fixed` entry per PM acceptance criterion.
+- New regression test (described below).
+
+### Sequence
+
+1. User runs `vibew bundle` in `/path/to/qr-dali` with no `name:` set.
+2. `runBundle` calls `config.LoadRaw(absConfig)` → `cfg` is returned with
+   `cfg.Name == ""`, `cfg.App.Image == ""`, `cfg.ProjectRoot == ""`.
+3. `runBundle` calls `projectName := deriveProjectName(cfg, absConfig)`.
+   - Step 1 (cfg.Name) → empty, skip.
+   - Step 2 (cfg.App.Image) → empty, skip.
+   - Step 3 → `ProjectNameFromConfig(absConfig)` returns `qr-dali` (sanitised).
+4. `runBundle` defaults `imageTag = projectName + "-app:latest"` = `qr-dali-app:latest`.
+5. `runBundle` passes `BundleOptions.ProjectName = projectName`, the bundle
+   service writes `IMAGE=qr-dali-app:latest` into `sample.env` / `.env`.
+
+For `vibew bundle --build`:
+
+1. Same steps 1–4.
+2. `runBundle` constructs `BuildOptions{Platform, ConfigPath, ImageTag:
+   imageTag}` and calls `BuildService.Run(ctx, cfg, opts, out)`.
+3. `BuildService.Run` sees `opts.ImageTag != ""` and uses `qr-dali-app:latest`
+   verbatim, skipping `resolveImageTag`.
+4. `docker build` runs with tag `qr-dali-app:latest`, matching the bundle
+   lookup byte-for-byte.
+
+For standalone `vibew build` (unrelated to this bug, but invariant
+preserved):
+
+1. `vibew build` does NOT pre-resolve a tag; it calls `BuildService.Run`
+   with `opts.ImageTag == ""`.
+2. `resolveImageTag` runs its existing chain (cfg → workDir base) — no
+   behavior change.
+
+### Error cases
+
+- `deriveProjectName` returns the empty string only when `absConfig`
+  itself is unusable (`ProjectNameFromConfig` returns empty AND `cfg.Name`
+  / `cfg.App.Image` are empty). `runBundle` should treat empty
+  `projectName` as a hard error: `"cannot derive project name from
+  configuration path %q"` and abort before any file is written. Without
+  this guard the image tag would default to `"-app:latest"` (a Docker
+  syntax error). Today the guard is implicit through Compose's last-resort
+  `"vibewarden"` literal — removing the literal removes the implicit
+  guard, so the explicit one must be added.
+- All other error paths are unchanged. `BuildService.Run` errors continue
+  to wrap as `"building image: %w"`.
+
+### Test strategy
+
+**Unit tests (table-driven, no mocks needed):**
+
+1. `internal/cli/cmd/bundle_test.go` (or new file) —
+   `TestRunBundle_ImageTagDerivation` table:
+   - `name: myapp` set → `myapp-app:latest`.
+   - `app.image: ghcr.io/org/myapp:latest` set, no `name:` → `myapp-app:latest`.
+   - Neither set, cwd basename `qr-dali` → `qr-dali-app:latest`.
+   - Neither set, cwd basename contains adversarial chars (`my; rm` ) →
+     sanitised tag (covered by existing
+     `TestDeriveProjectName_SanitisesAdversarialInput`; ensure unchanged).
+2. `internal/app/ops/build_test.go` —
+   `TestBuildService_Run_UsesPreResolvedImageTag`: when
+   `BuildOptions.ImageTag` is set, the recorded tag passed to the
+   `DockerBuilder` mock equals it byte-for-byte regardless of `cfg`
+   contents. Reuses existing fake builder.
+3. `internal/config/config_test.go` —
+   `TestComposeProjectName_FallsBackToVibewardenWhenProjectRootEmpty`:
+   document current behavior (returns `"vibewarden"` when all sources
+   empty). This is a guard test, not a behavior change. It pins the fact
+   that `ComposeProjectName()` is NOT the right authority for `runBundle`
+   without a populated `ProjectRoot`.
+
+**Integration test (the regression test PM asked for):**
+
+`internal/cli/cmd/bundle_integration_test.go` (or
+`test/integration/bundle_image_name_test.go`):
+
+- `TestVibewBundle_DerivesImageTagFromCwdBasename`:
+  1. `t.TempDir()` → rename or create subdir `qr-dali`.
+  2. Write a minimal `vibewarden.yaml` with no `name:`, no `app.image:`.
+  3. Invoke `runBundle` (or the cobra command) with `--skip-image`.
+  4. Assert the generated `sample.env` (and `.env`) contains
+     `IMAGE=qr-dali-app:latest`.
+- `TestVibewBundleBuild_TagMatchesBundleLookup`:
+  1. Same temp setup.
+  2. Inject a fake `DockerBuilder` (via the existing test seam if
+     available, otherwise via a constructor override) that records the
+     `(tag, workDir, platform)` triple.
+  3. Invoke `runBundle` with `--build`.
+  4. Assert the recorded build tag equals `qr-dali-app:latest` AND equals
+     the `IMAGE=` line in the generated env files.
+- Both tests are `qr-dali` so the failure mode named in the retro
+  reproduces directly.
+
+Existing `TestDeriveProjectName_SanitisesAdversarialInput` must continue
+to pass unchanged.
+
+### New dependencies
+
+None.
+
+## Consequences
+
+**Positive.**
+
+- `vibew bundle` and `vibew bundle --build` produce identical image tags
+  by construction, not by coincidence. The two-chain divergence is
+  eliminated.
+- `name:` remains optional, matching the ergonomic goal of #1144 / #1145.
+- `BuildService` becomes more testable: callers can pin the tag, removing
+  hidden dependence on `cfg.ComposeProjectName()` for callers that have
+  already resolved the name.
+- Standalone `vibew build` behavior is preserved (no flag-day for users
+  invoking `vibew build` directly).
+
+**Negative / trade-offs.**
+
+- `BuildOptions` grows a field. Mitigated by clear godoc and the explicit
+  short-circuit in `Run`.
+- `cfg.ComposeProjectName()` continues to return `"vibewarden"` in the
+  load path, which is a latent bug for any future caller that
+  re-introduces it without populating `ProjectRoot`. PM scoped the source
+  fix out; we accept the risk and document it in the new
+  `TestComposeProjectName_FallsBackToVibewardenWhenProjectRootEmpty` guard
+  test, which makes the misbehavior visible if anyone adds a new
+  consumer.
+
+**Future work (not in this issue).**
+
+- Track a follow-up to populate `cfg.ProjectRoot` inside `LoadRaw` (the
+  source fix). Once that lands, `ComposeProjectName()` becomes a valid
+  authority and `BuildOptions.ImageTag` can be removed if desired.

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -121,16 +121,16 @@ warning is raised). `vibew status` surfaces the same TLS state in its output tab
 
 ## Image tag convention
 
-`vibew build` tags the image as `<project>-app:latest`. The project name is
-resolved in this order:
+`vibew build` and `vibew bundle` tag the image as `<project>-app:latest`. The
+project name is resolved in this order:
 
-1. `name` field in vibewarden.yaml (explicit)
+1. `name` field in vibewarden.yaml (explicit) — optional in the common case
 2. `app.image` with registry prefix and tag stripped (e.g. `ghcr.io/org/myapp:latest` → `myapp`)
-3. Directory name containing vibewarden.yaml (fallback)
+3. Directory name containing vibewarden.yaml (cwd-basename fallback)
 
 For example, a project in `~/code/mysite` with no explicit `name` produces the
-image `mysite-app:latest`. This tag must match what Docker Compose expects for
-the app service.
+image `mysite-app:latest`. `vibew bundle` and `vibew bundle --build` both use
+this chain, so the bundle lookup and the build step always agree on the tag.
 
 ## TLS configuration keys
 

--- a/internal/app/ops/build.go
+++ b/internal/app/ops/build.go
@@ -50,6 +50,14 @@ type BuildOptions struct {
 	// WorkDir is the directory used both as the Docker build context and as
 	// the fallback source of the image name. Defaults to "." when empty.
 	WorkDir string
+
+	// ImageTag is a pre-resolved Docker image tag. When non-empty,
+	// BuildService skips its own derivation chain (resolveImageTag) and
+	// uses this value verbatim. Callers that have already resolved the
+	// project name (e.g. vibew bundle --build, via deriveProjectName)
+	// pass it here so the build step matches the bundle's image lookup
+	// byte-for-byte. When empty, the existing config/workdir chain runs.
+	ImageTag string
 }
 
 // Run executes the docker build command.
@@ -62,9 +70,17 @@ func (s *BuildService) Run(ctx context.Context, cfg *config.Config, opts BuildOp
 		workDir = "."
 	}
 
-	tag, err := resolveImageTag(cfg, workDir)
-	if err != nil {
-		return fmt.Errorf("resolving image tag: %w", err)
+	var tag string
+	if opts.ImageTag != "" {
+		// Caller has already resolved the project name; use it verbatim so
+		// the build step and the bundle lookup always agree on the tag.
+		tag = opts.ImageTag
+	} else {
+		var err error
+		tag, err = resolveImageTag(cfg, workDir)
+		if err != nil {
+			return fmt.Errorf("resolving image tag: %w", err)
+		}
 	}
 
 	fmt.Fprintf(out, "Building Docker image: %s\n", tag)
@@ -113,12 +129,17 @@ func (s *BuildService) probeShell(ctx context.Context, image string, out io.Writ
 
 // resolveImageTag returns the Docker image tag for the build.
 // The tag must match what docker-compose expects for the app service so that
-// `vibew build` followed by `vibew dev` or `vibew deploy` finds the image.
+// `vibew build` followed by `vibew dev` finds the image.
 //
 // Docker Compose names built images as "<project>-<service>:latest". Since the
 // app service is always called "app", the expected image name is
 // "<ComposeProjectName>-app:latest". This function uses the same derivation
 // logic as the deploy bundle to ensure consistency.
+//
+// Callers that have already resolved the project name (e.g. runBundle via
+// deriveProjectName) should set BuildOptions.ImageTag instead of relying on
+// this function. That ensures the build step and the bundle lookup always
+// use the same tag without re-running the derivation chain.
 //
 // Priority:
 //  1. cfg.ComposeProjectName() + "-app:latest" when cfg is non-nil and has a

--- a/internal/app/ops/build_test.go
+++ b/internal/app/ops/build_test.go
@@ -340,6 +340,59 @@ func TestBuildService_ShellProber_NilProber_NoWarning(t *testing.T) {
 	}
 }
 
+// TestBuildService_Run_UsesPreResolvedImageTag verifies that when
+// BuildOptions.ImageTag is set the BuildService uses it verbatim and does NOT
+// run its own resolveImageTag chain. This is the ADR-093 short-circuit that
+// lets vibew bundle --build pass the already-resolved tag so the build step
+// and the bundle lookup always agree.
+func TestBuildService_Run_UsesPreResolvedImageTag(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *config.Config
+		preResolved string
+		wantTag     string
+	}{
+		{
+			name:        "pre-resolved tag wins over cfg.Name",
+			cfg:         &config.Config{Name: "other-name"},
+			preResolved: "qr-dali-app:latest",
+			wantTag:     "qr-dali-app:latest",
+		},
+		{
+			name:        "pre-resolved tag wins over cfg.App.Image",
+			cfg:         &config.Config{App: config.AppConfig{Image: "ghcr.io/org/myapp:v1"}},
+			preResolved: "qr-dali-app:latest",
+			wantTag:     "qr-dali-app:latest",
+		},
+		{
+			name:        "pre-resolved tag wins when cfg is nil",
+			cfg:         nil,
+			preResolved: "qr-dali-app:latest",
+			wantTag:     "qr-dali-app:latest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fb := &fakeBuilder{}
+			svc := ops.NewBuildService(fb)
+
+			var out bytes.Buffer
+			err := svc.Run(context.Background(), tt.cfg, ops.BuildOptions{
+				WorkDir:  ".",
+				ImageTag: tt.preResolved,
+			}, &out)
+			if err != nil {
+				t.Fatalf("Run() unexpected error: %v", err)
+			}
+
+			if fb.capturedTag != tt.wantTag {
+				t.Errorf("tag = %q, want %q", fb.capturedTag, tt.wantTag)
+			}
+		})
+	}
+}
+
 // TestBuildService_Run_ImageNameMatchesComposeProjectName verifies that the
 // image tag produced by `vibew build` matches what docker-compose expects:
 // <ComposeProjectName>-app:latest.

--- a/internal/cli/cmd/bundle.go
+++ b/internal/cli/cmd/bundle.go
@@ -188,8 +188,11 @@ func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, o
 	}
 
 	projectName := deriveProjectName(cfg, absConfig)
+	if projectName == "" {
+		return 1, fmt.Errorf("cannot derive project name from configuration path %q", absConfig)
+	}
 	if imageTag == "" {
-		imageTag = cfg.ComposeProjectName() + "-app:latest"
+		imageTag = projectName + "-app:latest"
 	}
 	if targetPlatform == "" {
 		targetPlatform = "linux/amd64"
@@ -204,6 +207,7 @@ func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, o
 		buildOpts := opsapp.BuildOptions{
 			Platform:   targetPlatform,
 			ConfigPath: absConfig,
+			ImageTag:   imageTag,
 		}
 		if err := buildSvc.Run(cmd.Context(), cfg, buildOpts, cmd.OutOrStdout()); err != nil {
 			return 1, fmt.Errorf("building image: %w", err)

--- a/internal/cli/cmd/bundle_test.go
+++ b/internal/cli/cmd/bundle_test.go
@@ -353,6 +353,91 @@ func TestBundleCmd_DotEnvPreserved(t *testing.T) {
 	}
 }
 
+// TestRunBundle_ImageTagDerivation is the ADR-093 regression test.
+// It verifies that the image tag written into sample.env/.env matches
+// the project name derived by deriveProjectName for all three derivation paths:
+// explicit name:, app.image: strip, and cwd-basename fallback.
+func TestRunBundle_ImageTagDerivation(t *testing.T) {
+	tests := []struct {
+		name        string
+		yaml        string
+		dirName     string // subdirectory to run bundle in (cwd basename)
+		wantImageIn string // expected IMAGE= prefix in sample.env
+	}{
+		{
+			name:        "explicit name: takes precedence",
+			yaml:        "name: myapp\nserver:\n  port: 8080\nupstream:\n  port: 3000\n",
+			dirName:     "qr-dali",
+			wantImageIn: "VIBEWARDEN_APP_IMAGE=myapp-app:latest",
+		},
+		{
+			name:        "app.image: strip wins when name: unset",
+			yaml:        "server:\n  port: 8080\nupstream:\n  port: 3000\napp:\n  image: ghcr.io/org/webapp:v2\n",
+			dirName:     "qr-dali",
+			wantImageIn: "VIBEWARDEN_APP_IMAGE=webapp-app:latest",
+		},
+		{
+			name:        "cwd-basename fallback when name: and app.image: both unset",
+			yaml:        "server:\n  port: 8080\nupstream:\n  port: 3000\n",
+			dirName:     "qr-dali",
+			wantImageIn: "VIBEWARDEN_APP_IMAGE=qr-dali-app:latest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := t.TempDir()
+			projDir := filepath.Join(base, tt.dirName)
+			if err := os.MkdirAll(projDir, 0o750); err != nil {
+				t.Fatalf("mkdir %s: %v", projDir, err)
+			}
+			// Write scaffolding marker and config.
+			writeScaffoldingMarker(t, projDir)
+			if err := os.WriteFile(filepath.Join(projDir, "vibewarden.yaml"), []byte(tt.yaml), 0o644); err != nil {
+				t.Fatalf("writing vibewarden.yaml: %v", err)
+			}
+
+			// chdir into the project so bundle can find ./vibewarden.yaml.
+			origDir, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("getwd: %v", err)
+			}
+			if err := os.Chdir(projDir); err != nil {
+				t.Fatalf("chdir %s: %v", projDir, err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+			outDir := filepath.Join(projDir, "out")
+			root := cmd.NewRootCmd("test")
+			root.SetArgs([]string{"bundle", "--output", outDir, "--skip-image"})
+			var out bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&out)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("bundle: %v\noutput:\n%s", err, out.String())
+			}
+
+			// Check sample.env.
+			sampleEnv, err := os.ReadFile(filepath.Join(outDir, "sample.env"))
+			if err != nil {
+				t.Fatalf("reading sample.env: %v", err)
+			}
+			if !bytes.Contains(sampleEnv, []byte(tt.wantImageIn)) {
+				t.Errorf("sample.env missing %q\ngot:\n%s", tt.wantImageIn, sampleEnv)
+			}
+
+			// Check .env.
+			dotEnv, err := os.ReadFile(filepath.Join(outDir, ".env")) //nolint:gosec // test file
+			if err != nil {
+				t.Fatalf("reading .env: %v", err)
+			}
+			if !bytes.Contains(dotEnv, []byte(tt.wantImageIn)) {
+				t.Errorf(".env missing %q\ngot:\n%s", tt.wantImageIn, dotEnv)
+			}
+		})
+	}
+}
+
 func TestBundleCmd_Overwrite_ReplacesDotEnv(t *testing.T) {
 	dir := setupBundleProject(t)
 	outDir := filepath.Join(dir, "out")

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -145,16 +145,16 @@ Key rules:
 
 ## Image tag convention
 
-`vibew build` tags the image as `<project>-app:latest`. The project name is
-resolved in this order:
+`vibew build` and `vibew bundle` tag the image as `<project>-app:latest`. The
+project name is resolved in this order:
 
-1. `name` field in vibewarden.yaml (explicit)
+1. `name` field in vibewarden.yaml (explicit) — optional in the common case
 2. `app.image` with registry prefix and tag stripped (e.g. `ghcr.io/org/myapp:latest` → `myapp`)
-3. Directory name containing vibewarden.yaml (fallback)
+3. Directory name containing vibewarden.yaml (cwd-basename fallback)
 
 For example, a project in `~/code/mysite` with no explicit `name` produces the
-image `mysite-app:latest`. This tag must match what Docker Compose expects for
-the app service.
+image `mysite-app:latest`. `vibew bundle` and `vibew bundle --build` both use
+this chain, so the bundle lookup and the build step always agree on the tag.
 
 ## TLS configuration keys
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3251,6 +3251,26 @@ func TestComposeProjectName_DifferentDirs(t *testing.T) {
 	}
 }
 
+// TestComposeProjectName_FallsBackToVibewardenWhenProjectRootEmpty is a guard
+// test that pins the latent misbehavior identified in ADR-093: when neither
+// cfg.Name, cfg.App.Image, nor cfg.ProjectRoot is set (the state produced by
+// config.LoadRaw), ComposeProjectName() returns the literal "vibewarden".
+//
+// This is NOT correct behavior for runBundle — it was the root cause of #1141.
+// The fix in ADR-093 makes deriveProjectName (not ComposeProjectName) the
+// authority inside runBundle. This test exists so that if a future developer
+// re-introduces ComposeProjectName() as the imageTag source without populating
+// ProjectRoot, the test makes the regression visible immediately.
+func TestComposeProjectName_FallsBackToVibewardenWhenProjectRootEmpty(t *testing.T) {
+	cfg := &config.Config{}
+	// ProjectRoot is intentionally not set — this mirrors the state returned
+	// by config.LoadRaw, which never populates ProjectRoot.
+	got := cfg.ComposeProjectName()
+	if got != "vibewarden" {
+		t.Errorf("ComposeProjectName() with empty sources = %q, want %q (guard test — see ADR-093)", got, "vibewarden")
+	}
+}
+
 func TestResolvedBuildContext(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
Closes #1141

## Summary

- `deriveProjectName` is now the single project-name authority inside `runBundle`. Previously `runBundle` computed `imageTag` via `cfg.ComposeProjectName()` which silently returned `"vibewarden"` when `ProjectRoot` was unpopulated by `LoadRaw` — producing `vibewarden-app:latest` regardless of the actual directory name.
- `imageTag` default is now `projectName + "-app:latest"` where `projectName` comes from `deriveProjectName`, which correctly chains `name:` → `app.image:` strip → cwd-basename fallback.
- Added explicit guard: `runBundle` returns an error if `deriveProjectName` returns empty (previously implicit via the `"vibewarden"` literal).
- `BuildOptions.ImageTag` added to `internal/app/ops/build.go`. When set, `BuildService.Run` uses it verbatim and skips `resolveImageTag`. `runBundle` passes `ImageTag: imageTag` in the `--build` branch so the build step and bundle lookup always agree byte-for-byte.
- Standalone `vibew build` behavior is unchanged — it calls `BuildService.Run` with `opts.ImageTag == ""`, so `resolveImageTag` runs as before.

## Test plan

- `TestRunBundle_ImageTagDerivation` (new, `internal/cli/cmd/bundle_test.go`) — table-driven: `name:` set, `app.image:` strip, cwd-basename fallback (`qr-dali`); asserts `VIBEWARDEN_APP_IMAGE=<expected>-app:latest` in both `sample.env` and `.env`.
- `TestBuildService_Run_UsesPreResolvedImageTag` (new, `internal/app/ops/build_test.go`) — when `BuildOptions.ImageTag` is set, the recorded builder tag equals it regardless of `cfg`.
- `TestComposeProjectName_FallsBackToVibewardenWhenProjectRootEmpty` (new, `internal/config/config_test.go`) — guard test pinning the latent `LoadRaw` misbehavior per ADR-093.
- `TestDeriveProjectName_SanitisesAdversarialInput` — existing, still passes.
- All 100+ package tests pass; `make check` passes including golangci-lint.