### PR TITLE
chore(#1150): flag-gate multi-site at validate/add; bundle hard-fail points at #1169

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Changed
 
+- **Multi-site projects flag-gated as post-v1** (#1150). `vibew validate` and `vibew add` now refuse multi-site configs with a clear "see #1169" message. `vibew bundle`'s existing hard-fail updated to point at the same tracking issue. Multi-site dev (`vibew dev` reverse-proxying multiple apps on host headers) keeps working — only the production-deploy path is gated. The architecture for multi-app-per-VM bundles is tracked in #1169 (post-stable).
+
 - **`vibew eject` clarified as the non-Docker escape hatch** (#1147, [ADR-096](decisions/adr-096-vibew-eject-keep-and-clarify-non-docker-escape-hatch.md)). The `--help` lead line and the agents-template description now make clear: `vibew bundle` is the canonical Docker Compose path; `vibew eject` produces raw Caddy JSON for vanilla-Caddy / non-Docker deploys. No behavior change. The deeper consolidation (`vibew bundle --target ...`) is tracked separately.
 
 - **`vibew init` now generates a minimal `vibewarden.production.yaml`** (#1145). The generated file no longer carries commented `# auth: ...`, `# admin: ...`, `# rate_limit: ...` stubs. Override patterns moved to `docs/examples/production-overrides.md`. Per CLAUDE.md §Artifact policy: examples belong in docs, not in live config. `vibew add tls` / `vibew add waf` continue to work; they don't depend on the stubs being present.

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -239,11 +239,17 @@ Create `docker-compose.override.yml` next to your `vibewarden.yaml` for addition
 services like PostgreSQL or Redis. Docker Compose auto-merges it with the
 generated compose. VibeWarden never overwrites this file.
 
+## Multi-site (post-v1)
+
+The `sites/<name>/vibewarden.yaml` layout works for local dev (`vibew dev` reverse-proxies multiple apps on host headers), but `vibew bundle` does NOT support multi-site yet. Multi-app-per-VM deployment is the post-v1 #1169 architecture.
+
+For now: keep one site per project. Revisit when #1169 lands.
+
 ## Known limitations
 
 - WAF is in `detect` mode by default (logs but does not block). Set `waf.mode: block` in vibewarden.yaml to enforce blocking.
 - `vibew doctor` checks config, Docker, ports, container health, generated files, ACME email, image tag, upstream reachability, and TLS state (Obtaining/Obtained/Failing/SelfSignedLocal). Self-signed dev certs are identified correctly and do not trigger a spurious expiry warning.
-- Multi-site deployment is new and may have edge cases — report issues if routes or certs behave unexpectedly.
+- Multi-site local dev works; production deploy is post-v1 (see https://github.com/VibeWarden/vibewarden/issues/1169).
 - `vibew init` does not accept `--tls` or `--domain` flags — run `vibew add tls --domain <your-domain>` after init.
 
 ---

--- a/internal/app/multisite/multisite.go
+++ b/internal/app/multisite/multisite.go
@@ -1,0 +1,47 @@
+// Package multisite provides shared detection logic for multi-site project
+// layouts. A project is considered multi-site when at least one subdirectory
+// of the sites/ directory (adjacent to the root vibewarden.yaml) contains its
+// own vibewarden.yaml.
+//
+// This package is consumed by the validate, add, and bundle command surfaces
+// to give users consistent early feedback when they attempt production-deploy
+// operations on multi-site layouts that are not yet supported (post-v1, tracked
+// at https://github.com/VibeWarden/vibewarden/issues/1169).
+package multisite
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// IsProject reports whether the directory inferred from configPath is the root
+// of a multi-site project. A project is multi-site iff at least one
+// subdirectory of sites/ (sitting next to configPath) contains a readable
+// vibewarden.yaml file.
+//
+// Detection mirrors internal/config/sites.LoadSites: an empty sites/, a
+// sites/<name>/ with no YAML, or a sites/<name>/vibewarden.yaml that is
+// unreadable are all treated as single-site — consistent with LoadSites
+// silently skipping subdirectories that lack a vibewarden.yaml.
+//
+// configPath is the path to the root vibewarden.yaml (or any file inside the
+// project root). Only the directory component is used.
+func IsProject(configPath string) bool {
+	sitesDir := filepath.Join(filepath.Dir(configPath), "sites")
+	entries, err := os.ReadDir(sitesDir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		siteYAML := filepath.Join(sitesDir, e.Name(), "vibewarden.yaml")
+		info, statErr := os.Stat(siteYAML)
+		if statErr != nil || info.IsDir() {
+			continue
+		}
+		return true
+	}
+	return false
+}

--- a/internal/app/multisite/multisite_test.go
+++ b/internal/app/multisite/multisite_test.go
@@ -1,0 +1,110 @@
+package multisite_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/app/multisite"
+)
+
+// TestIsProject covers the full detection matrix for multi-site project
+// layouts. The detection logic mirrors internal/config/sites.LoadSites:
+// only a subdirectory of sites/ that contains a readable vibewarden.yaml
+// qualifies the project as multi-site.
+func TestIsProject(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T, root string)
+		wantMulti bool
+	}{
+		{
+			name:      "no sites dir",
+			setup:     func(_ *testing.T, _ string) {},
+			wantMulti: false,
+		},
+		{
+			name: "empty sites dir",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Join(root, "sites"), 0o750); err != nil {
+					t.Fatalf("mkdir sites: %v", err)
+				}
+			},
+			wantMulti: false,
+		},
+		{
+			name: "sites/<name>/ with no vibewarden.yaml",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Join(root, "sites", "blog"), 0o750); err != nil {
+					t.Fatalf("mkdir sites/blog: %v", err)
+				}
+			},
+			wantMulti: false,
+		},
+		{
+			name: "sites/<name>/vibewarden.yaml present",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				siteDir := filepath.Join(root, "sites", "blog")
+				if err := os.MkdirAll(siteDir, 0o750); err != nil {
+					t.Fatalf("mkdir sites/blog: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(siteDir, "vibewarden.yaml"), []byte("server:\n  port: 8443\n"), 0o600); err != nil {
+					t.Fatalf("writing site yaml: %v", err)
+				}
+			},
+			wantMulti: true,
+		},
+		{
+			name: "one empty site plus one populated site — populated wins",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Join(root, "sites", "empty"), 0o750); err != nil {
+					t.Fatalf("mkdir sites/empty: %v", err)
+				}
+				siteDir := filepath.Join(root, "sites", "shop")
+				if err := os.MkdirAll(siteDir, 0o750); err != nil {
+					t.Fatalf("mkdir sites/shop: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(siteDir, "vibewarden.yaml"), []byte("server:\n  port: 8443\n"), 0o600); err != nil {
+					t.Fatalf("writing site yaml: %v", err)
+				}
+			},
+			wantMulti: true,
+		},
+		{
+			name: "sites/ contains a file (not a directory) named like a site",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				sitesDir := filepath.Join(root, "sites")
+				if err := os.MkdirAll(sitesDir, 0o750); err != nil {
+					t.Fatalf("mkdir sites: %v", err)
+				}
+				// A plain file at sites/notadir should not be treated as a site.
+				if err := os.WriteFile(filepath.Join(sitesDir, "notadir"), []byte("data"), 0o600); err != nil {
+					t.Fatalf("writing notadir: %v", err)
+				}
+			},
+			wantMulti: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			configPath := filepath.Join(root, "vibewarden.yaml")
+			// Write a stub root config so filepath.Dir works naturally.
+			if err := os.WriteFile(configPath, []byte("server:\n  port: 8443\n"), 0o600); err != nil {
+				t.Fatalf("writing root config: %v", err)
+			}
+			tt.setup(t, root)
+
+			got := multisite.IsProject(configPath)
+			if got != tt.wantMulti {
+				t.Errorf("IsProject(%q) = %v, want %v", configPath, got, tt.wantMulti)
+			}
+		})
+	}
+}

