### PR TITLE
chore: release v0.18.2 — v0.18.1 retro fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+## [v0.18.2] — 2026-04-28
+
+Theme: v0.18.1 retrospective fixes. Eight retro-tagged issues + two smoke catches covering health-endpoint correctness, deploy-pipeline drift, language-agnostic onboarding, and a CI guard against re-introducing removed artifacts. Two breaking changes are user-visible: the `/_vibewarden/health` JSON wire format and `vibew bundle`'s arch-mismatch behavior. See "Breaking changes" first.
+
 ### Breaking changes
 
 **`/_vibewarden/health` wire-format change** (#1197, ADR-098). If you parse the JSON


### PR DESCRIPTION
## Summary

Release PR for v0.18.2: 8 retro-tagged pipelines (#1197 #1198 #1199 #1200 #1201 #1202 #1203 #1204) + 2 smoke catches (#1213 #1215). Adds the `## [v0.18.2] — 2026-04-28` header to CHANGELOG.

## Smoke test

End-to-end smoke against `demo.vibewarden.dev` with a fresh `vw-smoke` project (full retro flow: vibew init + add tls + add waf + bundle + scp + docker load + docker compose up):

```
$ curl https://demo.vibewarden.dev/_vibewarden/health
{"status":"ok","version":"0.18.2-smoke","components":{"sidecar":"ok","upstream":"ok"}}
```

`components.upstream: "ok"` (was hardcoded `"unknown"` pre-fix) — the load-bearing proof for #1197.

Container names prefixed `vw-smoke-` on both `vibew dev` (local) and the deployed stack (remote), confirming #1199. Bundle README's fenced deploy block had the substituted real domain (`demo.vibewarden.dev`), confirming #1215.

## Test plan
- [x] `make check` clean on main at HEAD
- [x] All 10 sub-PRs merged and CI green
- [x] Smoke test on demo.vibewarden.dev passing
- [ ] Tag v0.18.2 after this PR merges (goreleaser publishes binaries + ghcr Docker image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)