### PR TITLE
fix(#1200): vibew bundle fails on image arch vs target platform mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ yet completed (boot gap of ~5–10s). After that it is always `"ok"` or `"failin
 
 ### Fixed
 
+- **`vibew bundle` now fails (was: warned) when image architecture doesn't match `deploy.target_platform`** (#1200). The primary case is Apple Silicon builds (linux/arm64) landing on amd64 VPS hosts without being noticed. On mismatch the bundle aborts before writing any files and prints: `image arch is linux/arm64, target is linux/amd64. Rebuild with: vibew build --platform linux/amd64` / `Then re-run: vibew bundle`. Default target is `linux/amd64`. Override via `--target-platform` flag or `deploy.target_platform` in `vibewarden.production.yaml`.
 - **`/_vibewarden/health` now reports real upstream state** (#1197). Previously the route was a hard-coded Caddy `static_response` that always returned `"upstream":"unknown"` regardless of actual upstream health. The existing `HTTPChecker` adapter, `UpstreamHealthChecker` port, and `UpstreamHealth` domain entity were fully implemented but never wired into the production composition root. Fix: the route is replaced by a new `vibewarden_health` Caddy handler module that reads the cached probe result from `RuntimeServices`; the probe default changes from `enabled: false` to `enabled: true` with interval=5s/timeout=2s; the checker is constructed, started, and stopped in `cmd/vibewarden/wiring_serve.go`.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ body of this endpoint, update your parser before upgrading.
 `"unknown"` on `components.upstream` now means only one thing: the first probe has not
 yet completed (boot gap of ~5–10s). After that it is always `"ok"` or `"failing"`.
 
+**`vibew bundle` arch mismatch is now a hard failure** (#1200). Previously the mismatch
+emitted a warning and the bundle was written anyway. Any CI or deploy script that
+continued past a `vibew bundle` warning is now broken: the command exits with code 1
+and writes no files. Fix: run `vibew build --platform linux/amd64` before `vibew bundle`
+when the image arch does not match the VPS target.
+
 ### Fixed
 
 - **`vibew bundle` now fails (was: warned) when image architecture doesn't match `deploy.target_platform`** (#1200). The primary case is Apple Silicon builds (linux/arm64) landing on amd64 VPS hosts without being noticed. On mismatch the bundle aborts before writing any files and prints: `image arch is linux/arm64, target is linux/amd64. Rebuild with: vibew build --platform linux/amd64` / `Then re-run: vibew bundle`. Default target is `linux/amd64`. Override via `--target-platform` flag or `deploy.target_platform` in `vibewarden.production.yaml`.

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -161,8 +161,11 @@ No source code is ever copied to the production server — the image must
 be production-ready (all dependencies installed, assets compiled, etc.).
 
 **Cross-architecture builds:** If deploying from Apple Silicon (arm64) to
-an amd64 server, use `vibew build --platform linux/amd64`. Bundle ships
-whatever arch you built; there is no cross-arch auto-detection.
+an amd64 server, run `vibew build --platform linux/amd64` first. `vibew bundle`
+checks the bundled image arch against `deploy.target_platform` (default `linux/amd64`)
+and fails with exit code 1 before writing any files if they do not match. The error
+message contains the exact rebuild command to run. Set `deploy.target_platform:
+linux/arm64` in `vibewarden.production.yaml` if your VPS is Ampere/Graviton.
 
 ## Deploying to a VPS
 

--- a/docs/production-hardening.md
+++ b/docs/production-hardening.md
@@ -181,6 +181,51 @@ postgres:
 
 ---
 
+## Bundle and deploy
+
+### Image architecture (`deploy.target_platform`)
+
+`vibew bundle` checks the bundled image's architecture against the configured
+deploy target before writing any files. On mismatch the command fails immediately
+with an actionable error:
+
+```
+image arch is linux/arm64, target is linux/amd64. Rebuild with: vibew build --platform linux/amd64
+Then re-run: vibew bundle
+```
+
+The default target is `linux/amd64` (Hetzner and most cloud VMs). Set the target
+explicitly in `vibewarden.production.yaml`:
+
+```yaml
+deploy:
+  target_platform: linux/amd64   # or linux/arm64 for Ampere/Graviton VMs
+```
+
+Override once on the command line without editing the file:
+
+```bash
+vibew bundle --target-platform linux/arm64
+```
+
+Common scenarios:
+
+| Development host | VPS arch | Action |
+|---|---|---|
+| Apple Silicon (arm64) | amd64 (typical Hetzner) | `vibew build --platform linux/amd64 && vibew bundle` |
+| Apple Silicon (arm64) | arm64 (Ampere/Graviton) | Set `target_platform: linux/arm64` — default is wrong for you |
+| Intel/AMD (amd64) | amd64 | Default works; no action needed |
+| Intel/AMD (amd64) | arm64 | `vibew bundle --target-platform linux/arm64` (or set in yaml) |
+
+- [ ] Confirm `deploy.target_platform` in `vibewarden.production.yaml` matches
+  your VPS architecture before running `vibew bundle`.
+- [ ] Verify the bundled image arch matches by inspecting `image.tar` after bundling:
+  ```bash
+  docker image inspect <your-project>-app:latest --format '{{.Architecture}}'
+  ```
+
+---
+
 ## Network hardening
 
 ### Firewall rules

--- a/examples/vibewarden.production.yaml
+++ b/examples/vibewarden.production.yaml
@@ -243,3 +243,16 @@ telemetry:
   path_patterns:
     - "/api/v1/:resource"
     - "/api/v1/:resource/:id"
+
+# -------------------------------------------------------------------------
+# Bundle target platform
+# -------------------------------------------------------------------------
+# `vibew bundle` compares the bundled image's architecture against this value
+# and aborts before writing any files if they do not match. The error message
+# contains the exact rebuild command to run.
+#
+# Hetzner VMs and most cloud VPS targets are linux/amd64.
+# Set linux/arm64 for Ampere (Hetzner CAX) or AWS Graviton VMs.
+# Override once on the CLI: vibew bundle --target-platform linux/arm64
+deploy:
+  target_platform: linux/amd64

--- a/internal/app/bundle/bundle.go
+++ b/internal/app/bundle/bundle.go
@@ -215,10 +215,20 @@ func (s *Service) runImageHealthCheck(ctx context.Context, opts BundleOptions) e
 		return err
 	}
 
-	// Render the health block to opts.Out when provided.
+	// Render the health block to opts.Out when provided. The block is always
+	// rendered before any error is returned so the user (and agents) can see
+	// the Tag/Digest/Arch/Target side-by-side even on mismatch.
 	if opts.Out != nil {
 		RenderImageHealth(opts.Out, health)
 		fmt.Fprintln(opts.Out)
+	}
+
+	// Fail hard on arch mismatch — this is the primary regression guard for
+	// #1200 (Apple Silicon builds landing on amd64 VPS without being noticed).
+	// The error is returned AFTER rendering the health block so the agent/user
+	// has the full context.
+	if health.ArchMismatch {
+		return fmt.Errorf("%w: %s", ErrPlatformMismatch, platformMismatchMessage(health))
 	}
 
 	return nil

--- a/internal/app/bundle/image_health.go
+++ b/internal/app/bundle/image_health.go
@@ -174,18 +174,24 @@ func CheckImageHealth(ctx context.Context, opts CheckImageHealthOptions) (ImageH
 // The block is always printed, even when there are zero warnings — agents
 // depend on the stable layout. ANSI colour is never used.
 //
-// Example output:
+// When the image arch does not match the target platform, RenderImageHealth
+// still renders the full block (showing Arch and Target for context), and then
+// the caller (runImageHealthCheck) returns ErrPlatformMismatch with the
+// actionable rebuild instruction. The block itself does not include the
+// rebuild command — "Warnings: none" is shown when stale is the only absent
+// condition and no legacy tag is present.
+//
+// Example output (stale image, no arch mismatch):
 //
 //	Image health
 //	  Tag:          qr-van-gogh-app:latest
 //	  Digest:       sha256:abc123…
-//	  Arch:         linux/arm64
+//	  Arch:         linux/amd64
 //	  Created:      2026-04-19 14:02:11 UTC (1 day ago)
 //	  Size:         162.4 MB
 //	  Target:       linux/amd64  (override with --target-platform)
 //	  Freshness:    STALE — 12 source files changed since image was built
 //	  Warnings:
-//	    - image arch linux/arm64 != target linux/amd64 (rebuild: vibew build --platform linux/amd64)
 //	    - image is stale (pass --allow-stale to suppress, or rebuild)
 func RenderImageHealth(out io.Writer, h ImageHealth) {
 	age := formatAge(time.Since(h.Image.Created))

--- a/internal/app/bundle/image_health.go
+++ b/internal/app/bundle/image_health.go
@@ -10,6 +10,15 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
+// ErrPlatformMismatch is returned by runImageHealthCheck (and propagated by
+// Service.Bundle) when the bundled image's architecture does not match the
+// resolved deploy target. The CLI maps this to exit code 1.
+//
+// Note: local `docker image inspect` always returns a single architecture —
+// the variant that was loaded into the local Docker daemon. There is no
+// manifest-list case for vibew bundle; buildx --load writes only one arch.
+var ErrPlatformMismatch = errors.New("image platform mismatch")
+
 // defaultTargetPlatform is the expected deployment platform when no
 // --target-platform flag is supplied. VPS targets are almost always amd64.
 const defaultTargetPlatform = "linux/amd64"
@@ -220,17 +229,26 @@ func freshnessLabel(h ImageHealth) string {
 	return fmt.Sprintf("STALE — %d source files changed since image was built", h.Freshness.ChangedCount)
 }
 
+// platformMismatchMessage returns the exact actionable error copy for an arch
+// mismatch. The wording is pinned by tests — do not change it without updating
+// the test golden strings.
+//
+// Example output:
+//
+//	image arch is linux/arm64, target is linux/amd64. Rebuild with: vibew build --platform linux/amd64
+//	Then re-run: vibew bundle
+func platformMismatchMessage(h ImageHealth) string {
+	return fmt.Sprintf(
+		"image arch is %s, target is %s. Rebuild with: vibew build --platform %s\nThen re-run: vibew bundle",
+		h.Image.Platform(), h.Target, h.Target,
+	)
+}
+
 // collectWarnings builds the ordered list of human-readable warning strings
-// for the ImageHealth report.
+// for the ImageHealth report. Arch mismatch is NOT included here — it is a
+// hard failure returned by runImageHealthCheck before bundling proceeds.
 func collectWarnings(h ImageHealth) []string {
 	var warnings []string
-
-	if h.ArchMismatch {
-		warnings = append(warnings, fmt.Sprintf(
-			"image arch %s != target %s (rebuild: vibew build --platform %s)",
-			h.Image.Platform(), h.Target, h.Target,
-		))
-	}
 
 	if h.Freshness.Stale && !h.AllowStale {
 		warnings = append(warnings, "image is stale (pass --allow-stale to suppress, or rebuild)")

--- a/internal/app/bundle/image_health_test.go
+++ b/internal/app/bundle/image_health_test.go
@@ -199,6 +199,37 @@ func TestCheckImageHealth_DefaultTargetPlatform(t *testing.T) {
 	}
 }
 
+// TestCheckImageHealth_EmptyStringTargetPlatform verifies that an explicit
+// empty-string TargetPlatform (the value config.Load returns when the yaml
+// contains `deploy.target_platform: ""`) is treated as "use the default".
+// This guards the path: yaml empty-string → config.Load returns "" →
+// BundleOptions.TargetPlatform = "" → CheckImageHealth falls back to
+// defaultTargetPlatform ("linux/amd64"). Without this guard, a future
+// refactor removing CheckImageHealth's empty-check would silently accept the
+// wrong platform.
+func TestCheckImageHealth_EmptyStringTargetPlatform(t *testing.T) {
+	inspector := &fakeInspector{
+		info: ports.ImageInfo{OS: "linux", Architecture: "amd64"},
+	}
+	h, err := bundleapp.CheckImageHealth(context.Background(), bundleapp.CheckImageHealthOptions{
+		ImageTag:       "myapp:latest",
+		TargetPlatform: "", // explicit empty — same as yaml `target_platform: ""`
+		Inspector:      inspector,
+		Walker:         &fakeStalenessWalker{},
+	})
+	if err != nil {
+		t.Fatalf("CheckImageHealth() error = %v", err)
+	}
+	// Must resolve to linux/amd64, not remain as empty string.
+	if h.Target != "linux/amd64" {
+		t.Errorf("empty-string target resolved to %q, want %q", h.Target, "linux/amd64")
+	}
+	// An amd64 image against the resolved amd64 target must not be a mismatch.
+	if h.ArchMismatch {
+		t.Error("amd64 image vs resolved linux/amd64 target should not be an arch mismatch")
+	}
+}
+
 // TestRenderImageHealth_FreshNoWarnings is a golden test for the all-good case.
 func TestRenderImageHealth_FreshNoWarnings(t *testing.T) {
 	h := bundleapp.ImageHealth{

--- a/internal/app/bundle/image_health_test.go
+++ b/internal/app/bundle/image_health_test.go
@@ -267,6 +267,10 @@ func TestRenderImageHealth_StaleWithWarning(t *testing.T) {
 }
 
 // TestRenderImageHealth_ArchMismatch is a golden test for the arch mismatch case.
+// Since #1200, arch mismatch is a hard error (ErrPlatformMismatch) that the
+// caller returns before the next bundle step. The rendered health block still
+// shows the Arch and Target lines so the user has the context, but there is
+// no warning line for the mismatch — the error message carries that information.
 func TestRenderImageHealth_ArchMismatch(t *testing.T) {
 	h := bundleapp.ImageHealth{
 		Image: ports.ImageInfo{
@@ -286,14 +290,19 @@ func TestRenderImageHealth_ArchMismatch(t *testing.T) {
 	bundleapp.RenderImageHealth(&sb, h)
 	out := sb.String()
 
+	// Arch and Target must still appear in the block header lines.
 	if !strings.Contains(out, "linux/arm64") {
 		t.Errorf("expected image arch linux/arm64 in output\noutput:\n%s", out)
 	}
 	if !strings.Contains(out, "linux/amd64") {
 		t.Errorf("expected target linux/amd64 in output\noutput:\n%s", out)
 	}
-	if !strings.Contains(out, "vibew build --platform linux/amd64") {
-		t.Errorf("expected rebuild command in warning\noutput:\n%s", out)
+	// The rebuild command is no longer in the rendered block — it is in the
+	// ErrPlatformMismatch error string returned by runImageHealthCheck.
+	// Verify it is NOT duplicated here (the caller's error message is the
+	// single source of truth).
+	if strings.Contains(out, "vibew build --platform") {
+		t.Errorf("rendered block should NOT contain rebuild command (it lives in ErrPlatformMismatch)\noutput:\n%s", out)
 	}
 }
 
@@ -454,5 +463,204 @@ func TestBundle_HealthBlockEmittedOnce(t *testing.T) {
 	count := strings.Count(rendered, "Image health")
 	if count != 1 {
 		t.Errorf("'Image health' block emitted %d times, want exactly 1\noutput:\n%s", count, rendered)
+	}
+}
+
+// TestRunImageHealthCheck_ArchMismatch_ReturnsErrPlatformMismatch verifies
+// that runImageHealthCheck (via Bundle) returns ErrPlatformMismatch when the
+// image arch does not match the target platform. This is the primary regression
+// guard for #1200: Apple Silicon builds landing on amd64 VPS hosts.
+func TestRunImageHealthCheck_ArchMismatch_ReturnsErrPlatformMismatch(t *testing.T) {
+	mem := newMemBundleFS()
+	inspector := &fakeInspector{
+		info: ports.ImageInfo{
+			OS:           "linux",
+			Architecture: "arm64", // Apple Silicon local image
+			Created:      fixedTime,
+		},
+	}
+	walker := &fakeStalenessWalker{}
+
+	var out strings.Builder
+	svc := bundleapp.NewService(&fakeExecutor{}, &fakeGenerator{}).
+		WithBundleFS(mem).
+		WithImageInspector(inspector).
+		WithStalenessWalker(walker)
+
+	err := svc.Bundle(context.Background(), bundleapp.BundleOptions{
+		Config:         minimalBundleCfg(),
+		ConfigPath:     t.TempDir() + "/vibewarden.yaml",
+		ProjectName:    "myapp",
+		OutputDir:      t.TempDir(),
+		ImageTag:       "myapp-app:latest",
+		TargetPlatform: "linux/amd64", // amd64 VPS target
+		Out:            &out,
+	})
+
+	if err == nil {
+		t.Fatal("Bundle() expected error on arch mismatch, got nil")
+	}
+	if !errors.Is(err, bundleapp.ErrPlatformMismatch) {
+		t.Errorf("expected ErrPlatformMismatch, got: %v", err)
+	}
+
+	// Error message must contain arch and target.
+	msg := err.Error()
+	if !strings.Contains(msg, "linux/arm64") {
+		t.Errorf("error message missing image arch: %s", msg)
+	}
+	if !strings.Contains(msg, "linux/amd64") {
+		t.Errorf("error message missing target: %s", msg)
+	}
+	if !strings.Contains(msg, "vibew build --platform linux/amd64") {
+		t.Errorf("error message missing rebuild command: %s", msg)
+	}
+	if !strings.Contains(msg, "Then re-run: vibew bundle") {
+		t.Errorf("error message missing re-run instruction: %s", msg)
+	}
+
+	// Health block must be rendered to opts.Out BEFORE the error is returned.
+	rendered := out.String()
+	if !strings.Contains(rendered, "Image health") {
+		t.Errorf("health block not rendered before mismatch error: %s", rendered)
+	}
+	if !strings.Contains(rendered, "linux/arm64") {
+		t.Errorf("health block missing image arch: %s", rendered)
+	}
+}
+
+// TestBundle_ArchMismatch_NoFilesWritten verifies that no bundle files are
+// written when the image arch does not match the target platform.
+func TestBundle_ArchMismatch_NoFilesWritten(t *testing.T) {
+	mem := newMemBundleFS()
+	inspector := &fakeInspector{
+		info: ports.ImageInfo{
+			OS:           "linux",
+			Architecture: "arm64",
+			Created:      fixedTime,
+		},
+	}
+	walker := &fakeStalenessWalker{}
+
+	svc := bundleapp.NewService(&fakeExecutor{}, &fakeGenerator{}).
+		WithBundleFS(mem).
+		WithImageInspector(inspector).
+		WithStalenessWalker(walker)
+
+	outDir := t.TempDir()
+	err := svc.Bundle(context.Background(), bundleapp.BundleOptions{
+		Config:         minimalBundleCfg(),
+		ConfigPath:     t.TempDir() + "/vibewarden.yaml",
+		ProjectName:    "myapp",
+		OutputDir:      outDir,
+		ImageTag:       "myapp-app:latest",
+		TargetPlatform: "linux/amd64",
+	})
+
+	if err == nil {
+		t.Fatal("Bundle() expected error on arch mismatch")
+	}
+	if !errors.Is(err, bundleapp.ErrPlatformMismatch) {
+		t.Errorf("expected ErrPlatformMismatch, got: %v", err)
+	}
+
+	// The in-memory FS should have no files (health check aborts before generator).
+	if len(mem.files) != 0 {
+		t.Errorf("expected no files written on mismatch, got: %v", mem.files)
+	}
+}
+
+// TestBundle_ArchMatch_Succeeds verifies the happy path: matching arch does
+// not trigger ErrPlatformMismatch.
+func TestBundle_ArchMatch_Succeeds(t *testing.T) {
+	mem := newMemBundleFS()
+	inspector := &fakeInspector{
+		info: ports.ImageInfo{
+			OS:           "linux",
+			Architecture: "amd64",
+			Created:      fixedTime,
+		},
+	}
+	walker := &fakeStalenessWalker{}
+
+	svc := bundleapp.NewService(&fakeExecutor{}, &fakeGenerator{}).
+		WithBundleFS(mem).
+		WithImageInspector(inspector).
+		WithStalenessWalker(walker)
+
+	err := svc.Bundle(context.Background(), bundleapp.BundleOptions{
+		Config:         minimalBundleCfg(),
+		ConfigPath:     t.TempDir() + "/vibewarden.yaml",
+		ProjectName:    "myapp",
+		OutputDir:      t.TempDir(),
+		ImageTag:       "myapp-app:latest",
+		TargetPlatform: "linux/amd64",
+		SkipImage:      true,
+	})
+
+	if err != nil {
+		t.Fatalf("Bundle() unexpected error on matching arch: %v", err)
+	}
+}
+
+// TestBundle_NoInspector_SkipsArchCheck preserves the existing nil-inspector
+// path used by tests that predate ADR-089.
+func TestBundle_NoInspector_SkipsArchCheck(t *testing.T) {
+	// No WithImageInspector — health check is skipped entirely.
+	svc := bundleapp.NewService(&fakeExecutor{}, &fakeGenerator{})
+
+	err := svc.Bundle(context.Background(), bundleapp.BundleOptions{
+		Config:      minimalBundleCfg(),
+		ConfigPath:  t.TempDir() + "/vibewarden.yaml",
+		ProjectName: "myapp",
+		OutputDir:   t.TempDir(),
+		ImageTag:    "myapp-app:latest",
+	})
+
+	if err != nil {
+		t.Fatalf("Bundle() unexpected error when inspector is nil: %v", err)
+	}
+}
+
+// TestPlatformMismatchMessage_ExactWording pins the exact error copy for
+// #1200. Any change to this message must be reflected in all agent docs.
+func TestPlatformMismatchMessage_ExactWording(t *testing.T) {
+	inspector := &fakeInspector{
+		info: ports.ImageInfo{
+			OS:           "linux",
+			Architecture: "arm64",
+			Created:      fixedTime,
+		},
+	}
+	walker := &fakeStalenessWalker{}
+
+	svc := bundleapp.NewService(&fakeExecutor{}, &fakeGenerator{}).
+		WithBundleFS(newMemBundleFS()).
+		WithImageInspector(inspector).
+		WithStalenessWalker(walker)
+
+	err := svc.Bundle(context.Background(), bundleapp.BundleOptions{
+		Config:         minimalBundleCfg(),
+		ConfigPath:     t.TempDir() + "/vibewarden.yaml",
+		ProjectName:    "myapp",
+		OutputDir:      t.TempDir(),
+		ImageTag:       "myapp-app:latest",
+		TargetPlatform: "linux/amd64",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// Pin exact wording substrings that are load-bearing for agents.
+	wantSubstrings := []string{
+		"image arch is linux/arm64",
+		"target is linux/amd64",
+		"Rebuild with: vibew build --platform linux/amd64",
+		"Then re-run: vibew bundle",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message missing %q\nfull message: %s", want, err.Error())
+		}
 	}
 }

--- a/internal/app/scaffold/init_project_shared_templates_test.go
+++ b/internal/app/scaffold/init_project_shared_templates_test.go
@@ -226,3 +226,45 @@ func TestInitProject_WithRealFS_Description(t *testing.T) {
 		})
 	}
 }
+
+// TestInitProject_ProductionYAML_HasDeployTargetPlatform verifies that vibew init
+// writes deploy.target_platform: linux/amd64 as an actual yaml entry (not a
+// comment) in vibewarden.production.yaml. Guard for #1200.
+func TestInitProject_ProductionYAML_HasDeployTargetPlatform(t *testing.T) {
+	r := mustBuildRealRenderer(t)
+	svc := scaffoldapp.NewInitProjectService(r, nil)
+
+	parent := scaffoldAppTestDir(t)
+	opts := scaffoldapp.InitProjectOptions{
+		ProjectName: "deploytest",
+		Port:        3000,
+	}
+
+	if err := svc.InitProject(context.Background(), parent, opts); err != nil {
+		t.Fatalf("InitProject() unexpected error: %v", err)
+	}
+
+	prodPath := filepath.Join(parent, "deploytest", "vibewarden.production.yaml")
+	data, err := os.ReadFile(prodPath)
+	if err != nil {
+		t.Fatalf("reading vibewarden.production.yaml: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "target_platform: linux/amd64") {
+		t.Errorf("vibewarden.production.yaml missing 'target_platform: linux/amd64'\n\nContent:\n%s", content)
+	}
+
+	// Verify it is not commented out.
+	for _, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, "target_platform: linux/amd64") {
+			if strings.HasPrefix(strings.TrimSpace(line), "#") {
+				t.Errorf("target_platform is commented out — must be active yaml\nLine: %q", line)
+			}
+		}
+	}
+
+	if !strings.Contains(content, "deploy:") {
+		t.Errorf("vibewarden.production.yaml missing 'deploy:' block\n\nContent:\n%s", content)
+	}
+}

--- a/internal/cli/cmd/bundle.go
+++ b/internal/cli/cmd/bundle.go
@@ -197,8 +197,11 @@ func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, o
 
 	// Resolve platform precedence: CLI flag (if non-empty) → yaml
 	// deploy.target_platform → viper default "linux/amd64".
-	// cfg.Deploy.TargetPlatform is always populated by the viper default
-	// when the yaml field is absent.
+	// cfg.Deploy.TargetPlatform is populated by the viper default when the
+	// yaml field is absent entirely; however, when the yaml field is present
+	// but set to an empty string (""), viper returns "" (explicit empty
+	// overrides the default). In that case CheckImageHealth's own empty-check
+	// falls back to defaultTargetPlatform ("linux/amd64").
 	resolvedPlatform := targetPlatform
 	if resolvedPlatform == "" {
 		resolvedPlatform = cfg.Deploy.TargetPlatform

--- a/internal/cli/cmd/bundle.go
+++ b/internal/cli/cmd/bundle.go
@@ -134,7 +134,8 @@ Examples:
 	cmd.Flags().BoolVar(&skipImage, "skip-image", false, "do not package image.tar (for users pulling from a registry)")
 	cmd.Flags().BoolVar(&build, "build", false, "build the app image before bundling (use when: image is missing or stale)")
 	cmd.Flags().BoolVar(&allowStale, "allow-stale", false, "suppress the stale-image warning (bundle proceeds regardless of freshness)")
-	cmd.Flags().StringVar(&targetPlatform, "target-platform", "linux/amd64", "expected deployment platform, e.g. linux/arm64 (use when: your VPS differs from your laptop arch)")
+	cmd.Flags().StringVar(&targetPlatform, "target-platform", "",
+		"expected deployment platform, e.g. linux/arm64 (default: deploy.target_platform from vibewarden.production.yaml, or linux/amd64)")
 
 	return cmd
 }
@@ -193,8 +194,14 @@ func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, o
 	if imageTag == "" {
 		imageTag = projectName + "-app:latest"
 	}
-	if targetPlatform == "" {
-		targetPlatform = "linux/amd64"
+
+	// Resolve platform precedence: CLI flag (if non-empty) → yaml
+	// deploy.target_platform → viper default "linux/amd64".
+	// cfg.Deploy.TargetPlatform is always populated by the viper default
+	// when the yaml field is absent.
+	resolvedPlatform := targetPlatform
+	if resolvedPlatform == "" {
+		resolvedPlatform = cfg.Deploy.TargetPlatform
 	}
 
 	// --build: run `vibew build --platform <target>` before inspecting or
@@ -204,7 +211,7 @@ func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, o
 		buildSvc := opsapp.NewBuildService(builder).
 			WithShellProber(opsadapter.NewShellProberAdapter())
 		buildOpts := opsapp.BuildOptions{
-			Platform:   targetPlatform,
+			Platform:   resolvedPlatform,
 			ConfigPath: absConfig,
 			ImageTag:   imageTag,
 		}
@@ -253,7 +260,7 @@ func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, o
 		Overwrite:      overwrite,
 		SkipImage:      skipImage,
 		ImageTag:       imageTag,
-		TargetPlatform: targetPlatform,
+		TargetPlatform: resolvedPlatform,
 		AllowStale:     allowStale,
 		Out:            cmd.OutOrStdout(),
 	})
@@ -264,6 +271,9 @@ func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, o
 		}
 		if errors.Is(bundleErr, ports.ErrDockerUnavailable) {
 			return 3, bundleErr
+		}
+		if errors.Is(bundleErr, bundleapp.ErrPlatformMismatch) {
+			return 1, bundleErr
 		}
 		return 1, fmt.Errorf("creating bundle: %w", bundleErr)
 	}

--- a/internal/cli/cmd/bundle_target_platform_test.go
+++ b/internal/cli/cmd/bundle_target_platform_test.go
@@ -1,0 +1,104 @@
+package cmd_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/cli/cmd"
+)
+
+// setupBundleProjectWithProdYAML is like setupBundleProject but also writes a
+// vibewarden.production.yaml with the given content alongside vibewarden.yaml.
+func setupBundleProjectWithProdYAML(t *testing.T, prodYAML string) string {
+	t.Helper()
+	dir := setupBundleProject(t)
+	prodPath := filepath.Join(dir, "vibewarden.production.yaml")
+	if err := os.WriteFile(prodPath, []byte(prodYAML), 0o600); err != nil {
+		t.Fatalf("writing vibewarden.production.yaml: %v", err)
+	}
+	return dir
+}
+
+// TestBundleCmd_TargetPlatform_FlagRegistered verifies that --target-platform
+// is a registered flag on the bundle command.
+func TestBundleCmd_TargetPlatform_FlagRegistered(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	bundleCmd, _, err := root.Find([]string{"bundle"})
+	if err != nil {
+		t.Fatalf("Find(bundle) error: %v", err)
+	}
+	f := bundleCmd.Flags().Lookup("target-platform")
+	if f == nil {
+		t.Fatal("expected --target-platform flag on bundle command")
+	}
+	// Default must be empty so we can detect "user did not pass flag".
+	if f.DefValue != "" {
+		t.Errorf("--target-platform default = %q, want %q (empty sentinel)", f.DefValue, "")
+	}
+}
+
+// TestBundleCmd_NoYAML_NoFlag_DefaultsToAmd64 verifies that when no
+// vibewarden.production.yaml exists and no --target-platform flag is passed,
+// the bundle succeeds (default linux/amd64 is used). The actual image is not
+// inspected because --skip-image is set; we are testing the flag resolution path.
+func TestBundleCmd_NoYAML_NoFlag_DefaultsToAmd64(t *testing.T) {
+	dir := setupBundleProject(t)
+	outDir := filepath.Join(dir, "out")
+
+	root := cmd.NewRootCmd("test")
+	root.SetArgs([]string{"bundle", "--output", outDir, "--skip-image"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+
+	err := root.Execute()
+	if err != nil {
+		t.Fatalf("bundle without flag or yaml should succeed (--skip-image): %v\noutput: %s", err, out.String())
+	}
+}
+
+// TestBundleCmd_YAMLTargetPlatform_AcceptedByStrict verifies that a
+// production.yaml with deploy.target_platform is accepted by LoadStrict
+// (i.e., the field is not rejected as unknown). The bundle then succeeds
+// because --skip-image bypasses the image inspection.
+func TestBundleCmd_YAMLTargetPlatform_AcceptedByStrict(t *testing.T) {
+	prodYAML := "server:\n  port: 443\ndeploy:\n  target_platform: linux/amd64\n"
+	dir := setupBundleProjectWithProdYAML(t, prodYAML)
+	outDir := filepath.Join(dir, "out")
+
+	root := cmd.NewRootCmd("test")
+	root.SetArgs([]string{"bundle", "--output", outDir, "--skip-image"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("bundle with deploy.target_platform in yaml should succeed: %v\noutput: %s", err, out.String())
+	}
+}
+
+// TestBundleCmd_YAMLUnknownDeployKey_RejectedByStrict verifies that a
+// production.yaml with an unknown deploy.* key is rejected by LoadStrict
+// before any files are written.
+func TestBundleCmd_YAMLUnknownDeployKey_RejectedByStrict(t *testing.T) {
+	prodYAML := "deploy:\n  target_platform: linux/amd64\n  bogus_key: oops\n"
+	dir := setupBundleProjectWithProdYAML(t, prodYAML)
+	outDir := filepath.Join(dir, "out")
+
+	root := cmd.NewRootCmd("test")
+	root.SetArgs([]string{"bundle", "--output", outDir, "--skip-image"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown deploy.bogus_key, got nil")
+	}
+	if !strings.Contains(err.Error(), "bogus_key") && !strings.Contains(out.String(), "bogus_key") {
+		t.Errorf("error/output should mention unknown key 'bogus_key'\nerr: %v\nout: %s", err, out.String())
+	}
+}

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -191,7 +191,7 @@ Key flags:
 - `--allow-stale` — suppress STALE warning when you know the image is correct
 - `--target-platform linux/<arch>` — set when your VPS arch differs from your laptop
 
-Exit codes: 0=success (with or without warnings), 2=image missing, 3=docker daemon unreachable.
+Exit codes: 0=success (with or without warnings), 1=image arch does not match target platform (rebuild with `vibew build --platform <target>`), 2=image missing, 3=docker daemon unreachable.
 
 `vibew bundle` then emits a deterministic `docker-compose.yml` (image: pinned,
 never build:), the merged `vibewarden.yaml`, `sample.env`, `.env`, an

--- a/internal/cli/templates/init-vibewarden.production.yaml.tmpl
+++ b/internal/cli/templates/init-vibewarden.production.yaml.tmpl
@@ -6,4 +6,9 @@
 server:
   port: 443
 
+deploy:
+  # Target platform for `vibew bundle`. The bundle aborts if the image arch
+  # does not match. Hetzner and most cloud VMs are linux/amd64.
+  target_platform: linux/amd64
+
 # Add overrides below.

--- a/internal/cli/templates/production_yaml_test.go
+++ b/internal/cli/templates/production_yaml_test.go
@@ -112,3 +112,57 @@ func TestInitProject_ProductionYAML_NoCommentedStubs(t *testing.T) {
 		}
 	})
 }
+
+// TestInitProject_ProductionYAML_HasDeployTargetPlatform verifies that the
+// rendered init-vibewarden.production.yaml.tmpl contains deploy.target_platform
+// as an actual yaml mapping (not a comment) — guard for #1200.
+func TestInitProject_ProductionYAML_HasDeployTargetPlatform(t *testing.T) {
+	renderer := templateadapter.NewRenderer(templates.FS)
+
+	data := domainscaffold.InitProjectData{
+		ProjectName: "myapp",
+		Port:        3000,
+		Name:        "myapp",
+	}
+
+	rendered, err := renderer.Render("init-vibewarden.production.yaml.tmpl", data)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	content := string(rendered)
+
+	// Must contain deploy: block as a real yaml key (no leading #).
+	t.Run("has_deploy_block", func(t *testing.T) {
+		lines := strings.Split(content, "\n")
+		found := false
+		for _, line := range lines {
+			// A top-level deploy: key: not indented, not a comment.
+			if strings.TrimSpace(line) == "deploy:" && !strings.HasPrefix(strings.TrimSpace(line), "#") {
+				// Verify it is truly uncommented (no leading # before deploy:).
+				if !strings.HasPrefix(line, "#") {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			t.Errorf("rendered production.yaml missing active 'deploy:' block\n\nContent:\n%s", content)
+		}
+	})
+
+	// Must contain target_platform: linux/amd64 as an actual entry.
+	t.Run("has_target_platform_amd64", func(t *testing.T) {
+		if !strings.Contains(content, "target_platform: linux/amd64") {
+			t.Errorf("rendered production.yaml missing 'target_platform: linux/amd64'\n\nContent:\n%s", content)
+		}
+		// Must not be a commented line.
+		lines := strings.Split(content, "\n")
+		for _, line := range lines {
+			if strings.Contains(line, "target_platform: linux/amd64") {
+				if strings.HasPrefix(strings.TrimSpace(line), "#") {
+					t.Errorf("target_platform: linux/amd64 is commented out — must be active yaml\n\nLine: %q", line)
+				}
+			}
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,6 +122,10 @@ type Config struct {
 	// Watch configures the config file watcher for hot reload.
 	Watch WatchConfig `mapstructure:"watch"`
 
+	// Deploy configures `vibew bundle` deploy-target settings. Fields here
+	// describe the deploy *target* and have no effect on the running sidecar.
+	Deploy DeployConfig `mapstructure:"deploy"`
+
 	// DeployMode is set to true by the deploy service when generating files for
 	// a deploy bundle. Templates use this to adjust paths (e.g. build context
 	// is the original App.Build value in deploy mode instead of the resolved
@@ -466,6 +470,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("compression.algorithms", []string{"zstd", "gzip"})
 	v.SetDefault("watch.enabled", true)
 	v.SetDefault("watch.debounce", "500ms")
+	v.SetDefault("deploy.target_platform", "linux/amd64")
 }
 
 // rejectRemovedAuthEnabled returns a load-time error when the user's YAML

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3452,6 +3452,12 @@ func TestLoad_DeployTargetPlatform_DefaultIsAmd64(t *testing.T) {
 
 // TestLoad_DeployTargetPlatform_FromYAML verifies that deploy.target_platform
 // is populated when the yaml carries the field.
+//
+// Note on empty-string yaml: when the yaml contains `deploy.target_platform: ""`
+// (explicit empty string), viper returns "" — the explicit empty overrides the
+// viper default. The caller (CheckImageHealth / runBundle) is responsible for
+// treating "" as "use defaultTargetPlatform". This test documents that
+// config.Load returns "" in that case so callers are not surprised.
 func TestLoad_DeployTargetPlatform_FromYAML(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -3467,6 +3473,14 @@ func TestLoad_DeployTargetPlatform_FromYAML(t *testing.T) {
 			name:     "amd64 explicit in yaml",
 			yaml:     "deploy:\n  target_platform: linux/amd64\n",
 			wantPlat: "linux/amd64",
+		},
+		{
+			// Explicit empty string in yaml: viper returns "" (does not fall
+			// back to the default "linux/amd64"). CheckImageHealth treats ""
+			// as defaultTargetPlatform; config.Load must not silently hide it.
+			name:     "empty string in yaml returns empty",
+			yaml:     "deploy:\n  target_platform: \"\"\n",
+			wantPlat: "",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3431,3 +3431,70 @@ func TestValidate_RolePaths(t *testing.T) {
 		})
 	}
 }
+
+// TestLoad_DeployTargetPlatform_DefaultIsAmd64 verifies that when no yaml
+// contains deploy.target_platform the viper default resolves to linux/amd64.
+func TestLoad_DeployTargetPlatform_DefaultIsAmd64(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "vibewarden.yaml")
+	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8443\n"), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Deploy.TargetPlatform != "linux/amd64" {
+		t.Errorf("Deploy.TargetPlatform = %q, want %q", cfg.Deploy.TargetPlatform, "linux/amd64")
+	}
+}
+
+// TestLoad_DeployTargetPlatform_FromYAML verifies that deploy.target_platform
+// is populated when the yaml carries the field.
+func TestLoad_DeployTargetPlatform_FromYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantPlat string
+	}{
+		{
+			name:     "arm64 from yaml",
+			yaml:     "deploy:\n  target_platform: linux/arm64\n",
+			wantPlat: "linux/arm64",
+		},
+		{
+			name:     "amd64 explicit in yaml",
+			yaml:     "deploy:\n  target_platform: linux/amd64\n",
+			wantPlat: "linux/amd64",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "vibewarden.yaml")
+			if err := os.WriteFile(cfgPath, []byte(tt.yaml), 0o600); err != nil {
+				t.Fatalf("writing config: %v", err)
+			}
+			cfg, err := config.Load(cfgPath)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if cfg.Deploy.TargetPlatform != tt.wantPlat {
+				t.Errorf("Deploy.TargetPlatform = %q, want %q", cfg.Deploy.TargetPlatform, tt.wantPlat)
+			}
+		})
+	}
+}
+
+// TestLoad_DeployBlock_MissingEntirelyUsesDefault verifies that when the yaml
+// contains no deploy: block at all the viper default (linux/amd64) applies.
+func TestLoad_DeployBlock_MissingEntirelyUsesDefault(t *testing.T) {
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatalf("Load(\"\") error = %v", err)
+	}
+	if cfg.Deploy.TargetPlatform != "linux/amd64" {
+		t.Errorf("Deploy.TargetPlatform = %q, want %q", cfg.Deploy.TargetPlatform, "linux/amd64")
+	}
+}

--- a/internal/config/deploy.go
+++ b/internal/config/deploy.go
@@ -1,0 +1,14 @@
+package config
+
+// DeployConfig holds settings consumed by `vibew bundle` when producing the
+// deploy artifact. Fields here describe the deploy *target* — they have no
+// effect on the running sidecar (vibewarden serve never reads them).
+type DeployConfig struct {
+	// TargetPlatform is the expected deployment platform, in the standard
+	// Docker Buildx format "<os>/<arch>" (e.g. "linux/amd64", "linux/arm64").
+	// `vibew bundle` compares this against the bundled image's architecture
+	// and aborts on mismatch with an actionable rebuild command.
+	//
+	// Default: "linux/amd64" (Hetzner and most cloud VMs).
+	TargetPlatform string `mapstructure:"target_platform"`
+}

--- a/internal/config/strict_test.go
+++ b/internal/config/strict_test.go
@@ -209,3 +209,63 @@ func TestUnknownKeyError_Error(t *testing.T) {
 		})
 	}
 }
+
+// TestLoadStrict_DeployTargetPlatform_Accepted verifies that the new
+// deploy.target_platform field is accepted by LoadStrict and does not
+// trigger an UnknownKeyError. This ensures that production yaml files
+// carrying this field are not rejected.
+func TestLoadStrict_DeployTargetPlatform_Accepted(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "vibewarden.yaml")
+	if err := os.WriteFile(basePath, []byte("server:\n  port: 8443\n"), 0o600); err != nil {
+		t.Fatalf("writing base: %v", err)
+	}
+	prodPath := filepath.Join(dir, "vibewarden.production.yaml")
+	prodYAML := "server:\n  port: 443\ndeploy:\n  target_platform: linux/amd64\n"
+	if err := os.WriteFile(prodPath, []byte(prodYAML), 0o600); err != nil {
+		t.Fatalf("writing prod: %v", err)
+	}
+
+	cfg, err := config.LoadStrict(basePath, prodPath)
+	if err != nil {
+		t.Fatalf("LoadStrict() error = %v (deploy.target_platform must be accepted)", err)
+	}
+	if cfg.Deploy.TargetPlatform != "linux/amd64" {
+		t.Errorf("Deploy.TargetPlatform = %q, want %q", cfg.Deploy.TargetPlatform, "linux/amd64")
+	}
+}
+
+// TestLoadStrict_DeployUnknownKey_Rejected verifies that unknown sibling keys
+// under the deploy namespace are rejected by LoadStrict.
+func TestLoadStrict_DeployUnknownKey_Rejected(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "vibewarden.yaml")
+	if err := os.WriteFile(basePath, []byte("server:\n  port: 8443\n"), 0o600); err != nil {
+		t.Fatalf("writing base: %v", err)
+	}
+	prodPath := filepath.Join(dir, "vibewarden.production.yaml")
+	prodYAML := "deploy:\n  target_platform: linux/amd64\n  foo: bar\n"
+	if err := os.WriteFile(prodPath, []byte(prodYAML), 0o600); err != nil {
+		t.Fatalf("writing prod: %v", err)
+	}
+
+	_, err := config.LoadStrict(basePath, prodPath)
+	if err == nil {
+		t.Fatal("LoadStrict() returned nil, want error for deploy.foo")
+	}
+
+	var unknown *config.UnknownKeyError
+	if !errors.As(err, &unknown) {
+		t.Fatalf("want *UnknownKeyError, got %T: %v", err, err)
+	}
+	found := false
+	for _, k := range unknown.Keys {
+		if k == "deploy.foo" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("UnknownKeyError.Keys = %v, want to contain %q", unknown.Keys, "deploy.foo")
+	}
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -770,6 +770,21 @@ Local observability stack (Grafana, Prometheus, Loki, Promtail).
     config.reload_failed  Validation or reload error
 
 