--- a/internal/cli/cmd/add.go
+++ b/internal/cli/cmd/add.go
@@ -1,13 +1,20 @@
 package cmd
 
 import (
+	"fmt"
+	"path/filepath"
+
 	"github.com/spf13/cobra"
+
+	multisiteapp "github.com/vibewarden/vibewarden/internal/app/multisite"
 )
 
 // NewAddCmd creates the `vibew add` subcommand group.
 //
 // The add command group contains subcommands that incrementally enable
 // VibeWarden features in an existing project by modifying vibewarden.yaml.
+// All subcommands refuse on multi-site project roots because multi-site
+// support is post-v1 (#1169).
 func NewAddCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add",
@@ -27,6 +34,24 @@ Examples:
 		// Default: print help when no subcommand is given.
 		Run: func(cmd *cobra.Command, _ []string) {
 			cmd.Help() //nolint:errcheck
+		},
+		// PersistentPreRunE runs before every subcommand in this group.
+		// It rejects multi-site project roots because the add commands only
+		// know how to modify a single vibewarden.yaml; multi-site support is
+		// post-v1 and tracked at #1169.
+		PersistentPreRunE: func(_ *cobra.Command, args []string) error {
+			dir := "."
+			if len(args) > 0 {
+				dir = args[0]
+			}
+			configPath, err := filepath.Abs(filepath.Join(dir, "vibewarden.yaml"))
+			if err != nil {
+				configPath = filepath.Join(dir, "vibewarden.yaml")
+			}
+			if multisiteapp.IsProject(configPath) {
+				return fmt.Errorf("multi-site projects are post-v1 (see #1169) — use a single-site project and revisit when #1169 lands")
+			}
+			return nil
 		},
 	}
 

