### PR TITLE
fix(#1186): vibew obs up success message lists all UIs (Grafana, Prometheus, Loki, Jaeger)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`vibew obs up` success message lists all UIs** (#1186). Previously printed only Grafana + Prometheus URLs; now also lists Loki (`/ready`) and Jaeger. Ports come from `observability.*_port` config keys (Jaeger is hardcoded — Jaeger port is not yet a config key).
+
 ---
 
 ## [v0.18.0] — 2026-04-28

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -397,6 +397,7 @@ vibew down -v --yes
 | Grafana    | http://localhost:3001        | Anonymous access, Admin role, no login |
 | Prometheus | http://localhost:9090        | No authentication required             |
 | Loki       | http://localhost:3100/ready  | API only; query logs via Grafana       |
+| Jaeger     | http://localhost:16686       | Distributed tracing UI; port is not yet a config key |
 
 Grafana is configured with anonymous authentication so there is no login screen in
 the local dev environment. This is intentional — do not use this configuration in

--- a/internal/app/ops/dev_test.go
+++ b/internal/app/ops/dev_test.go
@@ -98,6 +98,11 @@ func defaultConfig() *config.Config {
 		},
 		Telemetry: config.TelemetryConfig{Prometheus: config.PrometheusExporterConfig{Enabled: true}},
 		Kratos:    config.KratosConfig{PublicURL: "http://127.0.0.1:4433", AdminURL: "http://127.0.0.1:4434"},
+		Observability: config.ObservabilityConfig{
+			GrafanaPort:    3001,
+			PrometheusPort: 9090,
+			LokiPort:       3100,
+		},
 	}
 }
 

--- a/internal/app/ops/obs.go
+++ b/internal/app/ops/obs.go
@@ -113,8 +113,10 @@ func (s *ObsService) Up(ctx context.Context, cfg *config.Config, opts ObsUpOptio
 
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "Observability stack started.")
-	fmt.Fprintln(out, "Grafana:    http://localhost:3001")
-	fmt.Fprintln(out, "Prometheus: http://localhost:9090")
+	fmt.Fprintf(out, "Grafana:    http://localhost:%d\n", cfg.Observability.GrafanaPort)
+	fmt.Fprintf(out, "Prometheus: http://localhost:%d\n", cfg.Observability.PrometheusPort)
+	fmt.Fprintf(out, "Loki:       http://localhost:%d/ready\n", cfg.Observability.LokiPort)
+	fmt.Fprintln(out, "Jaeger:     http://localhost:16686")
 	fmt.Fprintln(out, "Stop:       vibew obs down")
 
 	return nil

--- a/internal/app/ops/obs_test.go
+++ b/internal/app/ops/obs_test.go
@@ -62,6 +62,109 @@ func TestObsService_Up_PrintsGrafanaAndPrometheusURLs(t *testing.T) {
 	}
 }
 
+func TestObsService_Up_PrintsAllFourURLs(t *testing.T) {
+	// Success message must include Grafana, Prometheus, Loki, and Jaeger URLs.
+	fc := &fakeCompose{}
+	svc := ops.NewObsService(fc, nil)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	if err := svc.Up(context.Background(), cfg, ops.ObsUpOptions{}, &buf); err != nil {
+		t.Fatalf("Up() unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{
+		"localhost:3001",
+		"localhost:9090",
+		"localhost:3100/ready",
+		"localhost:16686",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestObsService_Up_PortsReflectConfig(t *testing.T) {
+	// When ports are set to non-default values, the success message must use
+	// the configured values — no hardcoded ports for Grafana, Prometheus, or Loki.
+	tests := []struct {
+		name           string
+		grafanaPort    int
+		prometheusPort int
+		lokiPort       int
+		wantLines      []string
+	}{
+		{
+			name:           "default ports",
+			grafanaPort:    3001,
+			prometheusPort: 9090,
+			lokiPort:       3100,
+			wantLines: []string{
+				"localhost:3001",
+				"localhost:9090",
+				"localhost:3100/ready",
+				"localhost:16686",
+			},
+		},
+		{
+			name:           "custom ports",
+			grafanaPort:    3002,
+			prometheusPort: 9091,
+			lokiPort:       3101,
+			wantLines: []string{
+				"localhost:3002",
+				"localhost:9091",
+				"localhost:3101/ready",
+				"localhost:16686",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc := &fakeCompose{}
+			svc := ops.NewObsService(fc, nil)
+			cfg := defaultConfig()
+			cfg.Observability.GrafanaPort = tt.grafanaPort
+			cfg.Observability.PrometheusPort = tt.prometheusPort
+			cfg.Observability.LokiPort = tt.lokiPort
+			var buf bytes.Buffer
+
+			if err := svc.Up(context.Background(), cfg, ops.ObsUpOptions{}, &buf); err != nil {
+				t.Fatalf("Up() unexpected error: %v", err)
+			}
+
+			out := buf.String()
+			for _, want := range tt.wantLines {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected %q in output, got:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
+func TestObsService_Up_DoesNotPrintPromtailOrOtelCollector(t *testing.T) {
+	// Promtail and otel-collector have no host-bound UI ports and must NOT
+	// appear in the success message.
+	fc := &fakeCompose{}
+	svc := ops.NewObsService(fc, nil)
+	cfg := defaultConfig()
+	var buf bytes.Buffer
+
+	if err := svc.Up(context.Background(), cfg, ops.ObsUpOptions{}, &buf); err != nil {
+		t.Fatalf("Up() unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	for _, unwanted := range []string{"promtail", "otel-collector"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("success message must not contain %q, got:\n%s", unwanted, out)
+		}
+	}
+}
+
 func TestObsService_Up_ComposeError_ReturnsError(t *testing.T) {
 	fc := &fakeCompose{upErr: errors.New("docker not running")}
 	svc := ops.NewObsService(fc, nil)


### PR DESCRIPTION
Closes #1186

## Summary

- Extended the `fmt.Fprintln` block in `internal/app/ops/obs.go` lines 114-118 to print Loki and Jaeger URLs after the existing Grafana and Prometheus lines.
- Grafana, Prometheus, and Loki ports come from `cfg.Observability.*Port`; Jaeger is hardcoded at `16686` (no config key exists in v1).
- Loki URL uses `/ready` path — the bare host:port returns 404; `/ready` is Loki's canonical readiness endpoint.
- Added `Observability` default ports to `defaultConfig()` in `dev_test.go` (was zero-valued, which broke `TestObsService_Up_PrintsGrafanaOnPort3001`).
- Added three new tests in `obs_test.go`: `TestObsService_Up_PrintsAllFourURLs`, `TestObsService_Up_PortsReflectConfig` (table-driven, custom ports), `TestObsService_Up_DoesNotPrintPromtailOrOtelCollector`.
- Existing `TestObsService_Up_PrintsGrafanaOnPort3001` continues to pass unmodified.
- CHANGELOG `[Unreleased]` updated.

## Test plan

- `make check` passes locally (all tests green, golangci-lint clean).
- `TestObsService_Up_PrintsAllFourURLs` — asserts `localhost:3001`, `localhost:9090`, `localhost:3100/ready`, `localhost:16686` all appear in output.
- `TestObsService_Up_PortsReflectConfig` — sets `GrafanaPort=3002/PrometheusPort=9091/LokiPort=3101` and asserts the message reflects custom values; Jaeger stays `16686`.
- `TestObsService_Up_DoesNotPrintPromtailOrOtelCollector` — asserts neither `promtail` nor `otel-collector` appear in the message.