+### deploy (vibew bundle target settings)
+
+  deploy.target_platform  string  linux/amd64  Expected deployment platform for `vibew bundle`.
+
+  `vibew bundle` compares the bundled image's architecture against this value
+  and aborts with an actionable error on mismatch. The field lives in
+  vibewarden.production.yaml (not the base config) because it describes the
+  deploy target, not the running sidecar.
+
+  Resolution order: --target-platform flag > deploy.target_platform in yaml > default linux/amd64.
+
+  Typical values: linux/amd64 (most cloud VMs), linux/arm64 (Ampere/Graviton).
+  Invalid values are caught as a mismatch at bundle time — no explicit validation.
+
+
 ### webhooks (outbound event delivery)
 
   webhooks.endpoints: list
@@ -1395,11 +1410,14 @@ arch, created, size, target platform, freshness, warnings). Flags:
   missing or stale (off by default)
 - `--allow-stale` -- suppress the STALE freshness warning; bundle proceeds
   regardless of source-file content-hash change
-- `--target-platform linux/<arch>` -- expected deployment platform (default:
-  `linux/amd64`); use for Graviton / Pi / arm64 servers
+- `--target-platform linux/<arch>` -- override the deploy target platform.
+  Resolution order: flag > deploy.target_platform in vibewarden.production.yaml
+  > default linux/amd64. Bundle aborts (exit 1) on arch mismatch with an
+  actionable rebuild command — this is the primary guard for Apple Silicon
+  builds landing on amd64 VPS hosts without being noticed.
 