--- a/internal/cli/cmd/add_test.go
+++ b/internal/cli/cmd/add_test.go
@@ -376,3 +376,36 @@ func TestAddCmd_AgentContextRegenerated(t *testing.T) {
 		t.Errorf("unexpected output: %s", out)
 	}
 }
+
+// TestAddCmd_MultiSite_Refused verifies that every vibew add subcommand is
+// refused on a multi-site project root. The gate is in PersistentPreRunE on
+// the add command group; testing one representative subcommand (tls) is
+// sufficient because the pre-run hook fires before any subcommand's RunE.
+func TestAddCmd_MultiSite_Refused(t *testing.T) {
+	dir := scaffoldTestDir(t, false)
+
+	// Write root vibewarden.yaml so the dir looks like a real project.
+	if err := os.WriteFile(filepath.Join(dir, "vibewarden.yaml"), []byte(minimalVibeWardenYAML), 0o644); err != nil {
+		t.Fatalf("writing vibewarden.yaml: %v", err)
+	}
+
+	// Populate sites/<name>/vibewarden.yaml to make it a multi-site root.
+	siteDir := filepath.Join(dir, "sites", "shop")
+	if err := os.MkdirAll(siteDir, 0o750); err != nil {
+		t.Fatalf("mkdir sites/shop: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(siteDir, "vibewarden.yaml"), []byte("server:\n  port: 8443\n"), 0o600); err != nil {
+		t.Fatalf("writing site config: %v", err)
+	}
+
+	out, err := runAddCmd(t, dir, "tls", "--domain", "x.example.com")
+	if err == nil {
+		t.Fatalf("expected non-zero exit for multi-site project, got nil (output: %q)", out)
+	}
+	if !strings.Contains(err.Error()+out, "post-v1") {
+		t.Errorf("output/error should contain 'post-v1', got err=%v out=%q", err, out)
+	}
+	if !strings.Contains(err.Error()+out, "#1169") {
+		t.Errorf("output/error should contain '#1169', got err=%v out=%q", err, out)
+	}
+}

--- a/internal/cli/cmd/bundle.go
+++ b/internal/cli/cmd/bundle.go
@@ -16,6 +16,7 @@ import (
 	templateadapter "github.com/vibewarden/vibewarden/internal/adapters/template"
 	bundleapp "github.com/vibewarden/vibewarden/internal/app/bundle"
 	generateapp "github.com/vibewarden/vibewarden/internal/app/generate"
+	multisiteapp "github.com/vibewarden/vibewarden/internal/app/multisite"
 	opsapp "github.com/vibewarden/vibewarden/internal/app/ops"
 	"github.com/vibewarden/vibewarden/internal/config"
 	configtemplates "github.com/vibewarden/vibewarden/internal/config/templates"
@@ -28,10 +29,9 @@ import (
 const defaultBundleOutputDir = ".vibewarden/bundle"
 
 // multiSiteErrorMessage is the user-facing error returned when vibew bundle
-// is run against a multi-site project. See ADR-085 §7 and ADR-086 (sunset
-// vibew deploy). Multi-site bundling is tracked as a follow-up; there is no
-// working command for this case today — `vibew deploy` has been removed.
-const multiSiteErrorMessage = "multi-site bundle is not yet supported (see ADR-085); track progress at https://github.com/VibeWarden/vibewarden/issues"
+// is run against a multi-site project. Multi-site bundle is post-v1; the
+// N-apps-on-one-VM architecture is tracked at #1169.
+const multiSiteErrorMessage = "multi-site bundle is post-v1; see #1169 for the N-apps-on-one-VM architecture work."
 
 // NewBundleCmd creates the "vibew bundle" command.
 //
@@ -181,9 +181,9 @@ func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, o
 		return 1, fmt.Errorf("validating config: %w", err)
 	}
 
-	// Multi-site projects are deferred to a follow-up — see ADR-085.
-	// Local detection: presence of a sites/ directory next to the config.
-	if isMultiSiteProject(absConfig) {
+	// Multi-site bundle is post-v1 (#1169). Refuse early with a clear message
+	// so users discover the limitation before any files are written.
+	if multisiteapp.IsProject(absConfig) {
 		return 1, fmt.Errorf("%s", multiSiteErrorMessage)
 	}
 
@@ -397,35 +397,4 @@ func prodConfigPathForEnv(configPath, envName string) string {
 		return prodFile
 	}
 	return ""
-}
-
-// isMultiSiteProject reports whether configPath sits in a project whose
-// local layout implies multi-site bundling. A project is multi-site iff
-// at least one subdirectory of sites/ contains a readable vibewarden.yaml.
-//
-// Mirrors internal/config/sites.LoadSites so detection stays consistent
-// across commands: an empty sites/, a sites/<name>/ with no YAML, or a
-// sites/<name>/vibewarden.yaml that is unreadable (permission denied)
-// are all treated as single-site. That matches LoadSites' behaviour of
-// silently skipping subdirectories without a vibewarden.yaml. Previously
-// any subdir tripped the branch, which made scaffolding tools that
-// create an empty sites/blog/ before populating it hard-fail on bundle.
-func isMultiSiteProject(configPath string) bool {
-	sitesDir := filepath.Join(filepath.Dir(configPath), "sites")
-	entries, err := os.ReadDir(sitesDir)
-	if err != nil {
-		return false
-	}
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		siteYAML := filepath.Join(sitesDir, e.Name(), "vibewarden.yaml")
-		info, statErr := os.Stat(siteYAML)
-		if statErr != nil || info.IsDir() {
-			continue
-		}
-		return true
-	}
-	return false
 }

--- a/internal/cli/cmd/bundle_test.go
+++ b/internal/cli/cmd/bundle_test.go
@@ -131,11 +131,11 @@ func TestBundleCmd_MultiSite_HardErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected multi-site error, got nil")
 	}
