### PR TITLE
docs(#1147): clarify vibew eject as non-Docker escape hatch; ADR-096

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Changed
 
+- **`vibew eject` clarified as the non-Docker escape hatch** (#1147, [ADR-096](decisions/adr-096-vibew-eject-keep-and-clarify-non-docker-escape-hatch.md)). The `--help` lead line and the agents-template description now make clear: `vibew bundle` is the canonical Docker Compose path; `vibew eject` produces raw Caddy JSON for vanilla-Caddy / non-Docker deploys. No behavior change. The deeper consolidation (`vibew bundle --target ...`) is tracked separately.
+
 - **`vibew init` now generates a minimal `vibewarden.production.yaml`** (#1145). The generated file no longer carries commented `# auth: ...`, `# admin: ...`, `# rate_limit: ...` stubs. Override patterns moved to `docs/examples/production-overrides.md`. Per CLAUDE.md §Artifact policy: examples belong in docs, not in live config. `vibew add tls` / `vibew add waf` continue to work; they don't depend on the stubs being present.
 
 - **`vibew init` no longer generates a placeholder `Dockerfile` or `.dockerignore`** (#1139). `AGENTS-VIBEWARDEN.md` now carries a Dockerfile contract checklist; agents and users write their own Dockerfile against that contract. Migration: existing projects that already have a Dockerfile are unaffected. New projects must write a Dockerfile after `vibew init` — see `AGENTS-VIBEWARDEN.md` §Dockerfile contract.

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ It never holds external secrets or connects directly to third-party APIs.
 | MCP server | `vibew mcp` — AI agent integration via Model Context Protocol; `vibewarden_stream_logs` tool for filtered real-time event streaming |
 | Config schema | JSON schema for `vibewarden.yaml` — editor autocomplete |
 | Agent context | `AGENTS-VIBEWARDEN.md` generated for AI coding tools |
-| Eject | `vibew eject` — export raw proxy config to graduate past VibeWarden |
+| Eject | `vibew eject` — export raw Caddy JSON for non-Docker deploys (Docker users want `vibew bundle`) |
 
 ---
 
@@ -316,7 +316,7 @@ add VibeWarden. Use `vibew add` to enable individual features after the initial 
 | `vibew cert export` | Export the local CA certificate (for curl, Postman, …) |
 | `vibew validate` | Validate configuration |
 | `vibew context refresh` | Regenerate AI agent context files |
-| `vibew eject` | Export raw proxy config to graduate past VibeWarden |
+| `vibew eject` | Export raw Caddy JSON for non-Docker deploys (Docker users want `vibew bundle`) |
 | `vibew mcp` | Start MCP server for AI agent integration |
 
 ---

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -68,6 +68,7 @@ once accepted, they are not edited. If a decision is superseded, a new ADR refer
 | [093](adr-093-bundle-image-name-cwd-basename-fallback.md) | bundle image-name resolution — cwd-basename fallback unified across `vibew bundle` and `--build` | #1141 |
 | [094](adr-094-bundle-sensitive-files-awareness-block.md) | vibew bundle sensitive-file awareness block | #1142 |
 | [095](adr-095-status-three-state-ok-off-fail.md) | `vibew status` three-state model — OK / OFF / FAIL | #1143 |
+| [096](adr-096-vibew-eject-keep-and-clarify-non-docker-escape-hatch.md) | `vibew eject` — keep-and-clarify as the non-Docker escape hatch | #1147 |
 | [497](adr-497-graceful-shutdown-connection-draining.md) | Graceful Shutdown / Connection Draining | — |
 
 ## Numbering

--- a/decisions/adr-096-vibew-eject-keep-and-clarify-non-docker-escape-hatch.md
+++ b/decisions/adr-096-vibew-eject-keep-and-clarify-non-docker-escape-hatch.md
@@ -206,3 +206,8 @@ Docker Compose," and inferred eject and bundle were two paths to the same
 artifact. Replacing that one line with the correct description ("raw Caddy
 JSON for non-Docker deploys") removes the conflation entirely. The
 `--help` and README clarifications are belt-and-braces.
+
+The deeper consolidation — folding eject into `vibew bundle --target caddy-only`
+so vibew has a single deploy-artifact verb with swappable targets — is tracked
+in #1165 and deferred to a designed feature with its own ADR. This decision
+is keep-and-revisit, not permanent.

--- a/decisions/adr-096-vibew-eject-keep-and-clarify-non-docker-escape-hatch.md
+++ b/decisions/adr-096-vibew-eject-keep-and-clarify-non-docker-escape-hatch.md
@@ -1,0 +1,208 @@
+# ADR-096: `vibew eject` — keep-and-clarify as the non-Docker escape hatch
+
+**Date**: 2026-04-23
+**Issue**: #1147
+**Status**: Accepted
+
+## Context
+
+Retro 0.17.0 (agent additional drop #4) flagged `vibew eject` as redundant with
+`vibew bundle`. The PM investigation found that the two commands are
+**categorically different**:
+
+| Command | Output | Use case |
+|---|---|---|
+| `vibew eject` | Raw Caddy JSON to stdout | Operator running Caddy directly without Docker (vanilla Caddy / k8s sidecar) |
+| `vibew bundle` | Docker-Compose-shaped directory (`docker-compose.yml`, `image.tar`, merged YAML, `.env`, `README.md`) | Deploying the secured app to a VPS via Docker Compose |
+
+`vibew bundle` does not cover the non-Docker case at all (ADR-085 locks
+bundle as Compose-only).
+
+**Root cause of the agent confusion** is a single wrong line in the agents
+template (`internal/cli/templates/agents/agents-vibewarden.md.tmpl:94`):
+
+```
+| `vibew eject` | Eject to raw Docker Compose |
+```
+
+Eject has nothing to do with Docker Compose. That stale description is what
+makes agents conflate eject with bundle. The retro complaint is a docs problem
+masquerading as a feature problem.
+
+**Investment context**: `internal/app/eject/` was raised to 100% test coverage
+in PR #1128 (referenced from #1101). LOC: ~1127 (app + cmd + tests). External
+callers in docs/MCP/CI/examples/integration tests: zero.
+
+The PM spec recommended deprecate-and-remove in v0.19.0. The orchestrator
+pushed back: per CLAUDE.md §Artifact policy ("real or pure instruction"), eject
+is a real artifact (raw Caddy JSON) — the fix belongs at the instruction
+layer, not the verb. Removing a working escape hatch with 100% coverage
+because one line of doc was wrong is overcorrection.
+
+## Decision
+
+**Keep `vibew eject`. Fix the docs that caused the confusion.** No deprecation,
+no removal milestone.
+
+Three concrete doc-layer changes resolve the retro friction:
+
+1. **Fix the agents-template line** — replace the factually wrong "Eject to
+   raw Docker Compose" description with one that names the actual artifact
+   and the disambiguator.
+2. **Tighten `vibew eject --help`** — the `Short` description leads with the
+   non-Docker positioning; the `Long` description explicitly disambiguates
+   from `vibew bundle`.
+3. **Add a one-liner to README.md and llms-full.txt** that names the use
+   case (non-Docker) so the verb table rows are self-explanatory.
+
+No new ADR for the `vibew bundle` side — bundle's scope (Compose-only) is
+already locked by ADR-085.
+
+### Domain model changes
+
+None. No domain, ports, or adapter changes. This is a docs + cobra-string
+change.
+
+### Ports (interfaces)
+
+None.
+
+### Adapters
+
+None.
+
+### Application service
+
+No code changes to `internal/app/eject/`. The application service stays as-is
+(the 100% test coverage from #1128 is preserved).
+
+### File layout (no new files; edits only)
+
+- `internal/cli/cmd/eject.go` — update `Short` and `Long` strings on the
+  cobra command. Update the godoc on `NewEjectCmd`.
+- `internal/cli/templates/agents/agents-vibewarden.md.tmpl` — line 94: replace
+  the wrong description.
+- `README.md` — lines 210 and 319: clarify the use case.
+- `llms-full.txt` — line 1341: clarify the use case.
+- `docs/examples/AGENTS-VIBEWARDEN.md` — if it carries the same wrong line,
+  fix it (the dev should grep to confirm; PM's investigation said zero
+  occurrence, but the developer must verify).
+
+### Sequence
+
+This is a docs change. There is no runtime sequence change. The runtime
+behaviour of `vibew eject` is unchanged.
+
+### Concrete copy
+
+**`vibew eject` `Short` (cobra)** — replace:
+
+> Export the equivalent raw proxy config from vibewarden.yaml
+
+with:
+
+> Export raw Caddy JSON for non-Docker deploys (most users want `vibew bundle`)
+
+**`vibew eject` `Long` (cobra)** — first paragraph replacement:
+
+> Export the raw Caddy JSON configuration equivalent to the current
+> vibewarden.yaml. Use this when you run Caddy directly (vanilla Caddy host,
+> k8s sidecar, or any non-Docker setup) and want VibeWarden to generate the
+> Caddy config for you.
+>
+> If you deploy via Docker Compose, use `vibew bundle` instead — it produces
+> a complete deploy package (compose file, image tar, merged config, .env,
+> README) rather than just the raw proxy config.
+
+The remainder of `Long` (supported formats, internal-endpoint note,
+examples) stays as-is.
+
+**`agents-vibewarden.md.tmpl:94`** — replace:
+
+```
+| `vibew eject` | Eject to raw Docker Compose |
+```
+
+with:
+
+```
+| `vibew eject` | Export raw Caddy JSON config for non-Docker deploys (most setups should use `vibew bundle` instead) |
+```
+
+**README.md:210** — replace:
+
+```
+| Eject | `vibew eject` — export raw proxy config to graduate past VibeWarden |
+```
+
+with:
+
+```
+| Eject | `vibew eject` — export raw Caddy JSON for non-Docker deploys (Docker users want `vibew bundle`) |
+```
+
+**README.md:319 and llms-full.txt:1341** — same disambiguation tail
+(`(Docker users want `vibew bundle`)`).
+
+### Error cases
+
+No new error paths. Existing error paths in `internal/app/eject/` and
+`internal/cli/cmd/eject.go` are unchanged.
+
+### Test strategy
+
+This is a copy/docs change with two test-worthy invariants:
+
+1. **`vibew eject --help` output contains the disambiguating phrase.** Add
+   one assertion to an existing CLI-help test (or a new tiny test in
+   `internal/cli/cmd/eject_test.go`) that checks `Short` and `Long` mention
+   the words `non-Docker` and `vibew bundle`. This locks the
+   "agent reads --help, knows when to use it" guarantee.
+
+2. **The agents template no longer says "Docker Compose" on the eject row.**
+   Add an assertion to the agents-template test (the file already has
+   coverage; locate it via `grep -rn "agents-vibewarden.md.tmpl" internal/`
+   — likely under `internal/cli/templates/agents/` or
+   `internal/app/scaffold/`). Check that the rendered template does **not**
+   match `vibew eject.*Docker Compose` and **does** match `vibew eject.*Caddy`.
+
+3. **Existing `internal/app/eject/` tests stay green** (no behaviour change).
+
+No new integration tests; no new unit tests beyond the two assertions above.
+
+### New dependencies
+
+None.
+
+## Consequences
+
+**Positive:**
+
+- Preserves a real escape hatch (raw Caddy JSON for non-Docker users) at
+  zero ongoing cost. The 100% coverage from #1128 is not wasted.
+- Resolves the retro friction at its actual source (the wrong agents-template
+  line) rather than amputating the feature.
+- No deprecation cycle, no migration burden, no v0.19.0 follow-up issue.
+- Honours CLAUDE.md §Artifact policy: keep the real artifact, fix the
+  instructions.
+
+**Trade-offs / negative:**
+
+- One more verb in the surface area — agents must learn one more disambiguation
+  rule (Docker → bundle, non-Docker → eject). The clarified docs make this
+  explicit, but it is one more thing to read.
+- `--format` flag still only supports `caddy`. The stub `nginx`/`traefik`
+  values in earlier comments remain dead surface. **This ADR does not address
+  format expansion.** If the dead-format question becomes pressing, file a
+  follow-up issue; do not bundle it into the docs fix.
+- If a future retro re-raises the same complaint, we revisit deprecation.
+  The clarified docs are the test: if agents still get confused after this
+  change, the hypothesis (docs were the problem) was wrong and removal
+  becomes the right answer.
+
+**Did the agents-template fix alone prevent the qr-dali agent's confusion?**
+Yes. The investigation showed the agent read line 94, saw "Eject to raw
+Docker Compose," and inferred eject and bundle were two paths to the same
+artifact. Replacing that one line with the correct description ("raw Caddy
+JSON for non-Docker deploys") removes the conflation entirely. The
+`--help` and README clarifications are belt-and-braces.

--- a/internal/cli/cmd/eject.go
+++ b/internal/cli/cmd/eject.go
@@ -19,10 +19,11 @@ import (
 
 // NewEjectCmd creates the "vibew eject" subcommand.
 //
-// The command reads vibewarden.yaml (or the path supplied via --config) and
-// prints the equivalent raw proxy configuration to stdout. This allows
-// operators to graduate past VibeWarden and run the underlying proxy (e.g.
-// Caddy) directly with an equivalent configuration.
+// Use this command when you run Caddy directly on the host (vanilla Caddy,
+// k8s sidecar, or any non-Docker setup) and want VibeWarden to generate the
+// Caddy config for you. If you deploy via Docker Compose, use vibew bundle
+// instead — it produces a complete deploy package rather than just the raw
+// proxy config.
 //
 // Only --format caddy is supported in v1. Additional formats (nginx, traefik)
 // are reserved for future releases.
@@ -34,12 +35,15 @@ func NewEjectCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "eject",
-		Short: "Export the equivalent raw proxy config from vibewarden.yaml",
-		Long: `Export the raw proxy configuration equivalent to the current vibewarden.yaml.
+		Short: "Export raw Caddy JSON for non-Docker deploys (most users want `vibew bundle`)",
+		Long: `Export the raw Caddy JSON configuration equivalent to the current vibewarden.yaml.
 
-The generated configuration can be used to run the underlying proxy directly,
-without VibeWarden. This is useful when you have outgrown VibeWarden and want
-to manage the proxy configuration yourself.
+Use this when you run Caddy directly (vanilla Caddy host, k8s sidecar, or any
+non-Docker setup) and want VibeWarden to generate the Caddy config for you.
+
+If you deploy via Docker Compose, use ` + "`vibew bundle`" + ` instead — it produces
+a complete deploy package (compose file, image tar, merged config, .env,
+README) rather than just the raw proxy config.
 
 Supported formats:
   caddy  — Caddy JSON config (default). Feed it to Caddy's /load API or use

--- a/internal/cli/cmd/eject_test.go
+++ b/internal/cli/cmd/eject_test.go
@@ -217,6 +217,38 @@ upstream:
 	}
 }
 
+// TestEjectCmd_HelpTextDisambiguates verifies that the --help output for
+// "vibew eject" mentions both "non-Docker" and "vibew bundle" so that agents
+// reading cold --help output know when to use eject vs bundle (ADR-096).
+func TestEjectCmd_HelpTextDisambiguates(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	ejectCmd, _, _ := root.Find([]string{"eject"})
+	if ejectCmd == nil {
+		t.Fatal("eject subcommand not found")
+	}
+
+	short := ejectCmd.Short
+	long := ejectCmd.Long
+
+	tests := []struct {
+		name    string
+		field   string
+		keyword string
+	}{
+		{"Short contains non-Docker", short, "non-Docker"},
+		{"Short contains vibew bundle", short, "vibew bundle"},
+		{"Long contains non-Docker", long, "non-Docker"},
+		{"Long contains vibew bundle", long, "vibew bundle"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !strings.Contains(tt.field, tt.keyword) {
+				t.Errorf("eject help text missing %q\n\nText:\n%s", tt.keyword, tt.field)
+			}
+		})
+	}
+}
+
 // mapKeys returns the string keys of a map, for use in error messages.
 func mapKeys(m map[string]any) []string {
 	ks := make([]string, 0, len(m))

--- a/internal/cli/templates/agent_context_templates_test.go
+++ b/internal/cli/templates/agent_context_templates_test.go
@@ -140,6 +140,32 @@ func TestAgentsVibewardenTemplate_NoDockerfileExamples(t *testing.T) {
 	}
 }
 
+// TestAgentsVibewardenTemplate_EjectRowDisambiguated verifies that the rendered
+// agents-vibewarden.md.tmpl eject row no longer says "Docker Compose" and does
+// say "Caddy" — this locks the fix for the qr-dali agent confusion (ADR-096).
+func TestAgentsVibewardenTemplate_EjectRowDisambiguated(t *testing.T) {
+	renderer := templateadapter.NewRenderer(templates.FS)
+
+	out, err := renderer.Render("agents/agents-vibewarden.md.tmpl", domainscaffold.InitProjectData{
+		ProjectName: "testapp",
+		Port:        3000,
+	})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	rendered := string(out)
+
+	ejectDockerCompose := regexp.MustCompile(`vibew eject.*Docker Compose`)
+	if ejectDockerCompose.MatchString(rendered) {
+		t.Error("agents-vibewarden.md.tmpl eject row must not mention 'Docker Compose' — update the template (ADR-096)")
+	}
+
+	ejectCaddy := regexp.MustCompile(`vibew eject.*Caddy`)
+	if !ejectCaddy.MatchString(rendered) {
+		t.Error("agents-vibewarden.md.tmpl eject row must mention 'Caddy' to disambiguate from vibew bundle (ADR-096)")
+	}
+}
+
 // TestAgentContextTemplates_AgentsMd verifies that agents/agents.md.tmpl renders
 // the expected reference to AGENTS-VIBEWARDEN.md.
 func TestAgentContextTemplates_AgentsMd(t *testing.T) {

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -91,7 +91,7 @@ Output uses OK / OFF / FAIL labels; OFF means the component is disabled in confi
 | `vibew cert export` | Export TLS certificate |
 | `vibew validate` | Validate vibewarden.yaml |
 | `vibew add auth` | Enable authentication |
-| `vibew eject` | Eject to raw Docker Compose |
+| `vibew eject` | Export raw Caddy JSON config for non-Docker deploys (most setups should use `vibew bundle` instead) |
 
 ## Multi-site deployment
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1338,7 +1338,7 @@ VibeWarden is operated via the `vibew` CLI. Below is the complete command list.
 | `vibew validate` | Validate configuration |
 | `vibew context refresh` | Regenerate AI agent context files |
 | `vibew tls status` | Show remote TLS certificate details (issuer, expiry, domain) |
-| `vibew eject` | Export raw proxy config to graduate past VibeWarden |
+| `vibew eject` | Export raw Caddy JSON for non-Docker deploys (Docker users want `vibew bundle`) |
 | `vibew mcp` | Start MCP server for AI agent integration |
 
 ### init flags


### PR DESCRIPTION
Closes #1147

## Summary

- Tightened `vibew eject --help`: `Short` now leads with `"Export raw Caddy JSON for non-Docker deploys (most users want \`vibew bundle\`)"` and `Long` explicitly disambiguates eject (non-Docker) from bundle (Docker Compose).
- Fixed the factually wrong agents-template line (`agents-vibewarden.md.tmpl:94`): replaced `"Eject to raw Docker Compose"` with `"Export raw Caddy JSON config for non-Docker deploys (most setups should use \`vibew bundle\` instead)"` — this was the qr-dali agent's confusion source.
- Updated `README.md` (lines 210 and 319) and `llms-full.txt` (line 1341) with the same disambiguation tail.
- Added ADR-096 (`decisions/adr-096-vibew-eject-keep-and-clarify-non-docker-escape-hatch.md`) capturing the keep-and-clarify decision rationale.
- `decisions/README.md` index already carried ADR-096 row (pre-populated by architect); confirmed correct position after 095.
- `CHANGELOG.md` `[Unreleased]` `### Changed` entry added.
- Two new test assertions: `TestEjectCmd_HelpTextDisambiguates` checks `Short`/`Long` contain `non-Docker` and `vibew bundle`; `TestAgentsVibewardenTemplate_EjectRowDisambiguated` checks rendered template does not match `vibew eject.*Docker Compose` and does match `vibew eject.*Caddy`.

No behaviour change. `internal/app/eject/` tests stay green.

## Test plan

- `make check` passes (lint + build + all tests including new assertions).
- `vibew eject --help` output contains `non-Docker` and `vibew bundle`.
- Rendered `agents-vibewarden.md.tmpl` eject row says `Caddy`, not `Docker Compose`.