### PR TITLE
feat(#1144): vibew validate catches real next-command failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Changed
 
+- **`vibew validate` now checks name collision, EXPOSE/upstream.port mismatch, image-tag drift, ACME-incompatible domain, and WAF prod-mode sanity** (#1144). Five runtime checks run after strict schema validation and catch conditions that cause the next `vibew bundle` or `vibew up` to fail. Each failing check emits a `FAIL` row on stderr with an actionable hint; checks that do not apply (no Dockerfile, no `.env`, non-ACME provider) are silently skipped. Exit code 1 when any check fails. New config key `waf.acknowledge_log_mode: true` suppresses the WAF log-mode check when intentional.
+
 - **Multi-site projects flag-gated as post-v1** (#1150). `vibew validate` and `vibew add` now refuse multi-site configs with a clear "see #1169" message. `vibew bundle`'s existing hard-fail updated to point at the same tracking issue. Multi-site dev (`vibew dev` reverse-proxying multiple apps on host headers) keeps working — only the production-deploy path is gated. The architecture for multi-app-per-VM bundles is tracked in #1169 (post-stable).
 
 - **`vibew eject` clarified as the non-Docker escape hatch** (#1147, [ADR-096](decisions/adr-096-vibew-eject-keep-and-clarify-non-docker-escape-hatch.md)). The `--help` lead line and the agents-template description now make clear: `vibew bundle` is the canonical Docker Compose path; `vibew eject` produces raw Caddy JSON for vanilla-Caddy / non-Docker deploys. No behavior change. The deeper consolidation (`vibew bundle --target ...`) is tracked separately.

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -98,6 +98,8 @@ of four values: `Obtaining` (ACME in progress), `Obtained` (cert active and vali
 `Failing` (ACME failed), or `SelfSignedLocal` (dev self-signed cert — no expiry
 warning is raised). `vibew status` surfaces the same TLS state in its output table. Output uses OK / OFF / FAIL labels; OFF means the component is disabled in config and was not probed.
 
+`vibew validate` now catches real next-command failures before they reach `vibew bundle` or `vibew up`: name collision (directory named "vibewarden" with no explicit `name:` set), Dockerfile EXPOSE/upstream.port mismatch, image-tag drift in `.env`, ACME-incompatible domain (localhost, IP literal, `.local`/`.test` TLD), and WAF log-mode enabled in a production config. Any of these conditions exits with code 1 and a FAIL row on stderr; fix the config or set the appropriate acknowledgement key before running the next command.
+
 ## Dockerfile contract
 
 > **Pin the toolchain first.** Read your project's manifest **before** writing the `FROM` line. Stale base images surface as opaque deep-stack errors (`go mod download exit code 1`, `npm ERR! engine`, `pip: ERROR: Package requires a different Python`) with no hint that the base image is the cause. Match the manifest:

--- a/internal/app/bundle/projectname.go
+++ b/internal/app/bundle/projectname.go
@@ -1,0 +1,65 @@
+package bundle
+
+import (
+	"strings"
+
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+// DeriveProjectName returns the project name for use in Docker image tags and
+// bundle directory naming. It mirrors the derivation chain used by vibew bundle
+// and is the single source of truth shared by both the bundle command and the
+// validate checks.
+//
+// Derivation order:
+//  1. cfg.Name, sanitised.
+//  2. cfg.App.Image, stripped of tag and registry prefix, sanitised.
+//  3. ProjectNameFromConfig(absConfigPath) fallback, sanitised.
+//
+// Every candidate is run through SanitiseProjectName so that downstream path
+// and README interpolations cannot be affected by special characters in a
+// crafted vibewarden.yaml (ADR-085 §7).
+func DeriveProjectName(cfg *config.Config, absConfigPath string) string {
+	if name := SanitiseProjectName(cfg.Name); name != "" {
+		return name
+	}
+	if cfg.App.Image != "" {
+		image := cfg.App.Image
+		if idx := strings.LastIndex(image, ":"); idx > 0 {
+			image = image[:idx]
+		}
+		if idx := strings.LastIndex(image, "/"); idx >= 0 {
+			image = image[idx+1:]
+		}
+		if name := SanitiseProjectName(image); name != "" {
+			return name
+		}
+	}
+	return SanitiseProjectName(ProjectNameFromConfig(absConfigPath))
+}
+
+// SanitiseProjectName strips any byte outside the shell-safe subset
+// [a-zA-Z0-9_-] and returns the result. Returns the empty string when the
+// input contains no safe characters — callers fall through to the next
+// derivation step in that case.
+//
+// This is the defensive layer that protects README.md and path interpolation
+// from crafted inputs like `myproject" && rm -rf /` in vibewarden.yaml's
+// `name:` key. The config schema does not currently validate `name` against
+// this subset, so the bundle pipeline carries the guard (ADR-085 §7, #1061).
+func SanitiseProjectName(in string) string {
+	var b strings.Builder
+	b.Grow(len(in))
+	for _, r := range in {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '-':
+		default:
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}

--- a/internal/app/bundle/projectname_test.go
+++ b/internal/app/bundle/projectname_test.go
@@ -1,0 +1,106 @@
+package bundle_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	bundleapp "github.com/vibewarden/vibewarden/internal/app/bundle"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+func TestSanitiseProjectName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"all safe chars", "myapp-v2_dev", "myapp-v2_dev"},
+		{"mixed case", "MyApp", "MyApp"},
+		{"spaces become empty", "my app", "myapp"},
+		{"dots stripped", "my.app", "myapp"},
+		{"shell metacharacters stripped", `myproject" && rm -rf /`, "myprojectrm-rf"},
+		{"empty input", "", ""},
+		{"all unsafe", "!@#$%", ""},
+		{"underscores and dashes kept", "my_app-v1", "my_app-v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bundleapp.SanitiseProjectName(tt.input)
+			if got != tt.want {
+				t.Errorf("SanitiseProjectName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeriveProjectName(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "myproject", "vibewarden.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("server:\n  port: 8443\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		cfgName    string
+		appImage   string
+		configPath string
+		want       string
+	}{
+		{
+			name:       "explicit name takes precedence",
+			cfgName:    "myapp",
+			appImage:   "otherapp:latest",
+			configPath: configPath,
+			want:       "myapp",
+		},
+		{
+			name:       "app.image used when name is empty",
+			cfgName:    "",
+			appImage:   "ghcr.io/org/webapp:v1.0",
+			configPath: configPath,
+			want:       "webapp",
+		},
+		{
+			name:       "directory basename fallback",
+			cfgName:    "",
+			appImage:   "",
+			configPath: configPath,
+			want:       "myproject",
+		},
+		{
+			name:       "adversarial name is sanitised",
+			cfgName:    `myproject" && rm -rf /`,
+			appImage:   "",
+			configPath: configPath,
+			want:       "myprojectrm-rf",
+		},
+		{
+			name:       "image tag stripped",
+			cfgName:    "",
+			appImage:   "myapp:latest",
+			configPath: configPath,
+			want:       "myapp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Name: tt.cfgName,
+				App: config.AppConfig{
+					Image: tt.appImage,
+				},
+			}
+			got := bundleapp.DeriveProjectName(cfg, tt.configPath)
+			if got != tt.want {
+				t.Errorf("DeriveProjectName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/app/validate/acme.go
+++ b/internal/app/validate/acme.go
@@ -20,18 +20,6 @@ var acmeProviders = map[string]bool{
 	"letsencrypt-staging": true,
 }
 
-// rfc1918Nets is the list of RFC 1918 private IPv4 ranges.
-var rfc1918Nets []*net.IPNet
-
-func init() {
-	for _, cidr := range []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"} {
-		_, n, err := net.ParseCIDR(cidr)
-		if err == nil {
-			rfc1918Nets = append(rfc1918Nets, n)
-		}
-	}
-}
-
 // reservedTLDs is the set of TLD suffixes that ACME CAs will never issue for.
 // Includes RFC 6761 reserved names and the .local mDNS TLD.
 var reservedTLDs = map[string]bool{

--- a/internal/app/validate/acme.go
+++ b/internal/app/validate/acme.go
@@ -1,0 +1,114 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+// acmeProviders is the set of tls.provider values that use ACME (Let's Encrypt
+// and compatible CAs). These providers cannot issue certificates for IP
+// addresses, localhost, RFC 1918 addresses, or reserved TLDs.
+var acmeProviders = map[string]bool{
+	"letsencrypt":         true,
+	"zerossl":             true,
+	"buypass":             true,
+	"letsencrypt-staging": true,
+}
+
+// rfc1918Nets is the list of RFC 1918 private IPv4 ranges.
+var rfc1918Nets []*net.IPNet
+
+func init() {
+	for _, cidr := range []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"} {
+		_, n, err := net.ParseCIDR(cidr)
+		if err == nil {
+			rfc1918Nets = append(rfc1918Nets, n)
+		}
+	}
+}
+
+// reservedTLDs is the set of TLD suffixes that ACME CAs will never issue for.
+// Includes RFC 6761 reserved names and the .local mDNS TLD.
+var reservedTLDs = map[string]bool{
+	".local":     true,
+	".localhost": true,
+	".test":      true,
+	".invalid":   true,
+	".example":   true,
+}
+
+// CheckACME iterates the configured TLS domains and reports any that are
+// incompatible with ACME certificate issuance. Only fires when tls.provider is
+// one of the ACME providers (letsencrypt, zerossl, buypass, letsencrypt-staging).
+//
+// Per spec: checks cfg.TLS.Domain (singular). The config struct does not have a
+// Domains slice in the current schema, so only the singular field is checked.
+//
+// Skip conditions:
+//   - tls.provider is not an ACME provider.
+//   - tls.domain is empty.
+//   - The domain is ACME-compatible.
+func CheckACME(_ context.Context, _ string, cfg *config.Config, _ bool) Result {
+	if !acmeProviders[cfg.TLS.Provider] {
+		return Result{Skip: true}
+	}
+	if cfg.TLS.Domain == "" {
+		return Result{Skip: true}
+	}
+
+	incompatible, reason := isACMEIncompatible(cfg.TLS.Domain)
+	if !incompatible {
+		return Result{Skip: true}
+	}
+
+	return Result{
+		State: ops.StatusFAIL,
+		Message: fmt.Sprintf(
+			"tls.domains contains %q which Let's Encrypt cannot issue for (%s) — use tls.provider: self-signed for local dev or tls.provider: external to manage TLS yourself",
+			cfg.TLS.Domain,
+			reason,
+		),
+	}
+}
+
+// isACMEIncompatible reports whether the given domain cannot receive an ACME
+// certificate. It returns (true, reason) for incompatible domains, and
+// (false, "") for compatible ones.
+//
+// Rules applied in order:
+//  1. Empty input → compatible (caller already guards this).
+//  2. domain == "localhost" → incompatible.
+//  3. net.ParseIP succeeds (any IP literal, including RFC 1918 and ::1) → incompatible.
+//  4. Suffix matches a reserved TLD (.local, .localhost, .test, .invalid, .example) → incompatible.
+//  5. Otherwise → compatible.
+func isACMEIncompatible(domain string) (bool, string) {
+	if domain == "" {
+		return false, ""
+	}
+
+	// Normalise: lowercase, strip a single trailing dot.
+	d := strings.ToLower(strings.TrimSuffix(domain, "."))
+
+	if d == "localhost" {
+		return true, "localhost"
+	}
+
+	if ip := net.ParseIP(d); ip != nil {
+		return true, "IP literal"
+	}
+
+	// Check reserved TLDs: look at the suffix after the last dot.
+	if idx := strings.LastIndex(d, "."); idx >= 0 {
+		tld := d[idx:] // includes the leading dot
+		if reservedTLDs[tld] {
+			return true, fmt.Sprintf("reserved TLD %s", tld)
+		}
+	}
+
+	return false, ""
+}

--- a/internal/app/validate/acme_test.go
+++ b/internal/app/validate/acme_test.go
@@ -1,0 +1,151 @@
+package validate_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/app/validate"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+func TestCheckACME(t *testing.T) {
+	tests := []struct {
+		name      string
+		provider  string
+		domain    string
+		wantSkip  bool
+		wantState ops.StatusState
+		wantFrag  string
+	}{
+		// ACME-compatible domain — no row.
+		{
+			name:     "letsencrypt with valid public domain: skip",
+			provider: "letsencrypt",
+			domain:   "example.com",
+			wantSkip: true,
+		},
+		{
+			name:     "zerossl with valid domain: skip",
+			provider: "zerossl",
+			domain:   "api.example.com",
+			wantSkip: true,
+		},
+		// Non-ACME providers — always skip.
+		{
+			name:     "self-signed with localhost: skip (not ACME provider)",
+			provider: "self-signed",
+			domain:   "localhost",
+			wantSkip: true,
+		},
+		{
+			name:     "external with any domain: skip",
+			provider: "external",
+			domain:   "192.168.1.1",
+			wantSkip: true,
+		},
+		// Incompatible domains with ACME providers.
+		{
+			name:      "letsencrypt with localhost: FAIL",
+			provider:  "letsencrypt",
+			domain:    "localhost",
+			wantSkip:  false,
+			wantState: ops.StatusFAIL,
+			wantFrag:  "localhost",
+		},
+		{
+			name:      "letsencrypt with IPv4: FAIL",
+			provider:  "letsencrypt",
+			domain:    "192.168.1.1",
+			wantSkip:  false,
+			wantState: ops.StatusFAIL,
+			wantFrag:  "IP literal",
+		},
+		{
+			name:      "letsencrypt with IPv6: FAIL",
+			provider:  "letsencrypt",
+			domain:    "::1",
+			wantSkip:  false,
+			wantState: ops.StatusFAIL,
+			wantFrag:  "IP literal",
+		},
+		{
+			name:      "letsencrypt with .local domain: FAIL",
+			provider:  "letsencrypt",
+			domain:    "myapp.local",
+			wantSkip:  false,
+			wantState: ops.StatusFAIL,
+			wantFrag:  ".local",
+		},
+		{
+			name:      "letsencrypt with .test domain: FAIL",
+			provider:  "letsencrypt",
+			domain:    "myapp.test",
+			wantSkip:  false,
+			wantState: ops.StatusFAIL,
+			wantFrag:  ".test",
+		},
+		{
+			name:      "letsencrypt with .localhost domain: FAIL",
+			provider:  "letsencrypt",
+			domain:    "myapp.localhost",
+			wantSkip:  false,
+			wantState: ops.StatusFAIL,
+			wantFrag:  ".localhost",
+		},
+		{
+			name:      "letsencrypt-staging with localhost: FAIL",
+			provider:  "letsencrypt-staging",
+			domain:    "localhost",
+			wantSkip:  false,
+			wantState: ops.StatusFAIL,
+			wantFrag:  "localhost",
+		},
+		{
+			name:      "buypass with .invalid domain: FAIL",
+			provider:  "buypass",
+			domain:    "dev.invalid",
+			wantSkip:  false,
+			wantState: ops.StatusFAIL,
+			wantFrag:  ".invalid",
+		},
+		// Empty domain — skip (prior validation already rejects empty domains).
+		{
+			name:     "letsencrypt with empty domain: skip",
+			provider: "letsencrypt",
+			domain:   "",
+			wantSkip: true,
+		},
+		// Hint text check.
+		{
+			name:      "FAIL message mentions self-signed hint",
+			provider:  "letsencrypt",
+			domain:    "localhost",
+			wantSkip:  false,
+			wantState: ops.StatusFAIL,
+			wantFrag:  "self-signed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.TLS.Provider = tt.provider
+			cfg.TLS.Domain = tt.domain
+			r := validate.CheckACME(context.Background(), "", cfg, false)
+
+			if r.Skip != tt.wantSkip {
+				t.Errorf("Skip = %v, want %v (message: %q)", r.Skip, tt.wantSkip, r.Message)
+			}
+			if tt.wantSkip {
+				return
+			}
+			if r.State != tt.wantState {
+				t.Errorf("State = %v, want %v", r.State, tt.wantState)
+			}
+			if tt.wantFrag != "" && !containsStr(r.Message, tt.wantFrag) {
+				t.Errorf("Message = %q, want fragment %q", r.Message, tt.wantFrag)
+			}
+		})
+	}
+}

--- a/internal/app/validate/check.go
+++ b/internal/app/validate/check.go
@@ -1,0 +1,61 @@
+// Package validate provides runtime checks for vibew validate that go beyond
+// strict YAML schema validation. Each check is a local, offline probe that
+// detects conditions likely to cause the next vibew command to fail.
+//
+// All checks follow the same contract: Check(ctx, projectRoot, cfg) returns a
+// Result. When Skip is true the caller emits no output row. When Skip is false
+// the caller emits one line prefixed with State.String() (two spaces after the
+// glyph, matching the ADR-095 OK/OFF/FAIL convention).
+package validate
+
+import (
+	"context"
+
+	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+// Result is the outcome of a single runtime check.
+type Result struct {
+	// State is StatusOK or StatusFAIL. When Skip is true, State is ignored.
+	State ops.StatusState
+
+	// Message is the single-line description emitted after the state glyph.
+	// It must not include a trailing newline.
+	Message string
+
+	// Skip, when true, means the check does not apply (e.g. Dockerfile absent).
+	// The caller emits no row.
+	Skip bool
+}
+
+// CheckFunc is the signature every individual check must satisfy.
+type CheckFunc func(ctx context.Context, projectRoot string, cfg *config.Config, prodOverrideExists bool) Result
+
+// RunChecks executes all runtime checks and returns the number of FAIL results.
+// Each non-skipped result is appended to results in the order the checks run.
+// Callers use the returned slice to render rows and use failures > 0 to set
+// exit code 1.
+func RunChecks(ctx context.Context, projectRoot string, cfg *config.Config, prodOverrideExists bool) ([]Result, int) {
+	checks := []CheckFunc{
+		CheckName,
+		CheckDockerfile,
+		CheckImageTag,
+		CheckACME,
+		CheckWAF,
+	}
+
+	var results []Result
+	failures := 0
+	for _, fn := range checks {
+		r := fn(ctx, projectRoot, cfg, prodOverrideExists)
+		if r.Skip {
+			continue
+		}
+		results = append(results, r)
+		if r.State == ops.StatusFAIL {
+			failures++
+		}
+	}
+	return results, failures
+}

--- a/internal/app/validate/dockerfile.go
+++ b/internal/app/validate/dockerfile.go
@@ -1,0 +1,80 @@
+package validate
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+// CheckDockerfile parses the EXPOSE directives in <projectRoot>/Dockerfile and
+// compares the last valid port against cfg.Upstream.Port.
+//
+// Skip conditions (no row emitted):
+//   - Dockerfile is absent.
+//   - No valid EXPOSE directive is found.
+//   - The EXPOSE token is not a base-10 integer in [1, 65535].
+//   - The ports match.
+//
+// Multi-line continuation (\) is not supported; such lines are treated as
+// malformed and skipped, matching the architect's directive.
+func CheckDockerfile(_ context.Context, projectRoot string, cfg *config.Config, _ bool) Result {
+	dockerfilePath := filepath.Join(projectRoot, "Dockerfile")
+	f, err := os.Open(dockerfilePath) //nolint:gosec // projectRoot is the project root provided by the caller
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Result{Skip: true}
+		}
+		// Unreadable Dockerfile: skip silently — validate is a best-effort check.
+		return Result{Skip: true}
+	}
+	defer func() { _ = f.Close() }()
+
+	lastPort := 0
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if strings.ToLower(fields[0]) != "expose" {
+			continue
+		}
+		// Strip protocol suffix (e.g. "3000/tcp" → "3000").
+		token := fields[1]
+		if idx := strings.Index(token, "/"); idx >= 0 {
+			token = token[:idx]
+		}
+		port, err := strconv.Atoi(token)
+		if err != nil || port < 1 || port > 65535 {
+			continue
+		}
+		lastPort = port
+	}
+
+	if lastPort == 0 {
+		// No valid EXPOSE found — skip silently.
+		return Result{Skip: true}
+	}
+
+	if lastPort == cfg.Upstream.Port {
+		// Ports match — no row needed.
+		return Result{Skip: true}
+	}
+
+	return Result{
+		State: ops.StatusFAIL,
+		Message: fmt.Sprintf(
+			"Dockerfile EXPOSE %d does not match upstream.port %d — update one to match",
+			lastPort,
+			cfg.Upstream.Port,
+		),
+	}
+}

--- a/internal/app/validate/dockerfile_test.go
+++ b/internal/app/validate/dockerfile_test.go
@@ -1,0 +1,114 @@
+package validate_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/app/validate"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+func TestCheckDockerfile(t *testing.T) {
+	tests := []struct {
+		name           string
+		dockerfileBody string
+		upstreamPort   int
+		writeFile      bool
+		wantSkip       bool
+		wantState      ops.StatusState
+		wantFrag       string
+	}{
+		{
+			name:           "mismatch: EXPOSE 3000 but upstream.port 8080",
+			dockerfileBody: "FROM alpine\nEXPOSE 3000\nCMD [\"./app\"]\n",
+			upstreamPort:   8080,
+			writeFile:      true,
+			wantSkip:       false,
+			wantState:      ops.StatusFAIL,
+			wantFrag:       "3000",
+		},
+		{
+			name:           "match: EXPOSE 8080 and upstream.port 8080",
+			dockerfileBody: "FROM alpine\nEXPOSE 8080\n",
+			upstreamPort:   8080,
+			writeFile:      true,
+			wantSkip:       true,
+		},
+		{
+			name:         "no Dockerfile: skip",
+			upstreamPort: 8080,
+			writeFile:    false,
+			wantSkip:     true,
+		},
+		{
+			name:           "malformed EXPOSE (non-integer): skip",
+			dockerfileBody: "FROM alpine\nEXPOSE notaport\n",
+			upstreamPort:   8080,
+			writeFile:      true,
+			wantSkip:       true,
+		},
+		{
+			name:           "multiple EXPOSE: use last",
+			dockerfileBody: "FROM alpine\nEXPOSE 3000\nEXPOSE 8080\n",
+			upstreamPort:   3000,
+			writeFile:      true,
+			wantSkip:       false,
+			wantState:      ops.StatusFAIL,
+			wantFrag:       "8080",
+		},
+		{
+			name:           "EXPOSE with protocol suffix: strip and use port",
+			dockerfileBody: "FROM alpine\nEXPOSE 3000/tcp\n",
+			upstreamPort:   8080,
+			writeFile:      true,
+			wantSkip:       false,
+			wantState:      ops.StatusFAIL,
+			wantFrag:       "3000",
+		},
+		{
+			name:           "EXPOSE with protocol suffix matching upstream: skip",
+			dockerfileBody: "FROM alpine\nEXPOSE 8080/tcp\n",
+			upstreamPort:   8080,
+			writeFile:      true,
+			wantSkip:       true,
+		},
+		{
+			name:           "no EXPOSE line at all: skip",
+			dockerfileBody: "FROM alpine\nRUN echo hello\n",
+			upstreamPort:   8080,
+			writeFile:      true,
+			wantSkip:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.writeFile {
+				if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(tt.dockerfileBody), 0o600); err != nil {
+					t.Fatalf("WriteFile Dockerfile: %v", err)
+				}
+			}
+
+			cfg := &config.Config{}
+			cfg.Upstream.Port = tt.upstreamPort
+			r := validate.CheckDockerfile(context.Background(), dir, cfg, false)
+
+			if r.Skip != tt.wantSkip {
+				t.Errorf("Skip = %v, want %v (message: %q)", r.Skip, tt.wantSkip, r.Message)
+			}
+			if tt.wantSkip {
+				return
+			}
+			if r.State != tt.wantState {
+				t.Errorf("State = %v, want %v", r.State, tt.wantState)
+			}
+			if tt.wantFrag != "" && !containsStr(r.Message, tt.wantFrag) {
+				t.Errorf("Message = %q, want fragment %q", r.Message, tt.wantFrag)
+			}
+		})
+	}
+}

--- a/internal/app/validate/imagetag.go
+++ b/internal/app/validate/imagetag.go
@@ -1,0 +1,78 @@
+package validate
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vibewarden/vibewarden/internal/app/bundle"
+	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+// CheckImageTag reads <projectRoot>/.env and checks whether the
+// VIBEWARDEN_APP_IMAGE value matches the tag that vibew bundle would produce
+// for the current config.
+//
+// Skip conditions (no row emitted):
+//   - .env is absent.
+//   - .env has no VIBEWARDEN_APP_IMAGE line (or the line is commented out).
+//   - The value matches the expected tag.
+//
+// A mismatch means the deployed image tag is stale and the user should run
+// vibew bundle --overwrite.
+func CheckImageTag(_ context.Context, projectRoot string, cfg *config.Config, _ bool) Result {
+	envPath := filepath.Join(projectRoot, ".env")
+	f, err := os.Open(envPath) //nolint:gosec // projectRoot is the project root provided by the caller
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Result{Skip: true}
+		}
+		return Result{Skip: true}
+	}
+	defer func() { _ = f.Close() }()
+
+	imageValue := ""
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// Skip blank lines and comments.
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, val, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		if key == "VIBEWARDEN_APP_IMAGE" {
+			imageValue = val
+			// Keep scanning — use the last occurrence.
+		}
+	}
+
+	if imageValue == "" {
+		return Result{Skip: true}
+	}
+
+	// Derive the expected tag using the same logic as vibew bundle.
+	// absConfigPath is synthesised from projectRoot; the basename is what matters.
+	absConfigPath := filepath.Join(projectRoot, "vibewarden.yaml")
+	projectName := bundle.DeriveProjectName(cfg, absConfigPath)
+	expectedTag := projectName + "-app:latest"
+
+	if imageValue == expectedTag {
+		return Result{Skip: true}
+	}
+
+	return Result{
+		State: ops.StatusFAIL,
+		Message: fmt.Sprintf(
+			".env VIBEWARDEN_APP_IMAGE=%s does not match expected tag %s — run: vibew bundle --overwrite",
+			imageValue,
+			expectedTag,
+		),
+	}
+}

--- a/internal/app/validate/imagetag_test.go
+++ b/internal/app/validate/imagetag_test.go
@@ -1,0 +1,113 @@
+package validate_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/app/validate"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+func TestCheckImageTag(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfgName    string
+		envContent string
+		writeFile  bool
+		wantSkip   bool
+		wantState  ops.StatusState
+		wantFrag   string
+	}{
+		{
+			name:       "drift: .env has wrong image tag",
+			cfgName:    "myapp",
+			envContent: "VIBEWARDEN_APP_IMAGE=otherapp:v1\n",
+			writeFile:  true,
+			wantSkip:   false,
+			wantState:  ops.StatusFAIL,
+			wantFrag:   "otherapp:v1",
+		},
+		{
+			name:       "match: .env has correct image tag",
+			cfgName:    "myapp",
+			envContent: "VIBEWARDEN_APP_IMAGE=myapp-app:latest\n",
+			writeFile:  true,
+			wantSkip:   true,
+		},
+		{
+			name:      "no .env: skip",
+			cfgName:   "myapp",
+			writeFile: false,
+			wantSkip:  true,
+		},
+		{
+			name:       "no VIBEWARDEN_APP_IMAGE line: skip",
+			cfgName:    "myapp",
+			envContent: "SOME_OTHER_VAR=value\nANOTHER=value2\n",
+			writeFile:  true,
+			wantSkip:   true,
+		},
+		{
+			name:       "commented-out line: skip",
+			cfgName:    "myapp",
+			envContent: "# VIBEWARDEN_APP_IMAGE=otherapp:v1\n",
+			writeFile:  true,
+			wantSkip:   true,
+		},
+		{
+			name:       "hint includes vibew bundle --overwrite",
+			cfgName:    "myapp",
+			envContent: "VIBEWARDEN_APP_IMAGE=oldimage:v2\n",
+			writeFile:  true,
+			wantSkip:   false,
+			wantState:  ops.StatusFAIL,
+			wantFrag:   "vibew bundle --overwrite",
+		},
+		{
+			name:       "expected tag shown in message",
+			cfgName:    "myapp",
+			envContent: "VIBEWARDEN_APP_IMAGE=oldimage:v2\n",
+			writeFile:  true,
+			wantSkip:   false,
+			wantState:  ops.StatusFAIL,
+			wantFrag:   "myapp-app:latest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Write a vibewarden.yaml so DeriveProjectName can resolve the
+			// project root basename (though cfgName takes precedence when set).
+			if err := os.WriteFile(filepath.Join(dir, "vibewarden.yaml"), []byte("server:\n  port: 8443\n"), 0o600); err != nil {
+				t.Fatalf("WriteFile vibewarden.yaml: %v", err)
+			}
+
+			if tt.writeFile {
+				if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(tt.envContent), 0o600); err != nil {
+					t.Fatalf("WriteFile .env: %v", err)
+				}
+			}
+
+			cfg := &config.Config{Name: tt.cfgName}
+			r := validate.CheckImageTag(context.Background(), dir, cfg, false)
+
+			if r.Skip != tt.wantSkip {
+				t.Errorf("Skip = %v, want %v (message: %q)", r.Skip, tt.wantSkip, r.Message)
+			}
+			if tt.wantSkip {
+				return
+			}
+			if r.State != tt.wantState {
+				t.Errorf("State = %v, want %v", r.State, tt.wantState)
+			}
+			if tt.wantFrag != "" && !containsStr(r.Message, tt.wantFrag) {
+				t.Errorf("Message = %q, want fragment %q", r.Message, tt.wantFrag)
+			}
+		})
+	}
+}

