### PR TITLE
fix(#1173): CI path-filter covers all dependabot.yml ecosystems + dependabot-bot bypass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,13 @@ jobs:
           filters: |
             code:
               - '**/*.go'
-              - 'go.mod'
-              - 'go.sum'
-              - 'Dockerfile'
+              - '**/go.mod'
+              - '**/go.sum'
+              - 'Dockerfile*'
+              - '**/requirements*.txt'
+              - '**/package*.json'
+              - '**/.nvmrc'
+              - '**/pyproject.toml'
               - '.github/workflows/**'
               - 'internal/**'
               - 'cmd/**'
@@ -39,7 +43,10 @@ jobs:
   lint:
     name: Lint
     needs: [changes]
-    if: needs.changes.outputs.code == 'true'
+    # Run when path filter detects code change OR when Dependabot opened the PR.
+    # Defense in depth — any future ecosystem added to dependabot.yml that
+    # isn't in the path filter still gets the full check suite. See #1173.
+    if: needs.changes.outputs.code == 'true' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -60,7 +67,10 @@ jobs:
   build-and-test:
     name: Build & Test
     needs: [changes]
-    if: needs.changes.outputs.code == 'true'
+    # Run when path filter detects code change OR when Dependabot opened the PR.
+    # Defense in depth — any future ecosystem added to dependabot.yml that
+    # isn't in the path filter still gets the full check suite. See #1173.
+    if: needs.changes.outputs.code == 'true' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -110,7 +120,10 @@ jobs:
   integration:
     name: Integration Tests
     needs: [changes]
-    if: needs.changes.outputs.code == 'true'
+    # Run when path filter detects code change OR when Dependabot opened the PR.
+    # Defense in depth — any future ecosystem added to dependabot.yml that
+    # isn't in the path filter still gets the full check suite. See #1173.
+    if: needs.changes.outputs.code == 'true' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,15 +28,22 @@ jobs:
           filters: |
             code:
               - '**/*.go'
-              - 'go.mod'
-              - 'go.sum'
-              - 'Dockerfile'
+              - '**/go.mod'
+              - '**/go.sum'
+              - 'Dockerfile*'
+              - '**/requirements*.txt'
+              - '**/package*.json'
+              - '**/.nvmrc'
+              - '**/pyproject.toml'
               - '.github/workflows/**'
 
   semgrep:
     name: Semgrep SAST
     needs: [changes]
-    if: needs.changes.outputs.code == 'true'
+    # Run when path filter detects code change OR when Dependabot opened the PR.
+    # Defense in depth — any future ecosystem added to dependabot.yml that
+    # isn't in the path filter still gets the full check suite. See #1173.
+    if: needs.changes.outputs.code == 'true' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
@@ -68,7 +75,10 @@ jobs:
   trivy:
     name: Trivy Vulnerability Scan
     needs: [changes]
-    if: needs.changes.outputs.code == 'true'
+    # Run when path filter detects code change OR when Dependabot opened the PR.
+    # Defense in depth — any future ecosystem added to dependabot.yml that
+    # isn't in the path filter still gets the full check suite. See #1173.
+    if: needs.changes.outputs.code == 'true' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -130,7 +140,10 @@ jobs:
   govulncheck:
     name: Go Vulnerability Check
     needs: [changes]
-    if: needs.changes.outputs.code == 'true'
+    # Run when path filter detects code change OR when Dependabot opened the PR.
+    # Defense in depth — any future ecosystem added to dependabot.yml that
+    # isn't in the path filter still gets the full check suite. See #1173.
+    if: needs.changes.outputs.code == 'true' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
Closes #1173.

## Summary

CI path-filter in `ci.yml` + `security.yml` was matching root-level `go.mod`/`go.sum`/`Dockerfile` literally, letting Dependabot PRs for non-root manifests (examples/demo-app/go.mod, examples/python-flask/requirements.txt, Dockerfile.goreleaser) skip ALL required Go/security checks. Branch protection counted skipped as success → unscanned dep bumps merged.

Two complementary fixes:

1. **Glob the manifest patterns**: `**/go.mod`, `**/go.sum`, `Dockerfile*`, plus `**/requirements*.txt`, `**/package*.json`, `**/.nvmrc`, `**/pyproject.toml`.
2. **Defense in depth**: gated jobs now run when `github.actor == 'dependabot[bot]'` regardless of path-filter outcome.

## Why both

Globbing alone fixes today's coverage gap. The actor check ensures any FUTURE ecosystem added to `dependabot.yml` (e.g., a new Rust app, a Helm chart) without a corresponding path-filter glob still gets the full check suite.

## Verification

- ✅ `make check` clean
- ✅ Diff is contained to two workflow files
- ✅ Non-Dependabot, non-code PRs (docs-only) still skip the heavy checks (the OR clause only triggers for `dependabot[bot]`)

Pre-v0.18.0 release blocker (security gap).