-	if !strings.Contains(err.Error(), "multi-site bundle is not yet supported") {
+	if !strings.Contains(err.Error(), "multi-site bundle is post-v1") {
 		t.Errorf("error missing multi-site message, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "ADR-085") {
-		t.Errorf("error should reference ADR-085 for tracking, got: %v", err)
+	if !strings.Contains(err.Error(), "#1169") {
+		t.Errorf("error should reference #1169 for tracking, got: %v", err)
 	}
 	// vibew deploy has been removed (ADR-086): the multi-site branch must
 	// NOT direct users to a command that no longer exists (cobra now prints
@@ -227,7 +227,7 @@ func TestBundleCmd_IsMultiSiteProject_TableDriven(t *testing.T) {
 			root.SetErr(&out)
 			err := root.Execute()
 
-			gotMultiSite := err != nil && strings.Contains(err.Error(), "multi-site bundle is not yet supported")
+			gotMultiSite := err != nil && strings.Contains(err.Error(), "multi-site bundle is post-v1")
 			if gotMultiSite != tt.wantMultiSite {
 				t.Errorf("multi-site detection = %v, want %v (err = %v)", gotMultiSite, tt.wantMultiSite, err)
 			}

--- a/internal/cli/cmd/validate.go
+++ b/internal/cli/cmd/validate.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	multisiteapp "github.com/vibewarden/vibewarden/internal/app/multisite"
 	"github.com/vibewarden/vibewarden/internal/config"
 )
 
@@ -120,6 +121,19 @@ Examples:
 				}
 				fmt.Fprintf(cmd.ErrOrStderr(), "Configuration invalid: %v\n", err)
 				return fmt.Errorf("loading config: %w", err)
+			}
+
+			// Multi-site bundle is post-v1 (#1169). Emit a FAIL row consistent
+			// with the OK/OFF/FAIL convention from #1143/#1159 and exit 1 so
+			// that agents and scripts detect the limitation immediately.
+			checkPath := configPath
+			if checkPath == "" {
+				checkPath = "vibewarden.yaml"
+			}
+			absCheck, _ := filepath.Abs(checkPath)
+			if multisiteapp.IsProject(absCheck) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "FAIL  multi-site bundle is post-v1 (see #1169 — N apps on one VM architecture). Dev path works locally; no production deploy path yet.\n")
+				return fmt.Errorf("multi-site bundle is post-v1 (see #1169)")
 			}
 
 			errs := validateConfig(cfg)

