### PR TITLE
fix(#1181): vibew status annotates self-signed dev cert; no more "expires in 0 days" alarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Fixed
 
+- **`vibew status` annotates self-signed dev cert** (#1181). Self-signed dev certs (~12-hour TTL, auto-rotated by Caddy) used to render as `TLS: obtained (expires in 0 days)   OK` — technically correct (rotation happens) but visually alarming. The classifier now returns `KindSelfSignedLocal` whenever the cert was issued by the local CA regardless of `tls.provider` config, so the existing dev annotation from #1143 / ADR-095 fires correctly.
 - **`vibew obs up` success message lists all UIs** (#1186). Previously printed only Grafana + Prometheus URLs; now also lists Loki (`/ready`) and Jaeger. Ports come from `observability.*_port` config keys (Jaeger is hardcoded — Jaeger port is not yet a config key).
 
 ---

--- a/internal/adapters/caddy/tls_state.go
+++ b/internal/adapters/caddy/tls_state.go
@@ -117,10 +117,14 @@ func (r *InProcessResolver) Resolve(ctx context.Context) (tlsdomain.State, error
 		return tlsdomain.NewObtaining(), nil
 	}
 
-	// Self-signed branch is deterministic: issuer CN match → SelfSignedLocal,
-	// NO NotAfter inspection. The internal issuer rotates leaves on a
-	// short TTL and we trust it to do so.
-	if r.cfg.TLS.Provider == "self-signed" && leaf.Issuer.CommonName == caddyLocalIssuerCN {
+	// Issuer CN is authoritative — same rule as HandshakeResolver. The
+	// check is intentionally independent of cfg.TLS.Provider so that a
+	// Caddy-issued dev cert is classified as SelfSignedLocal even when the
+	// configured provider is "letsencrypt" (e.g. during vibew dev startup
+	// before the real ACME cert has been swapped in). No NotAfter
+	// inspection: the internal CA rotates leaves on a short TTL and we
+	// trust it to do so.
+	if leaf.Issuer.CommonName == caddyLocalIssuerCN {
 		return tlsdomain.NewSelfSignedLocal(), nil
 	}
 

--- a/internal/adapters/caddy/tls_state_handshake_test.go
+++ b/internal/adapters/caddy/tls_state_handshake_test.go
@@ -86,6 +86,27 @@ func TestHandshakeResolver_Resolve(t *testing.T) {
 		}
 	})
 
+	// Parity regression: HandshakeResolver must agree with InProcessResolver —
+	// a Caddy-issued dev cert served while provider="letsencrypt" must
+	// still resolve to KindSelfSignedLocal, not KindExpiringSoon.
+	t.Run("dev cert with letsencrypt provider → SelfSignedLocal", func(t *testing.T) {
+		// NotAfter is in the past to confirm expiry math is not reached.
+		host, port, cleanup := makeTLSServer(t, caddyLocalIssuerCN, fixedNow.Add(-1*time.Hour))
+		defer cleanup()
+
+		cfg := &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "letsencrypt"}}
+		r := NewHandshakeResolver(cfg, host, port)
+		r.now = func() time.Time { return fixedNow }
+
+		state, err := r.Resolve(context.Background())
+		if err != nil {
+			t.Fatalf("Resolve() unexpected error: %v", err)
+		}
+		if state.Kind() != tlsdomain.KindSelfSignedLocal {
+			t.Errorf("Kind() = %v, want SelfSignedLocal", state.Kind())
+		}
+	})
+
 	t.Run("external issuer with long expiry → Obtained", func(t *testing.T) {
 		host, port, cleanup := makeTLSServer(t, "ExampleCA", fixedNow.Add(90*24*time.Hour))
 		defer cleanup()

--- a/internal/adapters/caddy/tls_state_test.go
+++ b/internal/adapters/caddy/tls_state_test.go
@@ -97,10 +97,20 @@ func TestInProcessResolver_Resolve(t *testing.T) {
 			wantKind: tlsdomain.KindExpiringSoon,
 		},
 		{
-			name:     "self-signed with override issuer falls to expiry math",
+			name:     "self-signed with non-caddy issuer falls to expiry math",
 			cfg:      &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "self-signed"}},
 			provider: fakePeerCertProvider{leaf: makeLeaf("Not Caddy", expiryFar)},
 			wantKind: tlsdomain.KindObtained,
+		},
+		// Regression: dev cert served while provider is "letsencrypt" (e.g. vibew dev
+		// startup before ACME completes). Issuer CN is authoritative — provider gate
+		// must not short-circuit the check. NotAfter is in the past to confirm the
+		// old code would have returned KindExpiringSoon(0) here.
+		{
+			name:     "dev cert with letsencrypt provider and expired NotAfter → SelfSignedLocal",
+			cfg:      &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "letsencrypt"}},
+			provider: fakePeerCertProvider{leaf: makeLeaf(caddyLocalIssuerCN, fixedNow.Add(-1*time.Hour))},
+			wantKind: tlsdomain.KindSelfSignedLocal,
 		},
 	}
 

