### PR TITLE
chore: release v0.18.3 — v0.18.2 retro fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+## [v0.18.3] — 2026-04-28
+
+Theme: v0.18.2 retrospective fixes. Six retro-tagged pipelines (#1219–#1224) covering image-identity collision (the "most dangerous failure mode" of the retro), `--rebuild` recovery flag, local logs wrapper, doctor pre-stack noise reduction, bundle freshness false-positive (also fixed a security-relevant symlink-escape bug discovered during review), and macOS LibreSSL advisory. One breaking-for-existing-images change is user-visible: `vibew dev` blocks on stale images from a different project, recoverable via `vibew dev --rebuild`. See "Behavior changes" first.
+
 ### Behavior changes
 
 **`vibew dev` now blocks on stale images from a different project (#1219, ADR-100).**


### PR DESCRIPTION
## Summary

Release PR for v0.18.3: 6 retro-tagged pipelines (#1219–#1224). Adds the `## [v0.18.3] — 2026-04-28` header to CHANGELOG.

## Smoke test

End-to-end smoke against `demo.vibewarden.dev` with a fresh `vw3` project:

```
$ curl https://demo.vibewarden.dev/_vibewarden/health
{"status":"ok","version":"0.18.3-smoke","components":{"sidecar":"ok","upstream":"ok"}}
```

All 6 retro fixes verified locally:
- #1219: `docker inspect` shows `org.vibewarden.project-root-hash` + `org.vibewarden.project-root` labels on the freshly-built image.
- #1220: `vibew dev --help` lists `--rebuild` and `--volumes` flags.
- #1221: `vibew logs --help` lists known services + tip lines.
- #1222: `vibew doctor` pre-stack output has no "Generated files" / "Container health" / "TLS certificate" rows.
- #1223: two consecutive `vibew bundle --skip-image` runs both succeed without STALE warning.
- #1224: macOS doctor stdout includes the LibreSSL advisory at the bottom.

## Test plan
- [x] `make check` clean on main
- [x] All 6 sub-PRs merged + CI green
- [x] Smoke test on demo.vibewarden.dev passing
- [ ] Tag v0.18.3 after merge (goreleaser publishes binaries + ghcr Docker image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)