### PR TITLE
fix(#1188): vibew add tls --domain auto-sets provider:letsencrypt for LE-compatible domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+### Changed
+
+- **`vibew add tls --domain X` auto-sets `provider: letsencrypt` for LE-compatible domains** (#1188). Previously only wrote the domain to `vibewarden.production.yaml`, leaving the merged config with `provider: self-signed` (from base) plus a real-world domain — the v0.18.0 deploy to `demo.vibewarden.dev` had to manually edit production.yaml. Now the command classifies the domain via the same checker `vibew validate` uses (`internal/app/tlsdomain`); LE-compatible domains get `provider: letsencrypt` + domain; localhost / IP / RFC 1918 / `.local` / `.test` domains get only the domain plus a stderr hint about picking a provider manually. Explicit `--provider <self-signed|letsencrypt|external>` flag honored as override.
+
 ### Fixed
 
 - **`vibew status` annotates self-signed dev cert** (#1181). Self-signed dev certs (~12-hour TTL, auto-rotated by Caddy) used to render as `TLS: obtained (expires in 0 days)   OK` — technically correct (rotation happens) but visually alarming. The classifier now returns `KindSelfSignedLocal` whenever the cert was issued by the local CA regardless of `tls.provider` config, so the existing dev annotation from #1143 / ADR-095 fires correctly.

--- a/internal/app/tlsdomain/classify.go
+++ b/internal/app/tlsdomain/classify.go
@@ -1,0 +1,57 @@
+// Package tlsdomain provides domain classification helpers for TLS provider
+// selection. It is a pure, dependency-free package importable from both the
+// validate and CLI cmd packages without introducing cross-package cycles.
+package tlsdomain
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// reservedTLDs is the set of TLD suffixes that ACME CAs will never issue for.
+// Includes RFC 6761 reserved names and the .local mDNS TLD.
+var reservedTLDs = map[string]bool{
+	".local":     true,
+	".localhost": true,
+	".test":      true,
+	".invalid":   true,
+	".example":   true,
+}
+
+// IsACMEIncompatible reports whether the given domain cannot receive an ACME
+// certificate. It returns (true, reason) for incompatible domains, and
+// (false, "") for compatible ones.
+//
+// Rules applied in order:
+//  1. Empty input → compatible (caller already guards this).
+//  2. domain == "localhost" → incompatible.
+//  3. net.ParseIP succeeds (any IP literal, including RFC 1918 and ::1) → incompatible.
+//  4. Suffix matches a reserved TLD (.local, .localhost, .test, .invalid, .example) → incompatible.
+//  5. Otherwise → compatible.
+func IsACMEIncompatible(domain string) (bool, string) {
+	if domain == "" {
+		return false, ""
+	}
+
+	// Normalise: lowercase, strip a single trailing dot.
+	d := strings.ToLower(strings.TrimSuffix(domain, "."))
+
+	if d == "localhost" {
+		return true, "localhost"
+	}
+
+	if ip := net.ParseIP(d); ip != nil {
+		return true, "IP literal"
+	}
+
+	// Check reserved TLDs: look at the suffix after the last dot.
+	if idx := strings.LastIndex(d, "."); idx >= 0 {
+		tld := d[idx:] // includes the leading dot
+		if reservedTLDs[tld] {
+			return true, fmt.Sprintf("reserved TLD %s", tld)
+		}
+	}
+
+	return false, ""
+}

--- a/internal/app/tlsdomain/classify_test.go
+++ b/internal/app/tlsdomain/classify_test.go
@@ -1,0 +1,67 @@
+package tlsdomain_test
+
+import (
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/app/tlsdomain"
+)
+
+func TestIsACMEIncompatible(t *testing.T) {
+	tests := []struct {
+		name           string
+		domain         string
+		wantIncompat   bool
+		wantReasonPart string // substring of reason; empty means any is fine
+	}{
+		// Compatible domains (ACME can issue).
+		{"empty string is compatible", "", false, ""},
+		{"public domain is compatible", "example.com", false, ""},
+		{"subdomain is compatible", "sub.example.com", false, ""},
+		{"deep subdomain is compatible", "a.b.example.com", false, ""},
+		{"trailing dot normalised", "example.com.", false, ""},
+		{"uppercase normalised", "EXAMPLE.COM", false, ""},
+
+		// localhost
+		{"bare localhost is incompatible", "localhost", true, "localhost"},
+		{"uppercase LOCALHOST normalised", "LOCALHOST", true, "localhost"},
+		{"localhost with trailing dot", "localhost.", true, "localhost"},
+
+		// IP literals
+		{"IPv4 loopback is incompatible", "127.0.0.1", true, "IP literal"},
+		{"IPv4 RFC1918 10.x is incompatible", "10.0.0.1", true, "IP literal"},
+		{"IPv4 RFC1918 192.168.x is incompatible", "192.168.1.1", true, "IP literal"},
+		{"IPv6 loopback is incompatible", "::1", true, "IP literal"},
+		{"IPv4-mapped IPv6 is incompatible", "::ffff:192.168.0.1", true, "IP literal"},
+
+		// Reserved TLDs
+		{".local TLD is incompatible", "myapp.local", true, "reserved TLD .local"},
+		{".localhost TLD is incompatible", "myapp.localhost", true, "reserved TLD .localhost"},
+		{".test TLD is incompatible", "myapp.test", true, "reserved TLD .test"},
+		{".invalid TLD is incompatible", "myapp.invalid", true, "reserved TLD .invalid"},
+		{".example TLD is incompatible", "myapp.example", true, "reserved TLD .example"},
+		{"subdomain under .local is incompatible", "a.b.local", true, "reserved TLD .local"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			incompat, reason := tlsdomain.IsACMEIncompatible(tt.domain)
+
+			if incompat != tt.wantIncompat {
+				t.Errorf("IsACMEIncompatible(%q) incompat = %v, want %v (reason=%q)",
+					tt.domain, incompat, tt.wantIncompat, reason)
+			}
+
+			if tt.wantIncompat && tt.wantReasonPart != "" {
+				if reason != tt.wantReasonPart {
+					t.Errorf("IsACMEIncompatible(%q) reason = %q, want %q",
+						tt.domain, reason, tt.wantReasonPart)
+				}
+			}
+
+			if !tt.wantIncompat && reason != "" {
+				t.Errorf("IsACMEIncompatible(%q) compatible domain returned non-empty reason %q",
+					tt.domain, reason)
+			}
+		})
+	}
+}

--- a/internal/app/validate/acme.go
+++ b/internal/app/validate/acme.go
@@ -3,10 +3,9 @@ package validate
 import (
 	"context"
 	"fmt"
-	"net"
-	"strings"
 
 	"github.com/vibewarden/vibewarden/internal/app/ops"
+	"github.com/vibewarden/vibewarden/internal/app/tlsdomain"
 	"github.com/vibewarden/vibewarden/internal/config"
 )
 
@@ -18,16 +17,6 @@ var acmeProviders = map[string]bool{
 	"zerossl":             true,
 	"buypass":             true,
 	"letsencrypt-staging": true,
-}
-
-// reservedTLDs is the set of TLD suffixes that ACME CAs will never issue for.
-// Includes RFC 6761 reserved names and the .local mDNS TLD.
-var reservedTLDs = map[string]bool{
-	".local":     true,
-	".localhost": true,
-	".test":      true,
-	".invalid":   true,
-	".example":   true,
 }
 
 // CheckACME iterates the configured TLS domains and reports any that are
@@ -49,7 +38,7 @@ func CheckACME(_ context.Context, _ string, cfg *config.Config, _ bool) Result {
 		return Result{Skip: true}
 	}
 
-	incompatible, reason := isACMEIncompatible(cfg.TLS.Domain)
+	incompatible, reason := tlsdomain.IsACMEIncompatible(cfg.TLS.Domain)
 	if !incompatible {
 		return Result{Skip: true}
 	}
@@ -62,41 +51,4 @@ func CheckACME(_ context.Context, _ string, cfg *config.Config, _ bool) Result {
 			reason,
 		),
 	}
-}
-
-// isACMEIncompatible reports whether the given domain cannot receive an ACME
-// certificate. It returns (true, reason) for incompatible domains, and
-// (false, "") for compatible ones.
-//
-// Rules applied in order:
-//  1. Empty input → compatible (caller already guards this).
-//  2. domain == "localhost" → incompatible.
-//  3. net.ParseIP succeeds (any IP literal, including RFC 1918 and ::1) → incompatible.
-//  4. Suffix matches a reserved TLD (.local, .localhost, .test, .invalid, .example) → incompatible.
-//  5. Otherwise → compatible.
-func isACMEIncompatible(domain string) (bool, string) {
-	if domain == "" {
-		return false, ""
-	}
-
-	// Normalise: lowercase, strip a single trailing dot.
-	d := strings.ToLower(strings.TrimSuffix(domain, "."))
-
-	if d == "localhost" {
-		return true, "localhost"
-	}
-
-	if ip := net.ParseIP(d); ip != nil {
-		return true, "IP literal"
-	}
-
-	// Check reserved TLDs: look at the suffix after the last dot.
-	if idx := strings.LastIndex(d, "."); idx >= 0 {
-		tld := d[idx:] // includes the leading dot
-		if reservedTLDs[tld] {
-			return true, fmt.Sprintf("reserved TLD %s", tld)
-		}
-	}
-
-	return false, ""
 }

