### PR TITLE
chore(#1198): drop misleading upstream-reachable check from vibew doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ when the image arch does not match the VPS target.
 
 ### Changed
 
+- **`vibew doctor` no longer probes the upstream port directly** (#1198). The check was structurally wrong — the upstream lives on the docker-compose internal network, never bound to the host — and produced misleading "unreachable" warnings before `vibew dev` ran. Runtime upstream health is reported by `/_vibewarden/health` (#1197).
 - **Bundle README now opens with a fenced shell block containing the literal deploy commands** (was: prose-only) (#1204). `app.name` and `tls.domain` are substituted; empty values produce `<your-app>` / `<your-domain>` placeholders. With `--skip-image` the `docker load -i image.tar &&` clause is omitted so the block is always copy-pasteable.
 - **`vibew bundle` stdout now prints the literal `ssh`/`scp`/`docker compose up -d` sequence** with `app.name` and `tls.domain` substituted (#1204). An agent has a copy-pasteable next step without opening the README.
 

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -26,7 +26,7 @@ VibeWarden is language-agnostic — `vibew init` does not scaffold app code, a D
 - **Serve `GET /health` returning HTTP 200** on that same port. Any response body is acceptable — vibew checks the status code only. Without this endpoint the sidecar container never leaves the "Created" state and `vibew dev` hangs.
 - **Do not implement TLS, auth, rate-limiting, WAF, or security headers in app code** — the sidecar owns all of those (see §Security boundary rule).
 
-`vibew doctor` validates this contract at runtime: `EXPOSE` vs `upstream.port`, upstream reachability, `/health` response, and TLS state. Run it before `vibew dev` if you hit a connection-refused loop.
+`vibew doctor` validates this contract statically: `EXPOSE` vs `upstream.port` match, Dockerfile structure, and TLS state. Run it before `vibew dev` if you hit a connection-refused loop. For runtime upstream health, query `_vibewarden/health` after `vibew dev` is up.
 
 ## Sidecar-injected headers
 
@@ -97,10 +97,12 @@ vibew logs               # pretty-print structured logs
 
 `vibew doctor` checks (in order): config validity, Docker daemon, Docker Compose,
 proxy port availability, generated files, container health, ACME email, image tag
-consistency, upstream reachability, and TLS state. The TLS state check reports one
-of four values: `Obtaining` (ACME in progress), `Obtained` (cert active and valid),
-`Failing` (ACME failed), or `SelfSignedLocal` (dev self-signed cert — no expiry
-warning is raised). `vibew status` surfaces the same TLS state in its output table. Output uses OK / OFF / FAIL labels; OFF means the component is disabled in config and was not probed.
+consistency, and TLS state. The TLS state check reports one of four values:
+`Obtaining` (ACME in progress), `Obtained` (cert active and valid), `Failing`
+(ACME failed), or `SelfSignedLocal` (dev self-signed cert — no expiry warning is
+raised). `vibew status` surfaces the same TLS state in its output table. Output
+uses OK / OFF / FAIL labels; OFF means the component is disabled in config and was
+not probed. For runtime upstream health, query `_vibewarden/health` after `vibew dev` is up.
 
 `vibew validate` now catches real next-command failures before they reach `vibew bundle` or `vibew up`: name collision (directory named "vibewarden" with no explicit `name:` set), Dockerfile EXPOSE/upstream.port mismatch, image-tag drift in `.env`, ACME-incompatible domain (localhost, IP literal, `.local`/`.test` TLD), and WAF log-mode enabled in a production config. Any of these conditions exits with code 1 and a FAIL row on stderr; fix the config or set the appropriate acknowledgement key before running the next command.
 
@@ -257,7 +259,7 @@ For now: keep one site per project. Revisit when #1169 lands.
 ## Known limitations
 
 - WAF is in `detect` mode by default (logs but does not block). Set `waf.mode: block` in vibewarden.yaml to enforce blocking.
-- `vibew doctor` checks config, Docker, ports, container health, generated files, ACME email, image tag, upstream reachability, and TLS state (Obtaining/Obtained/Failing/SelfSignedLocal). Self-signed dev certs are identified correctly and do not trigger a spurious expiry warning. When a `Dockerfile` is present in the project root, `vibew doctor` also lints it against the contract: alpine base, `EXPOSE` matches `upstream.port`, no `HEALTHCHECK` directive, non-root `USER` (warn, non-blocking), multi-stage build for compiled languages, and builder image major.minor matches the project toolchain manifest (`go.mod`, `.nvmrc`, `pyproject.toml`). When no `Dockerfile` is present, the Dockerfile section is omitted entirely.
+- `vibew doctor` checks config, Docker, ports, container health, generated files, ACME email, image tag, and TLS state (Obtaining/Obtained/Failing/SelfSignedLocal). It does not probe runtime upstream health — use `curl https://<your-domain>/_vibewarden/health` after `vibew dev` is up for that. Self-signed dev certs are identified correctly and do not trigger a spurious expiry warning. When a `Dockerfile` is present in the project root, `vibew doctor` also lints it against the contract: alpine base, `EXPOSE` matches `upstream.port`, no `HEALTHCHECK` directive, non-root `USER` (warn, non-blocking), multi-stage build for compiled languages, and builder image major.minor matches the project toolchain manifest (`go.mod`, `.nvmrc`, `pyproject.toml`). When no `Dockerfile` is present, the Dockerfile section is omitted entirely.
 - Multi-site local dev works; production deploy is post-v1 (see https://github.com/VibeWarden/vibewarden/issues/1169).
 - `vibew init` does not accept `--tls` or `--domain` flags — run `vibew add tls --domain <your-domain>` after init.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,9 +7,10 @@ resolve the most common issues.
 
 ## `vibew doctor`
 
-`vibew doctor` is a first-aid command. It runs a series of independent diagnostics and
-prints a report so you can see exactly what is wrong before filing a bug or spending time
-searching logs.
+`vibew doctor` is a first-aid command. It validates static configuration and prints a
+report so you can see exactly what is wrong before filing a bug or spending time
+searching logs. For runtime upstream health, `curl https://<your-domain>/_vibewarden/health`
+after `vibew dev` is up — doctor only validates static config.
 
 ```bash
 vibew doctor
@@ -47,7 +48,6 @@ pre-flight scripts.
 
 | # | Check name | What it tests |
 |---|------------|---------------|
-| 9 | **Upstream reachable** | The configured upstream port is listening locally |
 | 10 | **TLS cert valid** | Performs a live TLS handshake against the sidecar, reads the leaf certificate from the handshake, and verifies it is not expired or expiring within 7 days. Reports WARN (`sidecar not reachable — start 'vibew dev'`) when the handshake fails, so the check no longer depends on a file-on-disk at a hardcoded path (ADR-084) |
 
 ### Severity levels

--- a/internal/app/ops/doctor.go
+++ b/internal/app/ops/doctor.go
@@ -52,7 +52,6 @@ func (c CheckResult) OK() bool { return c.Severity == SeverityOK }
 type DoctorService struct {
 	compose        ports.ComposeRunner
 	portChecker    ports.PortChecker
-	healthChecker  ports.HealthChecker
 	imageChecker   ports.DockerImageChecker
 	ownerProbe     ports.PortOwnerProbe
 	tlsState       ports.TLSStateResolver   // optional; nil falls back to handshake-on-demand
@@ -60,11 +59,10 @@ type DoctorService struct {
 }
 
 // NewDoctorService creates a new DoctorService.
-func NewDoctorService(compose ports.ComposeRunner, portChecker ports.PortChecker, healthChecker ports.HealthChecker) *DoctorService {
+func NewDoctorService(compose ports.ComposeRunner, portChecker ports.PortChecker) *DoctorService {
 	return &DoctorService{
-		compose:       compose,
-		portChecker:   portChecker,
-		healthChecker: healthChecker,
+		compose:     compose,
+		portChecker: portChecker,
 	}
 }
 
@@ -212,7 +210,6 @@ func (s *DoctorService) runChecks(ctx context.Context, cfg *config.Config, opts 
 	}
 
 	// --- Layer 2: Local Runtime ---
-	results = append(results, withSection(s.checkUpstreamReachable(ctx, cfg), sectionLocalRuntime))
 	results = append(results, withSection(s.checkTLSCertValid(ctx, cfg, proxyHost, proxyPort), sectionLocalRuntime))
 
 	// --- Dockerfile contract checks ---
@@ -385,46 +382,6 @@ func (s *DoctorService) checkContainerHealth(ctx context.Context, composePath st
 		Name:     "Container health",
 		Severity: SeverityOK,
 		Detail:   fmt.Sprintf("%d container(s) running", len(containers)),
-	}
-}
-
-// checkUpstreamReachable verifies that the upstream application responds to
-// HTTP health checks. This uses the HealthChecker port already injected into
-// the service.
-func (s *DoctorService) checkUpstreamReachable(ctx context.Context, cfg *config.Config) CheckResult {
-	host := cfg.Upstream.Host
-	if host == "" {
-		host = "127.0.0.1"
-	}
-	port := cfg.Upstream.Port
-	if port == 0 {
-		port = 3000
-	}
-
-	url := fmt.Sprintf("http://%s:%d", host, port)
-
-	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	ok, statusCode, err := s.healthChecker.CheckHealth(checkCtx, url)
-	if err != nil {
-		return CheckResult{
-			Name:     "Upstream reachable",
-			Severity: SeverityWarn,
-			Detail:   fmt.Sprintf("%s — unreachable (app may not be started yet)", url),
-		}
-	}
-	if !ok {
-		return CheckResult{
-			Name:     "Upstream reachable",
-			Severity: SeverityWarn,
-			Detail:   fmt.Sprintf("%s — responded with HTTP %d", url, statusCode),
-		}
-	}
-	return CheckResult{
-		Name:     "Upstream reachable",
-		Severity: SeverityOK,
-		Detail:   fmt.Sprintf("%s — HTTP %d", url, statusCode),
 	}
 }
 

--- a/internal/app/ops/doctor_dockerfile_test.go
+++ b/internal/app/ops/doctor_dockerfile_test.go
@@ -87,12 +87,11 @@ const goMod126 = "module example.com/app\n\ngo 1.26\n"
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 // doctorSvc returns a minimal DoctorService suitable for Dockerfile-only tests.
-// The compose/port/health fakes ensure all non-Dockerfile checks pass.
+// The compose/port fakes ensure all non-Dockerfile checks pass.
 func doctorSvc() *ops.DoctorService {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
-	return ops.NewDoctorService(fc, pc, hc)
+	return ops.NewDoctorService(fc, pc)
 }
 
 // projectWithDockerfile creates a temp dir with the given Dockerfile content

--- a/internal/app/ops/doctor_test.go
+++ b/internal/app/ops/doctor_test.go
@@ -53,22 +53,6 @@ func (f *fakePortOwnerProbe) ProbeOwner(_ context.Context, _ string, _ int) port
 	return f.owner
 }
 
-// reachableHealthChecker is a fakeHealthChecker that reports upstream as reachable.
-func reachableHealthChecker() *fakeHealthChecker {
-	return &fakeHealthChecker{
-		responses: map[string]healthResponse{
-			"http://127.0.0.1:3000": {ok: true, statusCode: 200},
-		},
-	}
-}
-
-// unreachableHealthChecker returns a fakeHealthChecker where upstream is unreachable.
-func unreachableHealthChecker() *fakeHealthChecker {
-	return &fakeHealthChecker{
-		responses: map[string]healthResponse{},
-	}
-}
-
 // noContainersCompose returns a fakeCompose whose PS returns an empty slice.
 func noContainersCompose() *fakeCompose {
 	return &fakeCompose{
@@ -172,9 +156,8 @@ func startTLSTestSidecar(t *testing.T, notBefore, notAfter time.Time) (host stri
 func TestDoctorService_Run_AllPassing(t *testing.T) {
 	fc := healthyContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
 
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	var buf bytes.Buffer
 
@@ -209,8 +192,7 @@ func TestDoctorService_Run_DockerNotRunning(t *testing.T) {
 		versionStr: "Docker Compose version v2.35.1",
 	}
 	pc := &fakePortChecker{}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	var buf bytes.Buffer
 
@@ -234,8 +216,7 @@ func TestDoctorService_Run_DockerComposeNotAvailable(t *testing.T) {
 		versionErr: errors.New("docker compose: command not found"),
 	}
 	pc := &fakePortChecker{}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	var buf bytes.Buffer
 
@@ -256,8 +237,7 @@ func TestDoctorService_Run_DockerComposeNotAvailable(t *testing.T) {
 func TestDoctorService_Run_PortInUse(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: false}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	var buf bytes.Buffer
 
@@ -320,8 +300,7 @@ func TestDoctorService_CheckPort_OwnershipMatrix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fc := noContainersCompose()
 			pc := &fakePortChecker{available: map[int]bool{8443: tt.available}}
-			hc := reachableHealthChecker()
-			svc := ops.NewDoctorService(fc, pc, hc)
+			svc := ops.NewDoctorService(fc, pc)
 			if tt.probe != nil {
 				svc = svc.WithPortOwnerProbe(tt.probe)
 			}
@@ -361,8 +340,7 @@ func TestDoctorService_CheckPort_OwnershipMatrix(t *testing.T) {
 func TestDoctorService_Run_ConfigPathInOutput(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	var buf bytes.Buffer
 
@@ -387,8 +365,7 @@ func TestDoctorService_ChecksAreIndependent(t *testing.T) {
 		psErr:      errors.New("ps failed"),
 	}
 	pc := &fakePortChecker{available: map[int]bool{8443: false}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	var buf bytes.Buffer
 
@@ -415,8 +392,7 @@ func TestDoctorService_ChecksAreIndependent(t *testing.T) {
 func TestDoctorService_Run_GeneratedFileMissing_IsWarn(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	var buf bytes.Buffer
 
@@ -447,8 +423,7 @@ func TestDoctorService_Run_UnhealthyContainer_IsFail(t *testing.T) {
 		},
 	}
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	var buf bytes.Buffer
 
@@ -469,8 +444,7 @@ func TestDoctorService_Run_UnhealthyContainer_IsFail(t *testing.T) {
 func TestDoctorService_Run_JSONOutput(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	var buf bytes.Buffer
 
@@ -505,8 +479,7 @@ func TestDoctorService_Run_OKFAILBadgesInOutput(t *testing.T) {
 		versionStr: "Docker Compose version v2.35.1",
 	}
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	var buf bytes.Buffer
 
@@ -527,8 +500,7 @@ func TestDoctorService_Run_OKFAILBadgesInOutput(t *testing.T) {
 func TestDoctorService_Run_ContainersHealthy_AllOK(t *testing.T) {
 	fc := healthyContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	var buf bytes.Buffer
 
@@ -550,58 +522,7 @@ func TestDoctorService_Run_ContainersHealthy_AllOK(t *testing.T) {
 	}
 }
 
-// --- New tests for Layer 2: Local Runtime checks ---
-
-func TestDoctorService_Run_UpstreamReachable(t *testing.T) {
-	fc := noContainersCompose()
-	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := doctorConfig()
-	var buf bytes.Buffer
-
-	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !allOK {
-		t.Errorf("expected allOK = true when upstream is reachable\noutput:\n%s", buf.String())
-	}
-
-	out := buf.String()
-	if !strings.Contains(out, "Upstream reachable") {
-		t.Errorf("expected 'Upstream reachable' check in output, got:\n%s", out)
-	}
-	if !strings.Contains(out, "HTTP 200") {
-		t.Errorf("expected 'HTTP 200' in upstream detail, got:\n%s", out)
-	}
-}
-
-func TestDoctorService_Run_UpstreamUnreachable(t *testing.T) {
-	fc := noContainersCompose()
-	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := unreachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
-	cfg := doctorConfig()
-	var buf bytes.Buffer
-
-	// Upstream unreachable is WARN, not FAIL, so allOK should still be true.
-	allOK, err := svc.Run(context.Background(), cfg, defaultOpts(t), &buf)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !allOK {
-		t.Errorf("expected allOK = true because upstream unreachable is WARN\noutput:\n%s", buf.String())
-	}
-
-	out := buf.String()
-	if !strings.Contains(out, "Upstream reachable") {
-		t.Errorf("expected 'Upstream reachable' check in output, got:\n%s", out)
-	}
-	if !strings.Contains(out, "unreachable") {
-		t.Errorf("expected 'unreachable' in upstream detail, got:\n%s", out)
-	}
-}
+// --- Tests for Layer 2: Local Runtime checks ---
 
 func TestDoctorService_Run_TLSCertValid(t *testing.T) {
 	host, port, cleanup := startTLSTestSidecar(t, time.Now().Add(-24*time.Hour), time.Now().Add(90*24*time.Hour))
@@ -609,8 +530,7 @@ func TestDoctorService_Run_TLSCertValid(t *testing.T) {
 
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{port: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := defaultConfig()
 	cfg.TLS.Provider = "self-signed"
 	cfg.Server.Host = host
@@ -642,8 +562,7 @@ func TestDoctorService_Run_TLSCertExpired(t *testing.T) {
 
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{port: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := defaultConfig()
 	cfg.TLS.Provider = "self-signed"
 	cfg.Server.Host = host
@@ -672,8 +591,7 @@ func TestDoctorService_Run_TLSCertExpiringSoon(t *testing.T) {
 
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{port: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := defaultConfig()
 	cfg.TLS.Provider = "self-signed"
 	cfg.Server.Host = host
@@ -710,8 +628,7 @@ func TestDoctorService_Run_TLSCertSidecarUnreachable(t *testing.T) {
 
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{addr.Port: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := defaultConfig()
 	cfg.TLS.Provider = "self-signed"
 	cfg.Server.Host = "127.0.0.1"
@@ -739,8 +656,7 @@ func TestDoctorService_Run_TLSCertSidecarUnreachable(t *testing.T) {
 func TestDoctorService_Run_TLSCertNonSelfSigned_Skipped(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	cfg.TLS.Provider = "letsencrypt"
 	cfg.TLS.Domain = "example.com"
@@ -763,8 +679,7 @@ func TestDoctorService_Run_TLSCertNonSelfSigned_Skipped(t *testing.T) {
 func TestDoctorService_Run_SectionHeaders(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	var buf bytes.Buffer
 
@@ -785,8 +700,7 @@ func TestDoctorService_Run_SectionHeaders(t *testing.T) {
 func TestDoctorService_Run_JSONOutput_IncludesSection(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	var buf bytes.Buffer
 
@@ -815,8 +729,7 @@ func TestDoctorService_Run_JSONOutput_IncludesSection(t *testing.T) {
 func TestDoctorService_Run_ACMEEmail_ZeroSSLWithoutEmail(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	cfg.TLS.Provider = "letsencrypt"
 	cfg.TLS.ACMECA = "https://acme.zerossl.com/v2/DV90"
@@ -843,8 +756,7 @@ func TestDoctorService_Run_ACMEEmail_ZeroSSLWithoutEmail(t *testing.T) {
 func TestDoctorService_Run_ACMEEmail_ZeroSSLWithEmail(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	cfg.TLS.Provider = "letsencrypt"
 	cfg.TLS.ACMECA = "https://acme.zerossl.com/v2/DV90"
@@ -871,8 +783,7 @@ func TestDoctorService_Run_ACMEEmail_ZeroSSLWithEmail(t *testing.T) {
 func TestDoctorService_Run_ACMEEmail_NonZeroSSL(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
-	svc := ops.NewDoctorService(fc, pc, hc)
+	svc := ops.NewDoctorService(fc, pc)
 	cfg := doctorConfig()
 	cfg.TLS.Provider = "letsencrypt"
 	cfg.TLS.ACMECA = "" // default Let's Encrypt
@@ -901,9 +812,8 @@ func TestDoctorService_Run_ACMEEmail_NonZeroSSL(t *testing.T) {
 func TestDoctorService_Run_ImageTag_Exists(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
 	ic := &fakeImageChecker{exists: true}
-	svc := ops.NewDoctorService(fc, pc, hc).WithImageChecker(ic)
+	svc := ops.NewDoctorService(fc, pc).WithImageChecker(ic)
 	cfg := doctorConfig()
 	cfg.App.Image = "myapp:latest"
 
@@ -928,9 +838,8 @@ func TestDoctorService_Run_ImageTag_Exists(t *testing.T) {
 func TestDoctorService_Run_ImageTag_Missing(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
 	ic := &fakeImageChecker{exists: false}
-	svc := ops.NewDoctorService(fc, pc, hc).WithImageChecker(ic)
+	svc := ops.NewDoctorService(fc, pc).WithImageChecker(ic)
 	cfg := doctorConfig()
 	cfg.App.Image = "myapp:latest"
 
@@ -955,9 +864,8 @@ func TestDoctorService_Run_ImageTag_Missing(t *testing.T) {
 func TestDoctorService_Run_ImageTag_CheckerError(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
 	ic := &fakeImageChecker{err: errors.New("docker daemon unavailable")}
-	svc := ops.NewDoctorService(fc, pc, hc).WithImageChecker(ic)
+	svc := ops.NewDoctorService(fc, pc).WithImageChecker(ic)
 	cfg := doctorConfig()
 	cfg.App.Image = "myapp:latest"
 
@@ -983,9 +891,8 @@ func TestDoctorService_Run_ImageTag_CheckerError(t *testing.T) {
 func TestDoctorService_Run_ImageTag_NoImage_Skipped(t *testing.T) {
 	fc := noContainersCompose()
 	pc := &fakePortChecker{available: map[int]bool{8443: true}}
-	hc := reachableHealthChecker()
 	ic := &fakeImageChecker{exists: false} // Should not be called.
-	svc := ops.NewDoctorService(fc, pc, hc).WithImageChecker(ic)
+	svc := ops.NewDoctorService(fc, pc).WithImageChecker(ic)
 	cfg := doctorConfig()
 	cfg.App.Image = "" // No image configured.
 
@@ -1038,7 +945,7 @@ func leRecords(n int) []ports.CrtShRecord {
 
 func TestDoctorService_Run_LERateLimit_WARN(t *testing.T) {
 	q := &fakeCTQuerier{records: leRecords(4)} // 4/5 → WARN, 1 remaining
-	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}).
 		WithLERateLimitService(apptlspreflight.NewService(q))
 
 	cfg := leCfg()
@@ -1065,7 +972,7 @@ func TestDoctorService_Run_LERateLimit_WARN(t *testing.T) {
 
 func TestDoctorService_Run_LERateLimit_FAIL(t *testing.T) {
 	q := &fakeCTQuerier{records: leRecords(5)} // 5/5 → FAIL
-	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}).
 		WithLERateLimitService(apptlspreflight.NewService(q))
 
 	cfg := leCfg()
@@ -1088,7 +995,7 @@ func TestDoctorService_Run_LERateLimit_FAIL(t *testing.T) {
 
 func TestDoctorService_Run_LERateLimit_SkipRateLimitCheck_Config(t *testing.T) {
 	q := &fakeCTQuerier{records: leRecords(5)} // Would be FAIL if checked.
-	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}).
 		WithLERateLimitService(apptlspreflight.NewService(q))
 
 	cfg := leCfg()
@@ -1112,7 +1019,7 @@ func TestDoctorService_Run_LERateLimit_SkipRateLimitCheck_Config(t *testing.T) {
 
 func TestDoctorService_Run_LERateLimit_SkipFlag(t *testing.T) {
 	q := &fakeCTQuerier{records: leRecords(5)} // Would be FAIL if checked.
-	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}).
 		WithLERateLimitService(apptlspreflight.NewService(q))
 
 	cfg := leCfg()
@@ -1136,7 +1043,7 @@ func TestDoctorService_Run_LERateLimit_SkipFlag(t *testing.T) {
 
 func TestDoctorService_Run_LERateLimit_NonLEProvider_Skipped(t *testing.T) {
 	q := &fakeCTQuerier{records: leRecords(5)} // Would be FAIL if checked.
-	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}).
 		WithLERateLimitService(apptlspreflight.NewService(q))
 
 	cfg := doctorConfig()
@@ -1162,7 +1069,7 @@ func TestDoctorService_Run_LERateLimit_NonLEProvider_Skipped(t *testing.T) {
 
 func TestDoctorService_Run_LERateLimit_ACMECASet_Skipped(t *testing.T) {
 	q := &fakeCTQuerier{records: leRecords(5)} // Would be FAIL if checked.
-	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}).
 		WithLERateLimitService(apptlspreflight.NewService(q))
 
 	cfg := leCfg()
@@ -1186,7 +1093,7 @@ func TestDoctorService_Run_LERateLimit_ACMECASet_Skipped(t *testing.T) {
 
 func TestDoctorService_Run_LERateLimit_NoDomainsInOpts_Skipped(t *testing.T) {
 	q := &fakeCTQuerier{records: leRecords(5)} // Would be FAIL if checked.
-	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}).
 		WithLERateLimitService(apptlspreflight.NewService(q))
 
 	cfg := leCfg()
@@ -1214,7 +1121,7 @@ func TestDoctorService_Run_LERateLimit_NoDomainsInOpts_Skipped(t *testing.T) {
 // satisfies the ADR-090 error-cases contract for un-normalisable domains.
 func TestDoctorService_Run_LERateLimit_SingleLabelDomain_WARN(t *testing.T) {
 	q := &fakeCTQuerier{records: leRecords(0)} // should never be called
-	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}).
 		WithLERateLimitService(apptlspreflight.NewService(q))
 
 	cfg := leCfg()
@@ -1246,7 +1153,7 @@ func TestDoctorService_Run_LERateLimit_SingleLabelDomain_WARN(t *testing.T) {
 
 func TestDoctorService_Run_LERateLimit_NetworkError_WARN(t *testing.T) {
 	q := &fakeCTQuerier{err: domaintlspreflight.ErrCTUnavailable}
-	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}).
 		WithLERateLimitService(apptlspreflight.NewService(q))
 
 	cfg := leCfg()
@@ -1270,7 +1177,7 @@ func TestDoctorService_Run_LERateLimit_NetworkError_WARN(t *testing.T) {
 
 func TestDoctorService_Run_LERateLimit_JSONOutput(t *testing.T) {
 	q := &fakeCTQuerier{records: leRecords(4)} // 4/5 → WARN
-	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}, reachableHealthChecker()).
+	svc := ops.NewDoctorService(noContainersCompose(), &fakePortChecker{}).
 		WithLERateLimitService(apptlspreflight.NewService(q))
 
 	cfg := leCfg()

--- a/internal/cli/cmd/doctor.go
+++ b/internal/cli/cmd/doctor.go
@@ -32,7 +32,12 @@ func NewDoctorCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Diagnose common configuration and environment issues",
-		Long: `Run a series of independent diagnostics and report any issues found.
+		Long: `Validate VibeWarden config, Docker, generated files, and the Dockerfile contract.
+
+vibew doctor validates static configuration: vibewarden.yaml, Dockerfile contract,
+Go toolchain version, TLS state. It does NOT probe runtime upstream health — that
+is reported by /_vibewarden/health once vibew dev is up.
+Run: curl https://<your-domain>/_vibewarden/health for runtime checks.
 
 Checks are organised into two layers:
 
@@ -48,7 +53,6 @@ Checks are organised into two layers:
     - LE rate-limit budget (when tls.provider is "letsencrypt")
 
   Local Runtime (always runs):
-    - Upstream application is reachable (HTTP GET)
     - TLS certificate is valid (if self-signed)
 
 Each check runs independently — a failure does not stop subsequent checks.
@@ -89,8 +93,6 @@ Examples:
 
 			compose := opsadapter.NewComposeAdapter()
 			portChecker := opsadapter.NewNetPortChecker()
-			httpClient := &http.Client{Timeout: 5 * time.Second}
-			healthChecker := opsadapter.NewHTTPHealthChecker(httpClient)
 			ownerProbe := opsadapter.NewVibeWardenHealthProbe(nil)
 
 			proxyHost := cfg.Server.Host
@@ -112,7 +114,7 @@ Examples:
 			ctClient := crtshAdapter.NewClient(&http.Client{Timeout: 10 * time.Second})
 			leRateLimitSvc := apptlspreflight.NewService(ctClient)
 
-			svc := opsapp.NewDoctorService(compose, portChecker, healthChecker).
+			svc := opsapp.NewDoctorService(compose, portChecker).
 				WithImageChecker(opsadapter.NewImageCheckerAdapter()).
 				WithPortOwnerProbe(ownerProbe).
 				WithTLSStateResolver(tlsResolver).

--- a/internal/cli/cmd/doctor.go
+++ b/internal/cli/cmd/doctor.go
@@ -109,8 +109,7 @@ Examples:
 			)
 
 			// Wire the LE rate-limit preflight service. The crt.sh HTTP client
-			// uses a separate 10-second timeout per AC-8 (separate from the
-			// 5-second healthChecker client above).
+			// uses a separate 10-second timeout per AC-8.
 			ctClient := crtshAdapter.NewClient(&http.Client{Timeout: 10 * time.Second})
 			leRateLimitSvc := apptlspreflight.NewService(ctClient)
 

--- a/internal/cli/cmd/doctor_test.go
+++ b/internal/cli/cmd/doctor_test.go
@@ -61,3 +61,33 @@ func TestDoctorCmd_LongDescription_MentionsPreflight(t *testing.T) {
 		t.Error("expected 'rate-limit' mentioned in doctor Long description")
 	}
 }
+
+// TestDoctorCmd_LongDescription_NoUpstreamReachable is a regression guard that
+// ensures the misleading upstream-reachable check is not re-added to the help
+// text. The upstream lives on the docker-compose internal network and was never
+// reachable from the host; the check only produced confusing WARN output.
+func TestDoctorCmd_LongDescription_NoUpstreamReachable(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	doctorCmd, _, _ := root.Find([]string{"doctor"})
+
+	forbidden := []string{
+		"Upstream application is reachable",
+		"Upstream reachable",
+	}
+	for _, s := range forbidden {
+		if strings.Contains(doctorCmd.Long, s) {
+			t.Errorf("doctor Long description must not mention %q (misleading upstream check was removed in #1198)", s)
+		}
+	}
+}
+
+// TestDoctorCmd_LongDescription_MentionsHealthEndpoint verifies the Long
+// description points operators at _vibewarden/health for runtime upstream checks.
+func TestDoctorCmd_LongDescription_MentionsHealthEndpoint(t *testing.T) {
+	root := cmd.NewRootCmd("test")
+	doctorCmd, _, _ := root.Find([]string{"doctor"})
+
+	if !strings.Contains(doctorCmd.Long, "_vibewarden/health") {
+		t.Error("expected '_vibewarden/health' mentioned in doctor Long description as runtime health pointer")
+	}
+}

--- a/internal/cli/cmd/mcp.go
+++ b/internal/cli/cmd/mcp.go
@@ -80,7 +80,7 @@ func buildMCPToolDeps() mcp.ToolDeps {
 	compose := opsadapter.NewComposeAdapter()
 	portChecker := opsadapter.NewNetPortChecker()
 	ownerProbe := opsadapter.NewVibeWardenHealthProbe(nil)
-	doctorSvc := opsapp.NewDoctorService(compose, portChecker, healthChecker).
+	doctorSvc := opsapp.NewDoctorService(compose, portChecker).
 		WithPortOwnerProbe(ownerProbe).
 		WithTLSStateResolver(buildMCPTLSStateResolver())
 

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -108,7 +108,7 @@ For now: keep one site per project. Revisit when #1169 lands.
 ## Known limitations
 
 - WAF is in `detect` mode by default (logs but does not block). Set `waf.mode: block` in vibewarden.yaml to enforce blocking.
-- `vibew doctor` checks config, Docker, ports, container health, generated files, ACME email, image tag, upstream reachability, and local TLS cert validity. When a `Dockerfile` is present in the project root, `vibew doctor` also lints it against the contract: alpine base, `EXPOSE` matches `upstream.port`, no `HEALTHCHECK` directive, non-root `USER` (warn, non-blocking), multi-stage build for compiled languages, and builder image major.minor matches the project toolchain manifest (`go.mod`, `.nvmrc`, `pyproject.toml`). When no `Dockerfile` is present, the Dockerfile section is omitted entirely.
+- `vibew doctor` checks config, Docker, ports, container health, generated files, ACME email, image tag, and local TLS cert validity. It does not probe runtime upstream health — use `curl https://<your-domain>/_vibewarden/health` after `vibew dev` is up for that. When a `Dockerfile` is present in the project root, `vibew doctor` also lints it against the contract: alpine base, `EXPOSE` matches `upstream.port`, no `HEALTHCHECK` directive, non-root `USER` (warn, non-blocking), multi-stage build for compiled languages, and builder image major.minor matches the project toolchain manifest (`go.mod`, `.nvmrc`, `pyproject.toml`). When no `Dockerfile` is present, the Dockerfile section is omitted entirely.
 - Multi-site local dev works; production deploy is post-v1 (see https://github.com/VibeWarden/vibewarden/issues/1169).
 - `vibew init` does not accept `--tls` or `--domain` flags — run `vibew add tls --domain <your-domain>` after init.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1576,6 +1576,8 @@ vibew doctor checks (in order):
          the project manifest go.mod/nvmrc/pyproject.toml (FAIL on mismatch; OFF when
          tag is "latest" or unrecognised, or when no manifest is found)
      All 6 checks are omitted when no Dockerfile is present in the project root.
+  Runtime upstream health is NOT checked by doctor — query /_vibewarden/health
+  after vibew dev is up for live upstream status.
 
 vibew doctor flags:
   --skip-le-preflight  skip the LE rate-limit CT log check for this run


### PR DESCRIPTION
Closes #1198

## Summary

Mechanical deletion per architect's design comment on #1198.

**Root cause:** `checkUpstreamReachable` dialed `127.0.0.1:<upstream.port>` from the host. The upstream app lives on the docker-compose internal network — it is never bound to the host loopback. The check structurally could not succeed before `vibew dev` ran, producing a confusing `[WARN] Upstream reachable — unreachable` at the exact moment users run `vibew doctor` to pre-flight a cold start. Rationale: #1197.

**What changed:**

- **`internal/app/ops/doctor.go`** — removed `healthChecker ports.HealthChecker` field, `NewDoctorService` third param, `checkUpstreamReachable` method, and its call site in `runChecks`. Layer-2 section now contains only `checkTLSCertValid`.
- **`internal/app/ops/doctor_test.go`** — deleted `TestDoctorService_Run_UpstreamReachable`, `TestDoctorService_Run_UpstreamUnreachable`, `reachableHealthChecker()`, `unreachableHealthChecker()`. Updated all 38 `NewDoctorService(fc, pc, hc)` call sites to `NewDoctorService(fc, pc)`.
- **`internal/app/ops/doctor_dockerfile_test.go`** — one call site updated.
- **`internal/cli/cmd/doctor.go`** — dropped `httpClient`/`healthChecker` locals, dropped third arg to `NewDoctorService`. Updated `Long` help text: names narrowed scope, points to `_vibewarden/health` for runtime checks. `net/http` import kept (still used by crt.sh client).
- **`internal/cli/cmd/mcp.go`** — dropped third arg from `NewDoctorService` call. `healthChecker` local kept (still used by `mcp.ToolDeps.HealthChecker`).
- **`internal/cli/cmd/doctor_test.go`** — added 2 regression guards: `TestDoctorCmd_LongDescription_NoUpstreamReachable` (asserts the misleading text is gone), `TestDoctorCmd_LongDescription_MentionsHealthEndpoint` (asserts `_vibewarden/health` pointer is present).
- **Docs:** `docs/troubleshooting.md` (removed upstream row, fixed duplicate `9 |` numbering bug, added runtime-health pointer), `docs/examples/AGENTS-VIBEWARDEN.md` (3 lines), template, `llms-full.txt`, `CHANGELOG.md`.

## Test plan

- `make check` clean (golangci-lint + build + race tests + demo-app) — confirmed locally
- Net test delta: **-2 tests** (2 upstream tests deleted, 2 regression guards added = net 0 in cmd, -2 in ops)
- `go test -race ./internal/app/ops/... ./internal/cli/cmd/...` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)