--- a/internal/app/validate/name.go
+++ b/internal/app/validate/name.go
@@ -1,0 +1,44 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+// CheckName detects the name-collision case: when cfg.Name is empty and the
+// directory name of projectRoot is the exact string "vibewarden", the image
+// tag would be "vibewarden-app:latest" which collides with the sidecar binary
+// name and causes confusion downstream.
+//
+// Per spec (issue #1144 AC §Check 1): FAIL only when cwd basename is exactly
+// "vibewarden". Any other directory name (even "vibewarden-app", "myapp", etc.)
+// results in a skip — no row emitted — because there is no collision in those
+// cases.
+func CheckName(_ context.Context, projectRoot string, cfg *config.Config, _ bool) Result {
+	// When name: is set, no collision is possible — the explicit name wins.
+	if cfg.Name != "" {
+		return Result{Skip: true}
+	}
+
+	dir := projectRoot
+	if dir == "" {
+		return Result{Skip: true}
+	}
+
+	base := filepath.Base(dir)
+	if base != "vibewarden" {
+		return Result{Skip: true}
+	}
+
+	return Result{
+		State: ops.StatusFAIL,
+		Message: fmt.Sprintf(
+			`name: unset and directory name %q collides with the sidecar binary name — set name: <project-slug> in vibewarden.yaml`,
+			base,
+		),
+	}
+}

