### PR TITLE
fix(validate): ACME error message uses singular tls.domain

### DIFF
--- a/internal/app/validate/acme.go
+++ b/internal/app/validate/acme.go
@@ -57,7 +57,7 @@ func CheckACME(_ context.Context, _ string, cfg *config.Config, _ bool) Result {
 	return Result{
 		State: ops.StatusFAIL,
 		Message: fmt.Sprintf(
-			"tls.domains contains %q which Let's Encrypt cannot issue for (%s) — use tls.provider: self-signed for local dev or tls.provider: external to manage TLS yourself",
+			"tls.domain is %q which Let's Encrypt cannot issue for (%s) — use tls.provider: self-signed for local dev or tls.provider: external to manage TLS yourself",
 			cfg.TLS.Domain,
 			reason,
 		),


### PR DESCRIPTION
## Summary

\`internal/app/validate/acme.go\` line 60 said \`tls.domains contains %q\` (plural) — but the config field is \`tls.domain\` (singular string). A user following the error message would search for \`tls.domains:\` in their config and find nothing.

One-line fix: \`tls.domains contains %q\` → \`tls.domain is %q\`.

## Discovery

V0.18.0-candidate smoke test, 2026-04-27 — BUG-4 in the smoke test notes (\`~/notes/vibewarden/smoke-v0.18.0-candidate.md\`).

## Test plan

- [x] \`make check\` clean
- [x] No test asserted on the old string (grep confirmed)