--- a/internal/cli/cmd/add_tls.go
+++ b/internal/cli/cmd/add_tls.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	yamlmodadapter "github.com/vibewarden/vibewarden/internal/adapters/yamlmod"
+	tlsdomain "github.com/vibewarden/vibewarden/internal/app/tlsdomain"
 	domainscaffold "github.com/vibewarden/vibewarden/internal/domain/scaffold"
 )
 
@@ -23,6 +24,11 @@ import (
 //
 // When TLS is not yet enabled, the command enables it in vibewarden.yaml and
 // also writes the domain to vibewarden.production.yaml.
+//
+// Provider auto-derivation (when --provider is not explicitly set):
+//   - ACME-compatible domain → writes provider: letsencrypt + domain to production.yaml.
+//   - ACME-incompatible domain (localhost, IP, reserved TLD) → writes only domain to
+//     production.yaml; prints a hint to stderr.
 func newAddTLSCmd() *cobra.Command {
 	var (
 		domain   string
@@ -41,6 +47,10 @@ to vibewarden.yaml) so that the base config stays correct for local dev.
 
 When TLS is already enabled, vibewarden.yaml is left unchanged and the domain
 is written only to vibewarden.production.yaml.
+
+Provider auto-derivation (when --provider is not supplied):
+  ACME-compatible domain  → provider: letsencrypt written to production.yaml
+  localhost / IP / reserved TLD → only domain written; stderr hint printed
 
 Supported providers:
   letsencrypt          Automatic certificate with fallback chain: LE -> ZeroSSL -> Buypass (default)
@@ -61,6 +71,12 @@ Examples:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if domain == "" {
 				return fmt.Errorf("--domain is required (e.g. --domain example.com)")
+			}
+
+			// Validate --provider value up-front, before any file writes.
+			providerChanged := cmd.Flags().Changed("provider")
+			if providerChanged && !validTLSProviders[provider] {
+				return fmt.Errorf("unknown --provider %q; valid: letsencrypt, zerossl, buypass, letsencrypt-staging, self-signed, external", provider)
 			}
 
 			dir := ""
@@ -99,9 +115,13 @@ Examples:
 				}
 			}
 