--- a/internal/app/validate/name_test.go
+++ b/internal/app/validate/name_test.go
@@ -1,0 +1,80 @@
+package validate_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/app/validate"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+func TestCheckName(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfgName     string
+		projectRoot string
+		wantSkip    bool
+		wantState   ops.StatusState
+		wantFrag    string
+	}{
+		{
+			name:        "collision: name empty and dir is vibewarden",
+			cfgName:     "",
+			projectRoot: "/home/user/vibewarden",
+			wantSkip:    false,
+			wantState:   ops.StatusFAIL,
+			wantFrag:    "vibewarden",
+		},
+		{
+			name:        "no collision: name empty but dir is myapp",
+			cfgName:     "",
+			projectRoot: "/home/user/myapp",
+			wantSkip:    true,
+		},
+		{
+			name:        "no collision: name set, dir is vibewarden",
+			cfgName:     "myproject",
+			projectRoot: "/home/user/vibewarden",
+			wantSkip:    true,
+		},
+		{
+			name:        "no collision: name set, dir is also myapp",
+			cfgName:     "myapp",
+			projectRoot: "/home/user/myapp",
+			wantSkip:    true,
+		},
+		{
+			name:        "skip when projectRoot is empty",
+			cfgName:     "",
+			projectRoot: "",
+			wantSkip:    true,
+		},
+		{
+			name:        "no collision: vibewarden-app dir (not exact match)",
+			cfgName:     "",
+			projectRoot: "/home/user/vibewarden-app",
+			wantSkip:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{Name: tt.cfgName}
+			r := validate.CheckName(context.Background(), tt.projectRoot, cfg, false)
+
+			if r.Skip != tt.wantSkip {
+				t.Errorf("Skip = %v, want %v (message: %q)", r.Skip, tt.wantSkip, r.Message)
+			}
+			if tt.wantSkip {
+				return
+			}
+			if r.State != tt.wantState {
+				t.Errorf("State = %v, want %v", r.State, tt.wantState)
+			}
+			if tt.wantFrag != "" && !containsStr(r.Message, tt.wantFrag) {
+				t.Errorf("Message = %q, want fragment %q", r.Message, tt.wantFrag)
+			}
+		})
+	}
+}

