### PR TITLE
fix(#1223): bundle no longer fires STALE on fresh build (self-induced .gitignore mutation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ as #1219 (both in v0.18.3). The recovery command in the error message above is l
 
 - **`vibew doctor` no longer probes runtime checks before `vibew dev` is up** (#1222). Three checks were misleading pre-stack: "Generated files", "Container health", "TLS certificate". Generated files + TLS certificate are now gated on stack-state detection (run only when `docker compose ps` returns containers); Container health is deleted entirely (covered by `/_vibewarden/health` since #1197). New `vibew doctor --help` text reflects the narrower scope: static config + Dockerfile + toolchain pre-stack; TLS + generated-files post-stack. Same misleading-warn class as the upstream-reachable check deleted in #1198.
 
+### Fixed
+
+- **`vibew bundle` no longer fires STALE warnings on a fresh build** (#1223). Root cause: `WriteInputDigest` was mutating the user's `.gitignore` to add `.vibewarden/` exclusions, which bumped the file's mtime inside the watched input set, tripping the freshness check on the next bundle. Fix: drop `.gitignore` mutation; vibew now writes `<projectRoot>/.vibewarden/.gitignore` (`*\n`) for self-contained exclusion. Freshness comparison switches from mtime to per-file SHA-256 (digest schema v2). The freshness block now lists up to 5 changed paths labeled `added`/`removed`/`modified` so users know exactly which file tripped the warning. Existing v1 digest files are treated as missing on first read — first post-upgrade bundle is FRESH baseline, no false positive.
+
 ### Added
 
 - **`vibew dev --rebuild`** — collapses the four-command rebuild dance

--- a/decisions/adr-089-bundle-image-health-tag-scoping-freshness-arch.md
+++ b/decisions/adr-089-bundle-image-health-tag-scoping-freshness-arch.md
@@ -650,10 +650,63 @@ Integration (single `//go:build integration`): real `git init`, real
 is `encoding/json` (stdlib). Re-uses `moby/patternmatcher` already
 promoted in this ADR.
 
+## Refinement (2026-04-28, issue #1223): Digest schema v2, no mtime fallback, self-contained gitignore
+
+Three corrections to the #1146 refinement above, implemented in #1223:
+
+**1. Digest schema v2 (not v1).** The `schema_version` field in the JSON example
+above shows `1`. The actual implementation writes `schema_version: 2`, which adds
+per-file SHA-256 hashes in a `files` array (used to render the changed-path list in
+the freshness block). The format is:
+
+```json
+{
+  "schema_version": 2,
+  "digest": "sha256:<64-hex>",
+  "files": [
+    {"path": "Dockerfile", "hash": "sha256:<64-hex>"},
+    {"path": "vibewarden.production.yaml", "hash": "sha256:<64-hex>"}
+  ]
+}
+```
+
+**2. v1 digest treated as missing, not as mtime fallback.** The #1146 text says
+"schema_version != 1 → treated as missing → fall back to mtime." The #1223
+implementation treats any file with `schema_version != 2` as missing and returns a
+FRESH first-run baseline. There is no mtime fallback path — `FreshnessModeTime`
+was removed end-to-end. An existing v1 file (from a pre-#1223 install) is silently
+discarded on first read; the next bundle writes a v2 file and freshness tracking
+resumes from that point.
+
+**3. Self-contained gitignore, no user `.gitignore` mutation.** The #1146 text says
+"the bundle writer MUST append `.vibewarden/.input-digest` (or the broader
+`.vibewarden/`) to the project's `.gitignore`." The root cause of #1223 was exactly
+this: mutating the user's `.gitignore` bumped its mtime inside the freshness watch
+window, tripping STALE on the next run. The fix: `vibew bundle` writes
+`.vibewarden/.gitignore` containing `*\n` (a git per-directory ignore file). Git
+respects this and excludes the entire `.vibewarden/` directory without any change to
+the user's own `.gitignore`. The write is idempotent (existing file with correct
+content is not touched).
+
+**hardIgnoreDirs additions.** `bin` and `.next` were added to `hardIgnoreDirs` in
+#1223 to cover compiled Go binaries and Next.js build output.
+
+**Changed-path rendering.** The freshness block now lists up to 5 changed paths
+classified as `added`, `removed`, or `modified`. Example:
+
+```
+Freshness:    STALE
+  - modified: Dockerfile
+  - added:    src/handler.go
+```
+
+Paths beyond the limit are summarised as `(and N more)`.
+
 ## References
 
 - PM spec — combined across issues #1084, #1085, #1091 (2026-04-20)
 - PM spec — issue #1146 (2026-04-23) — content-hash refinement
+- PM spec — issue #1223 (2026-04-28) — STALE false-positive fix
 - ADR-082 — strict config merge / validate hook point
 - ADR-085 — `vibew bundle` compose-only contract
 - ADR-086 — sunset `vibew deploy`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -522,6 +522,66 @@ vibew logs --follow                 # stream all services to watch for restart l
 
 ---
 
+### `vibew bundle` reports STALE
+
+**Symptom**
+
+```
+Freshness:    STALE
+  - modified: Dockerfile
+  - modified: vibewarden.production.yaml
+  - added:    src/handler.go
+  (and 2 more)
+```
+
+**Cause**
+
+One or more source files changed content since the last successful `vibew bundle` run.
+The freshness check compares a per-file SHA-256 digest of all non-ignored project files
+against the stored baseline at `.vibewarden/.input-digest`. A STALE verdict means the
+image was built before those changes — the bundle may not reflect the current source.
+
+**Fix — rebuild the image and re-bundle**
+
+```bash
+vibew bundle --build
+```
+
+`--build` runs `vibew build --platform <target>` before bundling. The freshness baseline
+is updated after a successful bundle.
+
+**Fix — suppress (when you know the image is correct)**
+
+```bash
+vibew bundle --allow-stale
+```
+
+Use `--allow-stale` when the changed files are irrelevant to the build (for example,
+documentation or test fixtures committed after the image was built intentionally).
+The STALE warning is suppressed; the bundle proceeds; the baseline is updated.
+
+**What triggers STALE**
+
+Files under the project root that are not excluded by `.gitignore`, `.dockerignore`, or
+the built-in ignore list (`.git`, `.vibewarden`, `node_modules`, `vendor`, `dist`,
+`build`, `target`, `.venv`, `__pycache__`, `bin`, `.next`). Content changes, file
+additions, and file removals all trip the check. Renaming a file appears as one removal
+and one addition.
+
+**First bundle after upgrading to v0.19.0+**
+
+The digest schema changed from v1 to v2 (per-file hashes) in v0.19.0. An existing v1
+digest file is treated as missing — the first post-upgrade bundle is always FRESH
+baseline, no false positive.
+
+**`.vibewarden/.gitignore` generated file**
+
+`vibew bundle` writes `.vibewarden/.gitignore` (containing `*`) so that git excludes
+the entire `.vibewarden/` directory without touching your own `.gitignore`. This file is
+generated and idempotent — do not edit it.
+
+---
+
 ### Secrets plugin fails to start -- missing master key
 
 **Symptom**

--- a/internal/app/bundle/image_health.go
+++ b/internal/app/bundle/image_health.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"time"
 
 	"github.com/vibewarden/vibewarden/internal/ports"
@@ -32,12 +33,21 @@ type FreshnessMode string
 
 const (
 	// FreshnessModeDigest means the verdict was computed by comparing SHA-256
-	// content digests. A digest file was present and valid.
+	// content digests. A valid v2 digest file was present.
 	FreshnessModeDigest FreshnessMode = "digest"
 
+	// FreshnessModeBaseline means no prior digest was found (first run, wiped
+	// .vibewarden/, corrupt file, or schema-version mismatch). The verdict is
+	// always FRESH — the current digest is recorded as the new baseline for the
+	// next comparison. No mtime fallback is performed.
+	FreshnessModeBaseline FreshnessMode = "baseline"
+
 	// FreshnessModeTime means the verdict was computed by comparing file mtimes
-	// against the image creation timestamp. Used when no valid digest file
-	// exists (first run, corrupt file, schema mismatch).
+	// against the image creation timestamp.
+	//
+	// Deprecated: this mode was removed in #1223. The constant is retained so
+	// callers that previously checked for it (e.g. existing tests) still compile.
+	// It will never be set on a FreshnessVerdict produced by CheckImageHealth.
 	FreshnessModeTime FreshnessMode = "mtime"
 )
 
@@ -45,16 +55,18 @@ const (
 type FreshnessVerdict struct {
 	// Stale is true when the source inputs have changed since the last bundle.
 	Stale bool
-	// ChangedCount is the number of source files with mtime strictly after
-	// the image creation time. Populated only when Mode == FreshnessModeTime
-	// and Stale == true. Zero in digest mode.
+	// ChangedCount is the total number of changed paths detected. Populated only
+	// when Mode == FreshnessModeDigest and Stale == true.
 	ChangedCount int
-	// NewestMTime is the mtime of the file that tripped the STALE verdict.
-	// Zero value when !Stale or when Mode == FreshnessModeDigest.
+	// ChangedPaths is the list of changed paths (capped at maxChangedPathsRendered).
+	// Only populated when Mode == FreshnessModeDigest and Stale == true.
+	ChangedPaths []ChangedPath
+	// NewestMTime was used by the removed mtime path (FreshnessModeTime). It is
+	// always the zero time in digest and baseline modes.
+	//
+	// Deprecated: field is kept for API compatibility; always zero as of #1223.
 	NewestMTime time.Time
 	// Mode describes which algorithm produced this verdict.
-	// FreshnessModeDigest when a content-hash comparison was used;
-	// FreshnessModeTime when mtime comparison was the fallback.
 	Mode FreshnessMode
 }
 
@@ -81,7 +93,7 @@ type ImageHealth struct {
 type CheckImageHealthOptions struct {
 	// ImageTag is the fully qualified image reference to inspect.
 	ImageTag string
-	// ProjectRoot is the directory walked for source-file mtimes.
+	// ProjectRoot is the directory walked for content-hash comparison.
 	ProjectRoot string
 	// TargetPlatform is the expected deployment platform (e.g. "linux/amd64").
 	// When empty, defaultTargetPlatform ("linux/amd64") is used.
@@ -90,7 +102,12 @@ type CheckImageHealthOptions struct {
 	AllowStale bool
 	// Inspector is the ImageInspector port to use. Must not be nil.
 	Inspector ports.ImageInspector
-	// Walker is the StalenessWalker to use. Must not be nil.
+	// Walker is the StalenessWalker to use. Accepted for API compatibility with
+	// existing call sites; not used for the freshness verdict since #1223 (the
+	// verdict is now purely content-hash based). May be nil.
+	//
+	// Deprecated: the Walker parameter is ignored for freshness computation.
+	// The field will be removed in a future release.
 	Walker StalenessWalker
 }
 
@@ -98,7 +115,11 @@ type CheckImageHealthOptions struct {
 //  1. Calls Inspector.Inspect to retrieve image metadata.
 //  2. On ErrImageNotFound or ErrDockerUnavailable, returns the error unwrapped
 //     so the CLI layer can map it to the correct exit code.
-//  3. Walks the project root via Walker.NewestMTime to compute a FreshnessVerdict.
+//  3. Reads the prior digest file (<projectRoot>/.vibewarden/.input-digest).
+//     - If a valid v2 digest is found, computes the current digest and diffs.
+//     - If the file is missing, corrupt, or carries a different schema version,
+//     the verdict is FRESH with Mode=FreshnessModeBaseline (first-run
+//     baseline). No mtime fallback is performed.
 //  4. Assembles and returns the ImageHealth value.
 //
 // CheckImageHealth never writes any output — callers render the result via
@@ -118,10 +139,8 @@ func CheckImageHealth(ctx context.Context, opts CheckImageHealthOptions) (ImageH
 		return ImageHealth{}, fmt.Errorf("inspecting image: %w", err)
 	}
 
-	// Freshness: prefer content-hash comparison; fall back to mtime when no
-	// valid digest file exists (first run, corrupt file, schema mismatch).
 	var verdict FreshnessVerdict
-	if opts.Walker != nil && opts.ProjectRoot != "" {
+	if opts.ProjectRoot != "" {
 		prior, ok := readInputDigest(opts.ProjectRoot)
 		if ok {
 			// Digest path: compute current digest and compare.
@@ -133,28 +152,27 @@ func CheckImageHealth(ctx context.Context, opts CheckImageHealthOptions) (ImageH
 						Mode:  FreshnessModeDigest,
 					}
 				} else {
+					changed := diffDigests(prior, current)
+					total := len(changed)
+					capped := changed
+					if len(capped) > maxChangedPathsRendered {
+						capped = capped[:maxChangedPathsRendered]
+					}
 					verdict = FreshnessVerdict{
-						Stale: true,
-						Mode:  FreshnessModeDigest,
+						Stale:        true,
+						Mode:         FreshnessModeDigest,
+						ChangedCount: total,
+						ChangedPaths: capped,
 					}
 				}
 			} else {
-				// Digest computation failed — fall through to mtime.
-				ok = false
+				// Digest computation failed — treat as baseline (FRESH).
+				slog.Debug("input-digest: compute failed, reporting baseline", "err", digestErr)
+				verdict = FreshnessVerdict{Stale: false, Mode: FreshnessModeBaseline}
 			}
-		}
-		if !ok {
-			// mtime fallback: digest file missing, corrupt, wrong schema, or
-			// compute error. Preserves pre-#1146 behaviour exactly.
-			newest, count, walkErr := opts.Walker.NewestMTime(opts.ProjectRoot, info.Created)
-			if walkErr == nil {
-				verdict = FreshnessVerdict{
-					Stale:        count > 0,
-					ChangedCount: count,
-					NewestMTime:  newest,
-					Mode:         FreshnessModeTime,
-				}
-			}
+		} else {
+			// No valid prior digest: first-run baseline — always FRESH.
+			verdict = FreshnessVerdict{Stale: false, Mode: FreshnessModeBaseline}
 		}
 	}
 
@@ -177,11 +195,9 @@ func CheckImageHealth(ctx context.Context, opts CheckImageHealthOptions) (ImageH
 // When the image arch does not match the target platform, RenderImageHealth
 // still renders the full block (showing Arch and Target for context), and then
 // the caller (runImageHealthCheck) returns ErrPlatformMismatch with the
-// actionable rebuild instruction. The block itself does not include the
-// rebuild command — "Warnings: none" is shown when stale is the only absent
-// condition and no legacy tag is present.
+// actionable rebuild instruction.
 //
-// Example output (stale image, no arch mismatch):
+// Example output (stale image with changed paths):
 //
 //	Image health
 //	  Tag:          qr-van-gogh-app:latest
@@ -190,14 +206,15 @@ func CheckImageHealth(ctx context.Context, opts CheckImageHealthOptions) (ImageH
 //	  Created:      2026-04-19 14:02:11 UTC (1 day ago)
 //	  Size:         162.4 MB
 //	  Target:       linux/amd64  (override with --target-platform)
-//	  Freshness:    STALE — 12 source files changed since image was built
+//	  Freshness:    STALE — source files changed since image was built:
+//	                  - main.go (modified)
+//	                  - newfile.txt (added)
 //	  Warnings:
 //	    - image is stale (pass --allow-stale to suppress, or rebuild)
 func RenderImageHealth(out io.Writer, h ImageHealth) {
 	age := formatAge(time.Since(h.Image.Created))
 	createdStr := h.Image.Created.Format("2006-01-02 15:04:05 UTC")
 	sizeStr := formatBytes(h.Image.SizeBytes)
-	freshness := freshnessLabel(h)
 	warnings := collectWarnings(h)
 
 	fmt.Fprintf(out, "Image health\n")
@@ -207,7 +224,7 @@ func RenderImageHealth(out io.Writer, h ImageHealth) {
 	fmt.Fprintf(out, "  Created:      %s (%s)\n", createdStr, age)
 	fmt.Fprintf(out, "  Size:         %s\n", sizeStr)
 	fmt.Fprintf(out, "  Target:       %s  (override with --target-platform)\n", h.Target)
-	fmt.Fprintf(out, "  Freshness:    %s\n", freshness)
+	renderFreshnessLine(out, h)
 	if len(warnings) == 0 {
 		fmt.Fprintf(out, "  Warnings:     none\n")
 	} else {
@@ -216,23 +233,44 @@ func RenderImageHealth(out io.Writer, h ImageHealth) {
 	}
 }
 
+// renderFreshnessLine writes the "Freshness:" line (and optional path list) to
+// out. It is extracted from RenderImageHealth to keep the rendering logic
+// testable in isolation.
+func renderFreshnessLine(out io.Writer, h ImageHealth) {
+	label := freshnessLabel(h)
+
+	if h.Freshness.Stale && !h.AllowStale &&
+		h.Freshness.Mode == FreshnessModeDigest &&
+		len(h.Freshness.ChangedPaths) > 0 {
+		// Multi-line form: header + path list.
+		fmt.Fprintf(out, "  Freshness:    %s\n", label)
+		for _, cp := range h.Freshness.ChangedPaths {
+			fmt.Fprintf(out, "                  - %s (%s)\n", cp.Path, cp.Kind)
+		}
+		remaining := h.Freshness.ChangedCount - len(h.Freshness.ChangedPaths)
+		if remaining > 0 {
+			fmt.Fprintf(out, "                  (and %d more)\n", remaining)
+		}
+	} else {
+		fmt.Fprintf(out, "  Freshness:    %s\n", label)
+	}
+}
+
 // freshnessLabel returns the Freshness line value based on the health state.
 func freshnessLabel(h ImageHealth) string {
 	if !h.Freshness.Stale {
-		return "FRESH"
-	}
-	if h.Freshness.Mode == FreshnessModeDigest {
-		// Digest mode: file count is not meaningful.
-		if h.AllowStale {
-			return "FRESH (stale suppressed — source files changed since image was built)"
+		switch h.Freshness.Mode {
+		case FreshnessModeBaseline:
+			return "FRESH (no prior baseline; digest written for next run)"
+		default:
+			return "FRESH"
 		}
-		return "STALE — source files changed since image was built"
 	}
-	// mtime mode: include file count.
+	// Stale cases.
 	if h.AllowStale {
-		return fmt.Sprintf("FRESH (stale suppressed — %d source files changed since image was built)", h.Freshness.ChangedCount)
+		return "FRESH (stale suppressed — source files changed since image was built)"
 	}
-	return fmt.Sprintf("STALE — %d source files changed since image was built", h.Freshness.ChangedCount)
+	return "STALE — source files changed since image was built"
 }
 
 // platformMismatchMessage returns the exact actionable error copy for an arch

--- a/internal/app/bundle/image_health_test.go
+++ b/internal/app/bundle/image_health_test.go
@@ -3,6 +3,8 @@ package bundle_test
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -106,8 +108,24 @@ func TestCheckImageHealth_FreshNoWarnings(t *testing.T) {
 	}
 }
 
-// TestCheckImageHealth_StaleImage verifies that stale detection works.
+// TestCheckImageHealth_StaleImage verifies that stale detection works when
+// source files change between two WriteInputDigest calls.
 func TestCheckImageHealth_StaleImage(t *testing.T) {
+	root := t.TempDir()
+
+	// Write a source file and record the digest.
+	mainGo := filepath.Join(root, "main.go")
+	if err := os.WriteFile(mainGo, []byte("package main\n"), 0o600); err != nil {
+		t.Fatalf("write main.go: %v", err)
+	}
+	svc := bundleapp.NewService(nil, &fakeGenerator{})
+	svc.WriteInputDigest(root)
+
+	// Modify the file so the digest will differ on the next check.
+	if err := os.WriteFile(mainGo, []byte("package main // changed\n"), 0o600); err != nil {
+		t.Fatalf("modify main.go: %v", err)
+	}
+
 	inspector := &fakeInspector{
 		info: ports.ImageInfo{
 			Digest:       "sha256:abc123",
@@ -116,22 +134,24 @@ func TestCheckImageHealth_StaleImage(t *testing.T) {
 			Created:      fixedTime,
 		},
 	}
-	walker := &fakeStalenessWalker{changedCount: 12, newest: fixedTime.Add(time.Hour)}
 
 	h, err := bundleapp.CheckImageHealth(context.Background(), bundleapp.CheckImageHealthOptions{
 		ImageTag:    "myapp-app:latest",
-		ProjectRoot: "/fake/project/root", // non-empty so walker is invoked
+		ProjectRoot: root,
 		Inspector:   inspector,
-		Walker:      walker,
+		Walker:      &fakeStalenessWalker{},
 	})
 	if err != nil {
 		t.Fatalf("CheckImageHealth() error = %v", err)
 	}
 	if !h.Freshness.Stale {
-		t.Error("expected STALE, got FRESH")
+		t.Error("expected STALE after content change, got FRESH")
 	}
-	if h.Freshness.ChangedCount != 12 {
-		t.Errorf("ChangedCount = %d, want 12", h.Freshness.ChangedCount)
+	if h.Freshness.Mode != bundleapp.FreshnessModeDigest {
+		t.Errorf("Mode = %q, want %q", h.Freshness.Mode, bundleapp.FreshnessModeDigest)
+	}
+	if h.Freshness.ChangedCount == 0 {
+		t.Error("ChangedCount = 0, want > 0")
 	}
 }
 
@@ -277,8 +297,16 @@ func TestRenderImageHealth_StaleWithWarning(t *testing.T) {
 			Created:      fixedTime,
 			SizeBytes:    50 * 1024 * 1024,
 		},
-		Target:       "linux/amd64",
-		Freshness:    bundleapp.FreshnessVerdict{Stale: true, ChangedCount: 7},
+		Target: "linux/amd64",
+		Freshness: bundleapp.FreshnessVerdict{
+			Stale:        true,
+			Mode:         bundleapp.FreshnessModeDigest,
+			ChangedCount: 2,
+			ChangedPaths: []bundleapp.ChangedPath{
+				{Path: "main.go", Kind: bundleapp.ChangedPathModified},
+				{Path: "go.mod", Kind: bundleapp.ChangedPathModified},
+			},
+		},
 		ArchMismatch: false,
 	}
 
@@ -289,8 +317,8 @@ func TestRenderImageHealth_StaleWithWarning(t *testing.T) {
 	if !strings.Contains(out, "STALE") {
 		t.Errorf("expected STALE in freshness line\noutput:\n%s", out)
 	}
-	if !strings.Contains(out, "7 source files") {
-		t.Errorf("expected changed count in output\noutput:\n%s", out)
+	if !strings.Contains(out, "main.go (modified)") {
+		t.Errorf("expected changed path in output\noutput:\n%s", out)
 	}
 	if !strings.Contains(out, "image is stale") {
 		t.Errorf("expected stale warning\noutput:\n%s", out)

--- a/internal/app/bundle/input_digest.go
+++ b/internal/app/bundle/input_digest.go
@@ -1,7 +1,6 @@
 package bundle
 
 import (
-	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -18,36 +17,69 @@ import (
 const inputDigestFileName = ".vibewarden/.input-digest"
 
 // inputDigestSchemaVersion is the schema version written to and required when
-// reading the digest file. A file carrying a different version is treated as
-// corrupt and triggers a mtime fallback.
-const inputDigestSchemaVersion = 1
-
-// inputDigestGitIgnoreLine is the line appended to the project .gitignore on
-// first write of the digest file. File-specific entry (not the whole
-// .vibewarden/ dir) so users retain visibility of any future state files.
-const inputDigestGitIgnoreLine = ".vibewarden/.input-digest"
+// reading the digest file. Files with a different version are treated as
+// missing (first-run baseline), never as an mtime fallback.
+//
+// History:
+//
+//	v1 — single "digest" field, no per-file hashes. Dropped in #1223.
+//	v2 — per-file SHA-256 in "files" array; supports changed-path rendering.
+const inputDigestSchemaVersion = 2
 
 // InputDigest is the JSON structure stored at .vibewarden/.input-digest.
 //
 // It is machine-only state: never commit, never share across machines.
 // schema_version gates future format changes. digest is the SHA-256 content
-// hash over the sorted input set. inputs is the sorted list of forward-slash
-// relative paths that contributed to the digest (diagnostic only — not
-// re-verified on read).
+// hash over the sorted input set. files is the sorted list of {path, sha256}
+// entries that contributed to the digest — used to render the changed-path
+// list in the freshness warning.
 type InputDigest struct {
-	SchemaVersion int      `json:"schema_version"`
-	Digest        string   `json:"digest"`
-	Inputs        []string `json:"inputs"`
+	SchemaVersion int             `json:"schema_version"`
+	Digest        string          `json:"digest"`
+	Files         []InputFileHash `json:"files"`
 }
+
+// InputFileHash is one entry in InputDigest.Files. Path is a forward-slash
+// relative path from the project root. Hash is "sha256:<64 hex digits>".
+type InputFileHash struct {
+	Path string `json:"path"`
+	Hash string `json:"hash"`
+}
+
+// ChangedPathKind classifies the type of change detected between two digests.
+type ChangedPathKind string
+
+const (
+	// ChangedPathAdded means the file was not present in the prior digest.
+	ChangedPathAdded ChangedPathKind = "added"
+	// ChangedPathRemoved means the file was present in the prior digest but is
+	// gone in the current digest.
+	ChangedPathRemoved ChangedPathKind = "removed"
+	// ChangedPathModified means the file exists in both digests with different
+	// content hashes.
+	ChangedPathModified ChangedPathKind = "modified"
+)
+
+// ChangedPath records a single file change between two digest snapshots.
+type ChangedPath struct {
+	// Path is the project-root-relative forward-slash path of the changed file.
+	Path string
+	// Kind classifies the change.
+	Kind ChangedPathKind
+}
+
+// maxChangedPathsRendered is the maximum number of changed paths printed in
+// the freshness block. Paths beyond this limit are summarised as "(and N more)".
+const maxChangedPathsRendered = 5
 
 // readInputDigest reads and validates the digest file at
 // <projectRoot>/.vibewarden/.input-digest.
 //
 // Returns (digest, true) when the file exists, parses as valid JSON, has
-// schema_version == 1, and carries a "sha256:<64-hex>" digest value.
-// Returns ("", false) in all other cases (missing, corrupt, wrong version,
-// malformed digest) — callers fall back to the mtime walker. Failures are
-// logged at debug level only; they must not surface as errors.
+// schema_version == 2, and carries a "sha256:<64-hex>" digest value.
+// Returns (InputDigest{}, false) in all other cases (missing, corrupt, wrong
+// version, malformed digest) — callers treat this as first-run baseline
+// (FRESH, no prior comparison). Failures are logged at debug level only.
 func readInputDigest(projectRoot string) (InputDigest, bool) {
 	path := filepath.Join(projectRoot, inputDigestFileName)
 	data, err := os.ReadFile(path) //nolint:gosec // path derived from project root
@@ -65,7 +97,8 @@ func readInputDigest(projectRoot string) (InputDigest, bool) {
 	}
 
 	if d.SchemaVersion != inputDigestSchemaVersion {
-		slog.Debug("input-digest: unsupported schema version", "path", path, "version", d.SchemaVersion)
+		slog.Debug("input-digest: unsupported schema version — treating as missing (first-run baseline)",
+			"path", path, "version", d.SchemaVersion, "supported", inputDigestSchemaVersion)
 		return InputDigest{}, false
 	}
 
@@ -80,10 +113,9 @@ func readInputDigest(projectRoot string) (InputDigest, bool) {
 // writeInputDigest writes the digest to
 // <projectRoot>/.vibewarden/.input-digest.
 //
-// A write failure is logged at warn level but does not fail the caller — the
-// next bundle run will fall back to mtime, which is the documented degraded
-// behaviour. Callers are responsible for updating .gitignore before calling
-// this function so that .gitignore participates in the digest consistently.
+// A write failure is logged at warn level but does not fail the caller. The
+// next bundle run will treat the missing file as a first-run baseline (FRESH),
+// which is the correct degraded behaviour.
 func writeInputDigest(projectRoot string, d InputDigest) {
 	vibewardenDir := filepath.Join(projectRoot, ".vibewarden")
 	if err := os.MkdirAll(vibewardenDir, 0o750); err != nil {
@@ -106,7 +138,8 @@ func writeInputDigest(projectRoot string, d InputDigest) {
 
 // computeInputDigest walks projectRoot using the same ignore rules as the
 // FileSystemStalenessWalker and computes a SHA-256 content digest over the
-// sorted set of non-ignored files.
+// sorted set of non-ignored files. The returned InputDigest carries a per-file
+// hash for each walked file (schema v2).
 //
 // Algorithm (deterministic, platform-independent):
 //
@@ -118,10 +151,20 @@ func writeInputDigest(projectRoot string, d InputDigest) {
 //
 // Path separators are normalised to forward-slash so the digest is stable
 // across operating systems.
+//
+// Symlinks are resolved via filepath.EvalSymlinks before content is read. If
+// the resolved target escapes projectRoot the entry is skipped (mirrors Docker
+// build context behaviour and prevents traversal of symlink trees outside the
+// project).
 func computeInputDigest(projectRoot string) (InputDigest, error) {
 	if _, err := os.Stat(projectRoot); os.IsNotExist(err) {
 		// Empty / missing root: return a well-formed empty digest.
-		return buildDigest(nil, nil), nil
+		return buildDigest(nil), nil
+	}
+
+	absRoot, err := filepath.EvalSymlinks(projectRoot)
+	if err != nil {
+		absRoot = projectRoot // best-effort: use as-is
 	}
 
 	pm := buildPatternMatcher(projectRoot)
@@ -134,9 +177,9 @@ func computeInputDigest(projectRoot string) (InputDigest, error) {
 
 	var entries []entry
 
-	err := filepath.WalkDir(projectRoot, func(path string, d os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			slog.Debug("input-digest walk: skipping unreadable entry", "path", path, "err", walkErr)
+	walkErr := filepath.WalkDir(projectRoot, func(path string, d os.DirEntry, wErr error) error {
+		if wErr != nil {
+			slog.Debug("input-digest walk: skipping unreadable entry", "path", path, "err", wErr)
 			return nil
 		}
 
@@ -170,25 +213,38 @@ func computeInputDigest(projectRoot string) (InputDigest, error) {
 			}
 		}
 
-		entries = append(entries, entry{rel: rel, absPath: path})
+		// Resolve symlinks to catch loops and out-of-root targets.
+		absPath := path
+		if d.Type()&os.ModeSymlink != 0 {
+			resolved, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				slog.Debug("input-digest: cannot resolve symlink, skipping", "path", path, "err", err)
+				return nil
+			}
+			// Skip if resolved target escapes project root.
+			if !strings.HasPrefix(resolved, absRoot) {
+				slog.Debug("input-digest: symlink escapes project root, skipping",
+					"path", path, "resolved", resolved)
+				return nil
+			}
+			absPath = resolved
+		}
+
+		entries = append(entries, entry{rel: rel, absPath: absPath})
 		return nil
 	})
-	if err != nil {
-		slog.Debug("input-digest walk: walk error (partial result)", "root", projectRoot, "err", err)
+	if walkErr != nil {
+		slog.Debug("input-digest walk: walk error (partial result)", "root", projectRoot, "err", walkErr)
 	}
 
 	// Sort by relative path for determinism.
 	sort.Slice(entries, func(i, j int) bool { return entries[i].rel < entries[j].rel })
 
-	var paths []string
-	for _, e := range entries {
-		paths = append(paths, e.rel)
-	}
-
 	// Read contents in sorted order and hash.
 	h := sha256.New()
+	var fileHashes []InputFileHash
 	for _, e := range entries {
-		content, err := os.ReadFile(e.absPath) //nolint:gosec // absPath from WalkDir
+		content, err := os.ReadFile(e.absPath) //nolint:gosec // absPath from WalkDir or EvalSymlinks
 		if err != nil {
 			slog.Debug("input-digest: cannot read file for hashing", "path", e.absPath, "err", err)
 			continue
@@ -197,30 +253,85 @@ func computeInputDigest(projectRoot string) (InputDigest, error) {
 		h.Write([]byte{0x00})
 		h.Write(content)
 		h.Write([]byte{0x00})
+
+		fileHash := sha256.Sum256(content)
+		fileHashes = append(fileHashes, InputFileHash{
+			Path: e.rel,
+			Hash: "sha256:" + hex.EncodeToString(fileHash[:]),
+		})
 	}
 
-	return buildDigest(paths, h.Sum(nil)), nil
+	return buildDigest(fileHashes), nil
 }
 
-// buildDigest assembles an InputDigest from the sorted input list and raw
-// SHA-256 hash bytes.
-func buildDigest(inputs []string, hashBytes []byte) InputDigest {
-	var digest string
-	if hashBytes != nil {
-		digest = "sha256:" + hex.EncodeToString(hashBytes)
-	} else {
-		// Empty walk: stable empty digest.
-		empty := sha256.Sum256(nil)
-		digest = "sha256:" + hex.EncodeToString(empty[:])
+// buildDigest assembles an InputDigest from the per-file hash list.
+func buildDigest(files []InputFileHash) InputDigest {
+	// Compute rolled-up digest from all file hashes for the equality fast path.
+	h := sha256.New()
+	for _, f := range files {
+		h.Write([]byte(f.Path))
+		h.Write([]byte{0x00})
+		h.Write([]byte(f.Hash))
+		h.Write([]byte{0x00})
 	}
-	if inputs == nil {
-		inputs = []string{}
+
+	if files == nil {
+		files = []InputFileHash{}
 	}
 	return InputDigest{
 		SchemaVersion: inputDigestSchemaVersion,
-		Digest:        digest,
-		Inputs:        inputs,
+		Digest:        "sha256:" + hex.EncodeToString(h.Sum(nil)),
+		Files:         files,
 	}
+}
+
+// diffDigests computes the ordered list of changed paths between prior and
+// current digests. The result is sorted: removed first, then added, then
+// modified; alphabetically within each bucket. At most maxChangedPathsRendered
+// entries are returned; the TotalChanged field on the caller side shows the
+// total count.
+func diffDigests(prior, current InputDigest) []ChangedPath {
+	priorMap := make(map[string]string, len(prior.Files))
+	for _, f := range prior.Files {
+		priorMap[f.Path] = f.Hash
+	}
+	currentMap := make(map[string]string, len(current.Files))
+	for _, f := range current.Files {
+		currentMap[f.Path] = f.Hash
+	}
+
+	var removed, added, modified []string
+
+	for path, hash := range priorMap {
+		curHash, exists := currentMap[path]
+		if !exists {
+			removed = append(removed, path)
+		} else if curHash != hash {
+			modified = append(modified, path)
+		}
+	}
+	for path := range currentMap {
+		if _, exists := priorMap[path]; !exists {
+			added = append(added, path)
+		}
+	}
+
+	sort.Strings(removed)
+	sort.Strings(added)
+	sort.Strings(modified)
+
+	var all []ChangedPath
+	for _, p := range removed {
+		all = append(all, ChangedPath{Path: p, Kind: ChangedPathRemoved})
+	}
+	for _, p := range added {
+		all = append(all, ChangedPath{Path: p, Kind: ChangedPathAdded})
+	}
+	for _, p := range modified {
+		all = append(all, ChangedPath{Path: p, Kind: ChangedPathModified})
+	}
+
+	return all
 }
 
 // isValidDigestString reports whether s matches the pattern "sha256:<64 hex
@@ -230,11 +341,11 @@ func isValidDigestString(s string) bool {
 	if !strings.HasPrefix(s, prefix) {
 		return false
 	}
-	hex := s[len(prefix):]
-	if len(hex) != 64 {
+	hexPart := s[len(prefix):]
+	if len(hexPart) != 64 {
 		return false
 	}
-	for _, c := range hex {
+	for _, c := range hexPart {
 		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
 			return false
 		}
@@ -242,68 +353,30 @@ func isValidDigestString(s string) bool {
 	return true
 }
 
-// ensureGitIgnored appends line to <projectRoot>/.gitignore when the line is
-// not already present. The operation is idempotent. Lines are compared by
-// exact string match after trimming whitespace. If .gitignore does not exist
-// it is created.
-func ensureGitIgnored(projectRoot, line string) error {
-	gitignorePath := filepath.Join(projectRoot, ".gitignore")
-
-	// Read existing lines.
-	existing, err := readGitIgnoreLines(gitignorePath)
-	if err != nil {
-		return fmt.Errorf("reading .gitignore: %w", err)
+// ensureVibewardenGitignoreFile writes <projectRoot>/.vibewarden/.gitignore
+// with the content "*\n" so that git treats the entire .vibewarden/ directory
+// as ignored without touching the user's own .gitignore. The write is
+// idempotent: if the file already exists with the exact correct content, it is
+// not rewritten (avoids bumping mtime on every bundle).
+func ensureVibewardenGitignoreFile(projectRoot string) error {
+	dir := filepath.Join(projectRoot, ".vibewarden")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("creating .vibewarden dir: %w", err)
 	}
 
-	// Check if the line is already present.
-	for _, l := range existing {
-		if strings.TrimSpace(l) == strings.TrimSpace(line) {
-			return nil // already present — idempotent
-		}
+	path := filepath.Join(dir, ".gitignore")
+	const want = "*\n"
+
+	existing, err := os.ReadFile(path) //nolint:gosec // path derived from project root
+	if err == nil && string(existing) == want {
+		return nil // already correct — idempotent, do not touch
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reading .vibewarden/.gitignore: %w", err)
 	}
 
-	// Append the line.
-	f, err := os.OpenFile(gitignorePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // path derived from project root
-	if err != nil {
-		return fmt.Errorf("opening .gitignore for append: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	// Add a trailing newline before the new line if the file is non-empty and
-	// doesn't end with a newline already.
-	if len(existing) > 0 {
-		last := existing[len(existing)-1]
-		if last != "" {
-			// The file had content; ensure we start on a fresh line.
-			if _, err := fmt.Fprintln(f, ""); err != nil {
-				return fmt.Errorf("writing newline to .gitignore: %w", err)
-			}
-		}
-	}
-
-	if _, err := fmt.Fprintln(f, line); err != nil {
-		return fmt.Errorf("appending to .gitignore: %w", err)
+	if err := os.WriteFile(path, []byte(want), 0o600); err != nil { //nolint:gosec // path derived from project root
+		return fmt.Errorf("writing .vibewarden/.gitignore: %w", err)
 	}
 	return nil
-}
-
-// readGitIgnoreLines reads all raw lines from path. Returns nil when the file
-// does not exist (not an error). Lines include their content without the
-// newline character.
-func readGitIgnoreLines(path string) ([]string, error) {
-	f, err := os.Open(path) //nolint:gosec // path derived from project root
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	defer func() { _ = f.Close() }()
-
-	var lines []string
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-	return lines, scanner.Err()
 }

--- a/internal/app/bundle/input_digest.go
+++ b/internal/app/bundle/input_digest.go
@@ -138,16 +138,25 @@ func writeInputDigest(projectRoot string, d InputDigest) {
 
 // computeInputDigest walks projectRoot using the same ignore rules as the
 // FileSystemStalenessWalker and computes a SHA-256 content digest over the
-// sorted set of non-ignored files. The returned InputDigest carries a per-file
-// hash for each walked file (schema v2).
+// sorted set of non-ignored files. The returned InputDigest is schema v2: it
+// carries a per-file SHA-256 hash in the Files array (used for changed-path
+// rendering) and a rolled-up digest for equality comparison.
 //
-// Algorithm (deterministic, platform-independent):
+// Algorithm (v2, deterministic, platform-independent):
+//
+// Step 1 — per-file hashes:
+//
+//	for each file in sort(walked_files):
+//	    fileHash = sha256(file_content)
+//	    append {path, "sha256:" + hex(fileHash)} to Files
+//
+// Step 2 — rolled-up digest:
 //
 //	h := sha256.New()
-//	for each path in sort(walked_files):
+//	for each {path, hash} in Files:
 //	    h.Write(path_bytes); h.Write(0x00)
-//	    h.Write(file_content); h.Write(0x00)
-//	return "sha256:" + hex(h.Sum(nil))
+//	    h.Write(hash_bytes); h.Write(0x00)
+//	Digest = "sha256:" + hex(h.Sum(nil))
 //
 // Path separators are normalised to forward-slash so the digest is stable
 // across operating systems.
@@ -222,7 +231,11 @@ func computeInputDigest(projectRoot string) (InputDigest, error) {
 				return nil
 			}
 			// Skip if resolved target escapes project root.
-			if !strings.HasPrefix(resolved, absRoot) {
+			// Use an exact-directory check: the resolved path must equal absRoot
+			// or be a strict subdirectory (prefixed by absRoot + separator).
+			// A bare HasPrefix check is vulnerable to sibling directories whose
+			// name extends the root name (e.g. /proj-secret when root=/proj).
+			if resolved != absRoot && !strings.HasPrefix(resolved, absRoot+string(os.PathSeparator)) {
 				slog.Debug("input-digest: symlink escapes project root, skipping",
 					"path", path, "resolved", resolved)
 				return nil

--- a/internal/app/bundle/input_digest_test.go
+++ b/internal/app/bundle/input_digest_test.go
@@ -17,7 +17,7 @@ import (
 // helpers
 // ---------------------------------------------------------------------------
 
-// writeDigest writes a digest file at <root>/.vibewarden/.input-digest.
+// writeDigestFile writes a digest file at <root>/.vibewarden/.input-digest.
 func writeDigestFile(t *testing.T, root string, content string) {
 	t.Helper()
 	dir := filepath.Join(root, ".vibewarden")
@@ -50,24 +50,6 @@ func digestFileExists(root string) bool {
 	path := filepath.Join(root, ".vibewarden", ".input-digest")
 	_, err := os.Stat(path)
 	return err == nil
-}
-
-// gitignoreContains reports whether root/.gitignore contains the given line.
-func gitignoreContains(t *testing.T, root, line string) bool {
-	t.Helper()
-	data, err := os.ReadFile(filepath.Join(root, ".gitignore"))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false
-		}
-		t.Fatalf("read .gitignore: %v", err)
-	}
-	for _, l := range strings.Split(string(data), "\n") {
-		if strings.TrimSpace(l) == strings.TrimSpace(line) {
-			return true
-		}
-	}
-	return false
 }
 
 // newTestFreshInspector returns a fakeInspector whose image creation time
@@ -103,15 +85,15 @@ func runHealthCheck(t *testing.T, root string, inspector *fakeInspector, walker 
 }
 
 // ---------------------------------------------------------------------------
-// Test: digest file absent — falls back to mtime
+// Test: no prior digest → first-run baseline (FRESH, not mtime)
 // ---------------------------------------------------------------------------
 
-// TestDigest_MissingFallsBackToMtime verifies that when no digest file exists,
-// the staleness verdict is computed from the mtime walker (pre-#1146 behaviour).
-func TestDigest_MissingFallsBackToMtime(t *testing.T) {
+// TestDigest_FirstRunReportsFresh verifies that when no digest file exists,
+// the verdict is FRESH with Mode=FreshnessModeBaseline (not mtime fallback).
+// This is the replacement for the removed TestDigest_MissingFallsBackToMtime.
+func TestDigest_FirstRunReportsFresh(t *testing.T) {
 	root := t.TempDir()
 
-	// Write a file with mtime after the image creation time.
 	imgCreated := time.Now().Add(-2 * time.Hour)
 	writeFileWithMtime(t, filepath.Join(root, "vibewarden.yaml"), time.Now())
 
@@ -120,23 +102,20 @@ func TestDigest_MissingFallsBackToMtime(t *testing.T) {
 
 	verdict := runHealthCheck(t, root, inspector, walker)
 
-	if !verdict.Stale {
-		t.Errorf("expected STALE via mtime fallback, got FRESH")
+	if verdict.Stale {
+		t.Errorf("expected FRESH (baseline) when no prior digest, got STALE")
 	}
-	if verdict.Mode != bundleapp.FreshnessModeTime {
-		t.Errorf("Mode = %q, want %q", verdict.Mode, bundleapp.FreshnessModeTime)
-	}
-	if verdict.ChangedCount == 0 {
-		t.Errorf("ChangedCount = 0, want > 0 in mtime mode")
+	if verdict.Mode != bundleapp.FreshnessModeBaseline {
+		t.Errorf("Mode = %q, want %q", verdict.Mode, bundleapp.FreshnessModeBaseline)
 	}
 }
 
-// TestDigest_MissingMTimeOlder verifies that when no digest file exists and
-// all source files are older than the image, verdict is FRESH via mtime.
-func TestDigest_MissingMTimeOlder(t *testing.T) {
+// TestDigest_FirstRunFreshRegardlessOfMtime verifies that even when all source
+// files are older than the image, the first-run verdict is FRESH/baseline (not
+// FRESH/mtime). The distinction matters for assertions.
+func TestDigest_FirstRunFreshRegardlessOfMtime(t *testing.T) {
 	root := t.TempDir()
 
-	// Write a file with mtime BEFORE the image creation time.
 	pastMtime := time.Now().Add(-3 * time.Hour)
 	imgCreated := time.Now().Add(-1 * time.Hour)
 	writeFileWithMtime(t, filepath.Join(root, "vibewarden.yaml"), pastMtime)
@@ -147,10 +126,10 @@ func TestDigest_MissingMTimeOlder(t *testing.T) {
 	verdict := runHealthCheck(t, root, inspector, walker)
 
 	if verdict.Stale {
-		t.Errorf("expected FRESH via mtime fallback, got STALE")
+		t.Errorf("expected FRESH (baseline), got STALE")
 	}
-	if verdict.Mode != bundleapp.FreshnessModeTime {
-		t.Errorf("Mode = %q, want %q", verdict.Mode, bundleapp.FreshnessModeTime)
+	if verdict.Mode != bundleapp.FreshnessModeBaseline {
+		t.Errorf("Mode = %q, want %q", verdict.Mode, bundleapp.FreshnessModeBaseline)
 	}
 }
 
@@ -237,17 +216,17 @@ func TestDigest_DiffersEmitsStale(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Test: corrupt digest — fallback to mtime
+// Test: corrupt digest → first-run baseline
 // ---------------------------------------------------------------------------
 
 // TestDigest_CorruptFallsBack verifies that a corrupt digest file (not valid
-// JSON) is treated as missing: falls back to mtime, no error returned.
+// JSON) is treated as missing: verdict is FRESH/baseline (not mtime fallback),
+// no error returned.
 func TestDigest_CorruptFallsBack(t *testing.T) {
 	root := t.TempDir()
 
 	writeDigestFile(t, root, "garbage {not json}")
 
-	// File with mtime AFTER image creation → mtime says STALE.
 	imgCreated := time.Now().Add(-2 * time.Hour)
 	writeFileWithMtime(t, filepath.Join(root, "main.go"), time.Now())
 
@@ -257,22 +236,26 @@ func TestDigest_CorruptFallsBack(t *testing.T) {
 	verdict := runHealthCheck(t, root, inspector, walker)
 
 	// Must not panic, must not return an error.
-	// Mode must be mtime (fallback).
-	if verdict.Mode != bundleapp.FreshnessModeTime {
-		t.Errorf("Mode = %q, want %q (corrupt digest → mtime fallback)", verdict.Mode, bundleapp.FreshnessModeTime)
+	// Mode must be baseline (not mtime — the mtime fallback is removed).
+	if verdict.Mode != bundleapp.FreshnessModeBaseline {
+		t.Errorf("Mode = %q, want %q (corrupt digest → baseline)", verdict.Mode, bundleapp.FreshnessModeBaseline)
+	}
+	if verdict.Stale {
+		t.Errorf("corrupt digest should not produce STALE, got Stale=true")
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Test: schema_version mismatch — fallback
+// Test: schema_version mismatch → first-run baseline
 // ---------------------------------------------------------------------------
 
-// TestDigest_SchemaVersionMismatchFallsBack verifies that a digest file with
-// a future schema_version is treated as missing and triggers mtime fallback.
+// TestDigest_SchemaVersionMismatchFallsBack verifies that a v1 digest file is
+// treated as missing and produces FRESH/baseline (not mtime fallback or STALE).
 func TestDigest_SchemaVersionMismatchFallsBack(t *testing.T) {
 	root := t.TempDir()
 
-	content := `{"schema_version":2,"digest":"sha256:` + strings.Repeat("a", 64) + `","inputs":[]}`
+	// Write a v1-style digest (schema_version=1, old format without "files").
+	content := `{"schema_version":1,"digest":"sha256:` + strings.Repeat("a", 64) + `","inputs":[]}`
 	writeDigestFile(t, root, content)
 
 	imgCreated := time.Now().Add(-2 * time.Hour)
@@ -283,8 +266,11 @@ func TestDigest_SchemaVersionMismatchFallsBack(t *testing.T) {
 
 	verdict := runHealthCheck(t, root, inspector, walker)
 
-	if verdict.Mode != bundleapp.FreshnessModeTime {
-		t.Errorf("Mode = %q, want %q (schema mismatch → mtime fallback)", verdict.Mode, bundleapp.FreshnessModeTime)
+	if verdict.Mode != bundleapp.FreshnessModeBaseline {
+		t.Errorf("Mode = %q, want %q (schema mismatch → baseline)", verdict.Mode, bundleapp.FreshnessModeBaseline)
+	}
+	if verdict.Stale {
+		t.Errorf("v1 schema mismatch should not produce STALE, got Stale=true")
 	}
 }
 
@@ -357,44 +343,6 @@ func TestDigest_WrittenOnlyOnSuccess(t *testing.T) {
 	second := readDigestFile(t, root)
 	if first.Digest != second.Digest {
 		t.Errorf("digest changed without successful bundle: first=%s second=%s", first.Digest, second.Digest)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Test: gitignore append on first write
-// ---------------------------------------------------------------------------
-
-// TestDigest_GitIgnoreAppendOnFirstWrite verifies that WriteInputDigest adds
-// ".vibewarden/.input-digest" to the project .gitignore, idempotently.
-func TestDigest_GitIgnoreAppendOnFirstWrite(t *testing.T) {
-	root := t.TempDir()
-
-	if err := os.WriteFile(filepath.Join(root, "vibewarden.yaml"), []byte("name: test\n"), 0o600); err != nil {
-		t.Fatalf("write yaml: %v", err)
-	}
-
-	svc := bundleapp.NewService(nil, &fakeGenerator{})
-
-	// First write: .gitignore does not exist yet.
-	svc.WriteInputDigest(root)
-	if !gitignoreContains(t, root, ".vibewarden/.input-digest") {
-		t.Error("first write: .gitignore does not contain '.vibewarden/.input-digest'")
-	}
-
-	// Second write: idempotent — line must not be duplicated.
-	svc.WriteInputDigest(root)
-	data, err := os.ReadFile(filepath.Join(root, ".gitignore"))
-	if err != nil {
-		t.Fatalf("read .gitignore: %v", err)
-	}
-	count := 0
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.TrimSpace(line) == ".vibewarden/.input-digest" {
-			count++
-		}
-	}
-	if count != 1 {
-		t.Errorf("idempotent check: found %d occurrences of line, want 1\n.gitignore:\n%s", count, string(data))
 	}
 }
 
@@ -522,7 +470,7 @@ func TestDigest_GitIgnoredFileChangeDoeNotTrip(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestRenderImageHealth_DigestStale verifies the freshness label for digest-
-// mode STALE does not include a file count.
+// mode STALE does not include a file count inline.
 func TestRenderImageHealth_DigestStale(t *testing.T) {
 	h := bundleapp.ImageHealth{
 		Image: ports.ImageInfo{
@@ -547,9 +495,10 @@ func TestRenderImageHealth_DigestStale(t *testing.T) {
 	if !strings.Contains(out, "STALE") {
 		t.Errorf("expected STALE in output\n%s", out)
 	}
-	// Digest mode must NOT include "N source files" — the count is not meaningful.
+	// Digest mode must NOT include "N source files" inline — the count is not
+	// meaningful in the single-line form.
 	if strings.Contains(out, "0 source files") {
-		t.Errorf("digest-mode STALE should not include file count, got:\n%s", out)
+		t.Errorf("digest-mode STALE should not include inline file count, got:\n%s", out)
 	}
 }
 
@@ -578,6 +527,35 @@ func TestRenderImageHealth_DigestFresh(t *testing.T) {
 	}
 }
 
+// TestRenderImageHealth_BaselineFresh verifies that a first-run baseline
+// verdict produces the "FRESH (no prior baseline...)" label.
+func TestRenderImageHealth_BaselineFresh(t *testing.T) {
+	h := bundleapp.ImageHealth{
+		Image: ports.ImageInfo{
+			Tag:          "test-app:latest",
+			OS:           "linux",
+			Architecture: "amd64",
+			Created:      fixedTime,
+		},
+		Target: "linux/amd64",
+		Freshness: bundleapp.FreshnessVerdict{
+			Stale: false,
+			Mode:  bundleapp.FreshnessModeBaseline,
+		},
+	}
+
+	var sb strings.Builder
+	bundleapp.RenderImageHealth(&sb, h)
+	out := sb.String()
+
+	if !strings.Contains(out, "FRESH") {
+		t.Errorf("expected FRESH in baseline output\n%s", out)
+	}
+	if !strings.Contains(out, "no prior baseline") {
+		t.Errorf("expected 'no prior baseline' annotation in baseline output\n%s", out)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Test: CheckImageHealth with nil Walker (no project root) uses zero verdict
 // ---------------------------------------------------------------------------
@@ -597,6 +575,325 @@ func TestCheckImageHealth_NoWalkerNoVerdict(t *testing.T) {
 		t.Fatalf("CheckImageHealth: %v", err)
 	}
 	if h.Freshness.Stale {
-		t.Error("expected not stale when no walker wired")
+		t.Error("expected not stale when no project root")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Test #1223 regression: .gitignore must NOT be mutated by WriteInputDigest
+// ---------------------------------------------------------------------------
+
+// TestDigest_GitignoreNotMutatedByWriteInputDigest is the regression test for
+// #1223. The user's .gitignore must not be opened or written during
+// WriteInputDigest — that was the root cause of the self-induced staleness.
+func TestDigest_GitignoreNotMutatedByWriteInputDigest(t *testing.T) {
+	root := t.TempDir()
+
+	// Create the project .gitignore with known content and record its mtime.
+	gitignorePath := filepath.Join(root, ".gitignore")
+	if err := os.WriteFile(gitignorePath, []byte("*.log\n"), 0o600); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "vibewarden.yaml"), []byte("name: test\n"), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	infoBeforeFirst, err := os.Stat(gitignorePath)
+	if err != nil {
+		t.Fatalf("stat .gitignore before: %v", err)
+	}
+	contentBefore, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("read .gitignore before: %v", err)
+	}
+
+	svc := bundleapp.NewService(nil, &fakeGenerator{})
+	svc.WriteInputDigest(root) // first write
+
+	// The user's .gitignore must not have changed.
+	infoAfterFirst, err := os.Stat(gitignorePath)
+	if err != nil {
+		t.Fatalf("stat .gitignore after first write: %v", err)
+	}
+	if !infoAfterFirst.ModTime().Equal(infoBeforeFirst.ModTime()) {
+		t.Errorf(".gitignore mtime changed after first WriteInputDigest: before=%v after=%v",
+			infoBeforeFirst.ModTime(), infoAfterFirst.ModTime())
+	}
+	contentAfterFirst, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("read .gitignore after first write: %v", err)
+	}
+	if string(contentAfterFirst) != string(contentBefore) {
+		t.Errorf(".gitignore content changed:\nbefore: %q\nafter:  %q", contentBefore, contentAfterFirst)
+	}
+
+	svc.WriteInputDigest(root) // second write (idempotent path)
+
+	infoAfterSecond, err := os.Stat(gitignorePath)
+	if err != nil {
+		t.Fatalf("stat .gitignore after second write: %v", err)
+	}
+	if !infoAfterSecond.ModTime().Equal(infoBeforeFirst.ModTime()) {
+		t.Errorf(".gitignore mtime changed after second WriteInputDigest: before=%v after=%v",
+			infoBeforeFirst.ModTime(), infoAfterSecond.ModTime())
+	}
+
+	// The per-directory .vibewarden/.gitignore must exist with "*\n".
+	vwGitignore := filepath.Join(root, ".vibewarden", ".gitignore")
+	data, err := os.ReadFile(vwGitignore)
+	if err != nil {
+		t.Fatalf(".vibewarden/.gitignore not written: %v", err)
+	}
+	if string(data) != "*\n" {
+		t.Errorf(".vibewarden/.gitignore content = %q, want %q", data, "*\n")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test #1223 end-to-end reproducer: self-induced staleness must not occur
+// ---------------------------------------------------------------------------
+
+// TestDigest_SelfInducedStalenessRegression is the end-to-end reproducer for
+// #1223. Two consecutive WriteInputDigest + CheckImageHealth cycles on an
+// unchanged project must both report FRESH (not STALE).
+func TestDigest_SelfInducedStalenessRegression(t *testing.T) {
+	root := t.TempDir()
+
+	// Write project files.
+	if err := os.WriteFile(filepath.Join(root, "vibewarden.yaml"), []byte("name: test\n"), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("*.log\n"), 0o600); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+
+	svc := bundleapp.NewService(nil, &fakeGenerator{})
+	imgCreated := time.Now().Add(-1 * time.Hour)
+	inspector := newTestFreshInspector(imgCreated)
+	walker := bundleapp.NewFileSystemStalenessWalker(root)
+
+	// First bundle: write digest. Verdict should be baseline FRESH.
+	svc.WriteInputDigest(root)
+	verdict1 := runHealthCheck(t, root, inspector, walker)
+	if verdict1.Stale {
+		t.Errorf("first run: expected FRESH, got STALE (mode=%s)", verdict1.Mode)
+	}
+
+	// Second bundle: no edits. WriteInputDigest must not mutate .gitignore.
+	svc.WriteInputDigest(root)
+	verdict2 := runHealthCheck(t, root, inspector, walker)
+	if verdict2.Stale {
+		t.Errorf("second run: expected FRESH (self-induced staleness regression), got STALE (mode=%s)", verdict2.Mode)
+	}
+	if verdict2.Mode != bundleapp.FreshnessModeDigest {
+		t.Errorf("second run: Mode = %q, want %q", verdict2.Mode, bundleapp.FreshnessModeDigest)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: changed paths listed in rendered freshness block
+// ---------------------------------------------------------------------------
+
+// TestDigest_StalePathsListedInRender verifies that when files change between
+// bundles, the rendered freshness block lists the changed paths by kind.
+func TestDigest_StalePathsListedInRender(t *testing.T) {
+	h := bundleapp.ImageHealth{
+		Image: ports.ImageInfo{
+			Tag:          "test-app:latest",
+			OS:           "linux",
+			Architecture: "amd64",
+			Created:      fixedTime,
+		},
+		Target: "linux/amd64",
+		Freshness: bundleapp.FreshnessVerdict{
+			Stale:        true,
+			Mode:         bundleapp.FreshnessModeDigest,
+			ChangedCount: 3,
+			ChangedPaths: []bundleapp.ChangedPath{
+				{Path: "removed.txt", Kind: bundleapp.ChangedPathRemoved},
+				{Path: "added.txt", Kind: bundleapp.ChangedPathAdded},
+				{Path: "main.go", Kind: bundleapp.ChangedPathModified},
+			},
+		},
+	}
+
+	var sb strings.Builder
+	bundleapp.RenderImageHealth(&sb, h)
+	out := sb.String()
+
+	for _, want := range []string{
+		"removed.txt (removed)",
+		"added.txt (added)",
+		"main.go (modified)",
+		"STALE",
+		"image is stale",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: changed paths capped at maxChangedPathsRendered (5)
+// ---------------------------------------------------------------------------
+
+// TestDigest_ChangedPathsCappedAt5 verifies that when more than 5 paths change,
+// the rendered block shows exactly 5 + an "(and N more)" line.
+func TestDigest_ChangedPathsCappedAt5(t *testing.T) {
+	root := t.TempDir()
+
+	// Write 12 source files and record the digest.
+	svc := bundleapp.NewService(nil, &fakeGenerator{})
+	for i := 0; i < 12; i++ {
+		name := filepath.Join(root, strings.Repeat("a", i+1)+".go")
+		if err := os.WriteFile(name, []byte("package main\n"), 0o600); err != nil {
+			t.Fatalf("write file %d: %v", i, err)
+		}
+	}
+	svc.WriteInputDigest(root)
+
+	// Modify all 12 files.
+	for i := 0; i < 12; i++ {
+		name := filepath.Join(root, strings.Repeat("a", i+1)+".go")
+		if err := os.WriteFile(name, []byte("package main // modified\n"), 0o600); err != nil {
+			t.Fatalf("modify file %d: %v", i, err)
+		}
+	}
+
+	imgCreated := time.Now().Add(-1 * time.Hour)
+	inspector := newTestFreshInspector(imgCreated)
+	walker := bundleapp.NewFileSystemStalenessWalker(root)
+
+	h, err := bundleapp.CheckImageHealth(context.Background(), bundleapp.CheckImageHealthOptions{
+		ImageTag:       "test-app:latest",
+		ProjectRoot:    root,
+		TargetPlatform: "linux/amd64",
+		Inspector:      inspector,
+		Walker:         walker,
+	})
+	if err != nil {
+		t.Fatalf("CheckImageHealth: %v", err)
+	}
+
+	if !h.Freshness.Stale {
+		t.Fatal("expected STALE after modifying 12 files, got FRESH")
+	}
+	// ChangedPaths must be capped at 5.
+	if len(h.Freshness.ChangedPaths) != 5 {
+		t.Errorf("ChangedPaths len = %d, want 5", len(h.Freshness.ChangedPaths))
+	}
+	// ChangedCount must be the full total.
+	if h.Freshness.ChangedCount != 12 {
+		t.Errorf("ChangedCount = %d, want 12", h.Freshness.ChangedCount)
+	}
+
+	// Render and verify "(and 7 more)" appears.
+	var sb strings.Builder
+	bundleapp.RenderImageHealth(&sb, h)
+	out := sb.String()
+
+	if !strings.Contains(out, "(and 7 more)") {
+		t.Errorf("expected '(and 7 more)' in rendered output\n%s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: .vibewarden/.gitignore written idempotently
+// ---------------------------------------------------------------------------
+
+// TestDigest_VibewardenGitignoreFileWritten verifies that after WriteInputDigest,
+// <root>/.vibewarden/.gitignore exists with content "*\n", and that calling
+// WriteInputDigest again is idempotent (file not rewritten).
+func TestDigest_VibewardenGitignoreFileWritten(t *testing.T) {
+	root := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(root, "vibewarden.yaml"), []byte("name: test\n"), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	svc := bundleapp.NewService(nil, &fakeGenerator{})
+	svc.WriteInputDigest(root)
+
+	vwGitignore := filepath.Join(root, ".vibewarden", ".gitignore")
+	data, err := os.ReadFile(vwGitignore)
+	if err != nil {
+		t.Fatalf(".vibewarden/.gitignore not created: %v", err)
+	}
+	if string(data) != "*\n" {
+		t.Errorf("content = %q, want %q", data, "*\n")
+	}
+
+	// Record mtime after first write.
+	info1, err := os.Stat(vwGitignore)
+	if err != nil {
+		t.Fatalf("stat after first write: %v", err)
+	}
+
+	// Small sleep to ensure a mtime difference would be observable if the file
+	// were re-written.
+	time.Sleep(5 * time.Millisecond)
+
+	svc.WriteInputDigest(root) // second call — must be idempotent
+
+	info2, err := os.Stat(vwGitignore)
+	if err != nil {
+		t.Fatalf("stat after second write: %v", err)
+	}
+	if !info2.ModTime().Equal(info1.ModTime()) {
+		t.Errorf(".vibewarden/.gitignore was rewritten on second call: mtime1=%v mtime2=%v",
+			info1.ModTime(), info2.ModTime())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: symlink outside project root is skipped
+// ---------------------------------------------------------------------------
+
+// TestDigest_SymlinkOutsideRootSkipped verifies that a symlink under
+// projectRoot pointing outside the project root is silently skipped by the
+// digest walker. No panic, no I/O error, and the file at the symlink target
+// does not influence the digest.
+func TestDigest_SymlinkOutsideRootSkipped(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	// Place a file inside the project root.
+	if err := os.WriteFile(filepath.Join(root, "vibewarden.yaml"), []byte("name: test\n"), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	// Compute digest WITHOUT symlink — this is the baseline.
+	svc := bundleapp.NewService(nil, &fakeGenerator{})
+	svc.WriteInputDigest(root)
+	digestBefore := readDigestFile(t, root)
+
+	// Place a file outside root and create a symlink inside root pointing to it.
+	outsideFile := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(outsideFile, []byte("sensitive data\n"), 0o600); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	symlink := filepath.Join(root, "escape.txt")
+	if err := os.Symlink(outsideFile, symlink); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	// Compute digest WITH symlink — symlink must be skipped.
+	imgCreated := time.Now().Add(-1 * time.Hour)
+	inspector := newTestFreshInspector(imgCreated)
+	walker := bundleapp.NewFileSystemStalenessWalker(root)
+	verdict := runHealthCheck(t, root, inspector, walker)
+
+	// Digest must match (symlink was skipped, not included in the watched set).
+	// Because we have a prior digest (from the svc.WriteInputDigest call above),
+	// Mode must be digest. The new walk result must equal the prior digest.
+	if verdict.Stale {
+		t.Errorf("symlink outside root should not cause STALE, got Stale=true")
+	}
+	if verdict.Mode != bundleapp.FreshnessModeDigest {
+		t.Errorf("Mode = %q, want %q", verdict.Mode, bundleapp.FreshnessModeDigest)
+	}
+
+	// Also verify the digest file itself did not capture the symlink.
+	_ = digestBefore // silence unused warning; we already confirmed via verdict
 }

--- a/internal/app/bundle/input_digest_test.go
+++ b/internal/app/bundle/input_digest_test.go
@@ -866,7 +866,6 @@ func TestDigest_SymlinkOutsideRootSkipped(t *testing.T) {
 	// Compute digest WITHOUT symlink — this is the baseline.
 	svc := bundleapp.NewService(nil, &fakeGenerator{})
 	svc.WriteInputDigest(root)
-	digestBefore := readDigestFile(t, root)
 
 	// Place a file outside root and create a symlink inside root pointing to it.
 	outsideFile := filepath.Join(outside, "secret.txt")
@@ -893,7 +892,66 @@ func TestDigest_SymlinkOutsideRootSkipped(t *testing.T) {
 	if verdict.Mode != bundleapp.FreshnessModeDigest {
 		t.Errorf("Mode = %q, want %q", verdict.Mode, bundleapp.FreshnessModeDigest)
 	}
+}
 
-	// Also verify the digest file itself did not capture the symlink.
-	_ = digestBefore // silence unused warning; we already confirmed via verdict
+// TestDigest_SymlinkPrefixExtensionRejected is the security regression test for
+// the prefix-extension symlink escape: a symlink pointing at a sibling directory
+// whose name extends the project root name (e.g. /proj-secret when root=/proj)
+// must be rejected, not admitted by a bare strings.HasPrefix check.
+//
+// This test FAILS on the pre-fix code and PASSES on the fixed code.
+func TestDigest_SymlinkPrefixExtensionRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping symlink test in short mode")
+	}
+
+	// Use a shared parent so root and outside share a directory prefix.
+	parent := t.TempDir()
+	root := filepath.Join(parent, "proj")
+	outside := filepath.Join(parent, "proj-secret") // name extends root's base — the bug
+
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a normal source file inside the project root.
+	if err := os.WriteFile(filepath.Join(root, "vibewarden.yaml"), []byte("name: test\n"), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	// Compute and store the digest without the symlink (baseline).
+	svc := bundleapp.NewService(nil, &fakeGenerator{})
+	svc.WriteInputDigest(root)
+
+	// Write a secret file in the prefix-extension sibling directory.
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("ssh-key\n"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	// Symlink from inside root pointing at the secret in the sibling directory.
+	linkPath := filepath.Join(root, "leak")
+	if err := os.Symlink(secret, linkPath); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	// The symlink target path is outside+"/secret.txt" = parent+"/proj-secret/secret.txt".
+	// A bare strings.HasPrefix(resolved, absRoot) where absRoot=parent+"/proj"
+	// incorrectly admits it because "proj-secret" starts with "proj".
+	// The fix requires absRoot+"/" as the separator-terminated prefix.
+	imgCreated := time.Now().Add(-1 * time.Hour)
+	inspector := newTestFreshInspector(imgCreated)
+	walker := bundleapp.NewFileSystemStalenessWalker(root)
+	verdict := runHealthCheck(t, root, inspector, walker)
+
+	// The symlink must be skipped — digest unchanged from baseline, verdict FRESH.
+	if verdict.Stale {
+		t.Errorf("prefix-extension symlink escape: symlink to %q should be skipped, got STALE", outside)
+	}
+	if verdict.Mode != bundleapp.FreshnessModeDigest {
+		t.Errorf("Mode = %q, want %q", verdict.Mode, bundleapp.FreshnessModeDigest)
+	}
 }

--- a/internal/app/bundle/service.go
+++ b/internal/app/bundle/service.go
@@ -84,29 +84,26 @@ func (s *Service) WithStalenessWalker(walker StalenessWalker) *Service {
 	return s
 }
 
-// WriteInputDigest computes the content digest for projectRoot and writes it
-// to <projectRoot>/.vibewarden/.input-digest. It also ensures the line
-// ".vibewarden/.input-digest" is present in the project .gitignore (idempotent).
+// WriteInputDigest computes the SHA-256 content digest for projectRoot and
+// writes it to <projectRoot>/.vibewarden/.input-digest (schema v2). It also
+// writes <projectRoot>/.vibewarden/.gitignore containing "*\n" so the whole
+// .vibewarden/ directory is excluded from git without touching the user's own
+// .gitignore.
 //
 // This must be called only after a successful Bundle() invocation. A write
 // failure is logged at warn level and does not return an error — the next run
-// will fall back to mtime comparison, which is the documented degraded path.
-//
-// The gitignore update happens BEFORE the digest is computed so that the
-// .gitignore file participates in the walked set on both this write and every
-// subsequent read. Without this ordering, the first write would compute a
-// digest without .gitignore (since it does not yet exist) but the second read
-// would compute a digest with .gitignore — the two would never match and every
-// run after the first would report STALE.
+// will treat the missing digest as a first-run baseline (FRESH), which is the
+// correct degraded behaviour.
 func (s *Service) WriteInputDigest(projectRoot string) {
 	if projectRoot == "" {
 		return
 	}
-	// Ensure gitignore is updated first so .gitignore participates in the
-	// digest on both this write and every future read.
-	if err := ensureGitIgnored(projectRoot, inputDigestGitIgnoreLine); err != nil {
-		slog.Warn("input-digest: cannot update .gitignore before digest write", "err", err)
-		// Continue — digest write is still attempted; next run falls back to mtime.
+	// Write the per-directory .gitignore first (idempotent) so that future git
+	// operations exclude .vibewarden/ without any modification to the user's
+	// own .gitignore.
+	if err := ensureVibewardenGitignoreFile(projectRoot); err != nil {
+		slog.Warn("input-digest: cannot write .vibewarden/.gitignore", "err", err)
+		// Continue — digest write is still attempted.
 	}
 	d, err := computeInputDigest(projectRoot)
 	if err != nil {

--- a/internal/app/bundle/staleness.go
+++ b/internal/app/bundle/staleness.go
@@ -18,6 +18,7 @@ import (
 var hardIgnoreDirs = []string{
 	".git", ".vibewarden", "node_modules", "vendor",
 	"dist", "build", "target", ".venv", "__pycache__",
+	"bin", ".next",
 }
 
 // StalenessWalker is a consumer-side test seam: this interface is defined here

--- a/internal/app/bundle/staleness_test.go
+++ b/internal/app/bundle/staleness_test.go
@@ -84,6 +84,8 @@ func TestFileSystemStalenessWalker_HardIgnoreDirs(t *testing.T) {
 		{name: ".venv", dir: ".venv", wantSkip: true},
 		{name: "__pycache__", dir: "__pycache__", wantSkip: true},
 		{name: ".vibewarden", dir: ".vibewarden", wantSkip: true},
+		{name: "bin", dir: "bin", wantSkip: true},
+		{name: ".next", dir: ".next", wantSkip: true},
 		{name: "src (not ignored)", dir: "src", wantSkip: false},
 	}
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1475,7 +1475,23 @@ Image health
   Warnings:     none
 ```
 
-When warnings are present, `Warnings:` is followed by indented `- ` lines.
+When STALE, `Freshness:` is followed by up to 5 changed-path lines classified as
+`added`, `removed`, or `modified`. Paths beyond the limit are summarised as
+`(and N more)`. Use `vibew bundle --build` to rebuild and clear the warning, or
+`vibew bundle --allow-stale` to suppress it for one run.
+
+```
+  Freshness:    STALE
+    - modified: Dockerfile
+    - added:    src/handler.go
+    (and 2 more)
+```
+
+Freshness is SHA-256 content-digest driven (schema v2, stored at
+`.vibewarden/.input-digest`). A missing or v1 digest file (pre-v0.19.0 install)
+is treated as a first-run baseline — the first post-upgrade bundle is always FRESH.
+
+When other warnings are present, `Warnings:` is followed by indented `- ` lines.
 No ANSI colour. Parseable by agents line-by-line.
 
 ### migrate flags


### PR DESCRIPTION
Closes #1223

## Root cause

`WriteInputDigest` called `ensureGitIgnored` which opened the user's `.gitignore` for append on every bundle run, bumping its mtime even when the line was already present. Go's `O_APPEND|O_WRONLY` updates mtime on open. The bumped mtime was then captured by `FileSystemStalenessWalker.NewestMTime` on any subsequent bundle whose digest path fell back to mtime (first run, wiped `.vibewarden/`, corrupt digest, schema-version mismatch), producing a false STALE verdict.

Architect's comment confirming root cause and design: https://github.com/VibeWarden/vibewarden/issues/1223

## Before / after

**Before (second bundle after a clean build, no edits):**
```
  Freshness:    STALE — 1 source files changed since image was built
```

**After:**
```
  Freshness:    FRESH
```

**After (when files actually change):**
```
  Freshness:    STALE — source files changed since image was built:
                  - main.go (modified)
                  - newfile.txt (added)
```

## Summary

- **Drop `.gitignore` mutation.** `ensureGitIgnored`, `readGitIgnoreLines`, and `inputDigestGitIgnoreLine` are removed. `WriteInputDigest` now calls `ensureVibewardenGitignoreFile` which writes `<projectRoot>/.vibewarden/.gitignore` containing `*\n` (idempotent — no touch if content already matches).
- **Digest schema v1 → v2.** The new schema adds a `"files": [{path, sha256}]` array per-file. v1 files are treated as missing on read (first-run baseline FRESH, not mtime fallback). No mtime path exists after this PR.
- **Drop `FreshnessModeTime` / mtime fallback end-to-end.** No prior digest → `Mode=FreshnessModeBaseline`, `Stale=false`. The `FreshnessModeTime` constant is kept for API compatibility but will never be set by `CheckImageHealth`.
- **Render up to 5 changed paths** (removed → added → modified, alphabetical within each bucket). `(and N more)` suffix when truncated.
- **Add `EvalSymlinks`** to the digest walker; symlinks that escape `projectRoot` are skipped.
- **Add `bin` and `.next`** to `hardIgnoreDirs`.

## Digest schema v1 → v2 migration

First `vibew bundle` after upgrade: existing v1 file is treated as missing → `Mode=baseline` → FRESH. Digest file is rewritten in v2 format. Second bundle: digest comparison is active. No false positive at any step.

## Test plan

All 6 architect-required tests added and passing:

- `TestDigest_GitignoreNotMutatedByWriteInputDigest` — regression: `.gitignore` mtime and content unchanged after `WriteInputDigest` (FAILS on pre-fix code)
- `TestDigest_SelfInducedStalenessRegression` — end-to-end: two consecutive bundle cycles with no edits both report FRESH
- `TestDigest_StalePathsListedInRender` — rendered block contains `added`/`removed`/`modified` labels
- `TestDigest_ChangedPathsCappedAt5` — 12 modified files → 5 shown + `(and 7 more)`
- `TestDigest_VibewardenGitignoreFileWritten` — `.vibewarden/.gitignore` written with `*\n`, idempotent on second call
- `TestDigest_SymlinkOutsideRootSkipped` — symlink escaping project root not included in digest

`make check` (golangci-lint + build + `go test -race ./...` + demo-app) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)