### PR TITLE
fix(#1194): match Caddy intermediate-CA issuer CN via prefix, not equality

### DIFF
--- a/internal/adapters/caddy/tls_state.go
+++ b/internal/adapters/caddy/tls_state.go
@@ -124,7 +124,7 @@ func (r *InProcessResolver) Resolve(ctx context.Context) (tlsdomain.State, error
 	// before the real ACME cert has been swapped in). No NotAfter
 	// inspection: the internal CA rotates leaves on a short TTL and we
 	// trust it to do so.
-	if leaf.Issuer.CommonName == caddyLocalIssuerCN {
+	if tlsdomain.IsCaddyLocalIssuer(leaf.Issuer.CommonName) {
 		return tlsdomain.NewSelfSignedLocal(), nil
 	}
 

--- a/internal/adapters/caddy/tls_state_handshake.go
+++ b/internal/adapters/caddy/tls_state_handshake.go
@@ -84,7 +84,7 @@ func (r *HandshakeResolver) Resolve(ctx context.Context) (tlsdomain.State, error
 	leaf := state.PeerCertificates[0]
 
 	// Caddy internal issuer → SelfSignedLocal regardless of config.
-	if leaf.Issuer.CommonName == caddyLocalIssuerCN {
+	if tlsdomain.IsCaddyLocalIssuer(leaf.Issuer.CommonName) {
 		return tlsdomain.NewSelfSignedLocal(), nil
 	}
 

--- a/internal/adapters/caddy/tls_state_test.go
+++ b/internal/adapters/caddy/tls_state_test.go
@@ -112,6 +112,21 @@ func TestInProcessResolver_Resolve(t *testing.T) {
 			provider: fakePeerCertProvider{leaf: makeLeaf(caddyLocalIssuerCN, fixedNow.Add(-1*time.Hour))},
 			wantKind: tlsdomain.KindSelfSignedLocal,
 		},
+		// Caddy actually stamps the leaf's issuer CN with the intermediate-CA
+		// suffix, e.g. "Caddy Local Authority - ECC Intermediate". The classifier
+		// must do a prefix match, not exact equality. Regression for #1194.
+		{
+			name:     "dev cert with intermediate-CA suffix → SelfSignedLocal",
+			cfg:      &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "self-signed"}},
+			provider: fakePeerCertProvider{leaf: makeLeaf(caddyLocalIssuerCN+" - ECC Intermediate", fixedNow.Add(8*time.Hour))},
+			wantKind: tlsdomain.KindSelfSignedLocal,
+		},
+		{
+			name:     "dev cert with RSA intermediate-CA suffix → SelfSignedLocal",
+			cfg:      &config.Config{TLS: config.TLSConfig{Enabled: true, Provider: "self-signed"}},
+			provider: fakePeerCertProvider{leaf: makeLeaf(caddyLocalIssuerCN+" - RSA Intermediate", fixedNow.Add(-1*time.Hour))},
+			wantKind: tlsdomain.KindSelfSignedLocal,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/app/ops/tls_handshake_fallback.go
+++ b/internal/app/ops/tls_handshake_fallback.go
@@ -11,10 +11,6 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
-// caddyLocalIssuerCN aliases the canonical constant from the domain layer
-// so this file avoids an app → adapter import violation.
-const caddyLocalIssuerCN = tlsdomain.CaddyLocalIssuerCN
-
 // inlineHandshakeResolver is an app-layer fallback TLS state resolver.
 // It performs the same TLS handshake as the caddy adapter's
 // HandshakeResolver but lives here so internal/app/ops does not need to
@@ -74,7 +70,7 @@ func (r *inlineHandshakeResolver) Resolve(ctx context.Context) (tlsdomain.State,
 	}
 	leaf := certs[0]
 
-	if leaf.Issuer.CommonName == caddyLocalIssuerCN {
+	if tlsdomain.IsCaddyLocalIssuer(leaf.Issuer.CommonName) {
 		return tlsdomain.NewSelfSignedLocal(), nil
 	}
 

--- a/internal/domain/tls/state.go
+++ b/internal/domain/tls/state.go
@@ -2,16 +2,25 @@ package tls
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
-// CaddyLocalIssuerCN is the Common Name Caddy stamps on internal self-signed
-// dev leaf certificates. It is the authoritative signal that the sidecar is
-// serving a KindSelfSignedLocal cert and that expiry heuristics must not be
-// applied. The constant lives in the domain layer so it can be imported by
-// both the caddy adapter and the app-layer fallback resolver without creating
-// an adapter → app or app → adapter dependency.
+// CaddyLocalIssuerCN is the prefix Caddy uses on the Common Name of issuers
+// stamped on its internal self-signed dev leaf certificates. The actual leaf
+// issuer is an intermediate CA whose CN is `Caddy Local Authority - ECC
+// Intermediate` (or `... - RSA Intermediate` depending on key type). The
+// prefix is the authoritative signal that the sidecar is serving a
+// KindSelfSignedLocal cert and that expiry heuristics must not be applied.
+// Callers MUST use IsCaddyLocalIssuer (prefix match), not direct equality.
 const CaddyLocalIssuerCN = "Caddy Local Authority"
+
+// IsCaddyLocalIssuer reports whether the given Issuer Common Name belongs to
+// Caddy's internal local-CA hierarchy (root or intermediate). Use this to
+// classify a leaf as KindSelfSignedLocal.
+func IsCaddyLocalIssuer(issuerCN string) bool {
+	return strings.HasPrefix(issuerCN, CaddyLocalIssuerCN)
+}
 
 // Kind identifies the TLS state variant.
 type Kind int


### PR DESCRIPTION
Closes #1194.

## Summary

The #1181 fix (PR #1190) used `leaf.Issuer.CommonName == "Caddy Local Authority"` but Caddy stamps the leaf's issuer as the intermediate CA's CN — e.g. `"Caddy Local Authority - ECC Intermediate"` or `"... - RSA Intermediate"`. Exact-equality check never fired. Dev certs continued to render as `KindObtained` with the `expires in 0 days` alarm.

## Fix

Introduce `tlsdomain.IsCaddyLocalIssuer(cn)` doing `strings.HasPrefix(cn, "Caddy Local Authority")`. All three classifier sites (`internal/adapters/caddy/tls_state.go`, `internal/adapters/caddy/tls_state_handshake.go`, `internal/app/ops/tls_handshake_fallback.go`) use the helper. The constant `CaddyLocalIssuerCN` keeps its value `"Caddy Local Authority"` — it's the prefix.

Tests added for both intermediate variants:
- `Caddy Local Authority - ECC Intermediate`
- `Caddy Local Authority - RSA Intermediate`

## Test plan

- [x] `make check` clean
- [x] Existing `KindSelfSignedLocal` tests still pass
- [x] New regression cases for ECC + RSA intermediate CN
- [x] Cleaned up dead `caddyLocalIssuerCN` alias from `internal/app/ops/tls_handshake_fallback.go` (no remaining users post-fix)

## Discovery

V0.18.0.1 smoke test, 2026-04-28. Filed as #1194 by smoke agent.