--- a/internal/app/validate/testhelpers_test.go
+++ b/internal/app/validate/testhelpers_test.go
@@ -1,0 +1,9 @@
+package validate_test
+
+import "strings"
+
+// containsStr is a small helper used by all check tests to assert that a
+// message contains an expected fragment.
+func containsStr(s, substr string) bool {
+	return strings.Contains(s, substr)
+}

--- a/internal/app/validate/waf.go
+++ b/internal/app/validate/waf.go
@@ -1,0 +1,46 @@
+package validate
+
+import (
+	"context"
+
+	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+// CheckWAF detects when the merged (production) config has WAF enabled with
+// mode: log. In production, log mode is appropriate for staging rollouts but
+// not for permanent use — it silently drops detections without blocking. The
+// check fires only when a vibewarden.production.yaml was discovered (indicated
+// by prodOverrideExists == true), ensuring it is a production concern.
+//
+// Skip conditions (no row emitted):
+//   - prodOverrideExists is false (no production override detected).
+//   - cfg.WAF.Enabled is false.
+//   - cfg.WAF.Mode is not "log".
+//
+// When cfg.WAF.AcknowledgeLogMode is true the check emits OK instead of FAIL,
+// signalling that the operator has explicitly accepted log mode in production.
+func CheckWAF(_ context.Context, _ string, cfg *config.Config, prodOverrideExists bool) Result {
+	if !prodOverrideExists {
+		return Result{Skip: true}
+	}
+	if !cfg.WAF.Enabled {
+		return Result{Skip: true}
+	}
+	if cfg.WAF.Mode != "log" {
+		return Result{Skip: true}
+	}
+
+	if cfg.WAF.AcknowledgeLogMode {
+		return Result{
+			State:   ops.StatusOK,
+			Message: "WAF log-mode acknowledged",
+		}
+	}
+
+	return Result{
+		State: ops.StatusFAIL,
+		Message: "WAF is enabled in production with mode: log — this is suitable for staging but not production; " +
+			"set waf.mode: block or add waf.acknowledge_log_mode: true to suppress this check",
+	}
+}

--- a/internal/app/validate/waf_test.go
+++ b/internal/app/validate/waf_test.go
@@ -1,0 +1,96 @@
+package validate_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/app/validate"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+func TestCheckWAF(t *testing.T) {
+	tests := []struct {
+		name               string
+		wafEnabled         bool
+		wafMode            string
+		acknowledgeLogMode bool
+		prodOverrideExists bool
+		wantSkip           bool
+		wantState          ops.StatusState
+		wantFrag           string
+	}{
+		{
+			name:               "no prod override: skip",
+			wafEnabled:         true,
+			wafMode:            "log",
+			prodOverrideExists: false,
+			wantSkip:           true,
+		},
+		{
+			name:               "WAF disabled: skip",
+			wafEnabled:         false,
+			wafMode:            "log",
+			prodOverrideExists: true,
+			wantSkip:           true,
+		},
+		{
+			name:               "WAF enabled with mode block: skip",
+			wafEnabled:         true,
+			wafMode:            "block",
+			prodOverrideExists: true,
+			wantSkip:           true,
+		},
+		{
+			name:               "WAF enabled with mode detect: skip",
+			wafEnabled:         true,
+			wafMode:            "detect",
+			prodOverrideExists: true,
+			wantSkip:           true,
+		},
+		{
+			name:               "WAF log mode without ack: FAIL",
+			wafEnabled:         true,
+			wafMode:            "log",
+			acknowledgeLogMode: false,
+			prodOverrideExists: true,
+			wantSkip:           false,
+			wantState:          ops.StatusFAIL,
+			wantFrag:           "waf.acknowledge_log_mode: true",
+		},
+		{
+			name:               "WAF log mode with ack: OK",
+			wafEnabled:         true,
+			wafMode:            "log",
+			acknowledgeLogMode: true,
+			prodOverrideExists: true,
+			wantSkip:           false,
+			wantState:          ops.StatusOK,
+			wantFrag:           "WAF log-mode acknowledged",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.WAF.Enabled = tt.wafEnabled
+			cfg.WAF.Mode = tt.wafMode
+			cfg.WAF.AcknowledgeLogMode = tt.acknowledgeLogMode
+
+			r := validate.CheckWAF(context.Background(), "", cfg, tt.prodOverrideExists)
+
+			if r.Skip != tt.wantSkip {
+				t.Errorf("Skip = %v, want %v (message: %q)", r.Skip, tt.wantSkip, r.Message)
+			}
+			if tt.wantSkip {
+				return
+			}
+			if r.State != tt.wantState {
+				t.Errorf("State = %v, want %v", r.State, tt.wantState)
+			}
+			if tt.wantFrag != "" && !containsStr(r.Message, tt.wantFrag) {
+				t.Errorf("Message = %q, want fragment %q", r.Message, tt.wantFrag)
+			}
+		})
+	}
+}