--- a/internal/cli/cmd/validate.go
+++ b/internal/cli/cmd/validate.go
@@ -130,7 +130,10 @@ Examples:
 			if checkPath == "" {
 				checkPath = "vibewarden.yaml"
 			}
-			absCheck, _ := filepath.Abs(checkPath)
+			absCheck, err := filepath.Abs(checkPath)
+			if err != nil {
+				return fmt.Errorf("resolving abs path %q: %w", checkPath, err)
+			}
 			if multisiteapp.IsProject(absCheck) {
 				fmt.Fprintf(cmd.ErrOrStderr(), "FAIL  multi-site bundle is post-v1 (see #1169 — N apps on one VM architecture). Dev path works locally; no production deploy path yet.\n")
 				return fmt.Errorf("multi-site bundle is post-v1 (see #1169)")

--- a/internal/cli/cmd/validate_test.go
+++ b/internal/cli/cmd/validate_test.go
@@ -723,3 +723,51 @@ tls:
 		t.Errorf("Execute() expected success with valid prod override, got: %v\nstderr: %s", err, errBuf.String())
 	}
 }
+
+// TestValidateCmd_MultiSite_FailRow verifies that vibew validate on a multi-site
+// project root emits a FAIL row on stderr and exits with code 1. This is the
+// #1150 acceptance criterion: users learn about the post-v1 limitation at
+// validate time rather than bundle time.
+func TestValidateCmd_MultiSite_FailRow(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "vibewarden.yaml")
+	baseYAML := `server:
+  port: 8080
+upstream:
+  port: 3000
+`
+	if err := os.WriteFile(basePath, []byte(baseYAML), 0o600); err != nil {
+		t.Fatalf("writing base config: %v", err)
+	}
+
+	// Populate sites/<name>/vibewarden.yaml to trigger multi-site detection.
+	siteDir := filepath.Join(dir, "sites", "shop")
+	if err := os.MkdirAll(siteDir, 0o750); err != nil {
+		t.Fatalf("mkdir sites/shop: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(siteDir, "vibewarden.yaml"), []byte("server:\n  port: 8443\n"), 0o600); err != nil {
+		t.Fatalf("writing site config: %v", err)
+	}
+
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"validate", basePath})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute() expected non-zero exit for multi-site project, got nil")
+	}
+
+	errOut := errBuf.String()
+	if !strings.Contains(errOut, "post-v1") {
+		t.Errorf("stderr should contain 'post-v1', got: %q", errOut)
+	}
+	if !strings.Contains(errOut, "#1169") {
+		t.Errorf("stderr should contain '#1169', got: %q", errOut)
+	}
+	if !strings.Contains(errOut, "FAIL") {
+		t.Errorf("stderr should contain 'FAIL' row label, got: %q", errOut)
+	}
+}

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -96,39 +96,17 @@ Output uses OK / OFF / FAIL labels; OFF means the component is disabled in confi
 | `vibew add auth` | Enable authentication |
 | `vibew eject` | Export raw Caddy JSON config for non-Docker deploys (most setups should use `vibew bundle` instead) |
 
-## Multi-site deployment
+## Multi-site (post-v1)
 
-VibeWarden supports hosting multiple sites behind a single sidecar instance.
-Each site gets its own vibewarden.yaml and app container while sharing TLS
-termination, WAF, rate limiting, and logging through the shared sidecar.
+The `sites/<name>/vibewarden.yaml` layout works for local dev (`vibew dev` reverse-proxies multiple apps on host headers), but `vibew bundle` does NOT support multi-site yet. Multi-app-per-VM deployment is the post-v1 #1169 architecture.
 
