### PR TITLE
feat(#1232): emit agent-kickoff-{dev,deploy}.txt as release artifacts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,15 @@ version: 2
 project_name: vibewarden
 
 # ---------------------------------------------------------------------------
+# Pre-build hooks
+# ---------------------------------------------------------------------------
+# Emit agent-kickoff-{dev,deploy}.txt before the main build. These files are
+# uploaded as GitHub Release assets via release.extra_files below (ADR-101).
+before:
+  hooks:
+    - bash scripts/release/emit-kickoff-artifacts.sh dist
+
+# ---------------------------------------------------------------------------
 # Build
 # ---------------------------------------------------------------------------
 builds:
@@ -145,6 +154,11 @@ release:
   draft: false
   prerelease: auto
   name_template: "{{ .ProjectName }} {{ .Version }}"
+  # Agent-kickoff canonical artifacts (ADR-101). The wrapper script writes
+  # these to dist/ in the before.hooks step above.
+  extra_files:
+    - glob: dist/agent-kickoff-dev.txt
+    - glob: dist/agent-kickoff-deploy.txt
   header: |
     ## VibeWarden {{ .Version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+### Added
+
+- **Release artifacts: `agent-kickoff-dev.txt` and `agent-kickoff-deploy.txt`** (#1232, ADR-101). Goreleaser now emits both flavors of the canonical agent kickoff prompt as release assets, with `{{prjname}}`, `{{description}}`, and `{{domain}}` two-brace placeholders for consumers to substitute. Stable URL: `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-dev.txt`. The website (vibewarden/vibewarden.dev) will fetch these at build time, replacing the hand-rolled JS template literal that drifted across three retros (vibewarden.dev#95). Forensic CI test asserts both artifacts contain the post-#1138 deploy contract (`docker load -i image.tar && docker compose up -d`), include the post-#1217 tar pipe transfer, and do NOT contain `bash deploy.sh` or the buggy `scp -r .vibewarden/bundle/*` glob form.
+
 ### Fixed
 
 - **fixed:** bundle stdout, bundle README, `vibew prompt-template --deploy` output, and `llms-full.txt § Agent Kickoff Prompt` all switch from `scp -r .vibewarden/bundle/* user@host:/path/` (which silently drops dotfiles like `.env`, `.credentials`, `.env.template` because shells don't include dotfiles in `*` glob) to a POSIX tar pipe: `tar -czf - -C .vibewarden/bundle . | ssh user@host 'tar -xzf - -C /opt/<app>/'`. Three retros (v0.18.1, v0.18.2, v0.18.3) flagged this; the v0.18.3 deploy shipped a "successful" stack that was missing `.env` and required manual recovery. Tar pipe is dotfile-safe by construction, single ssh connection, POSIX baseline. Forensic alignment test extended to enforce the new transfer command across all four surfaces and forbid the buggy form. (#1217)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,10 +101,18 @@ decisions/              # ADRs — one file per decision (see decisions/README.m
 ```
 
 **Content authority.** The main repo is the source of truth for all LLM-consumable
-content files (`llms.txt`, `llms-full.txt`, `vibewarden.reference.yaml`). The
+content files (`llms.txt`, `llms-full.txt`, `vibewarden.reference.yaml`,
+`agent-kickoff-dev.txt`, `agent-kickoff-deploy.txt`). The
 `vibewarden/vibewarden.dev` website repo is presentation only and fetches these
 files from the main repo's latest release tag at build time. Never duplicate
 these files in the website repo — edit them here.
+
+The `agent-kickoff-{dev,deploy}.txt` artifacts are *generated* at release time
+by `scripts/release/emit-kickoff-artifacts.sh` (ADR-101). Do not hand-roll
+kickoff prompt templates anywhere — fetch from the locked public URLs:
+  https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-dev.txt
+  https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-deploy.txt
+Renaming these files is a breaking change; treat the filenames as public API.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ all in a single binary that sits next to your app.
 Go to [vibewarden.dev/start](https://vibewarden.dev/start) and fill in two fields.
 The page generates a ready-to-paste prompt tailored to your app and stack.
 
+For tooling integrations that cannot ship a vibew binary, fetch the pre-rendered
+release artifacts and substitute the `{{prjname}}`, `{{description}}`, and `{{domain}}`
+placeholders before pasting:
+
+- `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-dev.txt`
+- `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-deploy.txt`
+
+These filenames are public API (ADR-101). See `docs/agent-kickoff.md` for substitution details.
+
 ---
 
 ### Path 2 — Copy a prompt template

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -73,6 +73,7 @@ once accepted, they are not edited. If a decision is superseded, a new ADR refer
 | [098](adr-098-upstream-health-probe.md) | Upstream health probe — wire the cached background probe into `/_vibewarden/health` | #1197 |
 | [099](adr-099-vibew-prompt-template-canonical-agent-kickoff.md) | `vibew prompt-template` — canonical agent kickoff prompt owned by the binary | — |
 | [100](adr-100-image-identity-via-project-root-label.md) | Image identity via `org.vibewarden.project-root-hash` label | — |
+| [101](adr-101-agent-kickoff-release-artifacts.md) | Agent-kickoff release artifacts — main repo emits canonical kickoff prompts as release assets | #1232 |
 | [497](adr-497-graceful-shutdown-connection-draining.md) | Graceful Shutdown / Connection Draining | — |
 
 ## Numbering

--- a/decisions/adr-101-agent-kickoff-release-artifacts.md
+++ b/decisions/adr-101-agent-kickoff-release-artifacts.md
@@ -1,0 +1,459 @@
+# ADR-101: Agent-kickoff release artifacts — main repo emits canonical kickoff prompts as release assets
+
+**Date**: 2026-04-30
+**Issue**: #1232
+**Status**: Accepted
+
+## Context
+
+Three retrospectives in a row — v0.18.1 (qr-code-blackhole), v0.18.2
+(qr-code-brutalist Go), v0.18.3 (qr-code-brutalist Node) — have flagged the same
+recurring defect: agents kicked off from `https://vibewarden.dev/start` are
+handed a prompt whose deploy section drifts from reality. The most recent
+incident (v0.18.3) shipped agents `bash deploy.sh` even though `deploy.sh` was
+removed in #1138 / ADR-088. The agent dutifully ran the obsolete command and
+hit `deploy.sh: No such file or directory` mid-task.
+
+Investigation traced the drift to a hand-rolled template literal in
+`vibewarden.dev:src/start/index.njk` (~line 32). A code comment on that very
+line literally admits the gap: `// Deploy — bundle + manual deploy.sh
+(vibew deploy was removed in ADR-086)`. The website also lacks the post-#1200
+`vibew build --platform linux/amd64` step required to avoid the silent Apple
+Silicon → amd64 runtime fail.
+
+ADR-099 (#1203) gave the kickoff prompt a canonical home in the binary
+(`vibew prompt-template`, embedded `text/template` in
+`internal/cli/templates/prompts/`). It did not, however, address the website,
+which is the single highest-traffic surface where agents pick up the prompt.
+As long as the website maintains its own copy, every deploy-contract change
+risks silently invalidating it — three retros confirm this is not theoretical.
+
+CLAUDE.md §Content authority already locks the pattern for this class of
+content-authority problem: the main repo is the source of truth for
+LLM-consumable content (`llms.txt`, `llms-full.txt`,
+`vibewarden.reference.yaml`), and the website fetches these files at build
+time from the latest release tag. The kickoff prompt is the same shape of
+content (canonical, version-stamped, URL-consumable by external builders),
+just generated rather than checked in. Extending the same pattern is the
+minimum-surprise fix.
+
+This ADR formalises that extension. It also constrains every future tool that
+wants to surface the kickoff prompt: from now on, the URL pattern below is the
+public contract; do not regress to hand-rolled templates.
+
+## Decision
+
+The release pipeline emits two new canonical artifacts per release tag, each
+uploaded to the GitHub Release as a downloadable asset. The website (and any
+other downstream consumer) fetches them at build time and runs a trivial
+mustache-style placeholder substitution to produce per-user prompts.
+
+### Artifacts
+
+| Asset filename            | Source command                                                                                              | Purpose                                  |
+|---------------------------|-------------------------------------------------------------------------------------------------------------|------------------------------------------|
+| `agent-kickoff-dev.txt`   | `vibew prompt-template --name "{{prjname}}" --describe "{{description}}"`                                   | Dev-only flavor (install + dev loop)     |
+| `agent-kickoff-deploy.txt`| `vibew prompt-template --deploy --name "{{prjname}}" --describe "{{description}}" --domain "{{domain}}"`    | Dev + deploy flavor (bundle + ssh + healthcheck) |
+
+Both files are produced by invoking the freshly-built binary inside the
+goreleaser pipeline. The `--name`, `--describe`, `--domain` flag values are
+literal mustache-style placeholders, kept verbatim in the rendered output.
+Downstream consumers (the website, third-party generators) interpolate by
+running `s.replaceAll("{{prjname}}", userName)` — no parsing required.
+
+### Placeholder format
+
+Two-brace mustache style:
+
+- `{{prjname}}` — sanitised project name (Docker-Compose-safe slug). Required.
+- `{{description}}` — one-line project description. Required.
+- `{{domain}}` — FQDN. Used by both flavors; `--deploy` requires it, `dev`
+  passes it through to `vibew add tls`.
+
+### Artifact header
+
+Every artifact opens with a self-describing header so a human reading the file
+directly understands what it is, how it was generated, and how to consume it.
+The header is appended *above* the existing template output by the wrapper
+script — the canonical `vibew prompt-template` body is left byte-for-byte
+unchanged so it stays in sync with what users see when they run the command
+locally.
+
+```
+# VibeWarden Agent Kickoff Release Artifact
+# Flavor: dev | deploy
+# vibew version: <version>
+# Generated: <RFC-3339 UTC timestamp>
+# Source command: vibew prompt-template ... (literal command, with placeholders)
+#
+# This file uses two-brace placeholders. Substitute before pasting:
+#   {{prjname}}     — project name (lowercase, hyphenated, no spaces)
+#   {{description}} — one-line project description
+#   {{domain}}      — FQDN the app will be served on (e.g. myapp.example.com)
+#
+# Regeneration:
+#   vibew prompt-template [--deploy] --name "{{prjname}}" --describe "{{description}}" [--domain "{{domain}}"]
+#
+# Canonical URL:
+#   https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-<flavor>.txt
+# ----------------------------------------------------------------------------
+
+<unmodified output of vibew prompt-template ...>
+```
+
+The header is shell-comment-safe (every line starts with `#`) so a curious user
+can `cat` the file without a special viewer. The body below the rule is the
+exact byte sequence produced by the binary — ADR-099's golden tests already
+guard that.
+
+### Annotation: optional `mkdir`
+
+The template's Step 2 currently emits:
+
+```
+  mkdir {{.Name}} && cd {{.Name}}
+```
+
+Per retro feedback, agents are often already inside a project directory. The
+template will be amended to:
+
+```
+  # Skip if you're already in the project directory:
+  mkdir {{.Name}} && cd {{.Name}}
+```
+
+This change lives in `internal/cli/templates/prompts/{dev,deploy}.tmpl` and is
+guarded by the existing golden tests in
+`internal/app/promptkickoff/golden_test.go`. It is *not* a release-pipeline
+concern — it ships in the binary and propagates into both the artifact body
+and `llms-full.txt § 21`.
+
+### Goreleaser hook approach
+
+**Option A — `before.hooks` shell wrapper.** Goreleaser's top-level `before:
+hooks:` runs commands after `git clone` and before any artifact build. We add
+a `make` target that:
+
+1. Builds vibew once with the same `-ldflags "-X main.version=<version>"`
+   stamp the goreleaser build uses.
+2. Invokes the freshly-built binary twice with the placeholder strings to
+   produce the two artifact bodies.
+3. Prepends the self-describing header to each.
+4. Writes the result to `dist/agent-kickoff-{dev,deploy}.txt`.
+
+The artifacts are then attached to the Release via `release.extra_files`
+(goreleaser v2 syntax).
+
+This is the chosen approach. Reasons:
+
+- Reuses the existing `vibew prompt-template` CLI verb without inventing a new
+  flag. ADR-099's golden tests stay authoritative.
+- Goreleaser's `before` hooks run exactly once per release and are the
+  documented home for this kind of pre-artifact generation.
+- `release.extra_files` is the documented mechanism for uploading
+  arbitrary files alongside built artifacts.
+- Snapshot builds (`goreleaser release --snapshot`) run hooks too, so the
+  release-dryrun workflow exercises this path on every PR that touches
+  goreleaser config.
+
+### Alternatives considered
+
+- **Hand-rolled website template (status quo).** Rejected — three retros
+  confirm drift recurs. The website team cannot be expected to track every
+  deploy-contract change in the main repo.
+- **Embed the binary in the website build.** Rejected — wrong distribution
+  model. The website is presentation only (CLAUDE.md §Content authority);
+  pulling a Go binary into the eleventy build crosses that boundary and
+  forces website CI to deal with cross-compilation.
+- **Fetch from latest commit on `main`.** Rejected — release tags are the
+  intentional content-authority boundary. `latest commit` would mean the
+  website renders pre-release commands the binary may not yet support.
+  The pattern already established for `llms-full.txt` is "fetch from latest
+  release tag"; this ADR mirrors it.
+- **Add a new `cmd/genkickoff/main.go` Go binary.** Rejected — a second
+  binary in `cmd/` is overkill when the existing CLI verb already does the
+  work. The wrapper-script approach is ~20 lines of shell.
+- **Add a `vibew prompt-template --emit-release-artifacts <dir>` flag.**
+  Rejected — adds a CLI surface that exists solely for the release pipeline.
+  The pipeline can shell-script around the existing flags.
+- **JSON envelope artifact.** Rejected — adds a parse step on every consumer
+  for no benefit. The `.txt` form is `replace`-friendly out of the box and
+  human-readable when piped to `cat`.
+
+## Domain model changes
+
+None. This ADR is a release-pipeline / packaging change; no domain entities,
+ports, or adapters are added or modified. The kickoff prompt domain model
+(`promptkickoff.Service`, `promptkickoff.Options`) was established in ADR-099
+and is reused unchanged.
+
+## Ports (interfaces)
+
+None added or modified. The wrapper script is an external orchestrator that
+shells out to the existing `vibew prompt-template` CLI; it does not cross the
+ports/adapters boundary because the CLI is already the public interface.
+
+## Adapters
+
+None added or modified.
+
+## Application service
+
+The existing `internal/app/promptkickoff/promptkickoff.go` `Service` is the
+generator. The release wrapper invokes it transparently via `vibew
+prompt-template`.
+
+The only behavioural tweak inside the binary is in the templates themselves
+(see *Annotation: optional `mkdir`* above) — a docstring comment line ahead
+of the `mkdir` command. This change is guarded by the existing golden tests.
+
+## File layout
+
+### New files
+
+| Path | Purpose |
+|------|---------|
+| `scripts/release/emit-kickoff-artifacts.sh` | Shell wrapper invoked by goreleaser `before` hook. Builds vibew, invokes `prompt-template` twice, prepends headers, writes to `dist/agent-kickoff-{dev,deploy}.txt`. |
+| `decisions/adr-101-agent-kickoff-release-artifacts.md` | This ADR. |
+| `internal/app/promptkickoff/release_artifact_test.go` | Forensic CI test: builds vibew, runs both `prompt-template` invocations with placeholder strings, asserts the post-#1138 deploy contract is present and the buggy forms are absent. Uses the existing `Service`+golden harness so it does not require a built binary. |
+
+### Modified files
+
+| Path | Change |
+|------|--------|
+| `.goreleaser.yml` | Add top-level `before: hooks:` running `bash scripts/release/emit-kickoff-artifacts.sh`. Add `release.extra_files:` listing the two artifacts. |
+| `internal/cli/templates/prompts/dev.tmpl` | Insert `# Skip if you're already in the project directory:` line above the `mkdir` line. |
+| `internal/cli/templates/prompts/deploy.tmpl` | Same as dev.tmpl. |
+| `internal/app/promptkickoff/testdata/dev.golden` | Regenerate via `UPDATE_GOLDEN=1 go test ./internal/app/promptkickoff/...` to capture the new annotation. |
+| `internal/app/promptkickoff/testdata/deploy.golden` | Same. |
+| `decisions/README.md` | Add ADR-101 row. |
+| `CHANGELOG.md` | Unreleased / Added entry pointing at #1232. |
+| `docs/agent-kickoff.md` | Add a "Release-asset URLs" subsection documenting the two `releases/latest/download/...` URLs. |
+| `llms-full.txt` § 21 | Append a one-paragraph note pointing at the release-asset URLs as the recommended consumption path for tools that don't ship the binary. |
+
+## Sequence
+
+### Release path (CI)
+
+1. Tag pushed to `main`. `.github/workflows/release.yml` triggers.
+2. GoReleaser starts. Top-level `before: hooks:` runs
+   `scripts/release/emit-kickoff-artifacts.sh`.
+3. The wrapper script:
+   a. Computes `VERSION` from `git describe --tags --always`.
+   b. Builds a vibew binary at `dist/.kickoff-vibew` with the same
+      `-ldflags "-X main.version=$VERSION"` stamp the main goreleaser build
+      uses.
+   c. Invokes `dist/.kickoff-vibew prompt-template --name "{{prjname}}"
+      --describe "{{description}}" --domain "{{domain}}"` and pipes stdout
+      to a temp file. The literal `{{...}}` strings pass through `--name`
+      because `SanitizeProjectName` rewrites non-alphanumerics to `-` —
+      see *Edge case: placeholder sanitisation* below.
+   d. Same for the `--deploy` flavor.
+   e. Composes the final artifact as `<header>` + `\n` + `<body>` and writes
+      to `dist/agent-kickoff-dev.txt` and `dist/agent-kickoff-deploy.txt`.
+4. GoReleaser proceeds to the normal build/archive/docker steps.
+5. At the `release` stage, `release.extra_files` uploads the two `.txt`
+   artifacts alongside the binary archives, checksums, and Docker images.
+6. The GitHub Release is created. The two artifacts are now reachable at:
+   - `https://github.com/vibewarden/vibewarden/releases/download/<tag>/agent-kickoff-dev.txt`
+   - `https://github.com/vibewarden/vibewarden/releases/download/<tag>/agent-kickoff-deploy.txt`
+   - `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-dev.txt` (auto-redirect to current latest)
+   - `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-deploy.txt` (auto-redirect to current latest)
+
+### Snapshot path (PR dryrun)
+
+`.github/workflows/release-dryrun.yml` runs
+`goreleaser release --snapshot --skip=publish --clean` on every PR that
+touches goreleaser config or wrapper scripts. The `before` hook still runs,
+the artifacts are written to `dist/`, but `release.extra_files` is a no-op
+because `--skip=publish` prevents asset upload. This validates the wrapper
+script does not regress on PRs that touch it without requiring a real release.
+
+### Consumer path (website)
+
+The website's eleventy build adds a build-time fetch step that resolves
+`https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-{dev,deploy}.txt`
+and substitutes the two-brace placeholders against form input. The website
+companion is filed separately (`vibewarden/vibewarden.dev:#TBD`) — that PR is
+the only place the website code changes. From the main repo's perspective,
+the contract is "those two URLs serve those two files in that format" and is
+locked by the forensic CI test below.
+
+## Error cases
+
+| Failure | Detection | Behavior |
+|---------|-----------|----------|
+| `vibew prompt-template` exits non-zero (CLI bug, missing flag) | Wrapper script `set -euo pipefail` | GoReleaser fails the release. No partial artifact uploaded. |
+| `SanitizeProjectName("{{prjname}}")` mangles the placeholder | Forensic CI test asserts `{{prjname}}` survives | Test fails before tagging; never reaches a release. |
+| Body output lacks `docker compose up -d` | Forensic CI test (extends ADR-099 §Test strategy) | Test fails before tagging. |
+| Body output contains `bash deploy.sh`, `./deploy.sh`, or `scp -r .vibewarden/bundle/*` | Forensic CI test | Test fails before tagging. |
+| Header is missing the source-command line or the placeholder list | Forensic CI test | Test fails before tagging. |
+| GoReleaser snapshot in dryrun fails to find `bash` | `release-dryrun.yml` runs on `ubuntu-latest` (always has bash) | N/A. |
+
+## Edge case: placeholder sanitisation
+
+`promptkickoff.Render` calls `config.SanitizeProjectName(opts.Name)` before
+templating. For the literal placeholder string `{{prjname}}`, the sanitiser
+runs through every rune and replaces non-`[a-z0-9-]` characters with `-`,
+then trims leading/trailing hyphens. Result: `{{prjname}}` becomes
+`prjname`. **The placeholder vanishes.**
+
+Two options:
+
+1. **Wrap in alphanumeric so the sanitiser preserves the markers.** Pass
+   `--name "x{{prjname}}x"` and have downstream consumers replace the wider
+   token. Ugly. Forces website to know the wrapping convention.
+2. **Update `SanitizeProjectName` to bypass `{{...}}` segments.** Rejected
+   — pollutes a domain primitive with release-tooling concerns.
+3. **Substitute the placeholder *into the artifact body after rendering*.**
+   The wrapper script invokes the binary with a real, sanitiser-friendly
+   sentinel like `__VW_PRJNAME__`, then runs a `sed` pass post-render that
+   converts each sentinel to the public `{{...}}` form. The sentinel
+   characters (uppercase + underscores) all survive sanitisation
+   verbatim (uppercase becomes lowercase: `__vw_prjname__`).
+
+**Decision: option 3** — sentinel + post-render rewrite. The sentinel set:
+
+| Public placeholder | Internal sentinel passed to vibew | Post-render rewrite (sed) |
+|--------------------|-----------------------------------|----------------------------|
+| `{{prjname}}`      | `vwprjname` (lowercase, alphanum) | `s/vwprjname/{{prjname}}/g` |
+| `{{description}}`  | passed via `--describe` (NOT sanitised — only trim+newline-check) | `s/<exact string>/{{description}}/g` |
+| `{{domain}}`       | `vwdomain.example.invalid`        | `s/vwdomain.example.invalid/{{domain}}/g` |
+
+Implementation note: `Describe` is not sanitised by `Render` (only trimmed
+and newline-checked), so passing `{{description}}` directly works for that
+field. Same for `Domain`, which is templated in verbatim. Only `Name`
+needs the sentinel dance.
+
+The `Name` sentinel `vwprjname` is chosen so that:
+
+- It survives `SanitizeProjectName` byte-for-byte.
+- It is unique enough that a `sed` substitution cannot collide with prose.
+- It is short and humane in case a `sed` step is ever skipped.
+
+The forensic CI test asserts the rewrite worked: the final artifact
+contains `{{prjname}}` literally and contains no `vwprjname` substring.
+
+## Test strategy
+
+### Unit-level (existing, reused)
+
+ADR-099 already established golden tests in
+`internal/app/promptkickoff/golden_test.go` covering both flavors. Those
+tests continue to enforce byte-for-byte stability of the `Render` output.
+The optional-`mkdir` annotation lands as a golden update in the same PR
+(no logic change, only a template-line addition).
+
+### New forensic CI test — `internal/app/promptkickoff/release_artifact_test.go`
+
+Self-contained Go test (no shell, no built binary required) that:
+
+1. Constructs a `promptkickoff.Service` via the existing `clitemplates.FS`.
+2. Invokes `Render` twice with `Name: "vwprjname"`, `Describe:
+   "{{description}}"`, `Domain: "vwdomain.example.invalid"`, deploy off
+   then on.
+3. Applies the same post-render rewrite the release wrapper applies.
+4. For each rendered+rewritten body, asserts:
+   - **Contains** `docker load -i image.tar && docker compose up -d`
+     (post-#1138 contract, mirrors ADR-099's TestDeployTemplate test).
+   - **Contains** `tar -czf - -C .vibewarden/bundle .` (post-#1217
+     dotfile-safe transfer).
+   - **Contains** `tar -xzf - -C` (post-#1217 dotfile-safe receive).
+   - **Contains** `# Skip if you're already in the project directory:`
+     immediately preceding the `mkdir` line.
+   - **Contains** `{{prjname}}` literally (rewrite preserved the marker).
+   - **Contains** `{{description}}` literally.
+   - **Contains** `{{domain}}` literally.
+   - **Does NOT contain** `bash deploy.sh`.
+   - **Does NOT contain** `./deploy.sh`.
+   - **Does NOT contain** `scp -r .vibewarden/bundle/*` (the buggy
+     pre-#1217 form).
+   - **Does NOT contain** `vwprjname` (rewrite removed all sentinels).
+
+The test runs as part of `make check` so any change to the templates that
+breaks the artifact contract fails before reaching a release.
+
+### Wrapper-script test
+
+The wrapper script `scripts/release/emit-kickoff-artifacts.sh` is
+exercised end-to-end by the `release-dryrun` workflow on every PR that
+touches goreleaser config or the wrapper itself (path filter already in
+place). No new workflow needed.
+
+A trivial Go test (`internal/app/promptkickoff/wrapper_script_test.go`)
+shells out to the wrapper script in a `t.TempDir()` working tree and
+diffs its output against the in-process `Render`+rewrite path: this
+guarantees the shell wrapper does not silently drift from the Go test's
+expectations. Skipped on Windows (`runtime.GOOS == "windows"`) because
+the wrapper is bash-only.
+
+### Architectural-invariant test
+
+No new architecture test required. `internal/domain/` and `internal/app/`
+are unchanged.
+
+## New dependencies
+
+None. The wrapper script uses only `bash`, `sed`, and the freshly-built
+vibew binary — all already required by the release pipeline. GoReleaser is
+already a dependency (MIT-licensed, approved per CLAUDE.md §Dependency
+rules).
+
+## Documentation surfaces
+
+| File | Update |
+|------|--------|
+| `decisions/README.md` | Add ADR-101 row. |
+| `CHANGELOG.md` | Unreleased / Added entry pointing at #1232. |
+| `docs/agent-kickoff.md` | Add subsection "Consuming via release artifacts" with the two URL patterns and the placeholder substitution recipe. Add to the "Reference" list. |
+| `llms-full.txt` § 21 | One-paragraph note: "If your tooling cannot ship a vibew binary, fetch the same canonical content from `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-{dev,deploy}.txt` and substitute `{{prjname}}`, `{{description}}`, `{{domain}}` against your inputs." |
+| `CLAUDE.md` § Content authority | Append `agent-kickoff-{dev,deploy}.txt` to the canonical-content list so future contributors know these artifacts are owned by the main repo. |
+
+The website-side companion is filed separately
+(`vibewarden/vibewarden.dev:#TBD`) and depends on this PR landing first so
+that the artifact URLs resolve at the next release.
+
+## Consequences
+
+### Positive
+
+- Three-retro recurrence resolved at the structural level. Drift between
+  website prompt and binary prompt is no longer possible: both come from the
+  same `text/template` rendering.
+- The kickoff prompt joins `llms.txt`, `llms-full.txt`, and
+  `vibewarden.reference.yaml` under a single, locked content-authority
+  pattern. Future canonical content additions follow the same playbook.
+- Every future deploy-contract change automatically propagates to the
+  website on the next release tag — zero website code changes required for
+  that class of update.
+- Forensic CI test forbids regressions to known-bad forms (`bash deploy.sh`,
+  `scp -r .../*`). Future deploy-contract bugs fail at PR time, not in
+  production retros.
+
+### Negative / trade-offs
+
+- The release pipeline now has a `before` hook that builds vibew once for
+  the artifact step. Negligible — adds a few seconds to a release that
+  already takes minutes for Docker buildx + multi-arch.
+- Snapshot builds emit kickoff artifacts that are not uploaded anywhere.
+  This is desirable (validates the wrapper) but does mean `dist/` has more
+  files in dryrun. No user impact.
+- The placeholder-sentinel dance adds a small amount of complexity to the
+  wrapper script. Trade-off accepted to avoid leaking release tooling into
+  `SanitizeProjectName`.
+
+### Future implications
+
+- Establishes the precedent that release artifacts can be *generated* from
+  the binary, not just *checked in*. Future canonical content (e.g.
+  per-version OpenAPI snapshots, version-stamped diagnostic checklists)
+  can follow the same pattern.
+- Locks the public URL contract:
+  `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-{dev,deploy}.txt`.
+  Any future renaming of the artifacts is a breaking change for the
+  website and any third-party tools that picked up the convention. Names
+  must be treated like a public API.
+- Constrains every future tool that wants to surface the kickoff prompt:
+  fetch from these URLs; do not hand-roll a template. Document the
+  constraint inside `CLAUDE.md` § Content authority and reject reviews
+  that violate it.

--- a/docs/agent-kickoff.md
+++ b/docs/agent-kickoff.md
@@ -97,7 +97,52 @@ The same canonical content is included in `llms-full.txt` as
 prompt-template` would print. The binary version of `vibew prompt-template` is
 canonical — the `llms-full.txt` section is a static snapshot of the dev flavor.
 
+## Consuming via release artifacts
+
+If your tooling cannot ship a vibew binary, fetch the pre-rendered artifacts
+from the GitHub Release and substitute the two-brace placeholders:
+
+| Asset | Stable URL |
+|-------|-----------|
+| Dev flavor | `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-dev.txt` |
+| Deploy flavor | `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-deploy.txt` |
+
+Each file opens with a `#`-prefixed header describing the flavor, version, and
+source command, followed by the byte-for-byte output of `vibew prompt-template`.
+
+### Placeholder substitution
+
+Both artifacts use two-brace mustache-style placeholders:
+
+| Placeholder | Meaning |
+|-------------|---------|
+| `{{prjname}}` | Project name (lowercase, hyphenated, no spaces) |
+| `{{description}}` | One-line project description |
+| `{{domain}}` | FQDN the app will be served on (e.g. `myapp.example.com`) |
+
+Substitute before pasting to an agent — no parsing required:
+
+```js
+// JavaScript example (website / eleventy build step)
+const prompt = artifactText
+  .replaceAll("{{prjname}}", projectName)
+  .replaceAll("{{description}}", description)
+  .replaceAll("{{domain}}", domain);
+```
+
+```bash
+# Shell example
+sed -e "s/{{prjname}}/myapp/g" \
+    -e "s/{{description}}/my todo app/g" \
+    -e "s/{{domain}}/myapp.example.com/g" \
+    agent-kickoff-deploy.txt
+```
+
+These URLs are the public contract locked by ADR-101. Renaming the files is a
+breaking change for any downstream consumer (the website, third-party tools).
+
 ## Reference
 
 - ADR-099: `decisions/adr-099-vibew-prompt-template-canonical-agent-kickoff.md`
+- ADR-101: `decisions/adr-101-agent-kickoff-release-artifacts.md`
 - `vibew prompt-template --help`

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -87,6 +87,21 @@ vibew add rate-limiting # enable rate limiting
 vibew add tls --domain app.yourcompany.com  # use a real domain you control; Let's Encrypt rejects example.com
 ```
 
+To regenerate this kickoff prompt (always matches the installed binary):
+
+```bash
+vibew prompt-template --name <project> --describe "<description>"
+vibew prompt-template --deploy --name <project> --describe "<description>" --domain <fqdn>
+```
+
+If your tooling cannot ship a vibew binary, fetch the pre-rendered release artifacts
+and substitute `{{prjname}}`, `{{description}}`, `{{domain}}` before pasting:
+
+- `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-dev.txt`
+- `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-deploy.txt`
+
+These filenames are public API (ADR-101). See `docs/agent-kickoff.md`.
+
 ## Troubleshooting
 
 ```bash

--- a/internal/app/promptkickoff/release_artifact_test.go
+++ b/internal/app/promptkickoff/release_artifact_test.go
@@ -1,0 +1,192 @@
+package promptkickoff_test
+
+// release_artifact_test.go — forensic CI test for ADR-101.
+//
+// This test verifies that the rendered-and-rewritten output that the release
+// wrapper script (scripts/release/emit-kickoff-artifacts.sh) uploads as
+// GitHub Release assets satisfies the post-#1138 and post-#1217 deploy
+// contracts and does NOT contain any of the known-bad forms (bash deploy.sh,
+// scp glob, etc.).
+//
+// The test uses the same in-process Render path as the wrapper script, then
+// applies the same post-render sed rewrite so no built binary is required.
+// The wrapper script is exercised end-to-end by wrapper_script_test.go.
+
+import (
+	"strings"
+	"testing"
+
+	templateadapter "github.com/vibewarden/vibewarden/internal/adapters/template"
+	"github.com/vibewarden/vibewarden/internal/app/promptkickoff"
+	clitemplates "github.com/vibewarden/vibewarden/internal/cli/templates"
+)
+
+// sentinelRewrite applies the same substitution the release wrapper script
+// applies via sed, converting internal sentinels to the public two-brace
+// placeholder form.
+func sentinelRewrite(s string) string {
+	s = strings.ReplaceAll(s, "vwprjname", "{{prjname}}")
+	s = strings.ReplaceAll(s, "vwdomain.example.invalid", "{{domain}}")
+	// {{description}} is passed literally to --describe and survives
+	// unsanitised through Render, so no rewrite is needed for that field.
+	return s
+}
+
+// renderWithSentinels invokes Render with the three sentinel/literal values
+// the release wrapper script passes and returns the post-rewrite body.
+func renderWithSentinels(t *testing.T, deploy bool) string {
+	t.Helper()
+	renderer := templateadapter.NewRenderer(clitemplates.FS)
+	svc := promptkickoff.NewService(renderer)
+
+	opts := promptkickoff.Options{
+		Name:         "vwprjname",
+		Describe:     "{{description}}",
+		Domain:       "vwdomain.example.invalid",
+		VibewVersion: "v0.0.0-test",
+		Deploy:       deploy,
+	}
+	if !deploy {
+		// dev flavor: domain not required. Pass it anyway so the template
+		// renders the TLS step with the domain sentinel.
+		opts.Domain = "vwdomain.example.invalid"
+	}
+
+	raw, err := svc.Render(opts)
+	if err != nil {
+		t.Fatalf("Render(deploy=%v) error: %v", deploy, err)
+	}
+	return sentinelRewrite(string(raw))
+}
+
+// TestReleaseArtifact_PlaceholdersPresent asserts that all two-brace
+// placeholders survive the sentinel rewrite and appear literally in both
+// artifact bodies.
+func TestReleaseArtifact_PlaceholdersPresent(t *testing.T) {
+	tests := []struct {
+		name   string
+		deploy bool
+		extra  []string
+	}{
+		{
+			name:   "dev",
+			deploy: false,
+		},
+		{
+			name:   "deploy",
+			deploy: true,
+			extra:  []string{"{{domain}}"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := renderWithSentinels(t, tt.deploy)
+
+			for _, ph := range []string{"{{prjname}}", "{{description}}"} {
+				if !strings.Contains(body, ph) {
+					t.Errorf("%s artifact: missing placeholder %q", tt.name, ph)
+				}
+			}
+			for _, ph := range tt.extra {
+				if !strings.Contains(body, ph) {
+					t.Errorf("%s artifact: missing placeholder %q", tt.name, ph)
+				}
+			}
+		})
+	}
+}
+
+// TestReleaseArtifact_SentinelNotInOutput asserts that neither the name
+// sentinel ("vwprjname") nor the domain sentinel ("vwdomain.example.invalid")
+// survives the rewrite.
+func TestReleaseArtifact_SentinelNotInOutput(t *testing.T) {
+	for _, deploy := range []bool{false, true} {
+		flavor := "dev"
+		if deploy {
+			flavor = "deploy"
+		}
+		t.Run(flavor, func(t *testing.T) {
+			body := renderWithSentinels(t, deploy)
+
+			if strings.Contains(body, "vwprjname") {
+				t.Errorf("%s artifact: sentinel 'vwprjname' leaked into output", flavor)
+			}
+			if strings.Contains(body, "vwdomain.example.invalid") {
+				t.Errorf("%s artifact: sentinel 'vwdomain.example.invalid' leaked into output", flavor)
+			}
+		})
+	}
+}
+
+// TestReleaseArtifact_OptionalMkdirAnnotation asserts that the optional-mkdir
+// annotation (ADR-101 §Annotation: optional mkdir) is present in both flavors.
+func TestReleaseArtifact_OptionalMkdirAnnotation(t *testing.T) {
+	for _, deploy := range []bool{false, true} {
+		flavor := "dev"
+		if deploy {
+			flavor = "deploy"
+		}
+		t.Run(flavor, func(t *testing.T) {
+			body := renderWithSentinels(t, deploy)
+			if !strings.Contains(body, "# Skip if you're already in the project directory:") {
+				t.Errorf("%s artifact: missing optional-mkdir annotation", flavor)
+			}
+		})
+	}
+}
+
+// TestReleaseArtifact_DeployContract asserts that the deploy artifact contains
+// the post-#1138 deploy contract and the post-#1217 dotfile-safe tar pipe
+// transfer, and does NOT contain any of the known-bad forms.
+func TestReleaseArtifact_DeployContract(t *testing.T) {
+	body := renderWithSentinels(t, true)
+
+	required := []struct {
+		name    string
+		snippet string
+	}{
+		{"docker load -i image.tar", "docker load -i image.tar"},
+		{"docker compose up -d", "docker compose up -d"},
+		{"tar -czf dotfile-safe send", "tar -czf - -C"},
+		{"tar -xzf dotfile-safe receive", "tar -xzf - -C"},
+		{"healthcheck endpoint", "_vibewarden/health"},
+	}
+
+	for _, r := range required {
+		t.Run("contains/"+r.name, func(t *testing.T) {
+			if !strings.Contains(body, r.snippet) {
+				t.Errorf("deploy artifact missing required snippet %q (post-deploy-contract drift)\n\nFull output:\n%s",
+					r.snippet, body)
+			}
+		})
+	}
+
+	forbidden := []struct {
+		name    string
+		snippet string
+	}{
+		{"bash deploy.sh", "bash deploy.sh"},
+		{"./deploy.sh", "./deploy.sh"},
+		{"scp glob star", "scp -r .vibewarden/bundle/*"},
+		{"scp glob dot", "scp -r .vibewarden/bundle/."},
+	}
+
+	for _, r := range forbidden {
+		t.Run("absent/"+r.name, func(t *testing.T) {
+			if strings.Contains(body, r.snippet) {
+				t.Errorf("deploy artifact contains forbidden snippet %q (regression)\n\nFull output:\n%s",
+					r.snippet, body)
+			}
+		})
+	}
+}
+
+// TestReleaseArtifact_NoDeployShInDevFlavor mirrors the existing
+// TestNoDeployShInAnyFlavor guard for the sentinel-based rendering path.
+func TestReleaseArtifact_NoDeployShInDevFlavor(t *testing.T) {
+	body := renderWithSentinels(t, false)
+	if strings.Contains(body, "deploy.sh") {
+		t.Errorf("dev artifact contains forbidden string 'deploy.sh'\n\nOutput:\n%s", body)
+	}
+}

--- a/internal/app/promptkickoff/testdata/deploy.golden
+++ b/internal/app/promptkickoff/testdata/deploy.golden
@@ -15,6 +15,7 @@ Verify: `vibew --version` should print a version string.
 
 ## Step 2 — Scaffold the project
 
+  # Skip if you're already in the project directory:
   mkdir foo && cd foo
   vibew init --name foo --describe "bar"
 

--- a/internal/app/promptkickoff/testdata/dev.golden
+++ b/internal/app/promptkickoff/testdata/dev.golden
@@ -15,6 +15,7 @@ Verify: `vibew --version` should print a version string.
 
 ## Step 2 — Scaffold the project
 
+  # Skip if you're already in the project directory:
   mkdir foo && cd foo
   vibew init --name foo --describe "bar"
 

--- a/internal/app/promptkickoff/wrapper_script_test.go
+++ b/internal/app/promptkickoff/wrapper_script_test.go
@@ -118,7 +118,10 @@ func TestWrapperScript_ArtifactsPassForensicChecks(t *testing.T) {
 
 	// Deploy-specific: post-#1138 and post-#1217 contract.
 	deployPath := filepath.Join(tmpDir, "agent-kickoff-deploy.txt")
-	deployBody, _ := os.ReadFile(deployPath)
+	deployBody, err := os.ReadFile(deployPath)
+	if err != nil {
+		t.Fatalf("read deploy artifact %s: %v", deployPath, err)
+	}
 	deploy := string(deployBody)
 
 	required := []struct {

--- a/internal/app/promptkickoff/wrapper_script_test.go
+++ b/internal/app/promptkickoff/wrapper_script_test.go
@@ -1,0 +1,158 @@
+package promptkickoff_test
+
+// wrapper_script_test.go — end-to-end test for the release wrapper script.
+//
+// Shells out to scripts/release/emit-kickoff-artifacts.sh in a temporary
+// directory and asserts that the artifacts it produces contain the same
+// structural guarantees as the in-process forensic tests (release_artifact_test.go).
+//
+// This test is skipped on Windows (the wrapper is bash-only) and when the
+// SKIP_WRAPPER_SCRIPT_TEST environment variable is set to "1" (useful for
+// environments where building the binary is not available, e.g. some CI
+// sandboxes).
+//
+// ADR-101.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// repoRoot returns the absolute path to the repository root. It resolves the
+// root by walking up from the test file's directory until it finds a go.mod.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	// Use the test binary's working directory — go test sets this to the
+	// package directory. Walk upward to find go.mod.
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repository root (go.mod not found)")
+		}
+		dir = parent
+	}
+}
+
+// TestWrapperScript_ArtifactsPassForensicChecks builds vibew, runs the
+// release wrapper script, and asserts the emitted artifacts pass the same
+// structural checks as the in-process forensic tests.
+func TestWrapperScript_ArtifactsPassForensicChecks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("wrapper script is bash-only; skipping on Windows")
+	}
+	if os.Getenv("SKIP_WRAPPER_SCRIPT_TEST") == "1" {
+		t.Skip("SKIP_WRAPPER_SCRIPT_TEST=1")
+	}
+
+	root := repoRoot(t)
+	tmpDir := t.TempDir()
+
+	script := filepath.Join(root, "scripts", "release", "emit-kickoff-artifacts.sh")
+
+	cmd := exec.Command(script, tmpDir) //nolint:gosec // script is a known path under the repo root
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("emit-kickoff-artifacts.sh failed: %v\n--- output ---\n%s", err, out)
+	}
+	t.Logf("script output:\n%s", out)
+
+	for _, flavor := range []string{"dev", "deploy"} {
+		path := filepath.Join(tmpDir, "agent-kickoff-"+flavor+".txt")
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("reading %s: %v", path, readErr)
+		}
+		s := string(body)
+
+		t.Run(flavor+"/header", func(t *testing.T) {
+			if !strings.Contains(s, "VibeWarden Agent Kickoff Release Artifact") {
+				t.Errorf("missing header sentinel")
+			}
+			if !strings.Contains(s, "Flavor: "+flavor) {
+				t.Errorf("missing flavor line")
+			}
+			if !strings.Contains(s, "Canonical URL:") {
+				t.Errorf("missing Canonical URL line")
+			}
+		})
+
+		t.Run(flavor+"/placeholders", func(t *testing.T) {
+			for _, ph := range []string{"{{prjname}}", "{{description}}"} {
+				if !strings.Contains(s, ph) {
+					t.Errorf("missing placeholder %q", ph)
+				}
+			}
+			if flavor == "deploy" && !strings.Contains(s, "{{domain}}") {
+				t.Errorf("deploy artifact missing {{domain}} placeholder")
+			}
+		})
+
+		t.Run(flavor+"/no-sentinel-leak", func(t *testing.T) {
+			if strings.Contains(s, "vwprjname") {
+				t.Errorf("sentinel 'vwprjname' leaked into output")
+			}
+			if strings.Contains(s, "vwdomain.example.invalid") {
+				t.Errorf("sentinel 'vwdomain.example.invalid' leaked into output")
+			}
+		})
+
+		t.Run(flavor+"/optional-mkdir-annotation", func(t *testing.T) {
+			if !strings.Contains(s, "# Skip if you're already in the project directory:") {
+				t.Errorf("missing optional-mkdir annotation")
+			}
+		})
+	}
+
+	// Deploy-specific: post-#1138 and post-#1217 contract.
+	deployPath := filepath.Join(tmpDir, "agent-kickoff-deploy.txt")
+	deployBody, _ := os.ReadFile(deployPath)
+	deploy := string(deployBody)
+
+	required := []struct {
+		name    string
+		snippet string
+	}{
+		{"docker load -i image.tar", "docker load -i image.tar"},
+		{"docker compose up -d", "docker compose up -d"},
+		{"tar -czf dotfile-safe send", "tar -czf - -C"},
+		{"tar -xzf dotfile-safe receive", "tar -xzf - -C"},
+		{"healthcheck endpoint", "_vibewarden/health"},
+	}
+	for _, r := range required {
+		t.Run("deploy/contains/"+r.name, func(t *testing.T) {
+			if !strings.Contains(deploy, r.snippet) {
+				t.Errorf("missing required snippet %q (post-deploy-contract drift)", r.snippet)
+			}
+		})
+	}
+
+	forbidden := []struct {
+		name    string
+		snippet string
+	}{
+		{"bash deploy.sh", "bash deploy.sh"},
+		{"./deploy.sh", "./deploy.sh"},
+		{"scp glob star", "scp -r .vibewarden/bundle/*"},
+		{"scp glob dot", "scp -r .vibewarden/bundle/."},
+	}
+	for _, r := range forbidden {
+		t.Run("deploy/absent/"+r.name, func(t *testing.T) {
+			if strings.Contains(deploy, r.snippet) {
+				t.Errorf("contains forbidden snippet %q (regression)", r.snippet)
+			}
+		})
+	}
+}

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -100,6 +100,7 @@ app port directly — it has no security.
 | `vibew cert export` | Export TLS certificate |
 | `vibew validate` | Validate vibewarden.yaml |
 | `vibew add auth` | Enable authentication |
+| `vibew prompt-template` | Print the canonical agent kickoff prompt to stdout. The output matches the installed binary version. Release artifacts (no binary required): `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-dev.txt` and `.../agent-kickoff-deploy.txt`. Substitute `{{"{{"}}prjname{{"}}"}}`, `{{"{{"}}description{{"}}"}}`, `{{"{{"}}domain{{"}}"}}` before pasting. |
 
 `vibew validate` now catches real next-command failures before they reach `vibew bundle` or `vibew up`: name collision (directory named "vibewarden" with no explicit name: set), Dockerfile EXPOSE/upstream.port mismatch, image-tag drift in .env, ACME-incompatible domain (localhost, IP literal, .local/.test TLD), and WAF log-mode enabled in a production config. Any of these conditions exits with code 1 and a FAIL row on stderr; fix the config or set the appropriate acknowledgement key before running the next command.
 

--- a/internal/cli/templates/prompts/deploy.tmpl
+++ b/internal/cli/templates/prompts/deploy.tmpl
@@ -15,6 +15,7 @@ Verify: `vibew --version` should print a version string.
 
 ## Step 2 — Scaffold the project
 
+  # Skip if you're already in the project directory:
   mkdir {{.Name}} && cd {{.Name}}
   vibew init --name {{.Name}} --describe "{{.Describe}}"
 

--- a/internal/cli/templates/prompts/dev.tmpl
+++ b/internal/cli/templates/prompts/dev.tmpl
@@ -15,6 +15,7 @@ Verify: `vibew --version` should print a version string.
 
 ## Step 2 — Scaffold the project
 
+  # Skip if you're already in the project directory:
   mkdir {{.Name}} && cd {{.Name}}
   vibew init --name {{.Name}} --describe "{{.Describe}}"
 

--- a/internal/quality/removed_artifacts_test.go
+++ b/internal/quality/removed_artifacts_test.go
@@ -69,6 +69,8 @@ func TestRemovedArtifacts_NoForbiddenReferences(t *testing.T) {
 		"prompt_template_test.go",
 		"golden_test.go",
 		"osfs_test.go",
+		"release_artifact_test.go",
+		"wrapper_script_test.go",
 		// Explanatory docs: historical context for why an artifact was removed.
 		"docs" + string(filepath.Separator) + "agent-kickoff.md",
 		"llms-full.txt",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1923,3 +1923,11 @@ Arch mismatch (Apple Silicon building for amd64 VPS): run
 hard-fails (exit 1) on arch mismatch; the error prints the exact rebuild command.
 
 See docs/agent-kickoff.md for the full reference and deploy flavor sample.
+
+If your tooling cannot ship a vibew binary, fetch the same canonical content
+from the GitHub Release and substitute the two-brace placeholders before pasting
+to an agent:
+  https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-dev.txt
+  https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-deploy.txt
+Placeholders: {{prjname}} (project name), {{description}} (one-line description),
+{{domain}} (FQDN). No parsing required — plain string substitution.

--- a/llms.txt
+++ b/llms.txt
@@ -66,6 +66,9 @@ cd my-app && vibew wrap --upstream 3000 && vibew dev
     `vibew prompt-template --name myapp --describe "todo list app"`
     `vibew prompt-template --deploy --name myapp --describe "todo list app" --domain myapp.example.com`
   See: docs/agent-kickoff.md and llms-full.txt § 21. Agent Kickoff Prompt.
+  Release artifacts (no binary required — substitute {{prjname}}/{{description}}/{{domain}} before use):
+    https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-dev.txt
+    https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-deploy.txt
 
 Full reference: https://vibewarden.dev/llms-full.txt
 

--- a/scripts/release/emit-kickoff-artifacts.sh
+++ b/scripts/release/emit-kickoff-artifacts.sh
@@ -37,6 +37,15 @@ fi
 # Sentinels used in place of the public two-brace placeholders.
 # vwprjname survives SanitizeProjectName (lowercase alphanum only).
 # vwdomain.example.invalid is a valid FQDN for the CLI validator.
+#
+# Reserved sentinel token. Used because config.SanitizeProjectName rewrites
+# `{{prjname}}` to `prjname`, so we can't pass the literal placeholder to
+# `vibew prompt-template --name`. The sed rewrite below is unanchored — if
+# any future template line happens to contain the substring `vwprjname` it
+# would be silently corrupted. The forensic test in
+# internal/app/promptkickoff/wrapper_script_test.go::TestWrapperScript_ArtifactsPassForensicChecks
+# guards against the leakage case but pick a different sentinel here if you
+# ever introduce a template line that legitimately contains `vwprjname`.
 NAME_SENTINEL="vwprjname"
 DOMAIN_SENTINEL="vwdomain.example.invalid"
 

--- a/scripts/release/emit-kickoff-artifacts.sh
+++ b/scripts/release/emit-kickoff-artifacts.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# emit-kickoff-artifacts.sh — Emit agent-kickoff-{dev,deploy}.txt artifacts
+# for the release.
+#
+# Invoked from .goreleaser.yml before.hooks so the artifacts are ready before
+# goreleaser's release stage uploads them via release.extra_files.
+#
+# Usage:
+#   ./scripts/release/emit-kickoff-artifacts.sh [OUT_DIR]
+#
+# OUT_DIR defaults to "dist". Both output files are written there:
+#   $OUT_DIR/agent-kickoff-dev.txt
+#   $OUT_DIR/agent-kickoff-deploy.txt
+#
+# Design: ADR-101.
+# Edge case: config.SanitizeProjectName rewrites curly braces in project names
+# to hyphens. The public placeholder {{prjname}} would be mangled to "prjname".
+# Solution: pass a sanitiser-safe sentinel ("vwprjname") for --name, then
+# sed-rewrite the rendered output to restore the two-brace placeholder form.
+# The --describe and --domain values are not sanitised by the CLI so they can
+# be passed through literally as {{description}} and a domain sentinel.
+
+set -euo pipefail
+
+OUT_DIR="${1:-dist}"
+mkdir -p "$OUT_DIR"
+
+# Build vibew once for this run. Goreleaser may have already built it; reuse
+# if the binary is present at the project root. The ldflags stamp matches the
+# goreleaser build so the version header in the artifact is accurate.
+VIBEW_BIN="./vibew"
+if [ ! -x "$VIBEW_BIN" ]; then
+  VERSION="$(git describe --tags --always 2>/dev/null || echo "dev")"
+  go build -o "$VIBEW_BIN" -ldflags "-X main.version=${VERSION}" ./cmd/vibewarden
+fi
+
+# Sentinels used in place of the public two-brace placeholders.
+# vwprjname survives SanitizeProjectName (lowercase alphanum only).
+# vwdomain.example.invalid is a valid FQDN for the CLI validator.
+NAME_SENTINEL="vwprjname"
+DOMAIN_SENTINEL="vwdomain.example.invalid"
+
+# write_header appends the self-describing artifact header (shell-comment-safe,
+# every line #-prefixed) to $outfile.
+write_header() {
+  local flavor="$1"
+  local outfile="$2"
+  local src_cmd="$3"
+  cat >> "$outfile" <<EOF
+# VibeWarden Agent Kickoff Release Artifact
+# Flavor: $flavor
+# vibew version: $("$VIBEW_BIN" --version 2>&1 | head -1)
+# Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+# Source command: $src_cmd
+#
+# This file uses two-brace placeholders. Substitute before pasting:
+#   {{prjname}}     — project name (lowercase, hyphenated, no spaces)
+#   {{description}} — one-line project description
+#   {{domain}}      — FQDN the app will be served on (e.g. myapp.example.com)
+#
+# Regeneration:
+#   vibew prompt-template [--deploy] --name "{{prjname}}" --describe "{{description}}" [--domain "{{domain}}"]
+#
+# Canonical URL:
+#   https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-$flavor.txt
+# ----------------------------------------------------------------------------
+EOF
+}
+
+# Dev flavor: --name sentinel, --describe literal placeholder.
+DEV_OUT="$OUT_DIR/agent-kickoff-dev.txt"
+: > "$DEV_OUT"  # truncate / create
+write_header \
+  "dev" \
+  "$DEV_OUT" \
+  'vibew prompt-template --name "{{prjname}}" --describe "{{description}}"'
+"$VIBEW_BIN" prompt-template \
+  --name "$NAME_SENTINEL" \
+  --describe "{{description}}" \
+  | sed "s/${NAME_SENTINEL}/{{prjname}}/g" \
+  >> "$DEV_OUT"
+
+# Deploy flavor: adds --deploy and --domain sentinel.
+DEPLOY_OUT="$OUT_DIR/agent-kickoff-deploy.txt"
+: > "$DEPLOY_OUT"  # truncate / create
+write_header \
+  "deploy" \
+  "$DEPLOY_OUT" \
+  'vibew prompt-template --deploy --name "{{prjname}}" --describe "{{description}}" --domain "{{domain}}"'
+"$VIBEW_BIN" prompt-template \
+  --deploy \
+  --name "$NAME_SENTINEL" \
+  --describe "{{description}}" \
+  --domain "$DOMAIN_SENTINEL" \
+  | sed -e "s/${NAME_SENTINEL}/{{prjname}}/g" \
+        -e "s/${DOMAIN_SENTINEL}/{{domain}}/g" \
+  >> "$DEPLOY_OUT"
+
+echo "Wrote $DEV_OUT and $DEPLOY_OUT"


### PR DESCRIPTION
Closes #1232

## Summary

ADR-101 implementation. Goreleaser now emits two canonical agent kickoff prompt artifacts as GitHub Release assets on every release tag, permanently fixing the three-retro drift problem (qr-code-blackhole, qr-code-brutalist Go, qr-code-brutalist Node) where the website's hand-rolled template silently fell behind the binary's deploy contract.

- **`scripts/release/emit-kickoff-artifacts.sh`** — bash wrapper invoked by `goreleaser before.hooks`. Builds vibew once, invokes `vibew prompt-template` twice (dev + deploy flavors) with sentinel values, sed-rewrites sentinels back to `{{prjname}}`/`{{domain}}` two-brace placeholders, prepends canonical header, writes to `dist/`.
- **`.goreleaser.yml`** — `before.hooks` entry + `release.extra_files` for both `.txt` artifacts.
- **`internal/app/promptkickoff/release_artifact_test.go`** — forensic CI test (in-process Render+rewrite). Asserts post-#1138 deploy contract, post-#1217 tar pipe, optional-mkdir annotation, placeholder survival, sentinel non-leak, forbidden forms absent.
- **`internal/app/promptkickoff/wrapper_script_test.go`** — end-to-end test that shells out to the script and diffs against the in-process path.
- **Templates** (`dev.tmpl`, `deploy.tmpl`) — added `# Skip if you're already in the project directory:` above `mkdir` per ADR-101.
- **Golden files** regenerated to capture the annotation.
- **`internal/quality/removed_artifacts_test.go`** — allowlisted `release_artifact_test.go` and `wrapper_script_test.go` (negative-assertion guards that reference `deploy.sh`).
- **Docs**: `docs/agent-kickoff.md` — "Consuming via release artifacts" subsection; `llms-full.txt § 21` — release-asset URL note; `CLAUDE.md § Content authority` — locked the artifact URLs as public API.

### Script invocation sample

```bash
bash scripts/release/emit-kickoff-artifacts.sh dist
# Wrote dist/agent-kickoff-dev.txt and dist/agent-kickoff-deploy.txt
```

### Artifact header (literal from local smoke run)

```
# VibeWarden Agent Kickoff Release Artifact
# Flavor: deploy
# vibew version: vibew dev
# Generated: 2026-04-30T09:33:40Z
# Source command: vibew prompt-template --deploy --name "{{prjname}}" --describe "{{description}}" --domain "{{domain}}"
#
# This file uses two-brace placeholders. Substitute before pasting:
#   {{prjname}}     — project name (lowercase, hyphenated, no spaces)
#   {{description}} — one-line project description
#   {{domain}}      — FQDN the app will be served on (e.g. myapp.example.com)
#
# Regeneration:
#   vibew prompt-template [--deploy] --name "{{prjname}}" --describe "{{description}}" [--domain "{{domain}}"]
#
# Canonical URL:
#   https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-deploy.txt
# ----------------------------------------------------------------------------
```

### Stable URLs (public contract, locked per ADR-101)

- `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-dev.txt`
- `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-deploy.txt`

### Website companion

`vibewarden/vibewarden.dev#95` — depends on this PR landing first so the release URLs resolve.

## Test plan

- [x] `make check` clean (lint, build, `go test -race ./...`, demo-app)
- [x] `go test ./internal/app/promptkickoff/... -v` — all 3 new test functions (14 subtests in `release_artifact_test.go`, 17 subtests in `wrapper_script_test.go`) pass
- [x] Smoke: script produces both artifacts with correct headers, no sentinel leaks, placeholders intact, optional-mkdir annotation present, deploy contract complete
- [x] `gofmt -l ./...` — empty
- [x] `scripts/release/emit-kickoff-artifacts.sh` is `chmod +x`
- [x] ADR-101 committed, decisions/README.md index row present

🤖 Generated with [Claude Code](https://claude.com/claude-code)