-			// Write the domain and email to vibewarden.production.yaml.
+			// Determine which provider (if any) to write to production.yaml.
+			prodProvider := resolveProdProvider(cmd, domain, provider, providerChanged)
+
+			// Write the domain, optional provider, and optional email to
+			// vibewarden.production.yaml.
 			prodPath := filepath.Join(projDir, "vibewarden.production.yaml")
-			prodDiff, prodErr := upsertTLSFieldsInProdConfig(prodPath, domain, email)
+			prodDiff, prodErr := upsertTLSFieldsInProdConfig(prodPath, domain, email, prodProvider)
 			if prodErr != nil {
 				// Parse failure is fatal — we must not silently regenerate
 				// the file and destroy the user's edits. The error already
@@ -126,21 +146,50 @@ Examples:
 	return cmd
 }
 
+// resolveProdProvider decides which provider string (if any) to write to
+// vibewarden.production.yaml, according to the following rules:
+//
+//   - Explicit --provider flag → always honor it (write provider).
+//   - ACME-compatible domain + no explicit flag → write "letsencrypt".
+//   - ACME-incompatible domain + no explicit flag → write nothing; emit hint to stderr.
+func resolveProdProvider(cmd *cobra.Command, domain, provider string, providerChanged bool) string {
+	if providerChanged {
+		return provider
+	}
+
+	incompatible, reason := tlsdomain.IsACMEIncompatible(domain)
+	if incompatible {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"hint: domain %q is %s; Let's Encrypt cannot issue for it. tls.provider stays at the base default (self-signed). To override in production.yaml, re-run with --provider self-signed (dev) or --provider external (you manage TLS).\n",
+			domain, reason,
+		)
+		return ""
+	}
+
+	return "letsencrypt"
+}
+
 // upsertTLSFieldsInProdConfig reads vibewarden.production.yaml, sets