-### Directory layout
-
-```
-vibewarden.yaml          # global config (server port, TLS, shared settings)
-sites/
-  app1/
-    vibewarden.yaml      # per-site config (upstream, auth, routes)
-    docker-compose.yml   # app1 container(s)
-  app2/
-    vibewarden.yaml
-    docker-compose.yml
-```
-
-### Key rules
-
-- `upstream.host` in each site config must match the Docker Compose service
-  (container) name of that site's app (e.g., `app1-app`).
-- The sidecar reads all site configs from `sites/` automatically on startup.
-- TLS certificates are managed centrally by the sidecar for all configured domains.
-- Multi-site bundle support is deferred; `vibew bundle` hard-fails on
-  multi-site projects today. See ADR-086 for the rationale.
+For now: keep one site per project. Revisit when #1169 lands.
 
 ## Known limitations
 
 - WAF is in `detect` mode by default (logs but does not block). Set `waf.mode: block` in vibewarden.yaml to enforce blocking.
 - `vibew doctor` checks config, Docker, ports, container health, generated files, ACME email, image tag, upstream reachability, and local TLS cert validity.
-- Multi-site deployment is new and may have edge cases — report issues if routes or certs behave unexpectedly.
+- Multi-site local dev works; production deploy is post-v1 (see https://github.com/VibeWarden/vibewarden/issues/1169).
 - `vibew init` does not accept `--tls` or `--domain` flags — run `vibew add tls --domain <your-domain>` after init.
 
 ## Environment separation

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1411,8 +1411,9 @@ Output layout:
 - `image.tar` -- omitted with `--skip-image`
 - `kratos/`, `.credentials` -- whatever the generator produces
 
-Multi-site projects (`sites/<name>/vibewarden.yaml`) hard-fail with
-`multi-site bundle is not yet supported`; see ADR-085 / ADR-086.
+Multi-site projects (`sites/<name>/vibewarden.yaml`) hard-fail on
+production bundle with `multi-site bundle is post-v1 (see #1169)`; the
+local dev / test paths continue to work unchanged.
 
 #### Image health block format
 
@@ -1455,10 +1456,9 @@ VibeWarden supports multi-app projects locally: multiple apps live under
 `sites/<name>/` each with their own `vibewarden.yaml`. A shared sidecar
 reverse-proxies all of them on the same VM.
 
-Remote orchestration for multi-site layouts is deferred per ADR-085 /
-ADR-086. `vibew bundle` currently hard-fails on multi-site projects with
-`multi-site bundle is not yet supported`; the local dev / test paths
-continue to work unchanged.
+Multi-site production bundle is post-v1 (see #1169 — N apps on one VM
+architecture). `vibew bundle` hard-fails on multi-site projects; the
+local dev / test paths continue to work unchanged.
 
 Full guide: https://vibewarden.dev/docs/multi-app/
 


### PR DESCRIPTION
Closes #1150

## Summary

- New package `internal/app/multisite/` with `IsProject(configPath string) bool` — single shared detector for all three command surfaces.
- `vibew validate` emits `FAIL  multi-site bundle is post-v1 (see #1169 ...)` on stderr and exits 1 when the project root contains `sites/<name>/vibewarden.yaml`.
- `vibew add` (all subcommands) refuses via `PersistentPreRunE` on the `add` group with message referencing #1169.
- `vibew bundle` `multiSiteErrorMessage` constant updated from the old ADR-085 reference to `#1169`.
- `internal/cli/cmd/bundle.go` local `isMultiSiteProject` function removed; replaced with `multisiteapp.IsProject` call.
- `internal/cli/templates/agents/agents-vibewarden.md.tmpl` and `docs/examples/AGENTS-VIBEWARDEN.md` both receive the architect's verbatim "Multi-site (post-v1)" section; old "deferred; hard-fails today" text and "may have edge cases" Known Limitations bullet removed.
- `CHANGELOG.md` `[Unreleased] ### Changed` entry added.

## Test plan

- `internal/app/multisite/multisite_test.go` — 6-case table covering: no sites dir, empty sites dir, subdir with no YAML, populated subdir, mixed (empty + populated), file at sites/ level.
- `TestValidateCmd_MultiSite_FailRow` — multi-site fixture → exit 1, stderr contains `FAIL`, `post-v1`, `#1169`.
- `TestAddCmd_MultiSite_Refused` — `vibew add tls --domain x.example.com` on multi-site fixture → non-zero exit, output contains `post-v1` and `#1169`.
- `TestBundleCmd_MultiSite_HardErrors` updated — asserts `#1169` instead of old `ADR-085`.
- `make check` passes (gofmt + golangci-lint + build + race tests).