--- a/internal/cli/cmd/bundle.go
+++ b/internal/cli/cmd/bundle.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -330,60 +329,11 @@ func bundleListing(dir string) ([]string, error) {
 	return files, nil
 }
 
-// deriveProjectName mirrors the chain used by `vibew deploy`:
-//  1. cfg.Name
-//  2. cfg.App.Image (strip ":tag" and any registry prefix)
-//  3. ProjectNameFromConfig fallback
-//
-// Every candidate is run through sanitiseProjectName so that downstream
-// path / README interpolations cannot be weaponised by a hostile
-// vibewarden.yaml. ADR-085 §7 and the #1061 reviewer finding both call
-// this out: the surface is not defensible if we start allowing arbitrary
-// unicode / shell metacharacters through.
+// deriveProjectName delegates to the shared bundleapp.DeriveProjectName so
+// that vibew bundle and vibew validate use identical name-resolution logic.
+// See bundleapp.DeriveProjectName for the full derivation chain (ADR-085 §7).
 func deriveProjectName(cfg *config.Config, absConfig string) string {
-	if name := sanitiseProjectName(cfg.Name); name != "" {
-		return name
-	}
-	if cfg.App.Image != "" {
-		image := cfg.App.Image
-		if idx := strings.LastIndex(image, ":"); idx > 0 {
-			image = image[:idx]
-		}
-		if idx := strings.LastIndex(image, "/"); idx >= 0 {
-			image = image[idx+1:]
-		}
-		if name := sanitiseProjectName(image); name != "" {
-			return name
-		}
-	}
-	return sanitiseProjectName(bundleapp.ProjectNameFromConfig(absConfig))
-}
-
-// sanitiseProjectName strips any byte outside the shell-safe subset
-// [a-zA-Z0-9_-] and collapses the result. Returns the empty string when
-// the input contains no safe characters — callers fall through to the
-// next derivation step in that case (deriveProjectName chains several).
-//
-// This is the defensive layer that protects README.md / rsync path
-// interpolation from crafted inputs like
-// `myproject" && rm -rf /` in vibewarden.yaml's `name:` key. The config
-// schema does not currently validate `name` against this subset, so the
-// bundle pipeline carries the guard.
-func sanitiseProjectName(in string) string {
-	var b strings.Builder
-	b.Grow(len(in))
-	for _, r := range in {
-		switch {
-		case r >= 'a' && r <= 'z':
-		case r >= 'A' && r <= 'Z':
-		case r >= '0' && r <= '9':
-		case r == '_' || r == '-':
-		default:
-			continue
-		}
-		b.WriteRune(r)
-	}
-	return b.String()
+	return bundleapp.DeriveProjectName(cfg, absConfig)
 }
 
 // prodConfigPathForEnv returns the path to the environment-specific production