-Exit codes: 0=success (includes warnings), 1=generic failure, 2=image missing,
-3=docker daemon unreachable.
+Exit codes: 0=success (includes warnings), 1=generic failure (including arch
+mismatch), 2=image missing, 3=docker daemon unreachable.
 
 Output layout:
 

--- a/vibewarden.reference.yaml
+++ b/vibewarden.reference.yaml
@@ -1049,3 +1049,17 @@ secrets:
       - "123456"
       - "admin"
       - "letmein"
+
+# Deploy settings — consumed by `vibew bundle`, not by `vibewarden serve`.
+# These fields describe the deploy *target* and have no effect on the running sidecar.
+deploy:
+  # Target platform for `vibew bundle`, in the Docker Buildx format "<os>/<arch>".
+  # The bundle aborts with an actionable rebuild command when the bundled image's
+  # architecture does not match this value.
+  #
+  # Hetzner VMs and most cloud VPS targets are linux/amd64.
+  # Apple Silicon development machines produce linux/arm64 images by default.
+  # Override on the command line with: vibew bundle --target-platform linux/arm64
+  #
+  # Default: linux/amd64
+  target_platform: linux/amd64


### PR DESCRIPTION
Closes #1200

## Summary

- **New config field** `deploy.target_platform` (default `linux/amd64`) in `internal/config/deploy.go`. Added to `Config` struct with `mapstructure:"deploy"` tag and viper default so `LoadStrict` reflection accepts the field in production yaml files.
- **Init template** `internal/cli/templates/init-vibewarden.production.yaml.tmpl` now writes `deploy.target_platform: linux/amd64` as an active yaml entry (not a comment).
- **CLI flag** `--target-platform` default changed from `"linux/amd64"` to `""` (empty sentinel). Resolution order: flag (if set) → `cfg.Deploy.TargetPlatform` (yaml or viper default) → `"linux/amd64"`.
- **Hard failure** on arch mismatch. `ErrPlatformMismatch` sentinel added to `internal/app/bundle/image_health.go`. `runImageHealthCheck` renders the health block first (so the user sees Tag/Arch/Target side-by-side), then returns the error if `health.ArchMismatch` is true. No bundle files are written. CLI maps it to exit code 1.
- **Exact error copy** (pinned by `TestPlatformMismatchMessage_ExactWording`):
  ```
  image arch is linux/arm64, target is linux/amd64. Rebuild with: vibew build --platform linux/amd64
  Then re-run: vibew bundle
  ```