--- a/internal/app/ops/status_tls_render_test.go
+++ b/internal/app/ops/status_tls_render_test.go
@@ -22,8 +22,9 @@ func TestRenderTLSStatusLine(t *testing.T) {
 		{"obtained", tlsdomain.NewObtained(expires), "obtained (expires 2026-07-21)", StatusOK},
 		// KindExpiringSoon must be StatusOK — near-expiry is an annotation, not a failure (ADR-095).
 		{"expiring soon", tlsdomain.NewExpiringSoon(3, expires), "obtained (expires in 3 days)", StatusOK},
-		// Self-signed case: verify no expiry alarm even with 0 days (would fire in old code).
-		{"expiring soon 0 days", tlsdomain.NewExpiringSoon(0, expires), "obtained (expires in 0 days)", StatusOK},
+		// Real CA cert at 0 days remaining — numeric countdown is shown; this is not a dev cert.
+		// A dev cert would carry KindSelfSignedLocal (issuer CN check) and never reach this branch.
+		{"expiring soon 0 days non-dev", tlsdomain.NewExpiringSoon(0, expires), "obtained (expires in 0 days)", StatusOK},
 		{"failing with error", tlsdomain.NewFailing("connection refused"), "failing (last error: connection refused)", StatusFAIL},
 		{"failing empty error", tlsdomain.NewFailing(""), "failing", StatusFAIL},
 		{"unknown", tlsdomain.NewUnknown(), "state unavailable — start 'vibew dev'", StatusOK},


### PR DESCRIPTION
Closes #1181

## Summary

- Drop the `cfg.TLS.Provider == "self-signed"` gate in `InProcessResolver.Resolve` so the issuer-CN check (`leaf.Issuer.CommonName == "Caddy Local Authority"`) fires unconditionally, matching the existing behaviour in `HandshakeResolver`. A Caddy dev cert is now classified as `KindSelfSignedLocal` regardless of the configured provider.
- Regression test: `InProcessResolver` with `Provider="letsencrypt"` + Caddy-issued leaf + `NotAfter` in the past → `KindSelfSignedLocal` (would have returned `KindExpiringSoon(0)` before).
- Parity test: same scenario on `HandshakeResolver` confirming both resolvers agree.
- Renamed misleading render test case `"expiring soon 0 days"` → `"expiring soon 0 days non-dev"` with a comment clarifying it covers a real CA cert, not a dev leaf.
- CHANGELOG `[Unreleased] ### Fixed` entry added.

## Test plan

- `make check` passes (all 90+ packages green, lint clean).
- New regression test `"dev cert with letsencrypt provider and expired NotAfter → SelfSignedLocal"` in `tls_state_test.go` fails on the old code, passes on the fix.
- New parity test `"dev cert with letsencrypt provider → SelfSignedLocal"` in `tls_state_handshake_test.go` confirms resolver agreement.
- Smoke: `vibew dev` → cert served by Caddy local CA → `vibew status` shows `TLS: self-signed (dev)   OK`, no numeric expiry countdown.