### PR TITLE
docs(#1224): macOS LibreSSL dev cert workaround note + darwin-only doctor advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ as #1219 (both in v0.18.3). The recovery command in the error message above is l
 
 ### Added
 
+- **`vibew doctor` advisory note for macOS**: system curl (LibreSSL) may fail handshake on the local dev cert. Doctor now prints a darwin-only note pointing at Homebrew curl + python3 ssl alternatives. See `docs/troubleshooting.md` for the workarounds. (#1224)
 - **`vibew dev --rebuild`** — collapses the four-command rebuild dance
   (`vibew down && docker rmi <tag> && vibew build && vibew dev`) into a single command
   (#1220). Stops the stack, removes the resolved app image, rebuilds via `vibew build`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -425,6 +425,47 @@ vibew dev
 
 ---
 
+### macOS: system curl fails handshake on dev cert
+
+**Symptom**
+
+```
+LibreSSL/3.3.6: error:06FFF064:digital envelope routines:CONF_modules_load:bad decrypt
+```
+
+`curl https://localhost:8443/` from a default macOS shell fails the TLS handshake against the Caddy local-CA dev certificate. Same command from Linux works.
+
+**Cause**
+
+macOS ships a system `curl` linked against LibreSSL, which is stricter than OpenSSL on certain self-signed certificate profiles. Caddy's local CA issues an ECC intermediate that triggers this. Not a vibew bug — works around it client-side.
+
+**Fix — Homebrew curl (recommended)**
+
+```bash
+brew install curl
+/opt/homebrew/opt/curl/bin/curl --insecure https://localhost:8443/_vibewarden/health
+```
+
+The Homebrew bottle is linked against OpenSSL and accepts the dev cert with `--insecure`. Do **not** alias `curl` to the Homebrew binary system-wide — only use it for sidecar testing.
+
+**Fix — Python `ssl` module**
+
+```bash
+python3 -c '
+import ssl, urllib.request
+ctx = ssl._create_unverified_context()
+print(urllib.request.urlopen("https://localhost:8443/_vibewarden/health", context=ctx).read().decode())
+'
+```
+
+Python's bundled OpenSSL accepts the cert when verification is disabled. Useful when you cannot install Homebrew.
+
+**Note**
+
+This applies to **dev / self-signed** certificates only. Production certs from Let's Encrypt or ZeroSSL handshake fine with macOS system curl.
+
+---
+
 ### Unhealthy containers (Kratos, Postgres)
 
 Runtime container health is no longer checked by `vibew doctor` — that check was

--- a/internal/app/ops/doctor.go
+++ b/internal/app/ops/doctor.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -18,6 +19,11 @@ import (
 	domaintlspreflight "github.com/vibewarden/vibewarden/internal/domain/tlspreflight"
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
+
+// goosFn returns the current operating system name. It is a package-level
+// function variable so tests can swap it without build tags. Production code
+// must not reference it outside this file; test helpers live in export_test.go.
+var goosFn = func() string { return runtime.GOOS }
 
 // Severity classifies the outcome of a single doctor check.
 type Severity string
@@ -145,6 +151,9 @@ func (s *DoctorService) Run(ctx context.Context, cfg *config.Config, opts Doctor
 		}
 	} else {
 		printDoctorReport(checks, out)
+		if goosFn() == "darwin" {
+			printDarwinCurlAdvisory(out)
+		}
 	}
 
 	allOK = true
@@ -550,6 +559,19 @@ func printDoctorJSON(results []CheckResult, out io.Writer) error {
 	enc := json.NewEncoder(out)
 	enc.SetIndent("", "  ")
 	return enc.Encode(results)
+}
+
+// printDarwinCurlAdvisory writes a human-readable advisory to out informing
+// macOS users that system curl (linked against LibreSSL) may fail the TLS
+// handshake against the Caddy local-CA dev certificate, and points them at
+// the Homebrew curl and python3 ssl workarounds documented in
+// docs/troubleshooting.md. The advisory is skipped in JSON mode (handled by
+// the caller) and on non-darwin platforms.
+func printDarwinCurlAdvisory(out io.Writer) {
+	fmt.Fprintln(out, "─────────────────────────────────────────")
+	fmt.Fprintln(out, "Note (macOS): system curl uses LibreSSL which may fail handshake on the local dev cert.")
+	fmt.Fprintln(out, "              Use Homebrew curl with --insecure or python3 ssl module for HTTPS testing.")
+	fmt.Fprintln(out, "              See: docs/troubleshooting.md")
 }
 
 // sanitizeOneLine trims a multiline string to its first non-empty line.

--- a/internal/app/ops/doctor_test.go
+++ b/internal/app/ops/doctor_test.go
@@ -1288,6 +1288,91 @@ func TestDoctor_StackUp_GeneratedFileMissing_StillWarns(t *testing.T) {
 	}
 }
 
+// --- Tests for macOS LibreSSL advisory (#1224) ---
+
+// TestDoctorService_Run_DarwinAdvisory is a table-driven test that verifies
+// the darwin-only LibreSSL curl advisory is emitted precisely when expected:
+// darwin + human mode → present; non-darwin → absent; JSON mode → absent.
+func TestDoctorService_Run_DarwinAdvisory(t *testing.T) {
+	const advisorySubstring = "Note (macOS): system curl uses LibreSSL"
+	const troubleshootingRef = "docs/troubleshooting.md"
+
+	tests := []struct {
+		name        string
+		goos        string
+		jsonMode    bool
+		wantPresent bool
+	}{
+		{
+			name:        "darwin human mode emits advisory",
+			goos:        "darwin",
+			jsonMode:    false,
+			wantPresent: true,
+		},
+		{
+			name:        "linux omits advisory",
+			goos:        "linux",
+			jsonMode:    false,
+			wantPresent: false,
+		},
+		{
+			name:        "windows omits advisory",
+			goos:        "windows",
+			jsonMode:    false,
+			wantPresent: false,
+		},
+		{
+			name:        "darwin JSON mode omits advisory",
+			goos:        "darwin",
+			jsonMode:    true,
+			wantPresent: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			restore := ops.SetGOOSForTest(tt.goos)
+			t.Cleanup(restore)
+
+			fc := noContainersCompose()
+			pc := &fakePortChecker{available: map[int]bool{8443: true}}
+			svc := ops.NewDoctorService(fc, pc)
+			cfg := doctorConfig()
+
+			opts := defaultOpts(t)
+			opts.JSON = tt.jsonMode
+
+			var buf bytes.Buffer
+			if _, err := svc.Run(context.Background(), cfg, opts, &buf); err != nil {
+				t.Fatalf("Run() unexpected error: %v", err)
+			}
+
+			out := buf.String()
+			if tt.wantPresent {
+				if !strings.Contains(out, advisorySubstring) {
+					t.Errorf("expected advisory substring %q in output\ngot:\n%s", advisorySubstring, out)
+				}
+				if !strings.Contains(out, troubleshootingRef) {
+					t.Errorf("expected troubleshooting ref %q in output\ngot:\n%s", troubleshootingRef, out)
+				}
+			} else {
+				if strings.Contains(out, "Note (macOS):") {
+					t.Errorf("expected advisory to be absent in output\ngot:\n%s", out)
+				}
+			}
+
+			// JSON mode: output must be valid JSON regardless of OS.
+			if tt.jsonMode {
+				var results []ops.CheckResult
+				if err := json.Unmarshal(buf.Bytes(), &results); err != nil {
+					t.Errorf("JSON mode output is not valid JSON: %v\nbody:\n%s", err, out)
+				}
+			}
+		})
+	}
+}
+
 // TestDoctor_ContainerHealth_AbsentInJSON is a regression guard for JSON mode:
 // no result in the JSON array may have Name == "Container health", regardless
 // of stack state. The check was deleted in #1222.

--- a/internal/app/ops/export_test.go
+++ b/internal/app/ops/export_test.go
@@ -6,3 +6,16 @@ package ops
 func FormatProjectRootMismatchForTest(tag, currentProjectRoot string, identity ImageIdentity) error {
 	return formatProjectRootMismatch(tag, currentProjectRoot, identity)
 }
+
+// SetGOOSForTest swaps the package-level goosFn to return the provided goos
+// string and returns a restore function that reverts the swap. Callers must
+// register the restore function via t.Cleanup to avoid leaking state across
+// tests.
+//
+// This helper exists solely for testability of the darwin-only advisory path
+// on non-darwin CI runners. Do not use it in production code.
+func SetGOOSForTest(goos string) (restore func()) {
+	prev := goosFn
+	goosFn = func() string { return goos }
+	return func() { goosFn = prev }
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1598,6 +1598,11 @@ vibew doctor checks (in order):
   Runtime container health is NOT checked by doctor — query /_vibewarden/health
   after vibew dev is up for live runtime status.
 
+vibew doctor output notes:
+  On darwin, human-mode output appends a one-time advisory after the check table:
+    "Note (macOS): system curl uses LibreSSL which may fail handshake on the local dev cert."
+  Skipped on Linux/Windows and in JSON mode (--json).
+
 vibew doctor flags:
   --skip-le-preflight  skip the LE rate-limit CT log check for this run
 
@@ -1635,6 +1640,27 @@ vibew doctor flags:
 
   vibew generate
   vibew dev
+
+### macOS: system curl fails handshake on dev cert
+
+  Symptom: curl https://localhost:8443/ exits with LibreSSL handshake error.
+  Cause: macOS system curl is linked against LibreSSL, which rejects the Caddy
+  local-CA ECC intermediate. Linux system curl (OpenSSL) accepts it.
+  vibew doctor prints this advisory automatically on darwin after the check table.
+
+  Fix 1 — Homebrew curl (recommended):
+    brew install curl
+    /opt/homebrew/opt/curl/bin/curl --insecure https://localhost:8443/_vibewarden/health
+
+  Fix 2 — Python ssl module (no Homebrew required):
+    python3 -c '
+    import ssl, urllib.request
+    ctx = ssl._create_unverified_context()
+    print(urllib.request.urlopen("https://localhost:8443/_vibewarden/health", context=ctx).read().decode())
+    '
+
+  Applies to dev/self-signed certs only. Production Let's Encrypt certs are fine.
+  See: docs/troubleshooting.md#macos-system-curl-fails-handshake-on-dev-cert
 
 ### vibew dev: image identity check failed (v0.18.3+)
 


### PR DESCRIPTION
Closes #1224

Architect's design comment: https://github.com/VibeWarden/vibewarden/issues/1224#issuecomment-1

## Summary

- **`vibew doctor` darwin advisory** — `Run` emits a visually separated note after the check table when `!opts.JSON && goosFn() == "darwin"`. Skipped on non-darwin and in JSON mode (programmatic consumers unaffected).
- **`goosFn` indirection** — package-level `var goosFn = func() string { return runtime.GOOS }` in `doctor.go` enables OS-faking in tests without build tags. Not exported; swapped only via `SetGOOSForTest` in `export_test.go`.
- **Docs section** — new `### macOS: system curl fails handshake on dev cert` H3 in `docs/troubleshooting.md`, inserted between "Generated files missing" and "Unhealthy containers". Documents both fixes (Homebrew curl + python3 ssl).
- **CHANGELOG** — Unreleased / Added bullet for #1224.

**Rendered advisory output (darwin, human mode):**

```
─────────────────────────────────────────
Note (macOS): system curl uses LibreSSL which may fail handshake on the local dev cert.
              Use Homebrew curl with --insecure or python3 ssl module for HTTPS testing.
              See: docs/troubleshooting.md
```

No behavior change for Linux, Windows, or JSON mode.

## Test plan

- `TestDoctorService_Run_DarwinAdvisory` — 4 table-driven sub-cases:
  - `darwin human mode emits advisory` — asserts advisory substring + troubleshooting ref present
  - `linux omits advisory` — asserts `Note (macOS):` absent
  - `windows omits advisory` — asserts `Note (macOS):` absent
  - `darwin JSON mode omits advisory` — asserts absence + valid JSON parse
- `make check` clean (golangci-lint 0 issues, all tests pass with `-race`, gofmt clean)