- **Docs**: `vibewarden.reference.yaml` + `docs/production-hardening.md` + `llms-full.txt` + `CHANGELOG.md` all updated.

## Multi-arch note

`docker image inspect` against a local image always returns the single architecture that was loaded into the local daemon (buildx `--load` writes only one arch). There is no manifest-list case for `vibew bundle`. This assumption is documented in the `ErrPlatformMismatch` godoc.

## Test plan

- `TestLoad_DeployTargetPlatform_DefaultIsAmd64` — viper default resolves correctly
- `TestLoad_DeployTargetPlatform_FromYAML` — yaml field overrides default
- `TestLoadStrict_DeployTargetPlatform_Accepted` — field accepted by strict loader
- `TestLoadStrict_DeployUnknownKey_Rejected` — unknown `deploy.foo` rejected
- `TestRunImageHealthCheck_ArchMismatch_ReturnsErrPlatformMismatch` — sentinel returned, health block rendered before error
- `TestBundle_ArchMismatch_NoFilesWritten` — no files written on mismatch
- `TestBundle_ArchMatch_Succeeds` — happy path unchanged
- `TestBundle_NoInspector_SkipsArchCheck` — nil-inspector path preserved
- `TestPlatformMismatchMessage_ExactWording` — exact error copy pinned
- `TestInitProject_ProductionYAML_HasDeployTargetPlatform` — two tests (template layer + scaffold integration layer)
- `TestBundleCmd_TargetPlatform_FlagRegistered` — flag registered with empty default
- `TestBundleCmd_NoYAML_NoFlag_DefaultsToAmd64` — default path
- `TestBundleCmd_YAMLTargetPlatform_AcceptedByStrict` — yaml field accepted end-to-end
- `TestBundleCmd_YAMLUnknownDeployKey_RejectedByStrict` — unknown sibling rejected

Architect's design comment: https://github.com/VibeWarden/vibewarden/issues/1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)