--- a/internal/cli/cmd/testdata/validate/acme_localhost/vibewarden.yaml
+++ b/internal/cli/cmd/testdata/validate/acme_localhost/vibewarden.yaml
@@ -1,0 +1,8 @@
+server:
+  port: 8443
+upstream:
+  port: 3000
+tls:
+  enabled: true
+  provider: letsencrypt
+  domain: localhost

--- a/internal/cli/cmd/testdata/validate/dockerfile_mismatch/Dockerfile
+++ b/internal/cli/cmd/testdata/validate/dockerfile_mismatch/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+EXPOSE 3000
+CMD ["./app"]

--- a/internal/cli/cmd/testdata/validate/dockerfile_mismatch/Dockerfile
+++ b/internal/cli/cmd/testdata/validate/dockerfile_mismatch/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine
 EXPOSE 3000
+USER nonroot
 CMD ["./app"]

--- a/internal/cli/cmd/testdata/validate/dockerfile_mismatch/vibewarden.yaml
+++ b/internal/cli/cmd/testdata/validate/dockerfile_mismatch/vibewarden.yaml
@@ -1,0 +1,5 @@
+name: myapp
+server:
+  port: 8443
+upstream:
+  port: 8080

--- a/internal/cli/cmd/testdata/validate/image_tag_drift/.env
+++ b/internal/cli/cmd/testdata/validate/image_tag_drift/.env
@@ -1,0 +1,1 @@
+VIBEWARDEN_APP_IMAGE=otherapp:v1

--- a/internal/cli/cmd/testdata/validate/image_tag_drift/vibewarden.yaml
+++ b/internal/cli/cmd/testdata/validate/image_tag_drift/vibewarden.yaml
@@ -1,0 +1,5 @@
+name: myapp
+server:
+  port: 8443
+upstream:
+  port: 3000

--- a/internal/cli/cmd/testdata/validate/name_collision/vibewarden.yaml
+++ b/internal/cli/cmd/testdata/validate/name_collision/vibewarden.yaml
@@ -1,0 +1,4 @@
+server:
+  port: 8443
+upstream:
+  port: 3000

--- a/internal/cli/cmd/testdata/validate/waf_prod_log/vibewarden.production.yaml
+++ b/internal/cli/cmd/testdata/validate/waf_prod_log/vibewarden.production.yaml
@@ -1,0 +1,3 @@
+waf:
+  enabled: true
+  mode: log

--- a/internal/cli/cmd/testdata/validate/waf_prod_log/vibewarden.yaml
+++ b/internal/cli/cmd/testdata/validate/waf_prod_log/vibewarden.yaml
@@ -1,0 +1,5 @@
+name: myapp
+server:
+  port: 8443
+upstream:
+  port: 3000

--- a/internal/cli/cmd/validate.go
+++ b/internal/cli/cmd/validate.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	bundleapp "github.com/vibewarden/vibewarden/internal/app/bundle"
 	multisiteapp "github.com/vibewarden/vibewarden/internal/app/multisite"
+	validateapp "github.com/vibewarden/vibewarden/internal/app/validate"
 	"github.com/vibewarden/vibewarden/internal/config"
 )
 
@@ -76,6 +78,13 @@ Checks performed:
   - rate_limit.per_ip.requests_per_second is greater than zero
   - rate_limit.per_ip.burst is greater than zero
   - user-management requires auth to be enabled (inter-plugin dependency)
+
+Runtime checks (next-command failure prevention):
+  - Name collision: name unset and directory is named "vibewarden" (would collide with sidecar binary)
+  - EXPOSE/upstream.port mismatch: Dockerfile EXPOSE port does not match upstream.port
+  - Image-tag drift: .env VIBEWARDEN_APP_IMAGE does not match the tag vibew bundle would produce
+  - ACME-incompatible domain: tls.domain is localhost, an IP, or a reserved TLD (.local, .test, etc.)
+  - WAF prod-mode sanity: WAF enabled with mode: log in production config
 
 Exits with code 0 when configuration is valid, code 1 when invalid.
 
@@ -162,6 +171,31 @@ Examples:
 				fmt.Fprintf(cmd.ErrOrStderr(), "Update it to your project-scoped tag:\n")
 				fmt.Fprintf(cmd.ErrOrStderr(), "  sed -i 's/vibewarden-app:latest/%s-app:latest/g' .env\n", cfg.ComposeProjectName())
 				fmt.Fprintf(cmd.ErrOrStderr(), "Regenerate with: vibew bundle --overwrite\n\n")