-// tls.domain and optionally tls.email to the given values, and writes the
-// file back while preserving comments and ordering. When the file does not
-// exist, it is created with sensible production defaults via
-// productionSeedFactory.
+// tls.domain, optionally tls.provider, and optionally tls.email to the given
+// values, and writes the file back while preserving comments and ordering.
+// When the file does not exist, it is created with sensible production
+// defaults via productionSeedFactory.
+//
+// provider is written only when it is non-empty. Pass an empty string to leave
+// any existing tls.provider key in the file untouched.
 //
 // If the file exists but cannot be parsed as YAML, this function returns a
 // wrapped error pointing the user at `vibew validate` — it never regenerates
 // the file from scratch, which would silently destroy the user's edits.
-func upsertTLSFieldsInProdConfig(path, domain, email string) (domainscaffold.Diff, error) {
+func upsertTLSFieldsInProdConfig(path, domain, email, provider string) (domainscaffold.Diff, error) {
 	return yamlmodadapter.UpsertFields(
 		path,
 		productionSeedFactory,
 		func(root *yaml.Node, b *yamlmodadapter.DiffBuilder) error {
 			yamlmodadapter.UpsertScalar(root, b, "tls", "domain", domain, "!!str")
+			if provider != "" {
+				yamlmodadapter.UpsertScalar(root, b, "tls", "provider", provider, "!!str")
+			}
 			if email != "" {
 				yamlmodadapter.UpsertScalar(root, b, "tls", "email", email, "!!str")
 			}
@@ -150,8 +199,9 @@ func upsertTLSFieldsInProdConfig(path, domain, email string) (domainscaffold.Dif
 }
 
 // productionSeedFactory returns the seed mapping written to a freshly-created
-// vibewarden.production.yaml. It matches the former map-round-trip defaults:
-// server.port = 443 and tls.enabled = true with provider = letsencrypt.
+// vibewarden.production.yaml. It sets server.port = 443 and tls.enabled = true.
+// The tls.provider is intentionally omitted here; it is written by
+// upsertTLSFieldsInProdConfig based on domain classification.
 func productionSeedFactory() *yaml.Node {
 	server := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
 	server.Content = append(server.Content,
@@ -163,8 +213,6 @@ func productionSeedFactory() *yaml.Node {
 	tls.Content = append(tls.Content,
 		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "enabled"},
 		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"},
-		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "provider"},
-		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "letsencrypt"},
 	)
 
 	root := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}

--- a/internal/cli/cmd/add_tls_test.go
+++ b/internal/cli/cmd/add_tls_test.go
@@ -1,0 +1,283 @@
+package cmd_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/cli/cmd"
+)
+
+// runAddTLSCmd runs `vibew add tls <extraArgs...> <dir>` and returns separate
+// stdout and stderr buffers so tests can assert on hint messages independently.
+func runAddTLSCmd(t *testing.T, dir string, extraArgs ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	allArgs := append([]string{"add", "tls"}, extraArgs...)
+	allArgs = append(allArgs, dir)
+	root.SetArgs(allArgs)
+	err = root.Execute()
+	return outBuf.String(), errBuf.String(), err
+}
+
+// tlsMinimalBase is a minimal vibewarden.yaml with TLS disabled, used as the
+// starting point for all add-tls integration tests.
+const tlsMinimalBase = `# vibewarden.yaml
+server:
+  host: "127.0.0.1"
+  port: 8080
+upstream:
+  host: "127.0.0.1"
+  port: 3000
+log:
+  level: "info"
+  format: "json"
+security_headers:
+  enabled: true
+tls:
+  enabled: false
+`
+
+// TestAddTLSCmd_AutoProvider covers the full provider auto-derivation matrix
+// defined in issue #1188.
+func TestAddTLSCmd_AutoProvider(t *testing.T) {
+	tests := []struct {
+		name string
+		// base is the content of vibewarden.yaml written before the command.
+		base string
+		// args are the extra flags/values passed after "add tls".
+		args []string
+		// wantErr is true when the command should return a non-nil error.
+		wantErr bool
+		// wantInProd are substrings that MUST appear in vibewarden.production.yaml.
+		wantInProd []string
+		// notInProd are substrings that must NOT appear in vibewarden.production.yaml.
+		notInProd []string
+		// wantStderrContains is a substring that must appear in stderr output.
+		wantStderrContains string
+		// wantNoStderrHint asserts that no hint was printed to stderr.
+		wantNoStderrHint bool
+	}{
+		{
+			name:             "LE-compatible domain without explicit provider → letsencrypt + domain",
+			base:             tlsMinimalBase,
+			args:             []string{"--domain", "example.com"},
+			wantInProd:       []string{"provider: letsencrypt", "domain: example.com"},
+			wantNoStderrHint: true,
+		},
+		{
+			name:               "LE-incompatible domain (localhost) without explicit provider → only domain + hint",
+			base:               tlsMinimalBase,
+			args:               []string{"--domain", "localhost"},
+			wantInProd:         []string{"domain: localhost"},
+			notInProd:          []string{"provider: letsencrypt"},
+			wantStderrContains: "--provider self-signed",
+		},
+		{
+			name:               "LE-incompatible domain (IP literal) without explicit provider → only domain + hint",
+			base:               tlsMinimalBase,
+			args:               []string{"--domain", "192.168.1.1"},
+			wantInProd:         []string{"domain: 192.168.1.1"},
+			notInProd:          []string{"provider: letsencrypt"},
+			wantStderrContains: "--provider",
+		},
+		{
+			name:               "LE-incompatible domain (.local TLD) without explicit provider → only domain + hint",
+			base:               tlsMinimalBase,
+			args:               []string{"--domain", "myapp.local"},
+			wantInProd:         []string{"domain: myapp.local"},
+			notInProd:          []string{"provider: letsencrypt"},
+			wantStderrContains: "--provider",
+		},
+		{
+			name:             "LE-compatible domain + explicit --provider external → external + domain",
+			base:             tlsMinimalBase,
+			args:             []string{"--domain", "example.com", "--provider", "external"},
+			wantInProd:       []string{"provider: external", "domain: example.com"},
+			wantNoStderrHint: true,
+		},
+		{
+			name:             "LE-compatible domain + explicit --provider letsencrypt → letsencrypt + domain",
+			base:             tlsMinimalBase,
+			args:             []string{"--domain", "example.com", "--provider", "letsencrypt"},
+			wantInProd:       []string{"provider: letsencrypt", "domain: example.com"},
+			wantNoStderrHint: true,
+		},
+		{
+			name: "LE-incompatible domain + explicit --provider self-signed → self-signed + domain; no hint",
+			base: tlsMinimalBase,
+			args: []string{"--domain", "localhost", "--provider", "self-signed"},
+			// When --provider is explicit, provider IS written even for LE-incompatible domains.
+			wantInProd:       []string{"provider: self-signed", "domain: localhost"},
+			wantNoStderrHint: true,
+		},
+		{
+			name:    "unknown --provider returns error before any file write",
+			base:    tlsMinimalBase,
+			args:    []string{"--domain", "example.com", "--provider", "unknownca"},
+			wantErr: true,
+		},
+		{
+			name:    "missing --domain returns error",
+			base:    tlsMinimalBase,
+			args:    []string{},
+			wantErr: true,
+		},
+		{
+			// The preferred resolution from the architect note: the seed factory no
+			// longer seeds provider: letsencrypt, so a fresh file for an
+			// LE-incompatible domain without explicit provider must NOT contain
+			// provider: letsencrypt.
+			name:       "fresh-init + localhost domain → production.yaml does NOT contain provider: letsencrypt",
+			base:       tlsMinimalBase,
+			args:       []string{"--domain", "localhost"},
+			notInProd:  []string{"provider: letsencrypt"},
+			wantInProd: []string{"domain: localhost"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := scaffoldTestDir(t, false)
+
+			if err := os.WriteFile(filepath.Join(dir, "vibewarden.yaml"), []byte(tt.base), 0o644); err != nil {
+				t.Fatalf("setup vibewarden.yaml: %v", err)
+			}
+
+			stdout, stderr, err := runAddTLSCmd(t, dir, tt.args...)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Execute() error = %v, wantErr %v (stdout=%q stderr=%q)", err, tt.wantErr, stdout, stderr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			// Read back the production file.
+			prodPath := filepath.Join(dir, "vibewarden.production.yaml")
+			prod, err := os.ReadFile(prodPath)
+			if err != nil {
+				t.Fatalf("reading vibewarden.production.yaml: %v", err)
+			}
+			prodStr := string(prod)
+
+			for _, want := range tt.wantInProd {
+				if !strings.Contains(prodStr, want) {
+					t.Errorf("production.yaml missing %q\n\n%s", want, prodStr)
+				}
+			}
+			for _, notWant := range tt.notInProd {
+				if strings.Contains(prodStr, notWant) {
+					t.Errorf("production.yaml must NOT contain %q\n\n%s", notWant, prodStr)
+				}
+			}
+
+			if tt.wantStderrContains != "" && !strings.Contains(stderr, tt.wantStderrContains) {
+				t.Errorf("stderr %q does not contain %q", stderr, tt.wantStderrContains)
+			}
+			if tt.wantNoStderrHint && strings.Contains(stderr, "--provider") {
+				t.Errorf("unexpected hint in stderr: %q", stderr)
+			}
+		})
+	}
+}
+
+// TestAddTLSCmd_TLSAlreadyEnabled_AutoProvider verifies that the auto-provider
+// logic also fires on the "TLS already enabled" fast path (no vibewarden.yaml
+// modification, only production.yaml is touched).
+func TestAddTLSCmd_TLSAlreadyEnabled_AutoProvider(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantInProd []string
+		notInProd  []string
+		wantHint   bool
+	}{
+		{
+			name:       "LE-compatible domain auto-sets letsencrypt in production",
+			args:       []string{"--domain", "mysite.com"},
+			wantInProd: []string{"provider: letsencrypt", "domain: mysite.com"},
+		},
+		{
+			name:       "LE-incompatible domain (localhost) does not set letsencrypt in production",
+			args:       []string{"--domain", "localhost"},
+			wantInProd: []string{"domain: localhost"},
+			notInProd:  []string{"provider: letsencrypt"},
+			wantHint:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := scaffoldTestDir(t, false)
+
+			// TLS already enabled in base config.
+			base := "tls:\n  enabled: true\n  provider: self-signed\n"
+			if err := os.WriteFile(filepath.Join(dir, "vibewarden.yaml"), []byte(base), 0o644); err != nil {
+				t.Fatalf("setup vibewarden.yaml: %v", err)
+			}
+
+			_, stderr, err := runAddTLSCmd(t, dir, tt.args...)
+			if err != nil {
+				t.Fatalf("Execute() error: %v", err)
+			}
+
+			prod, err := os.ReadFile(filepath.Join(dir, "vibewarden.production.yaml"))
+			if err != nil {
+				t.Fatalf("reading production.yaml: %v", err)
+			}
+			prodStr := string(prod)
+
+			for _, want := range tt.wantInProd {
+				if !strings.Contains(prodStr, want) {
+					t.Errorf("production.yaml missing %q\n\n%s", want, prodStr)
+				}
+			}
+			for _, notWant := range tt.notInProd {
+				if strings.Contains(prodStr, notWant) {
+					t.Errorf("production.yaml must NOT contain %q\n\n%s", notWant, prodStr)
+				}
+			}
+
+			if tt.wantHint && !strings.Contains(stderr, "--provider") {
+				t.Errorf("expected hint in stderr, got: %q", stderr)
+			}
+		})
+	}
+}
+
+// TestAddTLSCmd_NewRootCmd_StderrSeparate verifies that the hint is written to
+// stderr independently from stdout when using the full root command (the same
+// code path as real CLI usage). This catches regressions where hint output is
+// accidentally merged onto stdout.
+func TestAddTLSCmd_NewRootCmd_StderrSeparate(t *testing.T) {
+	dir := scaffoldTestDir(t, false)
+
+	if err := os.WriteFile(filepath.Join(dir, "vibewarden.yaml"), []byte(tlsMinimalBase), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	root := cmd.NewRootCmd("test")
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"add", "tls", "--domain", "localhost", dir})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	stdout := outBuf.String()
+	stderr := errBuf.String()
+
+	if strings.Contains(stdout, "--provider") {
+		t.Errorf("hint must not appear on stdout, got: %q", stdout)
+	}
+	if !strings.Contains(stderr, "--provider") {
+		t.Errorf("hint must appear on stderr, got stderr=%q stdout=%q", stderr, stdout)
+	}
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1370,7 +1370,7 @@ support `--tls` or `--domain` — use `vibew add tls` after init for TLS.
 or `vibew wrap`.
 
 - `vibew add tls --domain <domain>` -- enable TLS (--domain is required)
