### PR TITLE
fix(#1146): bundle staleness uses content-hash, not mtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Fixed
 
+- **`vibew bundle` staleness check now uses content-hash, not mtime** (#1146, [ADR-089](decisions/adr-089-bundle-image-health-tag-scoping-freshness-arch.md) §Refinement). `touch vibewarden.yaml` (no content change) no longer triggers a false STALE warning. SHA-256 is computed over the same file set the existing staleness walker considers (same `.gitignore` / `.dockerignore` / `hardIgnoreDirs` rules). The digest is stored at `.vibewarden/.input-digest` after every successful bundle and auto-appended to the project `.gitignore`. First-run and corrupt-digest paths fall back to the existing mtime comparison — no flag-day on upgrade.
+
 - **`vibew bundle` no longer ignores the cwd-basename fallback for project name** (#1141, [ADR-093](decisions/adr-093-bundle-image-name-cwd-basename-fallback.md)). With no `name:` field set, `vibew bundle` and `vibew bundle --build` now both look for `<dirname>-app:latest`, matching the documented behavior. Previously `vibew bundle` resolved the image tag via `cfg.ComposeProjectName()` which silently fell through to the literal `"vibewarden"` when `ProjectRoot` was not populated by the loader, while `vibew bundle --build` correctly derived the cwd-basename — two different names from the same input. `deriveProjectName` is now the single project-name authority inside `runBundle`; its result is fed to both the image-tag default and the `--build` step.
 
 ### Changed

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -37,3 +37,13 @@ Each ADR is a standalone file at `decisions/adr-NNN-title.md`.
 - `vibew init` stdout gains "Write your Dockerfile (see AGENTS-VIBEWARDEN.md §Dockerfile contract)" as the first "Next steps" line.
 - `test/quickstart/test.sh` requires no changes (tests `vibew wrap`, not `vibew init`; no Dockerfile assertions present).
 - Open questions: none.
+
+### 2026-04-23 — #1146 bundle staleness content-hash spec finalised
+
+- Posted full spec as a PM comment on #1146 (https://github.com/VibeWarden/vibewarden/issues/1146#issuecomment-4323182386).
+- Status label set to `status:ready-for-arch`.
+- Core decision: replace mtime-vs-image-Created comparison with a SHA-256 content hash of all inputs the staleness walker already visits. Hash stored at `.vibewarden/.input-digest` (format: `sha256:<hex>`). Written on successful bundle completion only.
+- Migration: missing digest file falls back to mtime behavior; corrupt digest file treated as missing (debug log, no error). First post-upgrade bundle writes the file; subsequent runs use content-hash.
+- ADR-089 §Freshness invariant must be amended to reflect the content-hash approach.
+- `.vibewarden/.input-digest` must be gitignored (automatically or documented — architect decides).
+- Open questions: none. Hash algorithm, aggregation order, and exact file placement within `internal/app/bundle/` delegated to architect.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -65,6 +65,7 @@ once accepted, they are not edited. If a decision is superseded, a new ADR refer
 | [090](adr-090-le-rate-limit-preflight.md) | Let's Encrypt rate-limit preflight via Certificate Transparency | #1057 |
 | [091](adr-091-ports-hygiene-delete-dead-session-checker-adapter-move-outbound-ports.md) | Ports hygiene — delete dead SessionChecker adapter; move three outbound ports to `internal/ports/`; rename `AdminServerIface` | #1106, #1107 |
 | [092](adr-092-caddy-handler-dependency-injection.md) | Caddy handler dependency injection via composition-root-populated services registry | #1102 |
+| [093](adr-093-bundle-image-name-cwd-basename-fallback.md) | bundle image-name resolution — cwd-basename fallback unified across `vibew bundle` and `--build` | #1141 |
 | [497](adr-497-graceful-shutdown-connection-draining.md) | Graceful Shutdown / Connection Draining | — |
 
 ## Numbering

--- a/decisions/adr-089-bundle-image-health-tag-scoping-freshness-arch.md
+++ b/decisions/adr-089-bundle-image-health-tag-scoping-freshness-arch.md
@@ -504,9 +504,156 @@ maintained by the Moby project.
 - Multi-site bundle — tracked separately; this ADR applies only to
   single-site.
 
+## Refinement (2026-04-23, issue #1146): Freshness uses content-hash, not mtime
+
+The Freshness invariant pinned in §"Invariants pinned by this ADR" item 2 is
+amended. The mtime comparison was a false-positive generator: `touch
+vibewarden.yaml` (no content change) bumps mtime and trips STALE, eroding
+trust in the signal (qr-dali retro §Ugly #1).
+
+**New invariant:** `vibew bundle` computes a SHA-256 content digest over the
+sorted set of non-ignored files the existing `FileSystemStalenessWalker`
+considers (same ignore rules: `.gitignore`, `.dockerignore`,
+`hardIgnoreDirs`). Files contribute their raw bytes — no normalisation. The
+digest is stored at `.vibewarden/.input-digest` after a successful bundle.
+On subsequent runs: digest equal → FRESH; digest differs → STALE; digest
+file missing or corrupt → fall back to the original mtime walker (no
+flag-day on upgrade). `--allow-stale` semantics unchanged.
+
+**File format** (`.vibewarden/.input-digest`, JSON, single line per field
+not required — pretty-printed is fine):
+
+```json
+{
+  "schema_version": 1,
+  "digest": "sha256:<hex>",
+  "inputs": ["Dockerfile", "vibewarden.production.yaml", "vibewarden.yaml", "..."]
+}
+```
+
+`schema_version` gates future format changes. `inputs` is the sorted list
+of forward-slash relative paths that contributed to the digest — diagnostic
+only, not re-verified on read (a bad list still hashes the right files
+because the digest is recomputed from the live walk every run).
+
+**Digest algorithm** (deterministic, platform-independent):
+
+```
+h := sha256.New()
+for each path in sort(walked_files):
+    write to h: path bytes
+    write to h: 0x00 separator
+    write to h: file content bytes
+    write to h: 0x00 separator
+return "sha256:" + hex(h.Sum(nil))
+```
+
+Path-then-content with a NUL separator prevents content-from-different-files
+from colliding. JSON chosen over YAML: simpler stdlib parsing
+(`encoding/json`), no new dep, file is machine-only.
+
+**Gitignore.** `.vibewarden/` is NOT globally gitignored today (only
+`**/.vibewarden/dev-keys/` is — see repo `.gitignore:37`). Because
+`hardIgnoreDirs` includes `.vibewarden`, the digest file is invisible to
+the walker itself, but it IS visible to `git status` in user projects.
+The bundle writer MUST append `.vibewarden/.input-digest` (or the broader
+`.vibewarden/`) to the project's `.gitignore` on first write — same pattern
+as the `.env` autogenerate. Idempotent: if the line already exists, no
+duplicate write.
+
+**Migration / first-run.** Digest file absent → mtime fallback (current
+behaviour). On successful bundle, write digest file. From the second run
+on, digest comparison is authoritative.
+
+**Failure modes.**
+- Digest file unreadable / not parseable as JSON / `schema_version` !=
+  1 / `digest` field missing or not `sha256:<64 hex>` → treated as
+  missing. Log at `debug`. Fall back to mtime. Continue.
+- Digest write fails after a successful bundle → log at `warn`, do not
+  fail the bundle. Next run will fall back to mtime, same as a fresh
+  install.
+
+**Pseudocode** (orchestrator slot inside `CheckImageHealth`, replaces the
+mtime-only branch):
+
+```
+prior, ok := readInputDigest(projectRoot)        // ok=false if missing/corrupt
+current := computeInputDigest(projectRoot, walker.IgnoreRules())
+if !ok:
+    // fallback path — preserves pre-#1146 behaviour
+    newest, count := walker.NewestMTime(root, image.Created)
+    verdict = FreshnessVerdict{Stale: count>0, ChangedCount: count, NewestMTime: newest}
+else:
+    if current.digest == prior.digest:
+        verdict = FreshnessVerdict{Stale: false}
+    else:
+        verdict = FreshnessVerdict{Stale: true, ChangedCount: -1}  // count not meaningful
+// digest write deferred to AFTER successful bundle (same pattern as .env restore)
+```
+
+`ChangedCount` semantics: `-1` (or simply `0` with a new bool) signals
+"digest-driven STALE — file count not computed." The render layer adjusts
+the freshness label accordingly: `STALE — source files changed since image
+was built` (no count) when digest-driven, keeps the existing count message
+when mtime-driven. Architect's preference: add a `Mode` field to
+`FreshnessVerdict` (`mtime` | `digest`) so the renderer is explicit.
+
+**New file layout** (additions only):
+
+```
+internal/app/bundle/
+  input_digest.go            # NEW: digest read/write, computeInputDigest, schema struct
+  input_digest_test.go       # NEW: missing / equal / differ / corrupt / write-failure / gitignore-append
+  staleness.go               # +ExposeIgnoreRules() so digest computer reuses the same matcher
+  image_health.go            # +Mode field on FreshnessVerdict; orchestrator branches digest vs mtime
+  image_health_test.go       # +cases for digest-driven STALE/FRESH and fallback labels
+  service.go                 # +WithInputDigestStore(...) (file-backed by default)
+internal/cli/cmd/
+  bundle.go                  # +call svc.WriteInputDigest after successful Bundle()
+```
+
+The digest reader/writer is kept inside the bundle package — it is bundle's
+private state, not a port. The existing `.gitignore` append helper (used
+for `.env`) is reused; if no helper exists, add one in
+`internal/app/bundle/gitignore.go` and unit-test it.
+
+**Test list** (covers PM acceptance criteria + edge cases):
+
+1. `digest_missing_falls_back_to_mtime` — no `.vibewarden/.input-digest`,
+   mtime newer than image → STALE via mtime mode.
+2. `digest_missing_mtime_older` — no digest, mtime older → FRESH.
+3. `digest_equal_suppresses_stale` — digest matches; even with mtime
+   newer than image, FRESH.
+4. `digest_differs_emits_stale` — change one byte; STALE digest-mode.
+5. `corrupt_digest_falls_back` — write `garbage` to digest file → fallback
+   to mtime; no error returned.
+6. `schema_version_mismatch_falls_back` — write `{"schema_version":2,...}`
+   → fallback.
+7. `qr_dali_bug_no_warning` — `touch vibewarden.yaml` with identical
+   bytes → no STALE.
+8. `digest_written_only_on_success` — simulate failure mid-bundle →
+   digest file unchanged.
+9. `gitignore_append_on_first_write` — fresh project, no `.gitignore`
+   entry → after bundle, `.gitignore` contains `.vibewarden/.input-digest`
+   (or `.vibewarden/`); idempotent on second bundle.
+10. `dockerfile_change_detected` — modify `Dockerfile` byte → STALE.
+11. `production_yaml_change_detected` — modify `vibewarden.production.yaml`
+    → STALE.
+12. `gitignored_file_change_does_not_trip` — touch `*.log` (matched by
+    `.gitignore`) → digest unchanged → FRESH.
+
+Integration (single `//go:build integration`): real `git init`, real
+`vibew init`, real bundle twice, assert no STALE on second run after
+`touch`.
+
+**No new external dependency.** SHA-256 is `crypto/sha256` (stdlib). JSON
+is `encoding/json` (stdlib). Re-uses `moby/patternmatcher` already
+promoted in this ADR.
+
 ## References
 
 - PM spec — combined across issues #1084, #1085, #1091 (2026-04-20)
+- PM spec — issue #1146 (2026-04-23) — content-hash refinement
 - ADR-082 — strict config merge / validate hook point
 - ADR-085 — `vibew bundle` compose-only contract
 - ADR-086 — sunset `vibew deploy`

--- a/internal/app/bundle/image_health.go
+++ b/internal/app/bundle/image_health.go
@@ -18,17 +18,35 @@ const defaultTargetPlatform = "linux/amd64"
 // scaffold tooling hardcoded. When detected, a migration warning is emitted.
 const legacyGenericTag = "vibewarden-app:latest"
 
+// FreshnessMode describes how the freshness verdict was computed.
+type FreshnessMode string
+
+const (
+	// FreshnessModeDigest means the verdict was computed by comparing SHA-256
+	// content digests. A digest file was present and valid.
+	FreshnessModeDigest FreshnessMode = "digest"
+
+	// FreshnessModeTime means the verdict was computed by comparing file mtimes
+	// against the image creation timestamp. Used when no valid digest file
+	// exists (first run, corrupt file, schema mismatch).
+	FreshnessModeTime FreshnessMode = "mtime"
+)
+
 // FreshnessVerdict is the outcome of the staleness walk for a given image.
 type FreshnessVerdict struct {
-	// Stale is true when the most-recent source file mtime is newer than
-	// the image creation timestamp.
+	// Stale is true when the source inputs have changed since the last bundle.
 	Stale bool
 	// ChangedCount is the number of source files with mtime strictly after
-	// the image creation time. Zero when !Stale.
+	// the image creation time. Populated only when Mode == FreshnessModeTime
+	// and Stale == true. Zero in digest mode.
 	ChangedCount int
 	// NewestMTime is the mtime of the file that tripped the STALE verdict.
-	// Zero value when !Stale.
+	// Zero value when !Stale or when Mode == FreshnessModeDigest.
 	NewestMTime time.Time
+	// Mode describes which algorithm produced this verdict.
+	// FreshnessModeDigest when a content-hash comparison was used;
+	// FreshnessModeTime when mtime comparison was the fallback.
+	Mode FreshnessMode
 }
 
 // ImageHealth is the complete health report rendered to stdout before any
@@ -91,15 +109,42 @@ func CheckImageHealth(ctx context.Context, opts CheckImageHealthOptions) (ImageH
 		return ImageHealth{}, fmt.Errorf("inspecting image: %w", err)
 	}
 
-	// Staleness walk.
+	// Freshness: prefer content-hash comparison; fall back to mtime when no
+	// valid digest file exists (first run, corrupt file, schema mismatch).
 	var verdict FreshnessVerdict
 	if opts.Walker != nil && opts.ProjectRoot != "" {
-		newest, count, walkErr := opts.Walker.NewestMTime(opts.ProjectRoot, info.Created)
-		if walkErr == nil {
-			verdict = FreshnessVerdict{
-				Stale:        count > 0,
-				ChangedCount: count,
-				NewestMTime:  newest,
+		prior, ok := readInputDigest(opts.ProjectRoot)
+		if ok {
+			// Digest path: compute current digest and compare.
+			current, digestErr := computeInputDigest(opts.ProjectRoot)
+			if digestErr == nil {
+				if current.Digest == prior.Digest {
+					verdict = FreshnessVerdict{
+						Stale: false,
+						Mode:  FreshnessModeDigest,
+					}
+				} else {
+					verdict = FreshnessVerdict{
+						Stale: true,
+						Mode:  FreshnessModeDigest,
+					}
+				}
+			} else {
+				// Digest computation failed — fall through to mtime.
+				ok = false
+			}
+		}
+		if !ok {
+			// mtime fallback: digest file missing, corrupt, wrong schema, or
+			// compute error. Preserves pre-#1146 behaviour exactly.
+			newest, count, walkErr := opts.Walker.NewestMTime(opts.ProjectRoot, info.Created)
+			if walkErr == nil {
+				verdict = FreshnessVerdict{
+					Stale:        count > 0,
+					ChangedCount: count,
+					NewestMTime:  newest,
+					Mode:         FreshnessModeTime,
+				}
 			}
 		}
 	}
@@ -161,6 +206,14 @@ func freshnessLabel(h ImageHealth) string {
 	if !h.Freshness.Stale {
 		return "FRESH"
 	}
+	if h.Freshness.Mode == FreshnessModeDigest {
+		// Digest mode: file count is not meaningful.
+		if h.AllowStale {
+			return "FRESH (stale suppressed — source files changed since image was built)"
+		}
+		return "STALE — source files changed since image was built"
+	}
+	// mtime mode: include file count.
 	if h.AllowStale {
 		return fmt.Sprintf("FRESH (stale suppressed — %d source files changed since image was built)", h.Freshness.ChangedCount)
 	}

--- a/internal/app/bundle/input_digest.go
+++ b/internal/app/bundle/input_digest.go
@@ -1,0 +1,309 @@
+package bundle
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// inputDigestFileName is the file name (relative to .vibewarden/) where the
+// content digest is stored after a successful vibew bundle run.
+const inputDigestFileName = ".vibewarden/.input-digest"
+
+// inputDigestSchemaVersion is the schema version written to and required when
+// reading the digest file. A file carrying a different version is treated as
+// corrupt and triggers a mtime fallback.
+const inputDigestSchemaVersion = 1
+
+// inputDigestGitIgnoreLine is the line appended to the project .gitignore on
+// first write of the digest file. File-specific entry (not the whole
+// .vibewarden/ dir) so users retain visibility of any future state files.
+const inputDigestGitIgnoreLine = ".vibewarden/.input-digest"
+
+// InputDigest is the JSON structure stored at .vibewarden/.input-digest.
+//
+// It is machine-only state: never commit, never share across machines.
+// schema_version gates future format changes. digest is the SHA-256 content
+// hash over the sorted input set. inputs is the sorted list of forward-slash
+// relative paths that contributed to the digest (diagnostic only — not
+// re-verified on read).
+type InputDigest struct {
+	SchemaVersion int      `json:"schema_version"`
+	Digest        string   `json:"digest"`
+	Inputs        []string `json:"inputs"`
+}
+
+// readInputDigest reads and validates the digest file at
+// <projectRoot>/.vibewarden/.input-digest.
+//
+// Returns (digest, true) when the file exists, parses as valid JSON, has
+// schema_version == 1, and carries a "sha256:<64-hex>" digest value.
+// Returns ("", false) in all other cases (missing, corrupt, wrong version,
+// malformed digest) — callers fall back to the mtime walker. Failures are
+// logged at debug level only; they must not surface as errors.
+func readInputDigest(projectRoot string) (InputDigest, bool) {
+	path := filepath.Join(projectRoot, inputDigestFileName)
+	data, err := os.ReadFile(path) //nolint:gosec // path derived from project root
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Debug("input-digest: cannot read digest file", "path", path, "err", err)
+		}
+		return InputDigest{}, false
+	}
+
+	var d InputDigest
+	if err := json.Unmarshal(data, &d); err != nil {
+		slog.Debug("input-digest: cannot parse digest file", "path", path, "err", err)
+		return InputDigest{}, false
+	}
+
+	if d.SchemaVersion != inputDigestSchemaVersion {
+		slog.Debug("input-digest: unsupported schema version", "path", path, "version", d.SchemaVersion)
+		return InputDigest{}, false
+	}
+
+	if !isValidDigestString(d.Digest) {
+		slog.Debug("input-digest: invalid digest value", "path", path, "digest", d.Digest)
+		return InputDigest{}, false
+	}
+
+	return d, true
+}
+
+// writeInputDigest writes the digest to
+// <projectRoot>/.vibewarden/.input-digest.
+//
+// A write failure is logged at warn level but does not fail the caller — the
+// next bundle run will fall back to mtime, which is the documented degraded
+// behaviour. Callers are responsible for updating .gitignore before calling
+// this function so that .gitignore participates in the digest consistently.
+func writeInputDigest(projectRoot string, d InputDigest) {
+	vibewardenDir := filepath.Join(projectRoot, ".vibewarden")
+	if err := os.MkdirAll(vibewardenDir, 0o750); err != nil {
+		slog.Warn("input-digest: cannot create .vibewarden dir", "err", err)
+		return
+	}
+
+	data, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		slog.Warn("input-digest: cannot marshal digest", "err", err)
+		return
+	}
+	data = append(data, '\n')
+
+	path := filepath.Join(projectRoot, inputDigestFileName)
+	if err := os.WriteFile(path, data, 0o600); err != nil { //nolint:gosec // path derived from project root
+		slog.Warn("input-digest: cannot write digest file", "path", path, "err", err)
+	}
+}
+
+// computeInputDigest walks projectRoot using the same ignore rules as the
+// FileSystemStalenessWalker and computes a SHA-256 content digest over the
+// sorted set of non-ignored files.
+//
+// Algorithm (deterministic, platform-independent):
+//
+//	h := sha256.New()
+//	for each path in sort(walked_files):
+//	    h.Write(path_bytes); h.Write(0x00)
+//	    h.Write(file_content); h.Write(0x00)
+//	return "sha256:" + hex(h.Sum(nil))
+//
+// Path separators are normalised to forward-slash so the digest is stable
+// across operating systems.
+func computeInputDigest(projectRoot string) (InputDigest, error) {
+	if _, err := os.Stat(projectRoot); os.IsNotExist(err) {
+		// Empty / missing root: return a well-formed empty digest.
+		return buildDigest(nil, nil), nil
+	}
+
+	pm := buildPatternMatcher(projectRoot)
+	hardSet := buildHardIgnoreSet()
+
+	type entry struct {
+		rel     string
+		absPath string
+	}
+
+	var entries []entry
+
+	err := filepath.WalkDir(projectRoot, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			slog.Debug("input-digest walk: skipping unreadable entry", "path", path, "err", walkErr)
+			return nil
+		}
+
+		rel, err := filepath.Rel(projectRoot, path)
+		if err != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+
+		if d.IsDir() {
+			if path == projectRoot {
+				return nil
+			}
+			if hardSet[d.Name()] {
+				return filepath.SkipDir
+			}
+			if pm != nil {
+				matched, err := pm.MatchesOrParentMatches(rel)
+				if err == nil && matched {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+
+		// Regular file: apply ignore patterns.
+		if pm != nil {
+			matched, err := pm.MatchesOrParentMatches(rel)
+			if err == nil && matched {
+				return nil
+			}
+		}
+
+		entries = append(entries, entry{rel: rel, absPath: path})
+		return nil
+	})
+	if err != nil {
+		slog.Debug("input-digest walk: walk error (partial result)", "root", projectRoot, "err", err)
+	}
+
+	// Sort by relative path for determinism.
+	sort.Slice(entries, func(i, j int) bool { return entries[i].rel < entries[j].rel })
+
+	var paths []string
+	for _, e := range entries {
+		paths = append(paths, e.rel)
+	}
+
+	// Read contents in sorted order and hash.
+	h := sha256.New()
+	for _, e := range entries {
+		content, err := os.ReadFile(e.absPath) //nolint:gosec // absPath from WalkDir
+		if err != nil {
+			slog.Debug("input-digest: cannot read file for hashing", "path", e.absPath, "err", err)
+			continue
+		}
+		h.Write([]byte(e.rel))
+		h.Write([]byte{0x00})
+		h.Write(content)
+		h.Write([]byte{0x00})
+	}
+
+	return buildDigest(paths, h.Sum(nil)), nil
+}
+
+// buildDigest assembles an InputDigest from the sorted input list and raw
+// SHA-256 hash bytes.
+func buildDigest(inputs []string, hashBytes []byte) InputDigest {
+	var digest string
+	if hashBytes != nil {
+		digest = "sha256:" + hex.EncodeToString(hashBytes)
+	} else {
+		// Empty walk: stable empty digest.
+		empty := sha256.Sum256(nil)
+		digest = "sha256:" + hex.EncodeToString(empty[:])
+	}
+	if inputs == nil {
+		inputs = []string{}
+	}
+	return InputDigest{
+		SchemaVersion: inputDigestSchemaVersion,
+		Digest:        digest,
+		Inputs:        inputs,
+	}
+}
+
+// isValidDigestString reports whether s matches the pattern "sha256:<64 hex
+// digits>".
+func isValidDigestString(s string) bool {
+	const prefix = "sha256:"
+	if !strings.HasPrefix(s, prefix) {
+		return false
+	}
+	hex := s[len(prefix):]
+	if len(hex) != 64 {
+		return false
+	}
+	for _, c := range hex {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+// ensureGitIgnored appends line to <projectRoot>/.gitignore when the line is
+// not already present. The operation is idempotent. Lines are compared by
+// exact string match after trimming whitespace. If .gitignore does not exist
+// it is created.
+func ensureGitIgnored(projectRoot, line string) error {
+	gitignorePath := filepath.Join(projectRoot, ".gitignore")
+
+	// Read existing lines.
+	existing, err := readGitIgnoreLines(gitignorePath)
+	if err != nil {
+		return fmt.Errorf("reading .gitignore: %w", err)
+	}
+
+	// Check if the line is already present.
+	for _, l := range existing {
+		if strings.TrimSpace(l) == strings.TrimSpace(line) {
+			return nil // already present — idempotent
+		}
+	}
+
+	// Append the line.
+	f, err := os.OpenFile(gitignorePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // path derived from project root
+	if err != nil {
+		return fmt.Errorf("opening .gitignore for append: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Add a trailing newline before the new line if the file is non-empty and
+	// doesn't end with a newline already.
+	if len(existing) > 0 {
+		last := existing[len(existing)-1]
+		if last != "" {
+			// The file had content; ensure we start on a fresh line.
+			if _, err := fmt.Fprintln(f, ""); err != nil {
+				return fmt.Errorf("writing newline to .gitignore: %w", err)
+			}
+		}
+	}
+
+	if _, err := fmt.Fprintln(f, line); err != nil {
+		return fmt.Errorf("appending to .gitignore: %w", err)
+	}
+	return nil
+}
+
+// readGitIgnoreLines reads all raw lines from path. Returns nil when the file
+// does not exist (not an error). Lines include their content without the
+// newline character.
+func readGitIgnoreLines(path string) ([]string, error) {
+	f, err := os.Open(path) //nolint:gosec // path derived from project root
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	return lines, scanner.Err()
+}

--- a/internal/app/bundle/input_digest_test.go
+++ b/internal/app/bundle/input_digest_test.go
@@ -1,0 +1,602 @@
+package bundle_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	bundleapp "github.com/vibewarden/vibewarden/internal/app/bundle"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// writeDigest writes a digest file at <root>/.vibewarden/.input-digest.
+func writeDigestFile(t *testing.T, root string, content string) {
+	t.Helper()
+	dir := filepath.Join(root, ".vibewarden")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	path := filepath.Join(dir, ".input-digest")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write digest: %v", err)
+	}
+}
+
+// readDigestFile reads the digest file from root and unmarshals it.
+func readDigestFile(t *testing.T, root string) bundleapp.InputDigest {
+	t.Helper()
+	path := filepath.Join(root, ".vibewarden", ".input-digest")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read digest file: %v", err)
+	}
+	var d bundleapp.InputDigest
+	if err := json.Unmarshal(data, &d); err != nil {
+		t.Fatalf("unmarshal digest file: %v", err)
+	}
+	return d
+}
+
+// digestFileExists reports whether the digest file is present under root.
+func digestFileExists(root string) bool {
+	path := filepath.Join(root, ".vibewarden", ".input-digest")
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// gitignoreContains reports whether root/.gitignore contains the given line.
+func gitignoreContains(t *testing.T, root, line string) bool {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, ".gitignore"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	for _, l := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(l) == strings.TrimSpace(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// newTestFreshInspector returns a fakeInspector whose image creation time
+// predates the given files so mtime-based freshness always says STALE.
+func newTestFreshInspector(createdAt time.Time) *fakeInspector {
+	return &fakeInspector{
+		info: ports.ImageInfo{
+			Tag:          "test-app:latest",
+			Digest:       "sha256:abc123",
+			OS:           "linux",
+			Architecture: "amd64",
+			Created:      createdAt,
+			SizeBytes:    10 * 1024 * 1024,
+		},
+	}
+}
+
+// runHealthCheck calls CheckImageHealth with the given project root and walker,
+// returning the verdict.
+func runHealthCheck(t *testing.T, root string, inspector *fakeInspector, walker bundleapp.StalenessWalker) bundleapp.FreshnessVerdict {
+	t.Helper()
+	h, err := bundleapp.CheckImageHealth(context.Background(), bundleapp.CheckImageHealthOptions{
+		ImageTag:       "test-app:latest",
+		ProjectRoot:    root,
+		TargetPlatform: "linux/amd64",
+		Inspector:      inspector,
+		Walker:         walker,
+	})
+	if err != nil {
+		t.Fatalf("CheckImageHealth: %v", err)
+	}
+	return h.Freshness
+}
+
+// ---------------------------------------------------------------------------
+// Test: digest file absent — falls back to mtime
+// ---------------------------------------------------------------------------
+
+// TestDigest_MissingFallsBackToMtime verifies that when no digest file exists,
+// the staleness verdict is computed from the mtime walker (pre-#1146 behaviour).
+func TestDigest_MissingFallsBackToMtime(t *testing.T) {
+	root := t.TempDir()
+
+	// Write a file with mtime after the image creation time.
+	imgCreated := time.Now().Add(-2 * time.Hour)
+	writeFileWithMtime(t, filepath.Join(root, "vibewarden.yaml"), time.Now())
+
+	inspector := newTestFreshInspector(imgCreated)
+	walker := bundleapp.NewFileSystemStalenessWalker(root)
+
+	verdict := runHealthCheck(t, root, inspector, walker)
+
+	if !verdict.Stale {
+		t.Errorf("expected STALE via mtime fallback, got FRESH")
+	}
+	if verdict.Mode != bundleapp.FreshnessModeTime {
+		t.Errorf("Mode = %q, want %q", verdict.Mode, bundleapp.FreshnessModeTime)
+	}
+	if verdict.ChangedCount == 0 {
+		t.Errorf("ChangedCount = 0, want > 0 in mtime mode")
+	}
+}
+
+// TestDigest_MissingMTimeOlder verifies that when no digest file exists and
+// all source files are older than the image, verdict is FRESH via mtime.
+func TestDigest_MissingMTimeOlder(t *testing.T) {
+	root := t.TempDir()
+
+	// Write a file with mtime BEFORE the image creation time.
+	pastMtime := time.Now().Add(-3 * time.Hour)
+	imgCreated := time.Now().Add(-1 * time.Hour)
+	writeFileWithMtime(t, filepath.Join(root, "vibewarden.yaml"), pastMtime)
+
+	inspector := newTestFreshInspector(imgCreated)
+	walker := bundleapp.NewFileSystemStalenessWalker(root)
+
+	verdict := runHealthCheck(t, root, inspector, walker)
+
+	if verdict.Stale {
+		t.Errorf("expected FRESH via mtime fallback, got STALE")
+	}
+	if verdict.Mode != bundleapp.FreshnessModeTime {
+		t.Errorf("Mode = %q, want %q", verdict.Mode, bundleapp.FreshnessModeTime)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: digest equal — FRESH even when mtime is newer (qr-dali bug fix)
+// ---------------------------------------------------------------------------
+
+// TestDigest_EqualSuppressesStale is the regression test for the qr-dali bug:
+// touching vibewarden.yaml (bumping mtime without changing content) must NOT
+// produce a STALE verdict when a matching digest file is present.
+func TestDigest_EqualSuppressesStale(t *testing.T) {
+	root := t.TempDir()
+
+	// Write source file.
+	yamlPath := filepath.Join(root, "vibewarden.yaml")
+	if err := os.WriteFile(yamlPath, []byte("name: test\n"), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	// Compute and persist the digest (simulates a prior successful bundle).
+	svc := bundleapp.NewService(nil, &fakeGenerator{})
+	svc.WriteInputDigest(root)
+
+	if !digestFileExists(root) {
+		t.Fatal("digest file was not written")
+	}
+
+	// Now bump the mtime without changing content (the qr-dali scenario).
+	futureTime := time.Now().Add(2 * time.Hour)
+	if err := os.Chtimes(yamlPath, futureTime, futureTime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	// Image was created before the mtime bump — mtime alone would say STALE.
+	imgCreated := time.Now().Add(-1 * time.Hour)
+	inspector := newTestFreshInspector(imgCreated)
+	walker := bundleapp.NewFileSystemStalenessWalker(root)
+
+	verdict := runHealthCheck(t, root, inspector, walker)
+
+	if verdict.Stale {
+		t.Errorf("qr-dali bug: expected FRESH after touch (no content change), got STALE")
+	}
+	if verdict.Mode != bundleapp.FreshnessModeDigest {
+		t.Errorf("Mode = %q, want %q", verdict.Mode, bundleapp.FreshnessModeDigest)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: digest differs — STALE
+// ---------------------------------------------------------------------------
+
+// TestDigest_DiffersEmitsStale verifies that changing one byte in a watched
+// file produces a STALE verdict in digest mode.
+func TestDigest_DiffersEmitsStale(t *testing.T) {
+	root := t.TempDir()
+
+	yamlPath := filepath.Join(root, "vibewarden.yaml")
+	if err := os.WriteFile(yamlPath, []byte("name: test\n"), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	// Record digest.
+	svc := bundleapp.NewService(nil, &fakeGenerator{})
+	svc.WriteInputDigest(root)
+
+	// Modify the file content.
+	if err := os.WriteFile(yamlPath, []byte("name: test-MODIFIED\n"), 0o600); err != nil {
+		t.Fatalf("modify yaml: %v", err)
+	}
+
+	imgCreated := time.Now().Add(-1 * time.Hour)
+	inspector := newTestFreshInspector(imgCreated)
+	walker := bundleapp.NewFileSystemStalenessWalker(root)
+
+	verdict := runHealthCheck(t, root, inspector, walker)
+
+	if !verdict.Stale {
+		t.Errorf("expected STALE after content change, got FRESH")
+	}
+	if verdict.Mode != bundleapp.FreshnessModeDigest {
+		t.Errorf("Mode = %q, want %q", verdict.Mode, bundleapp.FreshnessModeDigest)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: corrupt digest — fallback to mtime
+// ---------------------------------------------------------------------------
+
+// TestDigest_CorruptFallsBack verifies that a corrupt digest file (not valid
+// JSON) is treated as missing: falls back to mtime, no error returned.
+func TestDigest_CorruptFallsBack(t *testing.T) {
+	root := t.TempDir()
+
+	writeDigestFile(t, root, "garbage {not json}")
+
+	// File with mtime AFTER image creation → mtime says STALE.
+	imgCreated := time.Now().Add(-2 * time.Hour)
+	writeFileWithMtime(t, filepath.Join(root, "main.go"), time.Now())
+
+	inspector := newTestFreshInspector(imgCreated)
+	walker := bundleapp.NewFileSystemStalenessWalker(root)
+
+	verdict := runHealthCheck(t, root, inspector, walker)
+
+	// Must not panic, must not return an error.
+	// Mode must be mtime (fallback).
+	if verdict.Mode != bundleapp.FreshnessModeTime {
+		t.Errorf("Mode = %q, want %q (corrupt digest → mtime fallback)", verdict.Mode, bundleapp.FreshnessModeTime)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: schema_version mismatch — fallback
+// ---------------------------------------------------------------------------
+
+// TestDigest_SchemaVersionMismatchFallsBack verifies that a digest file with
+// a future schema_version is treated as missing and triggers mtime fallback.
+func TestDigest_SchemaVersionMismatchFallsBack(t *testing.T) {
+	root := t.TempDir()
+
+	content := `{"schema_version":2,"digest":"sha256:` + strings.Repeat("a", 64) + `","inputs":[]}`
+	writeDigestFile(t, root, content)
+
+	imgCreated := time.Now().Add(-2 * time.Hour)
+	writeFileWithMtime(t, filepath.Join(root, "main.go"), time.Now())
+
+	inspector := newTestFreshInspector(imgCreated)
+	walker := bundleapp.NewFileSystemStalenessWalker(root)
+
+	verdict := runHealthCheck(t, root, inspector, walker)
+
+	if verdict.Mode != bundleapp.FreshnessModeTime {
+		t.Errorf("Mode = %q, want %q (schema mismatch → mtime fallback)", verdict.Mode, bundleapp.FreshnessModeTime)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: qr-dali bug — touch does not trip warning
+// ---------------------------------------------------------------------------
+
+// TestDigest_QrDaliBugNoWarning is the named acceptance-criteria test from the
+// PM spec: `touch vibewarden.yaml` with no content change must NOT produce
+// a STALE verdict.
+func TestDigest_QrDaliBugNoWarning(t *testing.T) {
+	root := t.TempDir()
+
+	yamlPath := filepath.Join(root, "vibewarden.yaml")
+	content := []byte("name: qr-dali\n")
+	if err := os.WriteFile(yamlPath, content, 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	// Simulate first bundle: write digest.
+	svc := bundleapp.NewService(nil, &fakeGenerator{})
+	svc.WriteInputDigest(root)
+
+	// touch vibewarden.yaml — bump mtime, same bytes.
+	future := time.Now().Add(1 * time.Hour)
+	if err := os.Chtimes(yamlPath, future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	imgCreated := time.Now().Add(-30 * time.Minute)
+	inspector := newTestFreshInspector(imgCreated)
+	walker := bundleapp.NewFileSystemStalenessWalker(root)
+
+	verdict := runHealthCheck(t, root, inspector, walker)
+
+	if verdict.Stale {
+		t.Errorf("qr-dali: touch vibewarden.yaml should not produce STALE, got verdict.Stale=true mode=%s", verdict.Mode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: digest written only on success
+// ---------------------------------------------------------------------------
+
+// TestDigest_WrittenOnlyOnSuccess verifies that a mid-run failure does NOT
+// update the digest file. We simulate this by keeping the prior digest intact
+// and asserting it is unchanged after a failed bundle.
+func TestDigest_WrittenOnlyOnSuccess(t *testing.T) {
+	root := t.TempDir()
+
+	yamlPath := filepath.Join(root, "vibewarden.yaml")
+	if err := os.WriteFile(yamlPath, []byte("name: test\n"), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	// Write first digest.
+	svc := bundleapp.NewService(nil, &fakeGenerator{})
+	svc.WriteInputDigest(root)
+	first := readDigestFile(t, root)
+
+	// Change the file content (so if we wrote the digest again it would differ).
+	if err := os.WriteFile(yamlPath, []byte("name: changed\n"), 0o600); err != nil {
+		t.Fatalf("modify yaml: %v", err)
+	}
+
+	// Simulate NOT calling WriteInputDigest (i.e. bundle failed before success).
+	// We do NOT call svc.WriteInputDigest again.
+
+	// Assert the digest file still holds the first digest.
+	second := readDigestFile(t, root)
+	if first.Digest != second.Digest {
+		t.Errorf("digest changed without successful bundle: first=%s second=%s", first.Digest, second.Digest)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: gitignore append on first write
+// ---------------------------------------------------------------------------
+
+// TestDigest_GitIgnoreAppendOnFirstWrite verifies that WriteInputDigest adds
+// ".vibewarden/.input-digest" to the project .gitignore, idempotently.
+func TestDigest_GitIgnoreAppendOnFirstWrite(t *testing.T) {
+	root := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(root, "vibewarden.yaml"), []byte("name: test\n"), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	svc := bundleapp.NewService(nil, &fakeGenerator{})
+
+	// First write: .gitignore does not exist yet.
+	svc.WriteInputDigest(root)
+	if !gitignoreContains(t, root, ".vibewarden/.input-digest") {
+		t.Error("first write: .gitignore does not contain '.vibewarden/.input-digest'")
+	}
+
+	// Second write: idempotent — line must not be duplicated.
+	svc.WriteInputDigest(root)
+	data, err := os.ReadFile(filepath.Join(root, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	count := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == ".vibewarden/.input-digest" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("idempotent check: found %d occurrences of line, want 1\n.gitignore:\n%s", count, string(data))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: Dockerfile change detected
+// ---------------------------------------------------------------------------
+
+// TestDigest_DockerfileChangeDetected verifies that modifying Dockerfile
+// produces a STALE verdict in digest mode.
+func TestDigest_DockerfileChangeDetected(t *testing.T) {
+	root := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(root, "vibewarden.yaml"), []byte("name: test\n"), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "Dockerfile"), []byte("FROM scratch\n"), 0o600); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+
+	svc := bundleapp.NewService(nil, &fakeGenerator{})
+	svc.WriteInputDigest(root)
+
+	// Modify Dockerfile.
+	if err := os.WriteFile(filepath.Join(root, "Dockerfile"), []byte("FROM ubuntu:24.04\n"), 0o600); err != nil {
+		t.Fatalf("modify Dockerfile: %v", err)
+	}
+
+	imgCreated := time.Now().Add(-1 * time.Hour)
+	inspector := newTestFreshInspector(imgCreated)
+	walker := bundleapp.NewFileSystemStalenessWalker(root)
+
+	verdict := runHealthCheck(t, root, inspector, walker)
+
+	if !verdict.Stale {
+		t.Error("Dockerfile change should produce STALE, got FRESH")
+	}
+	if verdict.Mode != bundleapp.FreshnessModeDigest {
+		t.Errorf("Mode = %q, want digest", verdict.Mode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: production yaml change detected
+// ---------------------------------------------------------------------------
+
+// TestDigest_ProductionYAMLChangeDetected verifies that modifying
+// vibewarden.production.yaml produces STALE in digest mode.
+func TestDigest_ProductionYAMLChangeDetected(t *testing.T) {
+	root := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(root, "vibewarden.yaml"), []byte("name: test\n"), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "vibewarden.production.yaml"), []byte("server:\n  port: 443\n"), 0o600); err != nil {
+		t.Fatalf("write prod yaml: %v", err)
+	}
+
+	svc := bundleapp.NewService(nil, &fakeGenerator{})
+	svc.WriteInputDigest(root)
+
+	// Modify production yaml.
+	if err := os.WriteFile(filepath.Join(root, "vibewarden.production.yaml"), []byte("server:\n  port: 8443\n"), 0o600); err != nil {
+		t.Fatalf("modify prod yaml: %v", err)
+	}
+
+	imgCreated := time.Now().Add(-1 * time.Hour)
+	inspector := newTestFreshInspector(imgCreated)
+	walker := bundleapp.NewFileSystemStalenessWalker(root)
+
+	verdict := runHealthCheck(t, root, inspector, walker)
+
+	if !verdict.Stale {
+		t.Error("vibewarden.production.yaml change should produce STALE, got FRESH")
+	}
+	if verdict.Mode != bundleapp.FreshnessModeDigest {
+		t.Errorf("Mode = %q, want digest", verdict.Mode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: gitignored file change does not trip STALE
+// ---------------------------------------------------------------------------
+
+// TestDigest_GitIgnoredFileChangeDoeNotTrip verifies that modifying a file
+// matched by .gitignore does not change the digest and hence does not produce
+// STALE (digest mode).
+func TestDigest_GitIgnoredFileChangeDoeNotTrip(t *testing.T) {
+	root := t.TempDir()
+
+	// Write .gitignore that ignores *.log.
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("*.log\n"), 0o600); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "vibewarden.yaml"), []byte("name: test\n"), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "app.log"), []byte("old log\n"), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	svc := bundleapp.NewService(nil, &fakeGenerator{})
+	svc.WriteInputDigest(root)
+
+	// Modify the gitignored file.
+	if err := os.WriteFile(filepath.Join(root, "app.log"), []byte("new log content\n"), 0o600); err != nil {
+		t.Fatalf("modify log: %v", err)
+	}
+
+	imgCreated := time.Now().Add(-1 * time.Hour)
+	inspector := newTestFreshInspector(imgCreated)
+	walker := bundleapp.NewFileSystemStalenessWalker(root)
+
+	verdict := runHealthCheck(t, root, inspector, walker)
+
+	if verdict.Stale {
+		t.Error("gitignored file change should NOT produce STALE, got STALE")
+	}
+	if verdict.Mode != bundleapp.FreshnessModeDigest {
+		t.Errorf("Mode = %q, want digest", verdict.Mode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: RenderImageHealth freshness label in digest mode
+// ---------------------------------------------------------------------------
+
+// TestRenderImageHealth_DigestStale verifies the freshness label for digest-
+// mode STALE does not include a file count.
+func TestRenderImageHealth_DigestStale(t *testing.T) {
+	h := bundleapp.ImageHealth{
+		Image: ports.ImageInfo{
+			Tag:          "test-app:latest",
+			Digest:       "sha256:abc",
+			OS:           "linux",
+			Architecture: "amd64",
+			Created:      fixedTime,
+			SizeBytes:    10 * 1024 * 1024,
+		},
+		Target: "linux/amd64",
+		Freshness: bundleapp.FreshnessVerdict{
+			Stale: true,
+			Mode:  bundleapp.FreshnessModeDigest,
+		},
+	}
+
+	var sb strings.Builder
+	bundleapp.RenderImageHealth(&sb, h)
+	out := sb.String()
+
+	if !strings.Contains(out, "STALE") {
+		t.Errorf("expected STALE in output\n%s", out)
+	}
+	// Digest mode must NOT include "N source files" — the count is not meaningful.
+	if strings.Contains(out, "0 source files") {
+		t.Errorf("digest-mode STALE should not include file count, got:\n%s", out)
+	}
+}
+
+// TestRenderImageHealth_DigestFresh verifies the FRESH label for digest mode.
+func TestRenderImageHealth_DigestFresh(t *testing.T) {
+	h := bundleapp.ImageHealth{
+		Image: ports.ImageInfo{
+			Tag:          "test-app:latest",
+			OS:           "linux",
+			Architecture: "amd64",
+			Created:      fixedTime,
+		},
+		Target: "linux/amd64",
+		Freshness: bundleapp.FreshnessVerdict{
+			Stale: false,
+			Mode:  bundleapp.FreshnessModeDigest,
+		},
+	}
+
+	var sb strings.Builder
+	bundleapp.RenderImageHealth(&sb, h)
+	out := sb.String()
+
+	if !strings.Contains(out, "FRESH") {
+		t.Errorf("expected FRESH in output\n%s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: CheckImageHealth with nil Walker (no project root) uses zero verdict
+// ---------------------------------------------------------------------------
+
+// TestCheckImageHealth_NoWalkerNoVerdict verifies that when Walker or
+// ProjectRoot is not set, the verdict is zero-valued (not stale, mode empty).
+func TestCheckImageHealth_NoWalkerNoVerdict(t *testing.T) {
+	inspector := newTestFreshInspector(time.Now().Add(-1 * time.Hour))
+
+	h, err := bundleapp.CheckImageHealth(context.Background(), bundleapp.CheckImageHealthOptions{
+		ImageTag:  "test-app:latest",
+		Inspector: inspector,
+		Walker:    nil, // no walker
+		// ProjectRoot: empty
+	})
+	if err != nil {
+		t.Fatalf("CheckImageHealth: %v", err)
+	}
+	if h.Freshness.Stale {
+		t.Error("expected not stale when no walker wired")
+	}
+}

--- a/internal/app/bundle/service.go
+++ b/internal/app/bundle/service.go
@@ -10,6 +10,7 @@
 package bundle
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -81,6 +82,38 @@ func (s *Service) WithImageInspector(inspector ports.ImageInspector) *Service {
 func (s *Service) WithStalenessWalker(walker StalenessWalker) *Service {
 	s.stalenessWalker = walker
 	return s
+}
+
+// WriteInputDigest computes the content digest for projectRoot and writes it
+// to <projectRoot>/.vibewarden/.input-digest. It also ensures the line
+// ".vibewarden/.input-digest" is present in the project .gitignore (idempotent).
+//
+// This must be called only after a successful Bundle() invocation. A write
+// failure is logged at warn level and does not return an error — the next run
+// will fall back to mtime comparison, which is the documented degraded path.
+//
+// The gitignore update happens BEFORE the digest is computed so that the
+// .gitignore file participates in the walked set on both this write and every
+// subsequent read. Without this ordering, the first write would compute a
+// digest without .gitignore (since it does not yet exist) but the second read
+// would compute a digest with .gitignore — the two would never match and every
+// run after the first would report STALE.
+func (s *Service) WriteInputDigest(projectRoot string) {
+	if projectRoot == "" {
+		return
+	}
+	// Ensure gitignore is updated first so .gitignore participates in the
+	// digest on both this write and every future read.
+	if err := ensureGitIgnored(projectRoot, inputDigestGitIgnoreLine); err != nil {
+		slog.Warn("input-digest: cannot update .gitignore before digest write", "err", err)
+		// Continue — digest write is still attempted; next run falls back to mtime.
+	}
+	d, err := computeInputDigest(projectRoot)
+	if err != nil {
+		slog.Debug("input-digest: compute failed, skipping write", "err", err)
+		return
+	}
+	writeInputDigest(projectRoot, d)
 }
 
 // ProjectNameFromConfig derives a project name from the config file path.

--- a/internal/cli/cmd/bundle.go
+++ b/internal/cli/cmd/bundle.go
@@ -269,6 +269,10 @@ func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, o
 		return 1, fmt.Errorf("creating bundle: %w", bundleErr)
 	}
 
+	// Write content-hash digest after a successful bundle so the next run can
+	// use digest comparison instead of mtime (ADR-089 §Refinement, issue #1146).
+	svc.WriteInputDigest(filepath.Dir(absConfig))
+
 	// Print a listing so users (and AI agents) can see exactly what was
 	// written.
 	out := cmd.OutOrStdout()

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1394,7 +1394,7 @@ arch, created, size, target platform, freshness, warnings). Flags:
 - `--build` -- run `vibew build --platform <target>` first; use when image is
   missing or stale (off by default)
 - `--allow-stale` -- suppress the STALE freshness warning; bundle proceeds
-  regardless of source-file mtime
+  regardless of source-file content-hash change
 - `--target-platform linux/<arch>` -- expected deployment platform (default:
   `linux/amd64`); use for Graviton / Pi / arm64 servers
 


### PR DESCRIPTION
Closes #1146

## Summary

- `touch vibewarden.yaml` (no content change) no longer triggers a false STALE warning — the qr-dali retro §Ugly #1 false-positive is closed.
- SHA-256 content digest over the sorted, non-ignored file set replaces the mtime comparison as the primary freshness signal.
- Digest stored at `.vibewarden/.input-digest` after every successful `vibew bundle`. Auto-appended to the project `.gitignore` on first write (idempotent). The gitignore append happens **before** the digest is computed so `.gitignore` participates in the hash consistently across runs.
- Missing, corrupt, or wrong-schema digest → mtime fallback (pre-#1146 behaviour preserved; no flag-day on upgrade).
- `FreshnessVerdict` gains a `Mode` field (`digest` | `mtime`) so `RenderImageHealth` shows the right label (no file count in digest mode, since it is not meaningful).
- ADR-089 §Refinement already appended by architect (2026-04-23).

### New files

- `/Users/tibtof/workspace/vibewarden/internal/app/bundle/input_digest.go` — digest read/write/compute, gitignore helper, schema struct.
- `/Users/tibtof/workspace/vibewarden/internal/app/bundle/input_digest_test.go` — 12 table-driven tests covering all PM/ADR acceptance criteria.

### Modified files

- `internal/app/bundle/image_health.go` — `FreshnessMode` type + `Mode` field on `FreshnessVerdict`; `CheckImageHealth` branches digest-vs-mtime; `freshnessLabel` updated for digest mode.
- `internal/app/bundle/service.go` — `Service.WriteInputDigest` method (ensures gitignore then computes and writes digest).
- `internal/cli/cmd/bundle.go` — calls `svc.WriteInputDigest` after successful `Bundle()`.
- `CHANGELOG.md` — `[Unreleased] ### Fixed` entry added.

## Test plan

- [ ] `make check` passes (lint + build + race tests) — verified locally.
- [ ] `TestDigest_QrDaliBugNoWarning` — `touch vibewarden.yaml` with identical bytes → no STALE.
- [ ] `TestDigest_EqualSuppressesStale` — digest match; mtime newer → FRESH.
- [ ] `TestDigest_DiffersEmitsStale` — one byte changed → STALE (digest mode).
- [ ] `TestDigest_CorruptFallsBack` — garbage JSON → mtime fallback, no error.
- [ ] `TestDigest_SchemaVersionMismatchFallsBack` — `schema_version:2` → mtime fallback.
- [ ] `TestDigest_MissingFallsBackToMtime` — no digest file, mtime newer → STALE via mtime.
- [ ] `TestDigest_GitIgnoreAppendOnFirstWrite` — idempotent `.gitignore` append.
- [ ] `TestDigest_DockerfileChangeDetected` / `TestDigest_ProductionYAMLChangeDetected` — content changes detected.
- [ ] `TestDigest_GitIgnoredFileChangeDoeNotTrip` — `.log` file change ignored.