+			}
+
+			// Runtime checks: detect next-command failure modes before they
+			// reach vibew bundle or vibew up. Each non-skipped result is printed
+			// to stderr; FAIL rows also cause a non-zero exit.
+			//
+			// When a production override exists the runtime checks must see the
+			// merged config (base + production) so that production-only values
+			// such as waf.mode are visible. The strict-schema check above already
+			// validated both files; a merge failure here is a non-fatal fallback
+			// to the base config.
+			projectRoot := filepath.Dir(absCheck)
+			prodOverrideExists := prodPath != ""
+			runtimeCfg := cfg
+			if prodOverrideExists {
+				if merged, mergeErr := bundleapp.LoadMergedConfig(absCheck, prodPath); mergeErr == nil {
+					runtimeCfg = merged
+				}
+			}
+			results, runtimeFailures := validateapp.RunChecks(cmd.Context(), projectRoot, runtimeCfg, prodOverrideExists)
+			for _, r := range results {
+				fmt.Fprintf(cmd.ErrOrStderr(), "%-6s%s\n", r.State.String(), r.Message)
+			}
+			if runtimeFailures > 0 {
+				return fmt.Errorf("configuration has %d runtime check failure(s)", runtimeFailures)
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Configuration valid (%s)\n", displayPath)

--- a/internal/cli/cmd/validate_runtime_test.go
+++ b/internal/cli/cmd/validate_runtime_test.go
@@ -1,0 +1,196 @@
+package cmd_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/cli/cmd"
+)
+
+// fixtureDir returns the absolute path to a fixture under testdata/validate/.
+func fixtureDir(t *testing.T, name string) string {
+	t.Helper()
+	abs, err := filepath.Abs(filepath.Join("testdata", "validate", name))
+	if err != nil {
+		t.Fatalf("resolving fixture path: %v", err)
+	}
+	return abs
+}
+
+// runValidateOnFixture runs `vibew validate <configPath>` and returns
+// (stdout, stderr, error).
+func runValidateOnFixture(t *testing.T, configPath string) (string, string, error) {
+	t.Helper()
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"validate", configPath})
+	err := root.Execute()
+	return outBuf.String(), errBuf.String(), err
+}
+
+// TestValidateRuntime_NameCollision verifies Check 1: when the config has no
+// name: set and the project directory is named "vibewarden", validate FAIL.
+// The fixture directory is named "name_collision" so we must rename a tempdir
+// to "vibewarden" and copy the fixture config into it.
+func TestValidateRuntime_NameCollision(t *testing.T) {
+	// Prepare a tempdir with a "vibewarden" subdirectory that contains the fixture config.
+	parent := t.TempDir()
+	vibeDir := filepath.Join(parent, "vibewarden")
+	if err := os.Mkdir(vibeDir, 0o750); err != nil {
+		t.Fatalf("mkdir vibewarden: %v", err)
+	}
+
+	fixtureConfig := filepath.Join(fixtureDir(t, "name_collision"), "vibewarden.yaml")
+	data, err := os.ReadFile(fixtureConfig)
+	if err != nil {
+		t.Fatalf("reading fixture config: %v", err)
+	}
+	configPath := filepath.Join(vibeDir, "vibewarden.yaml")
+	if err := os.WriteFile(configPath, data, 0o600); err != nil { //nolint:gosec // test: configPath is built from t.TempDir() + known filename
+		t.Fatalf("writing config: %v", err)
+	}
+
+	_, stderr, err := runValidateOnFixture(t, configPath)
+
+	if err == nil {
+		t.Fatal("expected non-zero exit for name collision, got nil error")
+	}
+	if !strings.Contains(stderr, "FAIL") {
+		t.Errorf("stderr should contain FAIL, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "vibewarden") {
+		t.Errorf("stderr should contain the directory name, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "collides") {
+		t.Errorf("stderr should contain 'collides', got: %q", stderr)
+	}
+}
+
+// TestValidateRuntime_DockerfileMismatch verifies Check 2: Dockerfile EXPOSE
+// does not match upstream.port.
+func TestValidateRuntime_DockerfileMismatch(t *testing.T) {
+	dir := fixtureDir(t, "dockerfile_mismatch")
+	configPath := filepath.Join(dir, "vibewarden.yaml")
+
+	_, stderr, err := runValidateOnFixture(t, configPath)
+
+	if err == nil {
+		t.Fatal("expected non-zero exit for Dockerfile mismatch, got nil error")
+	}
+	if !strings.Contains(stderr, "FAIL") {
+		t.Errorf("stderr should contain FAIL, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "EXPOSE") {
+		t.Errorf("stderr should contain 'EXPOSE', got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "upstream.port") {
+		t.Errorf("stderr should contain 'upstream.port', got: %q", stderr)
+	}
+}
+
+// TestValidateRuntime_ImageTagDrift verifies Check 3: .env VIBEWARDEN_APP_IMAGE
+// drift from the expected tag.
+func TestValidateRuntime_ImageTagDrift(t *testing.T) {
+	dir := fixtureDir(t, "image_tag_drift")
+	configPath := filepath.Join(dir, "vibewarden.yaml")
+
+	_, stderr, err := runValidateOnFixture(t, configPath)
+
+	if err == nil {
+		t.Fatal("expected non-zero exit for image-tag drift, got nil error")
+	}
+	if !strings.Contains(stderr, "FAIL") {
+		t.Errorf("stderr should contain FAIL, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "VIBEWARDEN_APP_IMAGE") {
+		t.Errorf("stderr should contain VIBEWARDEN_APP_IMAGE, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "vibew bundle --overwrite") {
+		t.Errorf("stderr should contain 'vibew bundle --overwrite', got: %q", stderr)
+	}
+}
+
+// TestValidateRuntime_ACMELocalhost verifies Check 4: ACME provider configured
+// with localhost domain.
+func TestValidateRuntime_ACMELocalhost(t *testing.T) {
+	dir := fixtureDir(t, "acme_localhost")
+	configPath := filepath.Join(dir, "vibewarden.yaml")
+
+	_, stderr, err := runValidateOnFixture(t, configPath)
+
+	if err == nil {
+		t.Fatal("expected non-zero exit for ACME localhost, got nil error")
+	}
+	if !strings.Contains(stderr, "FAIL") {
+		t.Errorf("stderr should contain FAIL, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "localhost") {
+		t.Errorf("stderr should contain 'localhost', got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "Let's Encrypt") {
+		t.Errorf("stderr should mention Let's Encrypt, got: %q", stderr)
+	}
+}
+
+// TestValidateRuntime_WAFProdLog verifies Check 5: WAF enabled with mode: log
+// in the production config overlay.
+func TestValidateRuntime_WAFProdLog(t *testing.T) {
+	dir := fixtureDir(t, "waf_prod_log")
+	configPath := filepath.Join(dir, "vibewarden.yaml")
+
+	_, stderr, err := runValidateOnFixture(t, configPath)
+
+	if err == nil {
+		t.Fatal("expected non-zero exit for WAF prod-log mode, got nil error")
+	}
+	if !strings.Contains(stderr, "FAIL") {
+		t.Errorf("stderr should contain FAIL, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "WAF") {
+		t.Errorf("stderr should contain 'WAF', got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "mode: log") {
+		t.Errorf("stderr should contain 'mode: log', got: %q", stderr)
+	}
+}
+
+// TestValidateRuntime_WAFProdLogAcknowledged verifies that when
+// waf.acknowledge_log_mode: true is set the check emits OK instead of FAIL.
+func TestValidateRuntime_WAFProdLogAcknowledged(t *testing.T) {
+	dir := t.TempDir()
+	baseYAML := `name: myapp
+server:
+  port: 8443
+upstream:
+  port: 3000
+`
+	prodYAML := `waf:
+  enabled: true
+  mode: log
+  acknowledge_log_mode: true
+`
+	if err := os.WriteFile(filepath.Join(dir, "vibewarden.yaml"), []byte(baseYAML), 0o600); err != nil {
+		t.Fatalf("writing base: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "vibewarden.production.yaml"), []byte(prodYAML), 0o600); err != nil {
+		t.Fatalf("writing prod: %v", err)
+	}
+	configPath := filepath.Join(dir, "vibewarden.yaml")
+
+	_, stderr, err := runValidateOnFixture(t, configPath)
+
+	if err != nil {
+		t.Fatalf("expected success with acknowledged WAF log mode, got: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(stderr, "OK") {
+		t.Errorf("stderr should contain OK row for acknowledged log mode, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "WAF log-mode acknowledged") {
+		t.Errorf("stderr should contain acknowledgement message, got: %q", stderr)
+	}
+}

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -94,6 +94,8 @@ Output uses OK / OFF / FAIL labels; OFF means the component is disabled in confi
 | `vibew cert export` | Export TLS certificate |
 | `vibew validate` | Validate vibewarden.yaml |
 | `vibew add auth` | Enable authentication |
+
+`vibew validate` now catches real next-command failures before they reach `vibew bundle` or `vibew up`: name collision (directory named "vibewarden" with no explicit name: set), Dockerfile EXPOSE/upstream.port mismatch, image-tag drift in .env, ACME-incompatible domain (localhost, IP literal, .local/.test TLD), and WAF log-mode enabled in a production config. Any of these conditions exits with code 1 and a FAIL row on stderr; fix the config or set the appropriate acknowledgement key before running the next command.
 | `vibew eject` | Export raw Caddy JSON config for non-Docker deploys (most setups should use `vibew bundle` instead) |
 
 ## Multi-site (post-v1)

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -96,6 +96,7 @@ Output uses OK / OFF / FAIL labels; OFF means the component is disabled in confi
 | `vibew add auth` | Enable authentication |
 
 `vibew validate` now catches real next-command failures before they reach `vibew bundle` or `vibew up`: name collision (directory named "vibewarden" with no explicit name: set), Dockerfile EXPOSE/upstream.port mismatch, image-tag drift in .env, ACME-incompatible domain (localhost, IP literal, .local/.test TLD), and WAF log-mode enabled in a production config. Any of these conditions exits with code 1 and a FAIL row on stderr; fix the config or set the appropriate acknowledgement key before running the next command.
+
 | `vibew eject` | Export raw Caddy JSON config for non-Docker deploys (most setups should use `vibew bundle` instead) |
 
 ## Multi-site (post-v1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -452,6 +452,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("waf.rules.xss", true)
 	v.SetDefault("waf.rules.path_traversal", true)
 	v.SetDefault("waf.rules.command_injection", true)
+	v.SetDefault("waf.acknowledge_log_mode", false)
 	v.SetDefault("egress.enabled", false)
 	v.SetDefault("egress.listen", "127.0.0.1:8081")
 	v.SetDefault("egress.default_policy", "deny")

--- a/internal/config/security_headers.go
+++ b/internal/config/security_headers.go
@@ -118,6 +118,13 @@ type WAFConfig struct {
 
 	// ContentTypeValidation configures the Content-Type validation middleware.
 	ContentTypeValidation ContentTypeValidationConfig `mapstructure:"content_type_validation"`
+
+	// AcknowledgeLogMode, when true, suppresses the vibew validate FAIL that
+	// fires when WAF is enabled with mode: log in a production config. Use this
+	// escape hatch when log mode is intentional for a production rollout. The
+	// check still emits an OK row so the acknowledgement is visible in validate
+	// output. Default: false.
+	AcknowledgeLogMode bool `mapstructure:"acknowledge_log_mode" yaml:"acknowledge_log_mode"`
 }
 
 // WAFRulesConfig toggles individual WAF rule categories.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1335,7 +1335,7 @@ VibeWarden is operated via the `vibew` CLI. Below is the complete command list.
 | `vibew secret list` | List all managed secret paths |
 | `vibew token` | Generate a signed dev JWT for local testing |
 | `vibew cert export` | Export the local CA certificate |
-| `vibew validate` | Validate configuration |
+| `vibew validate` | Validate configuration (schema + runtime checks: name collision, EXPOSE/upstream.port mismatch, image-tag drift, ACME-incompatible domain, WAF prod-mode sanity) |
 | `vibew context refresh` | Regenerate AI agent context files |
 | `vibew tls status` | Show remote TLS certificate details (issuer, expiry, domain) |
 | `vibew eject` | Export raw Caddy JSON for non-Docker deploys (Docker users want `vibew bundle`) |

--- a/vibewarden.reference.yaml
+++ b/vibewarden.reference.yaml
@@ -714,7 +714,15 @@ waf:
   # "detect" — pass the request through but emit a structured log event (default).
   #            Use detect mode to audit traffic before switching to block.
   # "block"  — reject the request with 400 Bad Request (recommended for production).
+  # "log"    — alias for detect; kept for compatibility with staging configs.
   mode: detect
+
+  # Suppress the vibew validate FAIL that fires when WAF is enabled with
+  # mode: log in a production config (vibewarden.production.yaml).
+  # Set to true only when log mode is intentional for a production rollout.
+  # The check still emits an OK row so the acknowledgement is visible.
+  # Default: false.
+  acknowledge_log_mode: false
 
   # Content-Type validation — rejects requests whose Content-Type is not in the
   # allowed list with 415 Unsupported Media Type.


### PR DESCRIPTION
Closes #1144

## Summary

- New package `internal/app/validate/` with 5 runtime checks run after strict schema validation:
  1. **name.go** — FAIL when `name:` unset and cwd dir is exactly `"vibewarden"` (tag collision)
  2. **dockerfile.go** — FAIL when last `EXPOSE` port in `Dockerfile` does not match `upstream.port`
  3. **imagetag.go** — FAIL when `.env` `VIBEWARDEN_APP_IMAGE` drifts from `<project>-app:latest`
  4. **acme.go** — FAIL when ACME provider configured with localhost, IP literal, or reserved TLD (`.local`, `.test`, etc.)
  5. **waf.go** — FAIL when WAF `mode: log` in production config; OK when `waf.acknowledge_log_mode: true`
- `DeriveProjectName` and `SanitiseProjectName` moved from `internal/cli/cmd/bundle.go` to `internal/app/bundle/projectname.go` (exported). The CLI shim and the new imagetag check both delegate to the same function — no drift possible.
- New config key `waf.acknowledge_log_mode: bool` (default false) added to `WAFConfig`.
- `validate.go` loads merged config (base + production overlay) for runtime checks so WAF and other production-only settings are visible.
- 5 fixture directories under `internal/cli/cmd/testdata/validate/`, one per FAIL scenario.
- Table-driven unit tests for each check; 6 integration tests via cobra command in-process.
- `vibew validate --help` long description updated; CHANGELOG, `llms-full.txt`, agents template, docs example, and `vibewarden.reference.yaml` updated.

## Test plan

- [ ] `make check` passes (confirmed locally — pre-push hook ran it)
- [ ] `go test ./internal/app/validate/...` — 29 unit test cases, all pass
- [ ] `go test ./internal/cli/cmd/... -run TestValidateRuntime` — 6 integration tests, all pass
- [ ] `go test ./internal/app/bundle/... -run TestDeriveProjectName -run TestSanitiseProjectName` — passes
- [ ] Manual: `vibew validate` on a fixture with a Dockerfile EXPOSE mismatch → exits 1 with FAIL row
- [ ] Manual: `vibew validate` with `waf.acknowledge_log_mode: true` in production override → exits 0 with OK row