### PR TITLE
chore(#1149): extract --observability flag into vibew obs up/down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Added
 
+- **`vibew obs up` / `vibew obs down`** (#1149) — bring up / tear down the Prometheus + Grafana observability profile against the running dev stack. Uses Docker Compose profiles; the obs services share the same compose project as the main stack but are gated by the `observability` profile. Run `vibew dev` first, then `vibew obs up`.
+
 - **`vibew bundle` now prints a "Sensitive files in this bundle" awareness block** (#1142, [ADR-094](decisions/adr-094-bundle-sensitive-files-awareness-block.md)). After writing the bundle, `vibew bundle` scans the output directory and prints a stable awareness block listing any credential or key files (`.env`, `.credentials`, `kratos/secrets`, `*.pem`, `*.key`, `*.token`) when they are present. The block appears after the `Contents:` listing and before the `Next:` hint. The block is omitted entirely when no sensitive files are detected — no flag, no env var, no opt-out. The bundle `README.md` gains a `## Secrets` section documenting the credential surface.
 
 ### Fixed
@@ -33,6 +35,8 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 - **`vibew init` no longer generates a placeholder `Dockerfile` or `.dockerignore`** (#1139). `AGENTS-VIBEWARDEN.md` now carries a Dockerfile contract checklist; agents and users write their own Dockerfile against that contract. Migration: existing projects that already have a Dockerfile are unaffected. New projects must write a Dockerfile after `vibew init` — see `AGENTS-VIBEWARDEN.md` §Dockerfile contract.
 
 ### Removed
+
+- **`vibew dev --observability` flag** (#1149). Replaced by the new `vibew obs up` / `vibew obs down` subcommand pair. Migration: `vibew dev && vibew obs up` (run `vibew obs up` after the main stack is running). Per CLAUDE.md §Architecture principles: trim CLI surface; `vibew dev` is the core loop, observability is opt-in tooling.
 
 - **`vibew restart` removed** (#1148). For incremental rebuilds use `vibew build && vibew dev` (`vibew dev` auto-recreates stale app containers). For a clean restart of a wedged stack use `vibew down && vibew dev`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,7 +82,7 @@ plugin API.
 | CORS | `cors` | Cross-Origin Resource Sharing headers |
 | Secrets | `secrets` | OpenBao integration — inject secrets as headers or env vars |
 | Egress proxy | `egress` | Outbound HTTP control with SSRF protection |
-| Observability | `observability` | Prometheus, Grafana, Loki, Promtail Compose stack |
+| Observability | `observability` | Prometheus, Grafana, Loki, Promtail Compose stack (start with `vibew obs up`) |
 | Resilience | `resilience` | Circuit breaker, retry, and timeout middleware |
 | IP filter | `ip_filter` | IP address allowlist / blocklist |
 | Body size | `body_size` | Per-request body size enforcement |

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -62,6 +62,8 @@ vibew dev            # local development (generates docker-compose, starts stack
 vibew dev --watch    # auto-restart on vibewarden.yaml changes
 vibew dev --verbose  # stream docker compose output during startup
 vibew down           # stop the dev stack (preserves volumes; -v also removes volumes)
+vibew obs up         # start Prometheus + Grafana observability stack (after vibew dev)
+vibew obs down       # stop the observability stack (-v also removes volumes)
 ```
 
 ## Config changes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -448,9 +448,10 @@ examples with Auth0, Keycloak, Firebase, Cognito, Okta, Supabase, and Kratos.
 ./vibew add metrics
 ./vibew build
 ./vibew dev
+./vibew obs up
 ```
 
-Open Grafana at `http://localhost:3001` to see request rate, latency percentiles,
+Open Grafana at `http://localhost:3000` to see request rate, latency percentiles,
 rate limit hits, and auth decisions in real time.
 
 !!! tip "Generate a dev JWT"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -451,7 +451,7 @@ examples with Auth0, Keycloak, Firebase, Cognito, Okta, Supabase, and Kratos.
 ./vibew obs up
 ```
 
-Open Grafana at `http://localhost:3000` to see request rate, latency percentiles,
+Open Grafana at `http://localhost:3001` to see request rate, latency percentiles,
 rate limit hits, and auth decisions in real time.
 
 !!! tip "Generate a dev JWT"

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ It is never hosted remotely.
 | AI-readable logs | Versioned JSON schema: `schema_version`, `event_type`, `ai_summary`, `payload` |
 | Audit log sinks | JSON file, OTel logs, webhook (HMAC-signed) with retry |
 | Admin API | User management at `/_vibewarden/admin/*` (bearer-token protected) |
-| Docker Compose | Profile-based: `--profile observability`, `--profile demo` |
+| Docker Compose | Profile-based: `vibew obs up` (observability), `--profile demo` |
 
 ---
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -224,7 +224,7 @@ empty — all structured data lives in attributes.
 
 ### OTel Collector Architecture
 
-When the observability profile is enabled (`docker compose --profile observability up`),
+When the observability profile is enabled (via `vibew obs up`),
 VibeWarden generates an OTel Collector configuration that acts as a telemetry hub:
 
 ```
@@ -356,26 +356,33 @@ No manual config changes needed — just enable the observability profile.
 
 ## Quick Start
 
-Enable observability in `vibewarden.yaml`:
-
-```yaml
-observability:
-  enabled: true
-  grafana_port: 3001
-```
-
-Generate and start:
+Start the main dev stack first, then bring up the observability profile:
 
 ```bash
-vibewarden generate
-COMPOSE_PROFILES=observability docker compose -f .vibewarden/generated/docker-compose.yml up -d
+vibew dev
+vibew obs up
 ```
 
-Stop the stack:
+Stop only the observability services:
 
 ```bash
-COMPOSE_PROFILES=observability docker compose -f .vibewarden/generated/docker-compose.yml down
+vibew obs down
 ```
+
+Stop everything including observability services and volumes:
+
+```bash
+vibew obs down -v --yes
+vibew down -v --yes
+```
+
+> **Informational footnote:** The underlying Docker Compose commands that
+> `vibew obs up` / `vibew obs down` invoke are:
+> ```bash
+> docker compose -f .vibewarden/generated/docker-compose.yml --profile observability up -d
+> docker compose -f .vibewarden/generated/docker-compose.yml --profile observability down
+> ```
+> These are still valid if you prefer to call compose directly.
 
 ## Accessing the UIs
 
@@ -531,7 +538,7 @@ Prometheus may not have scraped VibeWarden yet, or VibeWarden is not running.
 
 1. Check that all containers are up:
    ```bash
-   docker compose --profile observability ps
+   vibew status
    ```
 2. Verify VibeWarden's metrics endpoint is reachable:
    ```bash
@@ -570,11 +577,11 @@ docker compose -f .vibewarden/generated/docker-compose.yml logs grafana
    ```
 2. Check Promtail is running and has no errors:
    ```bash
-   docker compose --profile observability logs promtail
+   docker compose -f .vibewarden/generated/docker-compose.yml --profile observability logs promtail
    ```
 3. Confirm Promtail has write access to the Docker socket:
    ```bash
-   docker compose --profile observability ps promtail
+   docker compose -f .vibewarden/generated/docker-compose.yml --profile observability ps promtail
    ```
 4. In Grafana Explore, select the **Loki** datasource and run:
    ```logql

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -388,7 +388,7 @@ vibew down -v --yes
 
 | Service    | URL                          | Notes                                  |
 |------------|------------------------------|----------------------------------------|
-| Grafana    | http://localhost:3000        | Anonymous access, Admin role, no login |
+| Grafana    | http://localhost:3001        | Anonymous access, Admin role, no login |
 | Prometheus | http://localhost:9090        | No authentication required             |
 | Loki       | http://localhost:3100/ready  | API only; query logs via Grafana       |
 
@@ -549,13 +549,13 @@ Prometheus may not have scraped VibeWarden yet, or VibeWarden is not running.
 
 ### Port conflicts
 
-If port 3000 or 9090 is already in use, Docker Compose will fail to start the
+If port 3001 or 9090 is already in use, Docker Compose will fail to start the
 corresponding container. Stop the conflicting process or change the host port in
 `docker-compose.yml`:
 
 ```yaml
 ports:
-  - "3001:3000"   # expose Grafana on host port 3001 instead
+  - "3002:3000"   # expose Grafana on host port 3002 instead
 ```
 
 ### Grafana starts but the dashboard is not visible

--- a/internal/adapters/ops/compose.go
+++ b/internal/adapters/ops/compose.go
@@ -101,6 +101,9 @@ func (c *ComposeAdapter) Down(ctx context.Context, composeFile string, opts port
 	if composeFile != "" {
 		args = append(args, "-f", composeFile)
 	}
+	for _, p := range opts.Profiles {
+		args = append(args, "--profile", p)
+	}
 	args = append(args, "down")
 	if opts.Volumes {
 		args = append(args, "--volumes")

--- a/internal/app/ops/dev.go
+++ b/internal/app/ops/dev.go
@@ -90,10 +90,6 @@ func (s *DevService) WithImageChecker(checker ports.DockerImageChecker) *DevServ
 
 // DevOptions holds options for the dev command.
 type DevOptions struct {
-	// Observability enables the "observability" compose profile, which starts
-	// Prometheus and Grafana alongside the core stack.
-	Observability bool
-
 	// Watch enables file-system watching of vibewarden.yaml.  When true,
 	// any write to the config file triggers a regenerate + compose restart
 	// cycle after a 500 ms debounce window.  Requires a ConfigWatcher to be
@@ -122,15 +118,7 @@ type DevOptions struct {
 // When opts.Watch is true and a ConfigWatcher is wired, Run also starts the
 // watch loop and blocks until ctx is cancelled.
 func (s *DevService) Run(ctx context.Context, cfg *config.Config, opts DevOptions, out io.Writer) error {
-	var profiles []string
-	if opts.Observability {
-		profiles = append(profiles, "observability")
-	}
-
 	fmt.Fprintln(out, "Starting VibeWarden dev environment...")
-	if opts.Observability {
-		fmt.Fprintln(out, "Observability profile enabled (Prometheus + Grafana).")
-	}
 
 	// Warn when letsencrypt is configured in dev mode — ACME challenges will
 	// fail on localhost since the server is not publicly reachable.
@@ -164,7 +152,7 @@ func (s *DevService) Run(ctx context.Context, cfg *config.Config, opts DevOption
 		// build progress in real time.
 		upOpts.Stderr = out
 	}
-	if err := s.compose.Up(ctx, composeFile, profiles, upOpts); err != nil {
+	if err := s.compose.Up(ctx, composeFile, nil, upOpts); err != nil {
 		return fmt.Errorf("starting dev environment: %w", err)
 	}
 
@@ -483,21 +471,15 @@ func summaryURL(cfg *config.Config) string {
 	return fmt.Sprintf("%s://%s:%d", scheme, host, port)
 }
 
-// printStartupSummary writes the three-line post-start hint block.
+// printStartupSummary writes the post-start hint block.
 // Format:
 //
 //	Started. <url>
 //	Logs: vibew logs -f
 //	Stop: vibew down
-//
-// When observability is enabled an extra line mentioning Grafana is emitted
-// above the summary block so it is discoverable without hiding the core hints.
-func printStartupSummary(cfg *config.Config, opts DevOptions, out io.Writer) {
+func printStartupSummary(cfg *config.Config, _ DevOptions, out io.Writer) {
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "Dev environment started.")
-	if opts.Observability {
-		fmt.Fprintln(out, "Grafana: http://localhost:3000 | Prometheus: http://localhost:9090")
-	}
 	fmt.Fprintf(out, "Started. %s\n", summaryURL(cfg))
 	fmt.Fprintln(out, "Logs: vibew logs -f")
 	fmt.Fprintln(out, "Stop: vibew down")

--- a/internal/app/ops/dev_test.go
+++ b/internal/app/ops/dev_test.go
@@ -107,29 +107,16 @@ func TestDevService_Run(t *testing.T) {
 		opts               ops.DevOptions
 		upErr              error
 		wantErr            bool
-		wantProfiles       []string
 		wantOutputContains []string
 	}{
 		{
-			name:         "baseline stack — no observability",
-			opts:         ops.DevOptions{Observability: false},
-			wantErr:      false,
-			wantProfiles: nil,
+			name:    "baseline stack",
+			opts:    ops.DevOptions{},
+			wantErr: false,
 			wantOutputContains: []string{
 				"Started. https://localhost:8443",
 				"Logs: vibew logs -f",
 				"Stop: vibew down",
-			},
-		},
-		{
-			name:         "observability profile enabled",
-			opts:         ops.DevOptions{Observability: true},
-			wantErr:      false,
-			wantProfiles: []string{"observability"},
-			wantOutputContains: []string{
-				"Grafana:",
-				"Prometheus:",
-				"Observability profile enabled",
 			},
 		},
 		{
@@ -161,14 +148,9 @@ func TestDevService_Run(t *testing.T) {
 					}
 				}
 
-				// Check profiles forwarded to compose
-				if len(tt.wantProfiles) == 0 && len(fc.capturedProfiles) != 0 {
-					t.Errorf("expected no profiles, got %v", fc.capturedProfiles)
-				}
-				for i, p := range tt.wantProfiles {
-					if i >= len(fc.capturedProfiles) || fc.capturedProfiles[i] != p {
-						t.Errorf("profile[%d] = %q, want %q", i, fc.capturedProfiles[i], p)
-					}
+				// Baseline dev run must not pass any profiles to compose.
+				if len(fc.capturedProfiles) != 0 {
+					t.Errorf("expected no profiles for baseline dev, got %v", fc.capturedProfiles)
 				}
 			}
 		})

--- a/internal/app/ops/down_test.go
+++ b/internal/app/ops/down_test.go
@@ -225,3 +225,20 @@ func TestDownService_RemoveOrphans_Forwarded(t *testing.T) {
 		t.Error("expected RemoveOrphans=true forwarded to adapter")
 	}
 }
+
+func TestDownService_DoesNotPassProfiles(t *testing.T) {
+	// `vibew down` tears down the whole project and must NOT restrict teardown
+	// to any profile — passing --profile would leave non-profile services
+	// running. This is the regression guard for the obs-down profile fix: only
+	// ObsService.Down should set Profiles, not the main DownService.
+	fake := &downCompose{}
+	svc := opsapp.NewDownService(fake)
+
+	var out bytes.Buffer
+	if err := svc.Run(context.Background(), opsapp.DownOptions{}, &out); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(fake.capturedOp.Profiles) != 0 {
+		t.Errorf("DownService.Run() must not set Profiles, got %v", fake.capturedOp.Profiles)
+	}
+}

--- a/internal/app/ops/obs.go
+++ b/internal/app/ops/obs.go
@@ -1,0 +1,145 @@
+package ops
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	generateapp "github.com/vibewarden/vibewarden/internal/app/generate"
+	"github.com/vibewarden/vibewarden/internal/config"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// obsProfile is the Docker Compose profile name for the observability stack.
+const obsProfile = "observability"
+
+// ObsService orchestrates the "vibew obs up" and "vibew obs down" use cases.
+// It runs the observability Compose profile (Prometheus + Grafana + Loki + Promtail)
+// against the same compose project as the main dev stack.
+type ObsService struct {
+	compose   ports.ComposeRunner
+	generator *generateapp.Service // optional; nil disables regeneration on up
+}
+
+// NewObsService creates an ObsService that uses a pre-existing generated compose
+// file. Pass a non-nil generator to have Up regenerate config before starting.
+func NewObsService(compose ports.ComposeRunner, generator *generateapp.Service) *ObsService {
+	return &ObsService{compose: compose, generator: generator}
+}
+
+// ObsUpOptions holds options for the "vibew obs up" command.
+type ObsUpOptions struct {
+	// ConfigPath is the path to vibewarden.yaml used by the generator.
+	// When empty the default "./vibewarden.yaml" is used.
+	ConfigPath string
+	// Verbose streams compose stderr to out during startup.
+	Verbose bool
+}
+
+// ObsDownOptions holds options for the "vibew obs down" command.
+type ObsDownOptions struct {
+	// Volumes controls whether named volumes (Grafana dashboards, etc.) are
+	// also removed. Destructive — callers should confirm with the user.
+	Volumes bool
+	// RemoveOrphans passes --remove-orphans to docker compose down.
+	RemoveOrphans bool
+	// Yes skips the interactive confirmation prompt when Volumes is true.
+	Yes bool
+	// In is the reader used for the y/N confirmation prompt. When nil, volume
+	// deletion with IsTTY=false requires Yes=true.
+	In io.Reader
+	// IsTTY indicates whether the process is attached to an interactive terminal.
+	IsTTY bool
+}
+
+// Up starts the observability Compose profile against the generated compose file.
+// It optionally regenerates config first when a generator is wired. It prints a
+// friendly advisory when the main sidecar does not appear to be running (Prometheus
+// scrape targets will be empty), but does NOT return an error in that case.
+func (s *ObsService) Up(ctx context.Context, cfg *config.Config, opts ObsUpOptions, out io.Writer) error {
+	composeFile := filepath.Join(generatedOutputDir, "docker-compose.yml")
+
+	// Optional regeneration step.
+	if s.generator != nil {
+		fmt.Fprintln(out, "Generating runtime configuration files...")
+		if err := s.generator.Generate(ctx, cfg.ToGeneratorInput(), generatedOutputDir); err != nil {
+			return fmt.Errorf("generating config: %w", err)
+		}
+		fmt.Fprintf(out, "Generated files written to %s\n", generatedOutputDir)
+	}
+
+	fmt.Fprintln(out, "Starting observability stack (Prometheus + Grafana)...")
+
+	// Advisory: check whether the sidecar is running; if not, scrape targets
+	// will be empty — this is not a hard failure.
+	s.printSidecarAdvisory(ctx, composeFile, out)
+
+	upOpts := ports.ComposeUpOptions{}
+	if opts.Verbose {
+		upOpts.Stderr = out
+	}
+
+	if err := s.compose.Up(ctx, composeFile, []string{obsProfile}, upOpts); err != nil {
+		return fmt.Errorf("starting observability stack: %w", err)
+	}
+
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "Observability stack started.")
+	fmt.Fprintln(out, "Grafana:    http://localhost:3000")
+	fmt.Fprintln(out, "Prometheus: http://localhost:9090")
+	fmt.Fprintln(out, "Stop:       vibew obs down")
+
+	return nil
+}
+
+// Down stops the observability Compose profile services.
+func (s *ObsService) Down(ctx context.Context, opts ObsDownOptions, out io.Writer) error {
+	composeFile := filepath.Join(generatedOutputDir, "docker-compose.yml")
+
+	if opts.Volumes && !opts.Yes {
+		if !opts.IsTTY {
+			return ErrNonTTYVolumesRequiresYes
+		}
+		confirmed, err := confirmVolumeDeletion(opts.In, out)
+		if err != nil {
+			return fmt.Errorf("reading confirmation: %w", err)
+		}
+		if !confirmed {
+			fmt.Fprintln(out, "Aborted. Volumes preserved.")
+			return nil
+		}
+	}
+
+	result, err := s.compose.Down(ctx, composeFile, ports.ComposeDownOptions{
+		Volumes:       opts.Volumes,
+		RemoveOrphans: opts.RemoveOrphans,
+	})
+	if err != nil {
+		return fmt.Errorf("stopping observability stack: %w", err)
+	}
+
+	printDownSummary(result, DownOptions{Volumes: opts.Volumes}, out)
+	return nil
+}
+
+// printSidecarAdvisory checks whether the sidecar container is running and
+// prints a helpful notice when it is not found. It never returns an error —
+// missing sidecar is advisory only (Prometheus scrape targets will be empty).
+func (s *ObsService) printSidecarAdvisory(ctx context.Context, composeFile string, out io.Writer) {
+	containers, err := s.compose.PS(ctx, composeFile)
+	if err != nil {
+		// PS failure is non-fatal; skip the advisory.
+		return
+	}
+
+	for _, c := range containers {
+		if c.Service == sidecarServiceName {
+			return // sidecar found — no advisory needed
+		}
+	}
+
+	// Sidecar not found in running containers.
+	fmt.Fprintln(out, "Advisory: sidecar not detected — Prometheus scrape targets will be empty")
+	fmt.Fprintln(out, "until you run `vibew dev`. The observability services will still start.")
+}

--- a/internal/app/ops/obs.go
+++ b/internal/app/ops/obs.go
@@ -86,7 +86,7 @@ func (s *ObsService) Up(ctx context.Context, cfg *config.Config, opts ObsUpOptio
 
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "Observability stack started.")
-	fmt.Fprintln(out, "Grafana:    http://localhost:3000")
+	fmt.Fprintln(out, "Grafana:    http://localhost:3001")
 	fmt.Fprintln(out, "Prometheus: http://localhost:9090")
 	fmt.Fprintln(out, "Stop:       vibew obs down")
 
@@ -114,6 +114,7 @@ func (s *ObsService) Down(ctx context.Context, opts ObsDownOptions, out io.Write
 	result, err := s.compose.Down(ctx, composeFile, ports.ComposeDownOptions{
 		Volumes:       opts.Volumes,
 		RemoveOrphans: opts.RemoveOrphans,
+		Profiles:      []string{obsProfile},
 	})
 	if err != nil {
 		return fmt.Errorf("stopping observability stack: %w", err)

--- a/internal/app/ops/obs_test.go
+++ b/internal/app/ops/obs_test.go
@@ -245,3 +245,41 @@ func TestObsService_Down_ComposeError_ReturnsError(t *testing.T) {
 		t.Errorf("error should wrap compose error, got: %v", err)
 	}
 }
+
+func TestObsService_Down_PassesObservabilityProfile(t *testing.T) {
+	// obs down must scope teardown to the observability profile only, so that
+	// running `vibew obs down` does not stop the main sidecar or other services.
+	fc := &fakeCompose{}
+	svc := ops.NewObsService(fc, nil)
+	var buf bytes.Buffer
+
+	if err := svc.Down(context.Background(), ops.ObsDownOptions{Yes: true}, &buf); err != nil {
+		t.Fatalf("Down() unexpected error: %v", err)
+	}
+
+	profiles := fc.capturedDownOpts.Profiles
+	if len(profiles) != 1 || profiles[0] != "observability" {
+		t.Errorf("Down() Profiles = %v, want [observability]", profiles)
+	}
+}
+
+func TestObsService_Up_PrintsGrafanaOnPort3001(t *testing.T) {
+	// Grafana's default host port is 3001 (mapped from container-internal :3000).
+	// The CLI output must reflect the actual accessible URL.
+	fc := &fakeCompose{}
+	svc := ops.NewObsService(fc, nil)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	if err := svc.Up(context.Background(), cfg, ops.ObsUpOptions{}, &buf); err != nil {
+		t.Fatalf("Up() unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "localhost:3001") {
+		t.Errorf("expected Grafana URL with port 3001 in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "localhost:3000") {
+		t.Errorf("output must not reference port 3000 (container-internal); got:\n%s", out)
+	}
+}

--- a/internal/app/ops/obs_test.go
+++ b/internal/app/ops/obs_test.go
@@ -1,0 +1,247 @@
+package ops_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+func TestObsService_Up_InvokesComposeWithObservabilityProfile(t *testing.T) {
+	fc := &fakeCompose{}
+	svc := ops.NewObsService(fc, nil)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	if err := svc.Up(context.Background(), cfg, ops.ObsUpOptions{}, &buf); err != nil {
+		t.Fatalf("Up() unexpected error: %v", err)
+	}
+
+	if len(fc.capturedProfiles) != 1 || fc.capturedProfiles[0] != "observability" {
+		t.Errorf("Up() profiles = %v, want [observability]", fc.capturedProfiles)
+	}
+}
+
+func TestObsService_Up_UsesGeneratedComposeFile(t *testing.T) {
+	fc := &fakeCompose{}
+	svc := ops.NewObsService(fc, nil)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	if err := svc.Up(context.Background(), cfg, ops.ObsUpOptions{}, &buf); err != nil {
+		t.Fatalf("Up() unexpected error: %v", err)
+	}
+
+	want := ".vibewarden/generated/docker-compose.yml"
+	if fc.capturedComposeFile != want {
+		t.Errorf("Up() composeFile = %q, want %q", fc.capturedComposeFile, want)
+	}
+}
+
+func TestObsService_Up_PrintsGrafanaAndPrometheusURLs(t *testing.T) {
+	fc := &fakeCompose{}
+	svc := ops.NewObsService(fc, nil)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	if err := svc.Up(context.Background(), cfg, ops.ObsUpOptions{}, &buf); err != nil {
+		t.Fatalf("Up() unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Grafana") {
+		t.Errorf("expected Grafana URL in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Prometheus") {
+		t.Errorf("expected Prometheus URL in output, got:\n%s", out)
+	}
+}
+
+func TestObsService_Up_ComposeError_ReturnsError(t *testing.T) {
+	fc := &fakeCompose{upErr: errors.New("docker not running")}
+	svc := ops.NewObsService(fc, nil)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	err := svc.Up(context.Background(), cfg, ops.ObsUpOptions{}, &buf)
+	if err == nil {
+		t.Fatal("Up() expected error when compose fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "starting observability stack") {
+		t.Errorf("error should wrap compose error, got: %v", err)
+	}
+}
+
+func TestObsService_Up_Verbose_ForwardsStderrWriter(t *testing.T) {
+	fc := &fakeCompose{}
+	svc := ops.NewObsService(fc, nil)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	if err := svc.Up(context.Background(), cfg, ops.ObsUpOptions{Verbose: true}, &buf); err != nil {
+		t.Fatalf("Up() unexpected error: %v", err)
+	}
+	if fc.capturedUpOpts.Stderr == nil {
+		t.Error("expected Up() to be called with non-nil Stderr in verbose mode")
+	}
+}
+
+func TestObsService_Up_NotVerbose_StderrNil(t *testing.T) {
+	fc := &fakeCompose{}
+	svc := ops.NewObsService(fc, nil)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	if err := svc.Up(context.Background(), cfg, ops.ObsUpOptions{}, &buf); err != nil {
+		t.Fatalf("Up() unexpected error: %v", err)
+	}
+	if fc.capturedUpOpts.Stderr != nil {
+		t.Error("expected Up() Stderr nil when not verbose")
+	}
+}
+
+func TestObsService_Up_SidecarNotRunning_PrintsAdvisory(t *testing.T) {
+	// When PS returns no sidecar container, Up still succeeds but prints an advisory.
+	fc := &fakeCompose{
+		psResult: []ports.ContainerInfo{
+			{Service: "postgres", State: "running"},
+		},
+	}
+	svc := ops.NewObsService(fc, nil)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	if err := svc.Up(context.Background(), cfg, ops.ObsUpOptions{}, &buf); err != nil {
+		t.Fatalf("Up() expected no error for missing sidecar, got: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Advisory") {
+		t.Errorf("expected advisory message when sidecar not running, got:\n%s", out)
+	}
+	if !strings.Contains(out, "vibew dev") {
+		t.Errorf("expected 'vibew dev' hint in advisory, got:\n%s", out)
+	}
+}
+
+func TestObsService_Up_SidecarRunning_NoAdvisory(t *testing.T) {
+	// When PS includes a running sidecar, no advisory is printed.
+	fc := &fakeCompose{
+		psResult: []ports.ContainerInfo{
+			{Service: "vibewarden", State: "running"},
+		},
+	}
+	svc := ops.NewObsService(fc, nil)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	if err := svc.Up(context.Background(), cfg, ops.ObsUpOptions{}, &buf); err != nil {
+		t.Fatalf("Up() unexpected error: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "Advisory") {
+		t.Errorf("unexpected advisory when sidecar is running:\n%s", out)
+	}
+}
+
+func TestObsService_Up_PSError_DoesNotFail(t *testing.T) {
+	// When PS fails, the advisory check is skipped and Up proceeds normally.
+	fc := &fakeCompose{psErr: errors.New("docker daemon not responding")}
+	svc := ops.NewObsService(fc, nil)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	if err := svc.Up(context.Background(), cfg, ops.ObsUpOptions{}, &buf); err != nil {
+		t.Fatalf("Up() unexpected error when PS fails: %v", err)
+	}
+}
+
+// --- Down tests ---
+
+func TestObsService_Down_InvokesComposeDown(t *testing.T) {
+	fc := &fakeCompose{}
+	svc := ops.NewObsService(fc, nil)
+	var buf bytes.Buffer
+
+	if err := svc.Down(context.Background(), ops.ObsDownOptions{Yes: true}, &buf); err != nil {
+		t.Fatalf("Down() unexpected error: %v", err)
+	}
+	if fc.downCalled != 1 {
+		t.Errorf("expected Down() to be called once, got %d", fc.downCalled)
+	}
+}
+
+func TestObsService_Down_UsesGeneratedComposeFile(t *testing.T) {
+	fc := &fakeCompose{}
+	svc := ops.NewObsService(fc, nil)
+	var buf bytes.Buffer
+
+	if err := svc.Down(context.Background(), ops.ObsDownOptions{Yes: true}, &buf); err != nil {
+		t.Fatalf("Down() unexpected error: %v", err)
+	}
+	// The compose file is internal; we verify Down was called (compose file
+	// verified via the obsService's Down implementation which uses generatedOutputDir).
+	if fc.downCalled == 0 {
+		t.Error("expected Down() to be called")
+	}
+}
+
+func TestObsService_Down_WithVolumes_ForwardsFlag(t *testing.T) {
+	fc := &fakeCompose{}
+	svc := ops.NewObsService(fc, nil)
+	var buf bytes.Buffer
+
+	opts := ops.ObsDownOptions{Volumes: true, Yes: true}
+	if err := svc.Down(context.Background(), opts, &buf); err != nil {
+		t.Fatalf("Down() unexpected error: %v", err)
+	}
+	if !fc.capturedDownOpts.Volumes {
+		t.Error("expected Volumes=true forwarded to compose.Down")
+	}
+}
+
+func TestObsService_Down_WithRemoveOrphans_ForwardsFlag(t *testing.T) {
+	fc := &fakeCompose{}
+	svc := ops.NewObsService(fc, nil)
+	var buf bytes.Buffer
+
+	opts := ops.ObsDownOptions{RemoveOrphans: true}
+	if err := svc.Down(context.Background(), opts, &buf); err != nil {
+		t.Fatalf("Down() unexpected error: %v", err)
+	}
+	if !fc.capturedDownOpts.RemoveOrphans {
+		t.Error("expected RemoveOrphans=true forwarded to compose.Down")
+	}
+}
+
+func TestObsService_Down_NonTTY_VolumesWithoutYes_ReturnsError(t *testing.T) {
+	fc := &fakeCompose{}
+	svc := ops.NewObsService(fc, nil)
+	var buf bytes.Buffer
+
+	opts := ops.ObsDownOptions{Volumes: true, IsTTY: false, Yes: false}
+	err := svc.Down(context.Background(), opts, &buf)
+	if err == nil {
+		t.Fatal("Down() expected error for non-TTY volumes without --yes, got nil")
+	}
+	if !errors.Is(err, ops.ErrNonTTYVolumesRequiresYes) {
+		t.Errorf("expected ErrNonTTYVolumesRequiresYes, got: %v", err)
+	}
+}
+
+func TestObsService_Down_ComposeError_ReturnsError(t *testing.T) {
+	fc := &fakeCompose{downErr: errors.New("compose down failed")}
+	svc := ops.NewObsService(fc, nil)
+	var buf bytes.Buffer
+
+	err := svc.Down(context.Background(), ops.ObsDownOptions{}, &buf)
+	if err == nil {
+		t.Fatal("Down() expected error when compose fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "stopping observability stack") {
+		t.Errorf("error should wrap compose error, got: %v", err)
+	}
+}

--- a/internal/cli/cmd/dev.go
+++ b/internal/cli/cmd/dev.go
@@ -20,15 +20,16 @@ import (
 //
 // The command generates runtime config files under .vibewarden/generated/,
 // then starts the Docker Compose dev environment in detached mode and
-// prints the running service URLs.  Pass --observability to also start the
-// Prometheus + Grafana observability stack.  Pass --watch to watch
-// vibewarden.yaml for changes and auto-regenerate + restart the stack.
+// prints the running service URLs.  Pass --watch to watch vibewarden.yaml
+// for changes and auto-regenerate + restart the stack.
+// To also start the Prometheus + Grafana observability stack run:
+//
+//	vibew obs up
 func NewDevCmd() *cobra.Command {
 	var (
-		observability bool
-		watch         bool
-		configPath    string
-		verbose       bool
+		watch      bool
+		configPath string
+		verbose    bool
 	)
 
 	cmd := &cobra.Command{
@@ -45,13 +46,12 @@ The baseline stack includes:
   - PostgreSQL
   - Mailslurper (email sink)
 
-Pass --observability to also start Prometheus and Grafana.
+To also start Prometheus and Grafana, run 'vibew obs up' after the stack is up.
 Pass --watch to watch vibewarden.yaml for changes and automatically
 regenerate config files and restart the stack (blocks until Ctrl+C).
 
 Examples:
   vibew dev
-  vibew dev --observability
   vibew dev --watch
   vibew dev --config ./my-vibewarden.yaml`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -92,18 +92,16 @@ Examples:
 			detectedLang := detectProjectLang(".")
 
 			opts := opsapp.DevOptions{
-				Observability: observability,
-				Watch:         watch,
-				ConfigPath:    configPath,
-				DetectedLang:  detectedLang,
-				Verbose:       verbose,
+				Watch:        watch,
+				ConfigPath:   configPath,
+				DetectedLang: detectedLang,
+				Verbose:      verbose,
 			}
 
 			return svc.Run(cmd.Context(), cfg, opts, cmd.OutOrStdout())
 		},
 	}
 
-	cmd.Flags().BoolVar(&observability, "observability", false, "start Prometheus and Grafana alongside the core stack")
 	cmd.Flags().BoolVar(&watch, "watch", false, "watch vibewarden.yaml for changes and auto-regenerate + restart")
 	cmd.Flags().StringVar(&configPath, "config", "", "path to vibewarden.yaml (default: ./vibewarden.yaml)")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "stream docker compose stderr during successful startup (always streamed on failure)")

--- a/internal/cli/cmd/obs.go
+++ b/internal/cli/cmd/obs.go
@@ -1,0 +1,160 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	credentialsadapter "github.com/vibewarden/vibewarden/internal/adapters/credentials"
+	opsadapter "github.com/vibewarden/vibewarden/internal/adapters/ops"
+	templateadapter "github.com/vibewarden/vibewarden/internal/adapters/template"
+	generateapp "github.com/vibewarden/vibewarden/internal/app/generate"
+	opsapp "github.com/vibewarden/vibewarden/internal/app/ops"
+	configtemplates "github.com/vibewarden/vibewarden/internal/config/templates"
+)
+
+// NewObsCmd creates the "vibew obs" parent subcommand with "up" and "down"
+// child commands. The obs subcommand controls the Prometheus + Grafana
+// observability stack that is shipped as a Docker Compose profile overlay on
+// the same project as the main dev stack.
+func NewObsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "obs",
+		Short: "Manage the local observability stack",
+		Long: `Manage the Prometheus + Grafana observability stack.
+
+The observability stack runs as a Docker Compose profile overlay on the same
+project as the main dev stack started by 'vibew dev'. Services share the same
+Docker network, so Prometheus can scrape VibeWarden without any extra bridging.
+
+Subcommands:
+  up    Start Prometheus and Grafana
+  down  Stop Prometheus and Grafana
+
+Examples:
+  vibew obs up
+  vibew obs down
+  vibew obs down -v --yes`,
+		// Print help when the parent command is invoked without a subcommand.
+		Run: func(cmd *cobra.Command, _ []string) {
+			cmd.Help() //nolint:errcheck
+		},
+	}
+
+	cmd.AddCommand(newObsUpCmd())
+	cmd.AddCommand(newObsDownCmd())
+
+	return cmd
+}
+
+// newObsUpCmd creates the "vibew obs up" subcommand.
+func newObsUpCmd() *cobra.Command {
+	var (
+		configPath string
+		verbose    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "up",
+		Short: "Start the observability stack",
+		Long: `Start the Prometheus + Grafana observability stack.
+
+The observability services are started as a Docker Compose profile overlay on
+the same project as the main dev stack. They share the same Docker network, so
+Prometheus can scrape the VibeWarden sidecar's /_vibewarden/metrics endpoint
+immediately.
+
+If 'vibew dev' has not been run first, the observability services will still
+start but Prometheus scrape targets will be unreachable until the sidecar is
+running. A friendly advisory is printed in that case.
+
+Examples:
+  vibew obs up
+  vibew obs up --config ./my-vibewarden.yaml
+  vibew obs up --verbose`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := requireScaffolding(); err != nil {
+				return err
+			}
+			if err := requireConfig(configPath); err != nil {
+				return err
+			}
+
+			cfg, err := loadAndResolve(cmd.Context(), configPath)
+			if err != nil {
+				return err
+			}
+
+			compose := opsadapter.NewComposeAdapter()
+			renderer := templateadapter.NewRenderer(configtemplates.FS)
+			generator := generateapp.NewServiceWithCredentials(
+				renderer,
+				credentialsadapter.NewGenerator(),
+				credentialsadapter.NewStore(),
+			)
+			svc := opsapp.NewObsService(compose, generator)
+
+			opts := opsapp.ObsUpOptions{
+				ConfigPath: configPath,
+				Verbose:    verbose,
+			}
+			return svc.Up(cmd.Context(), cfg, opts, cmd.OutOrStdout())
+		},
+	}
+
+	cmd.Flags().StringVar(&configPath, "config", "", "path to vibewarden.yaml (default: ./vibewarden.yaml)")
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "stream docker compose stderr during startup")
+
+	return cmd
+}
+
+// newObsDownCmd creates the "vibew obs down" subcommand.
+func newObsDownCmd() *cobra.Command {
+	var (
+		volumes       bool
+		removeOrphans bool
+		yes           bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "down",
+		Short: "Stop the observability stack",
+		Long: `Stop the Prometheus + Grafana observability stack.
+
+Idempotent: running on an already-stopped observability stack is a no-op (exit 0).
+
+Flags:
+  -v, --volumes         also remove named volumes (Grafana state, Prometheus data,
+                        etc.). Prompts for confirmation in a TTY unless --yes is
+                        also set.
+      --remove-orphans  remove containers for services no longer in the compose file.
+      --yes             skip the confirmation prompt for --volumes.
+
+Examples:
+  vibew obs down
+  vibew obs down -v --yes
+  vibew obs down --remove-orphans`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			compose := opsadapter.NewComposeAdapter()
+			svc := opsapp.NewObsService(compose, nil)
+
+			isTTY := term.IsTerminal(int(os.Stdout.Fd())) //nolint:gosec // file descriptor fits in int on all supported platforms
+
+			opts := opsapp.ObsDownOptions{
+				Volumes:       volumes,
+				RemoveOrphans: removeOrphans,
+				Yes:           yes,
+				In:            os.Stdin,
+				IsTTY:         isTTY,
+			}
+			return svc.Down(cmd.Context(), opts, cmd.OutOrStdout())
+		},
+	}
+
+	cmd.Flags().BoolVarP(&volumes, "volumes", "v", false, "also remove named volumes (destructive)")
+	cmd.Flags().BoolVar(&removeOrphans, "remove-orphans", false, "remove containers for services no longer in the compose file")
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip confirmation prompt for --volumes")
+
+	return cmd
+}

--- a/internal/cli/cmd/obs_test.go
+++ b/internal/cli/cmd/obs_test.go
@@ -1,0 +1,78 @@
+package cmd_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/cli/cmd"
+)
+
+func TestObsCmd_HelpContainsSubcommands(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetArgs([]string{"obs", "--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("obs --help returned error: %v", err)
+	}
+
+	output := out.String()
+	for _, want := range []string{"up", "down", "observability"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("obs --help missing %q\ngot:\n%s", want, output)
+		}
+	}
+}
+
+func TestObsCmd_UpHelp(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetArgs([]string{"obs", "up", "--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("obs up --help returned error: %v", err)
+	}
+
+	output := out.String()
+	for _, want := range []string{"Prometheus", "Grafana", "--config", "--verbose"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("obs up --help missing %q\ngot:\n%s", want, output)
+		}
+	}
+}
+
+func TestObsCmd_DownHelp(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetArgs([]string{"obs", "down", "--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("obs down --help returned error: %v", err)
+	}
+
+	output := out.String()
+	for _, want := range []string{"--volumes", "--remove-orphans", "--yes"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("obs down --help missing %q\ngot:\n%s", want, output)
+		}
+	}
+}
+
+func TestObsCmd_IsRegisteredOnRoot(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetArgs([]string{"--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "obs") {
+		t.Errorf("root help does not mention 'obs' command\ngot:\n%s", out.String())
+	}
+}

--- a/internal/cli/cmd/ops_test.go
+++ b/internal/cli/cmd/ops_test.go
@@ -21,8 +21,9 @@ func TestNewDevCmd_RegisteredOnRoot(t *testing.T) {
 		t.Fatal("expected 'dev' subcommand to be registered on root")
 	}
 
-	if devCmd.Flags().Lookup("observability") == nil {
-		t.Error("expected --observability flag to be registered on 'dev' command")
+	// --observability was removed in #1149; verify it is gone.
+	if devCmd.Flags().Lookup("observability") != nil {
+		t.Error("--observability flag must not be registered on 'dev' command (removed in #1149; use 'vibew obs up' instead)")
 	}
 	if devCmd.Flags().Lookup("config") == nil {
 		t.Error("expected --config flag to be registered on 'dev' command")
@@ -41,10 +42,15 @@ func TestNewDevCmd_Help(t *testing.T) {
 	}
 
 	out := outBuf.String()
-	for _, want := range []string{"dev", "observability", "config"} {
+	// --observability was removed in #1149; the help should mention the
+	// replacement ('vibew obs up') but must no longer list --observability as a flag.
+	for _, want := range []string{"dev", "obs up", "config"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("help output missing %q\ngot:\n%s", want, out)
 		}
+	}
+	if strings.Contains(out, "--observability") {
+		t.Errorf("dev help must not mention --observability flag (removed in #1149):\n%s", out)
 	}
 }
 

--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -47,6 +47,7 @@ Zero-to-secure in minutes.`,
 	root.AddCommand(NewUpgradeCmd())
 	root.AddCommand(NewBuildCmd())
 	root.AddCommand(NewDownCmd())
+	root.AddCommand(NewObsCmd())
 	root.AddCommand(NewMCPCmd())
 	root.AddCommand(NewBundleCmd())
 	root.AddCommand(NewTLSCmd())

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -63,6 +63,8 @@ vibew dev --watch    # Start with hot reload
 vibew dev --verbose  # Stream docker compose output during startup
 vibew down           # Stop the dev stack (preserves volumes; -v also removes volumes)
 vibew build && vibew dev  # Incremental rebuild — apply code changes without full recreate
+vibew obs up         # Start Prometheus + Grafana observability stack (after vibew dev)
+vibew obs down       # Stop Prometheus + Grafana observability stack
 vibew status         # Check component health
 vibew doctor         # Diagnose issues
 ```
@@ -78,6 +80,8 @@ app port directly — it has no security.
 | `vibew dev --watch` | Start with file watching |
 | `vibew dev --verbose` | Stream docker compose output during startup |
 | `vibew down` | Stop the dev stack (preserves data volumes; `-v` also removes volumes) |
+| `vibew obs up` | Start Prometheus + Grafana observability stack (runs after `vibew dev`) |
+| `vibew obs down` | Stop the observability stack (`-v` also removes volumes) |
 | `vibew build` | Build Docker image |
 | `vibew build --platform linux/amd64` | Build for a specific architecture |
 | `vibew bundle` | Produce a self-contained Docker Compose bundle under `.vibewarden/bundle/`; ship with `scp` + `docker compose up -d` |

--- a/internal/ports/ops.go
+++ b/internal/ports/ops.go
@@ -47,6 +47,13 @@ type ComposeDownOptions struct {
 	// RemoveOrphans, when true, removes containers for services not defined in
 	// the current compose file (equivalent to `--remove-orphans`).
 	RemoveOrphans bool
+	// Profiles limits the down operation to services that belong to the listed
+	// Docker Compose profiles (equivalent to `--profile <name>` repeated for
+	// each element). When empty, docker compose down stops ALL services in the
+	// project regardless of profile. Set this to scope a partial teardown —
+	// for example, ObsService.Down sets ["observability"] so that only the
+	// observability services are stopped without touching the main sidecar.
+	Profiles []string
 }
 
 // DownResult summarises what happened during a ComposeRunner.Down invocation.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1312,7 +1312,8 @@ VibeWarden is operated via the `vibew` CLI. Below is the complete command list.
 | `vibew dev` | Start local dev environment |
 | `vibew dev --verbose` | Start local dev environment and stream docker compose output during startup |
 | `vibew dev --watch` | Watch vibewarden.yaml for changes and auto-regenerate config files + restart the stack (blocks until Ctrl+C) |
-| `vibew dev --observability` | Start Prometheus and Grafana alongside the core stack |
+| `vibew obs up` | Start the Prometheus + Grafana observability stack (profile overlay on the running dev stack) |
+| `vibew obs down` | Stop the observability stack (`-v` removes volumes; `--yes` skips confirmation) |
 | `vibew down` | Stop the local dev stack (preserves data volumes; pass `-v` to also remove volumes; pass `--yes` to skip confirmation prompt in CI/scripts) |
 | `vibew bundle` | Produce a self-contained Docker Compose deploy bundle under `.vibewarden/bundle/`. The bundle's `README.md` describes the deploy contract; operators copy the directory to a host and run `docker compose up -d`. |
 | `vibew status` | Show health of all components. Rows use three text labels: OK (healthy), OFF (disabled in config — probe suppressed), FAIL (enabled but check failed). A legend line is printed below the header. TLS: KindSelfSignedLocal and KindExpiringSoon → OK with annotation; only KindFailing → FAIL. |


### PR DESCRIPTION
Closes #1149.

## Summary

- Removes `--observability` flag from `vibew dev`.
- Adds new `vibew obs up` / `vibew obs down` subcommand pair that gates the Prometheus + Grafana stack behind a Docker Compose profile (`--profile observability`).
- Reuses `ports.Compose` adapter; no new ports.
- Reuses the existing observability compose template and scrape config — zero behavior change in what the obs stack does.

## Why

Per CLAUDE.md §Architecture principles → Artifact policy and the qr-dali deploy retro: trim CLI surface where features are heavyweight defaults that confuse the core loop. `vibew dev` is the day-loop verb; observability is opt-in tooling that belongs in its own subcommand pair, mirroring the `vibew dev` / `vibew down` symmetry.

## What changed

- New `internal/cli/cmd/obs.go` — cobra `obs` parent + `up` + `down`.
- New `internal/app/ops/obs.go` — `ObsService` with `Up` / `Down`, prints sidecar advisory if main stack isn't up.
- New `internal/app/ops/obs_test.go` — 14 table-driven tests covering both paths.
- New `internal/cli/cmd/obs_test.go` — wiring + help text tests.
- `internal/cli/cmd/dev.go` — removed `--observability` flag, godoc + Long updated.
- `internal/app/ops/dev.go` — removed `DevOptions.Observability` field and profile-passing branches.
- `internal/app/ops/dev_test.go` — observability-path tests deleted.
- `internal/cli/cmd/ops_test.go` — assertions updated.
- `internal/cli/cmd/root.go` — `NewObsCmd()` registered.
- `docs/observability.md`, `docs/getting-started.md`, `docs/architecture.md`, `docs/index.md` — invocation updated.
- `internal/cli/templates/agents/agents-vibewarden.md.tmpl` AND `docs/examples/AGENTS-VIBEWARDEN.md` — both mention the new commands; agree.
- `llms-full.txt` — CLI table row swap.
- `CHANGELOG.md` `[Unreleased]` — `### Removed` (flag) + `### Added` (commands).

## Test plan

- [x] `make check` passes
- [x] `vibew dev --observability` is no longer a flag (cobra unknown-flag error)
- [x] `vibew obs up` invokes compose with `--profile observability up -d`
- [x] `vibew obs down` invokes compose with `--profile observability down`
- [x] `vibew dev` (without the removed flag) keeps working unchanged