-  - `--provider` (default letsencrypt) -- letsencrypt (with LE → ZeroSSL fallback when `tls.email` is set), zerossl, buypass (explicit opt-in; upstream currently unhealthy per ADR-083), letsencrypt-staging, self-signed, or external
+  - `--provider <letsencrypt|self-signed|external>` (auto-derived from --domain when unset) -- letsencrypt (with LE → ZeroSSL fallback when `tls.email` is set), zerossl, buypass (explicit opt-in; upstream currently unhealthy per ADR-083), letsencrypt-staging, self-signed, or external
   - `--email` -- ACME account email (required for zerossl, recommended for letsencrypt)
 - `vibew cert trust` -- install Caddy's local CA certificate into the OS trust store (macOS/Linux)
 - `vibew add auth` -- enable Ory Kratos authentication (no extra flags)


### PR DESCRIPTION
Closes #1188

## Summary

- New package `internal/app/tlsdomain/classify.go` exports `IsACMEIncompatible(domain string) (bool, string)` — extracted from the unexported `isACMEIncompatible` in `internal/app/validate/acme.go`. The validate package now delegates to it; zero behavioral change to `vibew validate`.
- `internal/cli/cmd/add_tls.go` — `resolveProdProvider` applies the matrix from the architect note:
  - `--provider` not set + LE-compatible → write `provider: letsencrypt`
  - `--provider` not set + LE-incompatible → write no provider; print stderr hint with `--provider self-signed` and `--provider external`
  - explicit `--provider X` → always honor X (validated against `validTLSProviders`)
- `upsertTLSFieldsInProdConfig` gains a `provider string` parameter; writes `tls.provider` only when non-empty.
- `productionSeedFactory` no longer seeds `provider: letsencrypt` — fixes the "fresh file for localhost still has letsencrypt" bug (preferred resolution from architect note).
- `internal/cli/cmd/add_tls_test.go` — 13 table-driven cases covering the full matrix, fast path (TLS already enabled), and stderr isolation.

## Test plan

- `go test ./internal/app/tlsdomain/...` — 21 classifier cases (compatible + all incompatible categories).
- `go test ./internal/app/validate/...` — existing CheckACME tests still pass (delegation unchanged).
- `go test ./internal/cli/cmd/... -run TestAddTLS` — all 13 new + all 4 pre-existing TLS cases pass.
- `make check` passes clean (gofmt, golangci-lint, build, tests, demo-app).