### PR TITLE
feat(#1233): vibew probe [--env name] — Go-stdlib HTTPS probe of /_vibewarden/health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Added
 
+- **`vibew probe [--env <name>]`** (#1233, ADR-102) — Go-stdlib HTTPS probe of `_vibewarden/health`. Default probes `https://localhost:<server.port>` with `InsecureSkipVerify` (bypasses macOS LibreSSL friction by construction). `--env <name>` resolves `vibewarden.<name>.yaml`, reads merged `tls.domain`, probes the production endpoint with full cert verification. Boot-gap retry: up to 10s when `components.upstream:"unknown"`. Generalizable env-resolver in `internal/app/env/` is available for future verbs to adopt (`vibew status --env prod`, `vibew validate --env prod`, etc.); migration of existing verbs is out of scope here.
+
 - **Release artifacts: `agent-kickoff-dev.txt` and `agent-kickoff-deploy.txt`** (#1232, ADR-101). Goreleaser now emits both flavors of the canonical agent kickoff prompt as release assets, with `{{prjname}}`, `{{description}}`, and `{{domain}}` two-brace placeholders for consumers to substitute. Stable URL: `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-dev.txt`. The website (vibewarden/vibewarden.dev) will fetch these at build time, replacing the hand-rolled JS template literal that drifted across three retros (vibewarden.dev#95). Forensic CI test asserts both artifacts contain the post-#1138 deploy contract (`docker load -i image.tar && docker compose up -d`), include the post-#1217 tar pipe transfer, and do NOT contain `bash deploy.sh` or the buggy `scp -r .vibewarden/bundle/*` glob form.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -308,7 +308,8 @@ features after the initial setup.
 | `vibew dev` | Start local dev environment |
 | `vibew dev --rebuild` | Stop stack, remove app image, rebuild, start — recovery for image-identity mismatch (v0.18.3+) |
 | `vibew bundle` | Produce a self-contained Docker Compose deploy artifact under `.vibewarden/bundle/` ([walkthrough](docs/guide/bundle-to-vps.md)) |
-| `vibew status` | Show health of all components |
+| `vibew probe` | One-shot HTTPS health check of `/_vibewarden/health` via Go's TLS stack (bypasses macOS LibreSSL friction). `--env <name>` probes a named environment overlay. |
+| `vibew status` | Show health of all components (richer dev-stack overview; use `vibew probe` for one-shot HTTPS verification) |
 | `vibew doctor` | Diagnose common issues |
 | `vibew logs [--tail N] [--follow] [--since <duration>] [<service>...]` | Stream local dev-stack logs (all services interleaved by default; scope with service name args) |
 | `vibew migrate` | Apply all pending database migrations (alias for `migrate up`) |

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -74,6 +74,7 @@ once accepted, they are not edited. If a decision is superseded, a new ADR refer
 | [099](adr-099-vibew-prompt-template-canonical-agent-kickoff.md) | `vibew prompt-template` — canonical agent kickoff prompt owned by the binary | — |
 | [100](adr-100-image-identity-via-project-root-label.md) | Image identity via `org.vibewarden.project-root-hash` label | — |
 | [101](adr-101-agent-kickoff-release-artifacts.md) | Agent-kickoff release artifacts — main repo emits canonical kickoff prompts as release assets | #1232 |
+| [102](adr-102-vibew-probe-go-stdlib-health-probe-and-env-resolver.md) | `vibew probe [--env <name>]` — Go-stdlib HTTPS probe of `/_vibewarden/health` and a generalisable env-resolver | #1233 |
 | [497](adr-497-graceful-shutdown-connection-draining.md) | Graceful Shutdown / Connection Draining | — |
 
 ## Numbering

--- a/decisions/adr-102-vibew-probe-go-stdlib-health-probe-and-env-resolver.md
+++ b/decisions/adr-102-vibew-probe-go-stdlib-health-probe-and-env-resolver.md
@@ -1,0 +1,518 @@
+# ADR-102: `vibew probe [--env <name>]` — Go-stdlib HTTPS probe of `/_vibewarden/health` and a generalisable env-resolver
+
+**Date**: 2026-04-30
+**Issue**: #1233
+**Status**: Accepted
+
+## Context
+
+The v0.18.3 retrospective (qr-code-brutalist Node deploy) flagged a recurring
+friction point that has now appeared across multiple retros:
+
+> Used Python for HTTPS testing because system curl on macOS uses LibreSSL
+> which couldn't handshake the self-signed dev cert. Workaround:
+> `python3 -c "import ssl, urllib.request..."`. A `vibew curl <path>` or
+> `vibew probe` helper that uses Go's TLS stack would erase a real friction
+> point.
+
+#1224 added a `vibew doctor` advisory that documents the LibreSSL workaround,
+but the friction itself remains: every dev session on macOS that wants to
+verify the local stack is forced into a Python one-liner because the system
+`curl` cannot handshake the dev self-signed cert. The advisory bought us a
+diagnostic; #1233 buys us the fix.
+
+Two architectural concerns are entangled in this work:
+
+1. **The local probe itself.** Needs to bypass the host's TLS stack and use
+   Go's stdlib `crypto/tls`, which does handshake the dev cert without
+   complaint. `InsecureSkipVerify: true` is appropriate for the dev path —
+   the cert is self-signed by construction and the target is `localhost`.
+
+2. **The `--env <name>` mechanism.** Multiple future verbs (`vibew status
+   --env prod`, `vibew validate --env prod`, etc.) want to operate against a
+   named environment overlay. Today `vibew bundle` rolls its own
+   `prodConfigPathForEnv` helper plus a targeted `readProdTLSDomain` reader,
+   and `vibew validate` rolls its own `discoverProdOverride` helper. Both
+   shapes already exist in the codebase but are duplicated and ad-hoc. The
+   shape we ship for `vibew probe --env <name>` will become the de facto
+   pattern for every `--env` verb that follows. This is architectural, not
+   incidental — hence ADR-worthy.
+
+The wire format the probe consumes is already locked by ADR-098 / #1197:
+
+```json
+{
+  "status": "ok|degraded",
+  "version": "0.18.4",
+  "components": {
+    "sidecar": "ok",
+    "upstream": "ok|failing|unknown"
+  }
+}
+```
+
+The 5–10s "boot gap" (where `components.upstream == "unknown"` because the
+background probe has not run its first cycle yet) is a known property of the
+sidecar. `vibew probe` must absorb that gap rather than report a spurious
+failure during it.
+
+### Alternatives considered
+
+- **`vibew curl <path>`** — rejected at triage. Re-implements curl, ratchets
+  scope, has no clear feature ceiling. The probe is a fixed verb against a
+  fixed endpoint and that is its strength.
+- **`vibew dev --no-tls`** — rejected at triage. Weakens dev/prod parity.
+  Caddy's TLS pipeline is exactly what we want covered by the dev loop.
+- **Shell out to system `curl`** — rejected. That is the bug we are fixing.
+  LibreSSL is the friction.
+- **Patch macOS LibreSSL trust upstream** — out of scope. Tracked separately;
+  even when fixed, the in-binary probe is still useful because it removes the
+  external dependency entirely.
+- **Reuse `internal/adapters/ops.VibeWardenHealthProbe`** — close, but that
+  port (`PortOwnerProbe`) returns a binary `OwnerVibeWarden | OwnerForeign`
+  for `vibew doctor`'s port-ownership check (ADR-084). It deliberately reads
+  only the first 512 bytes and matches a JSON prefix; it does not parse the
+  full health response. Reusing it would require widening its surface in a
+  way that defeats its purpose. We add a sibling adapter that parses the
+  full body.
+
+## Decision
+
+Add a new CLI verb, `vibew probe`, that performs an HTTPS GET against the
+sidecar's `/_vibewarden/health` endpoint using Go's stdlib HTTP client. Add
+a small, focused `internal/app/env` package whose `Resolver` type is the
+single canonical entry point for `--env <name>` flag handling across the
+CLI.
+
+### Domain model changes
+
+None. The probe is a CLI/app-layer use case that consumes the existing
+health wire format owned by `internal/adapters/caddy/health_handler.go`. No
+new domain entity is introduced.
+
+The probe response is modelled as a value object inside the new probe app
+package (`HealthDocument`, see below), but that type lives in the app layer
+because it is a transport/wire shape, not a domain concept. The domain
+already owns the underlying state model in `internal/domain/upstream` and
+`internal/domain/health`.
+
+### Ports (interfaces)
+
+Add **one** new outbound port:
+
+```go
+// internal/ports/health_prober.go
+package ports
+
+import "context"
+
+// HealthProber issues an HTTPS GET against a sidecar's /_vibewarden/health
+// endpoint and returns the parsed wire-format response.
+//
+// Implementations choose how strictly to verify the TLS cert chain — the
+// localhost adapter sets InsecureSkipVerify=true; the production adapter
+// uses the stdlib default (full chain verification). Callers express the
+// difference by selecting the adapter, not via flags on the port.
+type HealthProber interface {
+    // Probe performs a single HTTPS GET against url and returns the parsed
+    // body. Returns ErrProbeRefused when the connection is refused (stack
+    // not running). Returns ErrProbeMalformed when the body cannot be
+    // parsed as the expected wire format. Returns ErrProbeNon200 when the
+    // server returns a non-2xx status — Body and StatusCode on the wrapped
+    // error give the caller enough context to render a useful message.
+    Probe(ctx context.Context, url string) (HealthDocument, error)
+}
+
+// HealthDocument is the parsed shape of /_vibewarden/health (ADR-098).
+type HealthDocument struct {
+    Status     string            // "ok" | "degraded"
+    Version    string            // sidecar version, e.g. "0.18.4"
+    Site       string            // multisite scope, "" for single-site
+    Components map[string]string // {"sidecar": "ok", "upstream": "ok"|"failing"|"unknown"}
+}
+```
+
+Sentinel errors live alongside the port:
+
+```go
+// internal/ports/health_prober.go
+var (
+    ErrProbeRefused   = errors.New("connection refused — stack is not running")
+    ErrProbeMalformed = errors.New("malformed health response body")
+    ErrProbeNon200    = errors.New("non-2xx response from health endpoint")
+)
+
+// ProbeNon200Error wraps ErrProbeNon200 with the status code and a bounded
+// snippet of the response body so the CLI layer can render a useful message
+// without re-issuing the request.
+type ProbeNon200Error struct {
+    StatusCode int
+    Body       string // truncated to ~512 bytes
+}
+
+func (e *ProbeNon200Error) Error() string { ... }
+func (e *ProbeNon200Error) Unwrap() error { return ErrProbeNon200 }
+```
+
+No new inbound port. `vibew probe` is a CLI-driven use case, not an
+externally-driven one.
+
+### Adapters
+
+Add **one** new adapter, with a constructor for each TLS posture:
+
+```go
+// internal/adapters/health/prober.go
+package health
+
+// HTTPProber implements ports.HealthProber via Go's stdlib net/http.
+//
+// Construct with NewLocalhostProber for the dev path (InsecureSkipVerify),
+// or NewStrictProber for the --env path (full cert chain verification).
+type HTTPProber struct {
+    client *http.Client
+}
+
+func NewLocalhostProber(timeout time.Duration) *HTTPProber {
+    return &HTTPProber{client: &http.Client{
+        Timeout: timeout,
+        Transport: &http.Transport{
+            TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+        },
+    }}
+}
+
+func NewStrictProber(timeout time.Duration) *HTTPProber {
+    return &HTTPProber{client: &http.Client{Timeout: timeout}}
+}
+```
+
+Both constructors return the same concrete type; only the TLS config
+differs. The adapter file lives next to `internal/adapters/health/checker.go`
+which already houses the server-side background probe — the package's role
+is "everything HTTP-health-related on the client side as well as the server
+side".
+
+### Application service
+
+Add `internal/app/probe/`:
+
+```go
+// internal/app/probe/service.go
+package probe
+
+// Options is the parameter object for Service.Run.
+type Options struct {
+    URL          string         // resolved target URL
+    BootGapWait  time.Duration  // total wait budget for "upstream:unknown"; default 10s
+    BootGapPoll  time.Duration  // retry interval inside the boot gap; default 1s
+    PerProbe     time.Duration  // per-request timeout; default 3s
+}
+
+// Result is what the CLI renders. Keeps Doc separate from the URL so the
+// renderer can print the URL even on error paths.
+type Result struct {
+    URL string
+    Doc ports.HealthDocument
+}
+
+type Service struct {
+    prober ports.HealthProber
+    clock  func() time.Time            // injectable for tests
+    sleep  func(d time.Duration)       // injectable for tests
+}
+
+func NewService(prober ports.HealthProber) *Service { ... }
+
+// Run probes URL once, and if the response is healthy except for
+// components.upstream == "unknown", retries every BootGapPoll until either
+// the upstream clears or BootGapWait elapses. Returns the final Result.
+//
+// Sentinel errors propagate from the prober: ErrProbeRefused,
+// ErrProbeMalformed, *ProbeNon200Error.
+func (s *Service) Run(ctx context.Context, opts Options) (Result, error) { ... }
+```
+
+The boot-gap retry lives in the **app layer**, not the adapter, because it
+is a use-case policy: "this CLI is willing to wait 10s for the boot probe
+to converge". A different consumer (e.g. a future `vibew status` reuse)
+might want a 0s budget. The adapter stays a single-shot HTTP call.
+
+### Env-resolver package
+
+Add `internal/app/env/`:
+
+```go
+// internal/app/env/resolver.go
+package env
+
+// Resolver loads the merged config for an optional environment name.
+//
+// When name is empty, only the base vibewarden.yaml is loaded (via
+// config.Load). When name is non-empty, vibewarden.<name>.yaml is loaded
+// from the same directory and deep-merged on top of the base via the
+// existing bundleapp.LoadMergedConfig contract. Missing override files are
+// an error — explicit env names map to existing files.
+type Resolver interface {
+    Resolve(name string) (Resolved, error)
+}
+
+// Resolved carries the merged config plus the file paths that produced it.
+// Future verbs (vibew status --env prod, etc.) re-use this shape.
+type Resolved struct {
+    Cfg            *config.Config
+    BasePath       string // absolute path to vibewarden.yaml
+    OverridePath   string // absolute path to vibewarden.<name>.yaml; "" when name == ""
+    EnvName        string // echoes name; "" for default
+}
+
+// FileResolver is the default implementation. ProjectRoot defaults to the
+// caller's working directory when empty.
+type FileResolver struct {
+    ProjectRoot string
+}
+
+func NewFileResolver(projectRoot string) *FileResolver { ... }
+
+func (r *FileResolver) Resolve(name string) (Resolved, error) { ... }
+
+// Sentinel errors:
+var (
+    ErrBaseConfigMissing     = errors.New("base config not found: vibewarden.yaml")
+    ErrOverrideConfigMissing = errors.New("override config not found")
+)
+```
+
+`Resolve` delegates to `bundleapp.LoadMergedConfig` for the actual deep-merge
+(the merge logic stays in `internal/app/bundle/resolve.go` — no duplication;
+`env` is a thin coordinator that locates the files and forwards to the
+existing merger). When `name == ""`, `Resolve` calls `config.Load` directly.
+
+Migrating `vibew bundle` and `vibew validate` to consume `env.Resolver` is
+**explicitly out of scope** for #1233 — those verbs already work and
+swapping their plumbing risks regressions in unrelated code paths. The
+package is positioned as the canonical home for future adopters; the
+existing helpers stay until a follow-up issue migrates them.
+
+### Probe target resolution
+
+The `vibew probe` command resolves its target URL like this:
+
+| `--env` | Source                                   | URL form                                        | TLS verify |
+|---------|------------------------------------------|-------------------------------------------------|------------|
+| absent  | base `vibewarden.yaml` `server.port`     | `https://localhost:<port>/_vibewarden/health`   | skip       |
+| present | merged config `tls.domain`               | `https://<domain>/_vibewarden/health`           | full chain |
+
+When `--env <name>` is set but the merged `tls.domain` is empty (or the
+merged config's TLS plugin is not enabled), the command exits 1 with a
+message pointing at the user's `vibewarden.<name>.yaml` — there is no
+fallback to localhost in `--env` mode (that would mask a real config bug).
+
+### File layout
+
+New files (all paths absolute from repo root):
+
+```
+internal/ports/health_prober.go                          # port + sentinel errors + HealthDocument
+internal/adapters/health/prober.go                       # HTTPProber, NewLocalhostProber, NewStrictProber
+internal/adapters/health/prober_test.go                  # unit tests via httptest.Server
+internal/app/probe/service.go                            # Service + Options + Result; boot-gap retry
+internal/app/probe/service_test.go                       # unit tests with a fake prober
+internal/app/probe/render.go                             # Render(io.Writer, Result) — output formatter
+internal/app/probe/render_test.go                        # golden test for the output block
+internal/app/env/resolver.go                             # Resolver, FileResolver, Resolved, sentinels
+internal/app/env/resolver_test.go                        # unit tests covering name="" and name="prod"
+internal/cli/cmd/probe.go                                # cobra command, flag wiring, exit codes
+internal/cli/cmd/probe_test.go                           # CLI-level integration tests
+decisions/adr-102-vibew-probe-go-stdlib-health-probe-and-env-resolver.md  # this ADR
+```
+
+Modified files:
+
+```
+internal/cli/cmd/root.go                                 # AddCommand(NewProbeCmd())
+decisions/README.md                                      # ADR-102 row
+CHANGELOG.md                                             # Unreleased / Added entry
+```
+
+No new dependencies. The probe uses only `net/http`, `crypto/tls`,
+`encoding/json`, `time`, `context`, `errors`, all stdlib.
+
+### Sequence
+
+User types: `vibew probe --env production`
+
+1. cobra dispatches to `NewProbeCmd().RunE`.
+2. `requireScaffolding()` confirms a vibewarden project exists in cwd.
+3. `requireConfig("")` confirms `vibewarden.yaml` exists.
+4. Resolve probe target:
+   - If `--env` empty: `loadAndResolve(ctx, "")` → use `cfg.Server.Port`.
+     URL = `https://localhost:<port>/_vibewarden/health`. Construct
+     `health.NewLocalhostProber(3 * time.Second)`.
+   - If `--env <name>` set: `env.NewFileResolver(cwd).Resolve(name)` →
+     read `cfg.TLS.Domain` from the merged result. URL =
+     `https://<domain>/_vibewarden/health`. Construct
+     `health.NewStrictProber(3 * time.Second)`.
+5. Construct `probe.NewService(prober)`.
+6. Call `service.Run(ctx, probe.Options{URL: url, BootGapWait: 10s, BootGapPoll: 1s, PerProbe: 3s})`.
+7. Inside `Run`:
+   1. Issue first probe via `prober.Probe(ctx, url)`.
+   2. If `err == nil` and `Doc.Components["upstream"] != "unknown"`, return the result.
+   3. If `err == nil` and `upstream == "unknown"`, sleep `BootGapPoll` and re-probe; repeat until either upstream clears or `BootGapWait` elapses.
+   4. If a probe error occurs, return it immediately (no retry on hard errors — only on the soft "unknown" state).
+8. Back in the CLI handler: render the `Result` to stdout via `probe.Render`.
+9. Compute exit code:
+   - `Doc.Components["upstream"] == "ok"` → exit 0.
+   - Anything else (including post-retry "unknown", "failing", "degraded", or any error) → exit 1.
+
+### Output format
+
+Pinned by a golden test (`internal/app/probe/testdata/dev_ok.golden` plus
+peers for each branch). The renderer writes:
+
+```
+https://localhost:8443/_vibewarden/health
+  status:              ok
+  version:             0.18.4
+  components.sidecar:  ok
+  components.upstream: ok
+
+OK — dev stack healthy.
+```
+
+For non-default env:
+
+```
+https://app.example.com/_vibewarden/health
+  status:              ok
+  version:             0.18.4
+  components.sidecar:  ok
+  components.upstream: ok
+
+OK — production stack healthy.
+```
+
+For boot-gap exhaustion:
+
+```
+https://localhost:8443/_vibewarden/health
+  status:              degraded
+  version:             0.18.4
+  components.sidecar:  ok
+  components.upstream: unknown
+
+DEGRADED — upstream probe has not converged within 10s. Check `vibew logs vibewarden`.
+```
+
+For connection refused:
+
+```
+ERROR: https://localhost:8443/_vibewarden/health
+Stack is not running. Start with: vibew dev
+```
+
+For non-200:
+
+```
+https://app.example.com/_vibewarden/health
+  http_status: 502
+  body:        Bad Gateway
+
+ERROR: non-2xx response from health endpoint.
+```
+
+For malformed body:
+
+```
+ERROR: https://app.example.com/_vibewarden/health
+Malformed response body — not the VibeWarden health wire format.
+```
+
+The trailing one-line summary uses an ASCII em-dash (—) for visual
+consistency with `vibew status` (ADR-095) and `vibew bundle`.
+
+### Error cases
+
+| Condition                                         | Sentinel              | Exit | Stderr message |
+|---------------------------------------------------|-----------------------|------|----------------|
+| Connection refused (no listener)                  | `ErrProbeRefused`     | 1    | "Stack is not running. Start with: vibew dev" |
+| TLS handshake failure (`--env` mode only)         | wrapped by transport  | 1    | "TLS verification failed: <detail>" — points the user at their cert |
+| DNS / network error (`--env` mode only)           | wrapped by transport  | 1    | "Network error: <detail>" |
+| HTTP non-2xx                                      | `*ProbeNon200Error`   | 1    | "non-2xx response (<code>): <body snippet>" |
+| Body not JSON / missing fields                    | `ErrProbeMalformed`   | 1    | "Malformed response body — not the VibeWarden health wire format" |
+| `components.upstream == "unknown"` after 10s wait | none (success path)   | 1    | the rendered block above |
+| `components.upstream == "failing"`                | none (success path)   | 1    | the rendered block above |
+| `--env name` requested, override file missing     | `env.ErrOverrideConfigMissing` | 1 | "config file not found: vibewarden.<name>.yaml" |
+| `--env name` requested, merged `tls.domain` empty | local sentinel        | 1    | "tls.domain is empty in merged config; cannot resolve probe target" |
+
+`ports.ErrDockerUnavailable` (exit 3) is **not** applicable — `vibew probe`
+never touches docker. Reuse it would be misleading.
+
+### Test strategy
+
+Unit tests:
+
+- `internal/adapters/health/prober_test.go` — drive `HTTPProber` against
+  an `httptest.NewTLSServer`. Cases: 200 with valid body, 200 with
+  malformed body, non-200, connection refused (target a closed port),
+  body too large (truncation honoured).
+- `internal/app/probe/service_test.go` — drive `Service` with a fake
+  `ports.HealthProber`. Cases: first-probe ok → no retry; first-probe
+  unknown → retry until ok; first-probe unknown → all retries return
+  unknown → final result is unknown; first-probe error → returned
+  immediately. Inject a fake `sleep` so tests run instantly.
+- `internal/app/probe/render_test.go` — golden tests for every output
+  branch (dev ok, env ok, boot-gap exhausted, refused, non-200,
+  malformed). Goldens live under `internal/app/probe/testdata/`.
+- `internal/app/env/resolver_test.go` — covers: empty name, present
+  override, missing override (error), missing base (error), tls.domain
+  preserved through merge.
+
+Integration / CLI tests:
+
+- `internal/cli/cmd/probe_test.go` — end-to-end cobra invocation against an
+  `httptest.NewTLSServer` whose handler returns a synthesised wire-format
+  body. Covers the default path (no flag), the `--env` path (writes a
+  scratch `vibewarden.production.yaml` with `tls.domain` pointing at the
+  test server), and the failure paths. Uses `cobra.Command.SetOut/SetErr`
+  to capture output and asserts both content and exit code.
+
+No testcontainers dependency; the test server replaces the live sidecar.
+The probe is HTTP-only by construction so testcontainers would be
+overkill.
+
+### New dependencies
+
+None. All functionality is built on stdlib (`net/http`, `crypto/tls`,
+`encoding/json`, `time`, `context`, `errors`).
+
+## Consequences
+
+**Positive.** macOS dev sessions stop reaching for `python3 -c "import ssl..."`.
+The Go binary owns its TLS dance from end to end and the dev cert is
+handshakable by construction. The `--env` mechanism gets a single canonical
+home (`internal/app/env`) instead of three duplicated ad-hoc helpers.
+
+**Constraint on future code.** Every future verb that adopts `--env` must
+route through `env.Resolver`. New ad-hoc `prodConfigPathForEnv`-style
+helpers in CLI commands are now an architectural smell — the reviewer
+agent should flag them. The migration of existing helpers
+(`bundle.prodConfigPathForEnv`, `validate.discoverProdOverride`) is left
+to a follow-up issue but the canonical path is locked here.
+
+**TLS verification asymmetry is intentional.** `--env` mode does **not**
+fall back to `InsecureSkipVerify`. A user with a self-signed prod cert
+will get a clear handshake error rather than a silent "ok". The escape
+hatch for that case is a separate flag that we explicitly do not ship in
+v1 — that would weaken the safety property the `--env` path is meant to
+provide. If the demand surfaces, a follow-up ADR can justify adding a
+`--insecure-skip-verify` flag.
+
+**Boot-gap retry is fixed at 10s.** The window matches ADR-098's stated
+boot-gap range. If a future change to the background probe lengthens that
+window, this ADR's 10s budget needs to grow with it — flagged as a
+maintenance dependency in the implementation comment block.
+
+**No domain-layer impact.** The probe operates entirely at the app/adapter
+level. Domain layer remains untouched, preserving the zero-external-imports
+property required by CLAUDE.md §Architecture principles.

--- a/docs/agent-kickoff.md
+++ b/docs/agent-kickoff.md
@@ -87,6 +87,15 @@ rate-limiting, or security logic — VibeWarden handles those at the sidecar lay
   vibew dev
 
 The sidecar starts on localhost. Your app is proxied through it automatically.
+
+## Step 6 — Verify the stack
+
+  vibew probe
+
+Expected output ends with `OK — dev stack healthy.`
+On macOS, vibew probe bypasses system curl's LibreSSL limitation by using Go's
+TLS stack directly. If the output shows `upstream: unknown`, wait 10s — the
+first upstream probe cycle has not completed yet (vibew probe retries automatically).
 ```
 
 ## URL-discoverable copy

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -26,7 +26,7 @@ VibeWarden is language-agnostic — `vibew init` does not scaffold app code, a D
 - **Serve `GET /health` returning HTTP 200** on that same port. Any response body is acceptable — vibew checks the status code only. Without this endpoint the sidecar container never leaves the "Created" state and `vibew dev` hangs.
 - **Do not implement TLS, auth, rate-limiting, WAF, or security headers in app code** — the sidecar owns all of those (see §Security boundary rule).
 
-`vibew doctor` validates this contract statically: `EXPOSE` vs `upstream.port` match, Dockerfile structure, and TLS state. Run it before `vibew dev` if you hit a connection-refused loop. For runtime upstream health, query `_vibewarden/health` after `vibew dev` is up.
+`vibew doctor` validates this contract statically: `EXPOSE` vs `upstream.port` match, Dockerfile structure, and TLS state. Run it before `vibew dev` if you hit a connection-refused loop. For runtime upstream health, run `vibew probe` after `vibew dev` is up (preferred on macOS; bypasses LibreSSL friction).
 
 ## Sidecar-injected headers
 
@@ -69,6 +69,8 @@ vibew dev --rebuild  # stop stack, remove app image, rebuild, start — recovery
 vibew down           # stop the dev stack (preserves volumes; -v also removes volumes)
 vibew obs up         # start Prometheus + Grafana observability stack (after vibew dev)
 vibew obs down       # stop the observability stack (-v also removes volumes)
+vibew probe          # one-shot HTTPS health check after vibew dev (bypasses macOS LibreSSL friction — preferred over curl on macOS)
+vibew probe --env production  # health check against a named environment overlay
 ```
 
 ## Config changes
@@ -105,9 +107,11 @@ These filenames are public API (ADR-101). See `docs/agent-kickoff.md`.
 ## Troubleshooting
 
 ```bash
+vibew probe              # one-shot HTTPS health check (preferred on macOS — bypasses LibreSSL friction)
+vibew probe --env production  # health check for a named production environment
 vibew doctor             # diagnose common issues
 vibew doctor --json      # machine-readable output for AI agents
-vibew status             # check sidecar health
+vibew status             # check sidecar health (richer overview; probe is for one-shot HTTPS verification)
 vibew logs               # stream local dev-stack logs (all services)
 vibew logs vibewarden    # sidecar logs only
 vibew logs --follow      # stream continuously
@@ -119,8 +123,9 @@ proxy port availability, ACME email, image tag consistency, and LE rate-limit bu
 When the dev stack is running, two additional checks are added: generated files present
 and TLS certificate valid. Pre-stack those two rows are silently skipped — no misleading
 WARNs before `vibew dev` has been started. Container health is not checked by `vibew doctor`;
-use `curl https://<your-domain>/_vibewarden/health` after `vibew dev` is up for runtime
-health (response: `{"status":"ok","components":{"upstream":"ok"}}`).
+use `vibew probe` after `vibew dev` is up for runtime health (preferred on macOS; bypasses
+LibreSSL friction). For non-vibew tooling, fall back to
+`curl https://<your-domain>/_vibewarden/health` (expected: `{"status":"ok","components":{"upstream":"ok"}}`).
 `vibew status` surfaces component health with OK / OFF / FAIL labels; OFF means the
 component is disabled in config and was not probed.
 
@@ -209,7 +214,11 @@ The bundle is just files. The contract is in `.vibewarden/bundle/README.md`:
 5. On the host, in the bundle directory: load `image.tar` (in
    registry-pull mode the image is already published — skip this step
    and let compose pull it), then `docker compose up -d`.
-6. Verify against the public URL: `curl https://yourdomain/_vibewarden/health`.
+6. Verify against the public URL:
+   ```bash
+   vibew probe --env production
+   ```
+   Falls back to: `curl https://yourdomain/_vibewarden/health` for non-vibew tooling.
    Port **443** in production (TLS), not the dev port 8443.
 
 `vibew bundle` is deterministic (same inputs, same bytes), never opens
@@ -282,7 +291,7 @@ For now: keep one site per project. Revisit when #1169 lands.
 ## Known limitations
 
 - WAF is in `detect` mode by default (logs but does not block). Set `waf.mode: block` in vibewarden.yaml to enforce blocking.
-- `vibew doctor` checks config, Docker, ports, ACME email, image tag, and (when the dev stack is running) generated files and local TLS cert validity. It does not probe runtime container health — use `curl https://<your-domain>/_vibewarden/health` after `vibew dev` is up for that (expected response: `{"status":"ok","components":{"upstream":"ok"}}`). Pre-stack, the generated-files and TLS rows are silently skipped to avoid misleading WARNs. When a `Dockerfile` is present in the project root, `vibew doctor` also lints it against the contract: alpine base, `EXPOSE` matches `upstream.port`, no `HEALTHCHECK` directive, non-root `USER` (warn, non-blocking), multi-stage build for compiled languages, and builder image major.minor matches the project toolchain manifest (`go.mod`, `.nvmrc`, `pyproject.toml`). When no `Dockerfile` is present, the Dockerfile section is omitted entirely.
+- `vibew doctor` checks config, Docker, ports, ACME email, image tag, and (when the dev stack is running) generated files and local TLS cert validity. It does not probe runtime container health — use `vibew probe` after `vibew dev` is up for that (preferred on macOS; bypasses LibreSSL friction by using Go's TLS stack). On non-macOS or when non-vibew tooling needs to hit the endpoint, use `curl https://<your-domain>/_vibewarden/health` (expected response: `{"status":"ok","components":{"upstream":"ok"}}`). Pre-stack, the generated-files and TLS rows are silently skipped to avoid misleading WARNs. When a `Dockerfile` is present in the project root, `vibew doctor` also lints it against the contract: alpine base, `EXPOSE` matches `upstream.port`, no `HEALTHCHECK` directive, non-root `USER` (warn, non-blocking), multi-stage build for compiled languages, and builder image major.minor matches the project toolchain manifest (`go.mod`, `.nvmrc`, `pyproject.toml`). When no `Dockerfile` is present, the Dockerfile section is omitted entirely.
 - Multi-site local dev works; production deploy is post-v1 (see https://github.com/VibeWarden/vibewarden/issues/1169).
 - `vibew init` does not accept `--tls` or `--domain` flags — run `vibew add tls --domain <your-domain>` after init.
 - **Image identity check (v0.18.3+):** `vibew dev` verifies the app image's `org.vibewarden.project-root-hash` label before starting the stack. If the label is missing (image built before v0.18.3) or belongs to a different project, `vibew dev` exits 1 with an actionable message. Recovery: `vibew dev --rebuild`. This catches the silent-image-collision bug where two projects with the same directory name share a `:latest` tag. TRAP: if you reused a directory name from a prior vibew project, run `vibew dev --rebuild` — the old image blocks immediately. Custom images set via `app.image:` in vibewarden.yaml bypass this check.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -233,6 +233,22 @@ This command:
 Your app is protected at `https://localhost:8443`. Nothing else is required for the
 first run.
 
+    !!! tip "Health check after first run"
+        Verify the stack is healthy:
+
+        ```bash
+        vibew probe
+        ```
+
+        `vibew probe` uses Go's TLS stack and works on macOS without LibreSSL issues.
+        Expected output ends with `OK — dev stack healthy.` If you see
+        `upstream: unknown`, the boot probe has not completed yet — wait 10s and retry
+        (vibew probe retries automatically for up to 10s).
+        On non-macOS or when non-vibew tooling is needed:
+        ```bash
+        curl --insecure https://localhost:8443/_vibewarden/health
+        ```
+
 !!! warning "If your app image hasn't been built yet"
     `vibew dev` checks for the app Docker image before starting. If the image
     is missing you'll see an error like:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,8 +9,9 @@ resolve the most common issues.
 
 `vibew doctor` is a first-aid command. It validates static configuration and prints a
 report so you can see exactly what is wrong before filing a bug or spending time
-searching logs. For runtime upstream health, `curl https://<your-domain>/_vibewarden/health`
-after `vibew dev` is up — doctor only validates static config.
+searching logs. For runtime upstream health, run `vibew probe` after `vibew dev` is up
+— it uses Go's TLS stack and works on macOS without LibreSSL friction. Doctor only
+validates static config.
 
 ```bash
 vibew doctor
@@ -439,7 +440,15 @@ LibreSSL/3.3.6: error:06FFF064:digital envelope routines:CONF_modules_load:bad d
 
 macOS ships a system `curl` linked against LibreSSL, which is stricter than OpenSSL on certain self-signed certificate profiles. Caddy's local CA issues an ECC intermediate that triggers this. Not a vibew bug — works around it client-side.
 
-**Fix — Homebrew curl (recommended)**
+**Primary fix — `vibew probe` (no external tools required)**
+
+```bash
+vibew probe
+```
+
+`vibew probe` uses Go's stdlib TLS stack and bypasses LibreSSL entirely. It is the canonical health check after `vibew dev` on macOS. With `--env <name>` it reads `tls.domain` from the merged config and probes the production endpoint with full cert verification.
+
+**Fallback — Homebrew curl (when non-vibew tooling must hit the endpoint)**
 
 ```bash
 brew install curl
@@ -448,7 +457,7 @@ brew install curl
 
 The Homebrew bottle is linked against OpenSSL and accepts the dev cert with `--insecure`. Do **not** alias `curl` to the Homebrew binary system-wide — only use it for sidecar testing.
 
-**Fix — Python `ssl` module**
+**Fallback — Python `ssl` module (no Homebrew required)**
 
 ```bash
 python3 -c '
@@ -458,7 +467,7 @@ print(urllib.request.urlopen("https://localhost:8443/_vibewarden/health", contex
 '
 ```
 
-Python's bundled OpenSSL accepts the cert when verification is disabled. Useful when you cannot install Homebrew.
+Python's bundled OpenSSL accepts the cert when verification is disabled. Useful when you cannot install Homebrew and do not have the `vibew` binary available.
 
 **Note**
 
@@ -474,7 +483,10 @@ Use `_vibewarden/health` or `vibew logs` to diagnose container issues after the
 stack is running.
 
 ```bash
-# Check runtime health after vibew dev is up
+# Check runtime health after vibew dev is up (vibew probe preferred on macOS)
+vibew probe
+
+# Or with curl (works on Linux; on macOS requires Homebrew curl or Python workaround)
 curl https://localhost:8443/_vibewarden/health
 
 # Stream logs for a specific service

--- a/internal/adapters/health/prober.go
+++ b/internal/adapters/health/prober.go
@@ -1,0 +1,126 @@
+package health
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// maxBodySnippet is the maximum number of bytes read from a non-200 response
+// body for inclusion in the ProbeNon200Error.
+const maxBodySnippet = 512
+
+// wireHealth is the JSON shape of /_vibewarden/health (ADR-098). It is used
+// only for unmarshalling inside HTTPProber.Probe and is not exported.
+type wireHealth struct {
+	Status     string            `json:"status"`
+	Version    string            `json:"version"`
+	Site       string            `json:"site"`
+	Components map[string]string `json:"components"`
+}
+
+// HTTPProber implements ports.HealthProber via Go's stdlib net/http.
+//
+// Construct with NewLocalhostProber for the dev path (InsecureSkipVerify=true),
+// or NewStrictProber for the --env path (full cert chain verification via
+// the stdlib default transport).
+type HTTPProber struct {
+	client *http.Client
+}
+
+// NewLocalhostProber returns an HTTPProber whose TLS client skips certificate
+// verification. This is appropriate for the dev path where the sidecar
+// presents a self-signed certificate on localhost — and where system curl on
+// macOS (LibreSSL) cannot complete the handshake.
+//
+// timeout is the per-request deadline. Pass 3*time.Second for CLI use.
+func NewLocalhostProber(timeout time.Duration) *HTTPProber {
+	return &HTTPProber{
+		client: &http.Client{
+			Timeout: timeout,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // dev self-signed cert only; intentional per ADR-102
+			},
+		},
+	}
+}
+
+// NewStrictProber returns an HTTPProber that uses the stdlib default TLS
+// verification (full cert chain). This is the --env path where the target
+// is a production domain with a valid certificate.
+//
+// timeout is the per-request deadline. Pass 3*time.Second for CLI use.
+func NewStrictProber(timeout time.Duration) *HTTPProber {
+	return &HTTPProber{
+		client: &http.Client{Timeout: timeout},
+	}
+}
+
+// Probe performs a single HTTPS GET against url and returns the parsed
+// HealthDocument. Error semantics follow ports.HealthProber:
+//   - ports.ErrProbeRefused  — connection refused
+//   - ports.ErrProbeMalformed — body cannot be decoded
+//   - *ports.ProbeNon200Error — non-2xx HTTP status
+func (p *HTTPProber) Probe(ctx context.Context, url string) (ports.HealthDocument, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return ports.HealthDocument{}, fmt.Errorf("building probe request: %w", err)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		if isConnectionRefused(err) {
+			return ports.HealthDocument{}, ports.ErrProbeRefused
+		}
+		return ports.HealthDocument{}, fmt.Errorf("executing probe request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodySnippet))
+		return ports.HealthDocument{}, &ports.ProbeNon200Error{
+			StatusCode: resp.StatusCode,
+			Body:       strings.TrimSpace(string(snippet)),
+		}
+	}
+
+	var wire wireHealth
+	if err := json.NewDecoder(resp.Body).Decode(&wire); err != nil {
+		return ports.HealthDocument{}, fmt.Errorf("%w: %s", ports.ErrProbeMalformed, err.Error())
+	}
+
+	// Validate that the response looks like the VibeWarden health wire format.
+	// An empty status or nil components map indicates a foreign service.
+	if wire.Status == "" || wire.Components == nil {
+		return ports.HealthDocument{}, fmt.Errorf("%w: missing required fields", ports.ErrProbeMalformed)
+	}
+
+	return ports.HealthDocument{
+		Status:     wire.Status,
+		Version:    wire.Version,
+		Site:       wire.Site,
+		Components: wire.Components,
+	}, nil
+}
+
+// isConnectionRefused inspects the error chain from net/http to detect TCP
+// connection-refused failures. It checks the error message because Go's
+// stdlib does not export a typed sentinel for ECONNREFUSED from net.OpError.
+func isConnectionRefused(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "connect: connection refused")
+}
+
+// Compile-time assertion that HTTPProber satisfies ports.HealthProber.
+var _ ports.HealthProber = (*HTTPProber)(nil)

--- a/internal/adapters/health/prober_test.go
+++ b/internal/adapters/health/prober_test.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -185,6 +186,41 @@ func TestNewLocalhostProber_InsecureSkipVerify(t *testing.T) {
 	}
 	if doc.Status != "ok" {
 		t.Errorf("status = %q, want %q", doc.Status, "ok")
+	}
+}
+
+func TestNewStrictProber_RejectsSelfSignedCert(t *testing.T) {
+	// httptest.NewTLSServer presents a self-signed certificate. NewStrictProber
+	// uses the stdlib default TLS verification (no InsecureSkipVerify), so the
+	// handshake must fail with an x509 unknown-authority error. This is the
+	// symmetric counterpart to TestNewLocalhostProber_InsecureSkipVerify and
+	// validates the --env safety property: a production probe against an invalid
+	// cert is rejected, not silently accepted.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(healthBody("ok", "0.18.4", map[string]string{
+			"sidecar":  "ok",
+			"upstream": "ok",
+		}))
+	}))
+	defer srv.Close()
+
+	prober := NewStrictProber(3 * time.Second)
+	_, err := prober.Probe(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("NewStrictProber should reject a self-signed certificate, but got nil error")
+	}
+
+	// The error must be (or wrap) an x509.UnknownAuthorityError, proving that
+	// strict TLS verification is active. Accept either errors.As match or a
+	// substring check to remain robust across Go stdlib versions.
+	var unknownAuth x509.UnknownAuthorityError
+	msg := err.Error()
+	if !errors.As(err, &unknownAuth) &&
+		!strings.Contains(msg, "certificate signed by unknown authority") &&
+		!strings.Contains(msg, "x509") {
+		t.Errorf("expected x509 TLS rejection error, got: %v", err)
 	}
 }
 

--- a/internal/adapters/health/prober_test.go
+++ b/internal/adapters/health/prober_test.go
@@ -1,0 +1,237 @@
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// healthBody is a helper to produce a valid /_vibewarden/health JSON response.
+func healthBody(status, version string, components map[string]string) []byte {
+	b, _ := json.Marshal(map[string]any{
+		"status":     status,
+		"version":    version,
+		"components": components,
+	})
+	return b
+}
+
+func TestHTTPProber_Probe_200_ValidBody(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(healthBody("ok", "0.18.4", map[string]string{
+			"sidecar":  "ok",
+			"upstream": "ok",
+		}))
+	}))
+	defer srv.Close()
+
+	// Use the test server's own client (trusts its cert).
+	prober := &HTTPProber{client: srv.Client()}
+
+	doc, err := prober.Probe(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if doc.Status != "ok" {
+		t.Errorf("status = %q, want %q", doc.Status, "ok")
+	}
+	if doc.Version != "0.18.4" {
+		t.Errorf("version = %q, want %q", doc.Version, "0.18.4")
+	}
+	if doc.Components["upstream"] != "ok" {
+		t.Errorf("components.upstream = %q, want %q", doc.Components["upstream"], "ok")
+	}
+}
+
+func TestHTTPProber_Probe_200_MalformedBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"not json", "this is not json"},
+		{"missing status", `{"version":"0.18.4","components":{"sidecar":"ok"}}`},
+		{"missing components", `{"status":"ok","version":"0.18.4"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			prober := &HTTPProber{client: srv.Client()}
+			_, err := prober.Probe(context.Background(), srv.URL)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(err, ports.ErrProbeMalformed) {
+				t.Errorf("expected ErrProbeMalformed in chain, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestHTTPProber_Probe_Non200(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{"502 Bad Gateway", http.StatusBadGateway, "Bad Gateway"},
+		{"503 Service Unavailable", http.StatusServiceUnavailable, "Service Unavailable"},
+		{"404 Not Found", http.StatusNotFound, "not found"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			prober := &HTTPProber{client: srv.Client()}
+			_, err := prober.Probe(context.Background(), srv.URL)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(err, ports.ErrProbeNon200) {
+				t.Errorf("expected ErrProbeNon200 in chain, got: %v", err)
+			}
+			var ne *ports.ProbeNon200Error
+			if !errors.As(err, &ne) {
+				t.Fatalf("expected *ProbeNon200Error, got: %T", err)
+			}
+			if ne.StatusCode != tt.statusCode {
+				t.Errorf("StatusCode = %d, want %d", ne.StatusCode, tt.statusCode)
+			}
+			if !strings.Contains(ne.Body, tt.body) {
+				t.Errorf("body snippet %q does not contain %q", ne.Body, tt.body)
+			}
+		})
+	}
+}
+
+func TestHTTPProber_Probe_ConnectionRefused(t *testing.T) {
+	// Find a port that is definitely not listening.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("could not find free port: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	prober := NewLocalhostProber(2 * time.Second)
+	_, err = prober.Probe(context.Background(), "https://"+addr)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ports.ErrProbeRefused) {
+		t.Errorf("expected ErrProbeRefused, got: %v", err)
+	}
+}
+
+func TestHTTPProber_Probe_BodyTruncation(t *testing.T) {
+	// Response body larger than maxBodySnippet should be truncated.
+	longBody := strings.Repeat("x", maxBodySnippet*3)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(longBody))
+	}))
+	defer srv.Close()
+
+	prober := &HTTPProber{client: srv.Client()}
+	_, err := prober.Probe(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var ne *ports.ProbeNon200Error
+	if !errors.As(err, &ne) {
+		t.Fatalf("expected *ProbeNon200Error, got: %T", err)
+	}
+	if len(ne.Body) > maxBodySnippet {
+		t.Errorf("body snippet length %d exceeds maxBodySnippet %d", len(ne.Body), maxBodySnippet)
+	}
+}
+
+func TestNewLocalhostProber_InsecureSkipVerify(t *testing.T) {
+	// A TLS server presenting a self-signed cert should be reachable when
+	// using NewLocalhostProber (InsecureSkipVerify=true).
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(healthBody("ok", "0.18.4", map[string]string{
+			"sidecar":  "ok",
+			"upstream": "ok",
+		}))
+	}))
+	defer srv.Close()
+
+	prober := NewLocalhostProber(3 * time.Second)
+	doc, err := prober.Probe(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("NewLocalhostProber should succeed against self-signed TLS server: %v", err)
+	}
+	if doc.Status != "ok" {
+		t.Errorf("status = %q, want %q", doc.Status, "ok")
+	}
+}
+
+func TestHTTPProber_Probe_WithSite(t *testing.T) {
+	// When the server includes a "site" field it is preserved in the HealthDocument.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		b, _ := json.Marshal(map[string]any{
+			"status":     "ok",
+			"version":    "0.18.4",
+			"site":       "app1",
+			"components": map[string]string{"sidecar": "ok", "upstream": "ok"},
+		})
+		_, _ = w.Write(b)
+	}))
+	defer srv.Close()
+
+	prober := &HTTPProber{client: srv.Client()}
+	doc, err := prober.Probe(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Site != "app1" {
+		t.Errorf("site = %q, want %q", doc.Site, "app1")
+	}
+}
+
+func TestHTTPProber_Probe_ContextCancelled(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Block until the request context is cancelled.
+		<-r.Context().Done()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	prober := &HTTPProber{client: srv.Client()}
+	_, err := prober.Probe(ctx, srv.URL)
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	// The error should not be ErrProbeRefused (it's a cancellation).
+	if errors.Is(err, ports.ErrProbeRefused) {
+		t.Errorf("cancelled context should not produce ErrProbeRefused")
+	}
+	_ = fmt.Sprintf("%v", err) // suppress unused import warning
+}

--- a/internal/app/env/resolver.go
+++ b/internal/app/env/resolver.go
@@ -1,0 +1,147 @@
+// Package env provides the canonical env-resolver for VibeWarden CLI verbs
+// that accept an --env <name> flag.
+//
+// The Resolver interface is the single entry point for env-flag handling across
+// all CLI commands. Future verbs (vibew status --env prod, vibew validate --env
+// prod, etc.) must route through this package rather than rolling their own
+// ad-hoc config discovery helpers. See ADR-102 for the architectural rationale.
+package env
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	bundleapp "github.com/vibewarden/vibewarden/internal/app/bundle"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+// Sentinel errors returned by Resolver implementations.
+var (
+	// ErrBaseConfigMissing is returned when vibewarden.yaml cannot be found
+	// in the project root.
+	ErrBaseConfigMissing = errors.New("base config not found: vibewarden.yaml")
+
+	// ErrOverrideConfigMissing is returned when a non-empty env name was
+	// given but the corresponding vibewarden.<name>.yaml file does not exist.
+	// Explicit env names must map to existing files — there is no fallback to
+	// the base config.
+	ErrOverrideConfigMissing = errors.New("override config not found")
+)
+
+// Resolver loads the merged config for an optional environment name.
+//
+// When name is empty, only the base vibewarden.yaml is loaded (via
+// config.Load). When name is non-empty, vibewarden.<name>.yaml is located in
+// the same project root and deep-merged on top of the base via
+// bundleapp.LoadMergedConfig. Missing override files are an error — explicit
+// env names map to existing files.
+type Resolver interface {
+	Resolve(name string) (Resolved, error)
+}
+
+// Resolved carries the merged config plus the file paths that produced it.
+// Future verbs that adopt --env re-use this shape.
+type Resolved struct {
+	// Cfg is the merged (or base-only) config ready for use.
+	Cfg *config.Config
+
+	// BasePath is the absolute path to vibewarden.yaml.
+	BasePath string
+
+	// OverridePath is the absolute path to vibewarden.<name>.yaml.
+	// Empty when name == "" (base-only resolve).
+	OverridePath string
+
+	// EnvName echoes the name argument; empty for the default (base-only) resolve.
+	EnvName string
+}
+
+// FileResolver is the default Resolver implementation. It locates config files
+// on the local filesystem relative to ProjectRoot.
+//
+// When ProjectRoot is empty, os.Getwd() is used at Resolve time.
+type FileResolver struct {
+	// ProjectRoot is the directory that contains vibewarden.yaml.
+	// Defaults to the caller's working directory when empty.
+	ProjectRoot string
+}
+
+// NewFileResolver constructs a FileResolver rooted at projectRoot.
+// Pass an empty string to use the caller's working directory.
+func NewFileResolver(projectRoot string) *FileResolver {
+	return &FileResolver{ProjectRoot: projectRoot}
+}
+
+// Resolve loads the config for the given env name.
+//
+// When name is empty, only vibewarden.yaml is loaded via config.Load.
+// When name is non-empty, vibewarden.<name>.yaml must exist in ProjectRoot and
+// is deep-merged on top of vibewarden.yaml via bundleapp.LoadMergedConfig.
+//
+// Returns ErrBaseConfigMissing when vibewarden.yaml cannot be found.
+// Returns ErrOverrideConfigMissing when name is non-empty and the override
+// file does not exist.
+func (r *FileResolver) Resolve(name string) (Resolved, error) {
+	root, err := r.projectRoot()
+	if err != nil {
+		return Resolved{}, fmt.Errorf("resolving project root: %w", err)
+	}
+
+	basePath := filepath.Join(root, "vibewarden.yaml")
+	if _, err := os.Stat(basePath); err != nil {
+		if os.IsNotExist(err) {
+			return Resolved{}, fmt.Errorf("%w: %s", ErrBaseConfigMissing, basePath)
+		}
+		return Resolved{}, fmt.Errorf("accessing base config %s: %w", basePath, err)
+	}
+
+	if name == "" {
+		cfg, err := config.Load(basePath)
+		if err != nil {
+			return Resolved{}, fmt.Errorf("loading base config: %w", err)
+		}
+		return Resolved{
+			Cfg:          cfg,
+			BasePath:     basePath,
+			OverridePath: "",
+			EnvName:      "",
+		}, nil
+	}
+
+	overridePath := filepath.Join(root, "vibewarden."+name+".yaml")
+	if _, err := os.Stat(overridePath); err != nil {
+		if os.IsNotExist(err) {
+			return Resolved{}, fmt.Errorf("%w: %s", ErrOverrideConfigMissing, overridePath)
+		}
+		return Resolved{}, fmt.Errorf("accessing override config %s: %w", overridePath, err)
+	}
+
+	cfg, err := bundleapp.LoadMergedConfig(basePath, overridePath)
+	if err != nil {
+		return Resolved{}, fmt.Errorf("loading merged config for env %q: %w", name, err)
+	}
+
+	return Resolved{
+		Cfg:          cfg,
+		BasePath:     basePath,
+		OverridePath: overridePath,
+		EnvName:      name,
+	}, nil
+}
+
+// projectRoot returns the effective project root, resolving empty to os.Getwd.
+func (r *FileResolver) projectRoot() (string, error) {
+	if r.ProjectRoot != "" {
+		return r.ProjectRoot, nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getting working directory: %w", err)
+	}
+	return cwd, nil
+}
+
+// Compile-time assertion that FileResolver satisfies Resolver.
+var _ Resolver = (*FileResolver)(nil)

--- a/internal/app/env/resolver_test.go
+++ b/internal/app/env/resolver_test.go
@@ -1,0 +1,156 @@
+package env_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	envpkg "github.com/vibewarden/vibewarden/internal/app/env"
+)
+
+// writeFile is a test helper that creates a file with the given content.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writeFile(%q): %v", path, err)
+	}
+}
+
+// minimalBase returns a minimal vibewarden.yaml content suitable for tests.
+func minimalBase(port int) string {
+	return "server:\n  port: " + itoa(port) + "\n"
+}
+
+// itoa converts an int to a string. We avoid importing strconv to keep helpers minimal.
+func itoa(i int) string {
+	if i == 8443 {
+		return "8443"
+	}
+	return "9443"
+}
+
+func TestFileResolver_EmptyName_LoadsBaseOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "vibewarden.yaml"), minimalBase(8443))
+
+	r := envpkg.NewFileResolver(dir)
+	resolved, err := r.Resolve("")
+	if err != nil {
+		t.Fatalf("Resolve(%q) unexpected error: %v", "", err)
+	}
+	if resolved.EnvName != "" {
+		t.Errorf("EnvName = %q, want %q", resolved.EnvName, "")
+	}
+	if resolved.OverridePath != "" {
+		t.Errorf("OverridePath = %q, want empty", resolved.OverridePath)
+	}
+	if resolved.Cfg == nil {
+		t.Fatal("Cfg is nil")
+	}
+	if resolved.Cfg.Server.Port != 8443 {
+		t.Errorf("server.port = %d, want 8443", resolved.Cfg.Server.Port)
+	}
+}
+
+func TestFileResolver_NonEmptyName_MergesOverride(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "vibewarden.yaml"), minimalBase(8443))
+	writeFile(t, filepath.Join(dir, "vibewarden.production.yaml"),
+		"tls:\n  domain: app.example.com\n  enabled: true\n")
+
+	r := envpkg.NewFileResolver(dir)
+	resolved, err := r.Resolve("production")
+	if err != nil {
+		t.Fatalf("Resolve(%q) unexpected error: %v", "production", err)
+	}
+	if resolved.EnvName != "production" {
+		t.Errorf("EnvName = %q, want %q", resolved.EnvName, "production")
+	}
+	if resolved.OverridePath == "" {
+		t.Error("OverridePath should not be empty")
+	}
+	if resolved.Cfg == nil {
+		t.Fatal("Cfg is nil")
+	}
+	if resolved.Cfg.TLS.Domain != "app.example.com" {
+		t.Errorf("tls.domain = %q, want %q", resolved.Cfg.TLS.Domain, "app.example.com")
+	}
+}
+
+func TestFileResolver_TLSDomainPreservedThroughMerge(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "vibewarden.yaml"),
+		"server:\n  port: 8443\ntls:\n  enabled: true\n")
+	writeFile(t, filepath.Join(dir, "vibewarden.staging.yaml"),
+		"tls:\n  domain: staging.example.com\n")
+
+	r := envpkg.NewFileResolver(dir)
+	resolved, err := r.Resolve("staging")
+	if err != nil {
+		t.Fatalf("Resolve(%q) unexpected error: %v", "staging", err)
+	}
+	if resolved.Cfg.TLS.Domain != "staging.example.com" {
+		t.Errorf("tls.domain = %q, want staging.example.com", resolved.Cfg.TLS.Domain)
+	}
+	// Fields from base should still be present.
+	if resolved.Cfg.Server.Port != 8443 {
+		t.Errorf("server.port = %d, want 8443 (from base)", resolved.Cfg.Server.Port)
+	}
+}
+
+func TestFileResolver_MissingOverride_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "vibewarden.yaml"), minimalBase(8443))
+
+	r := envpkg.NewFileResolver(dir)
+	_, err := r.Resolve("production")
+	if err == nil {
+		t.Fatal("expected error for missing override, got nil")
+	}
+	if !errors.Is(err, envpkg.ErrOverrideConfigMissing) {
+		t.Errorf("expected ErrOverrideConfigMissing, got: %v", err)
+	}
+}
+
+func TestFileResolver_MissingBase_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	// No vibewarden.yaml in dir.
+
+	r := envpkg.NewFileResolver(dir)
+	_, err := r.Resolve("")
+	if err == nil {
+		t.Fatal("expected error for missing base config, got nil")
+	}
+	if !errors.Is(err, envpkg.ErrBaseConfigMissing) {
+		t.Errorf("expected ErrBaseConfigMissing, got: %v", err)
+	}
+}
+
+func TestFileResolver_MissingBase_NonEmptyName_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	// No vibewarden.yaml in dir.
+
+	r := envpkg.NewFileResolver(dir)
+	_, err := r.Resolve("production")
+	if err == nil {
+		t.Fatal("expected error for missing base config, got nil")
+	}
+	if !errors.Is(err, envpkg.ErrBaseConfigMissing) {
+		t.Errorf("expected ErrBaseConfigMissing, got: %v", err)
+	}
+}
+
+func TestFileResolver_BasePath_IsAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "vibewarden.yaml"), minimalBase(8443))
+
+	r := envpkg.NewFileResolver(dir)
+	resolved, err := r.Resolve("")
+	if err != nil {
+		t.Fatalf("Resolve(%q) unexpected error: %v", "", err)
+	}
+	if !filepath.IsAbs(resolved.BasePath) {
+		t.Errorf("BasePath %q is not absolute", resolved.BasePath)
+	}
+}

--- a/internal/app/probe/render.go
+++ b/internal/app/probe/render.go
@@ -1,0 +1,120 @@
+package probe
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// Render writes the probe result to w. The output format depends on the
+// result and error:
+//
+//   - nil error, upstream=="ok"         → dev-ok or env-ok block + "OK" summary
+//   - ErrBootGapExhausted               → degraded block + "DEGRADED" summary
+//   - ErrProbeRefused                   → "ERROR:" URL + stack-not-running hint
+//   - *ProbeNon200Error                 → URL block + "ERROR: non-2xx" summary
+//   - ErrProbeMalformed                 → "ERROR:" URL + malformed hint
+//   - nil error, upstream!="ok"         → degraded block (failing/unknown) + "DEGRADED" summary
+//
+// All output — including errors — is written to w. The caller controls whether
+// w is stdout or stderr.
+func Render(w io.Writer, result Result, err error) {
+	switch {
+	case errors.Is(err, ports.ErrProbeRefused):
+		renderRefused(w, result)
+	case errors.Is(err, ports.ErrProbeMalformed):
+		renderMalformed(w, result)
+	case isNon200(err):
+		renderNon200(w, result, err)
+	case errors.Is(err, ErrBootGapExhausted):
+		renderHealthBlock(w, result)
+		fmt.Fprintf(w, "\nDEGRADED — upstream probe has not converged within 10s. Check `vibew logs vibewarden`.\n")
+	case err != nil:
+		// Generic / TLS / network error.
+		renderGenericError(w, result, err)
+	default:
+		// No error: render the health block and pick the summary based on state.
+		renderHealthBlock(w, result)
+		if result.Doc.Components["upstream"] == "ok" {
+			renderOKSummary(w, result)
+		} else {
+			// Upstream is "failing" or some other non-ok state.
+			renderDegradedSummary(w, result)
+		}
+	}
+}
+
+// renderHealthBlock writes the URL + status table common to the ok, degraded,
+// and boot-gap-exhausted paths.
+func renderHealthBlock(w io.Writer, result Result) {
+	fmt.Fprintf(w, "%s\n", result.URL)
+
+	tw := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
+	fmt.Fprintf(tw, "  status:\t %s\n", result.Doc.Status)
+	fmt.Fprintf(tw, "  version:\t %s\n", result.Doc.Version)
+	fmt.Fprintf(tw, "  components.sidecar:\t %s\n", result.Doc.Components["sidecar"])
+	fmt.Fprintf(tw, "  components.upstream:\t %s\n", result.Doc.Components["upstream"])
+	_ = tw.Flush()
+}
+
+// renderOKSummary writes the trailing OK line, customised for the env.
+func renderOKSummary(w io.Writer, result Result) {
+	if result.EnvName == "" {
+		fmt.Fprintf(w, "\nOK — dev stack healthy.\n")
+	} else {
+		fmt.Fprintf(w, "\nOK — %s stack healthy.\n", result.EnvName)
+	}
+}
+
+// renderDegradedSummary writes the trailing DEGRADED line for a non-ok,
+// non-exhausted upstream state (e.g. "failing").
+func renderDegradedSummary(w io.Writer, _ Result) {
+	fmt.Fprintf(w, "\nDEGRADED — upstream is not healthy. Check `vibew logs vibewarden`.\n")
+}
+
+// renderRefused writes the connection-refused error block.
+func renderRefused(w io.Writer, result Result) {
+	fmt.Fprintf(w, "ERROR: %s\n", result.URL)
+	fmt.Fprintf(w, "Stack is not running. Start with: vibew dev\n")
+}
+
+// renderMalformed writes the malformed-body error block.
+func renderMalformed(w io.Writer, result Result) {
+	fmt.Fprintf(w, "ERROR: %s\n", result.URL)
+	fmt.Fprintf(w, "Malformed response body — not the VibeWarden health wire format.\n")
+}
+
+// renderNon200 writes the non-2xx error block.
+func renderNon200(w io.Writer, result Result, err error) {
+	var ne *ports.ProbeNon200Error
+	if !errors.As(err, &ne) {
+		renderGenericError(w, result, err)
+		return
+	}
+	fmt.Fprintf(w, "%s\n", result.URL)
+
+	tw := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
+	fmt.Fprintf(tw, "  http_status:\t %d\n", ne.StatusCode)
+	fmt.Fprintf(tw, "  body:\t %s\n", ne.Body)
+	_ = tw.Flush()
+
+	fmt.Fprintf(w, "\nERROR: non-2xx response from health endpoint.\n")
+}
+
+// renderGenericError writes a generic error block for TLS / network errors.
+func renderGenericError(w io.Writer, result Result, err error) {
+	fmt.Fprintf(w, "ERROR: %s\n", result.URL)
+	fmt.Fprintf(w, "%v\n", err)
+}
+
+// isNon200 reports whether err (or any error in its chain) is a *ProbeNon200Error.
+func isNon200(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ne *ports.ProbeNon200Error
+	return errors.As(err, &ne)
+}

--- a/internal/app/probe/render_test.go
+++ b/internal/app/probe/render_test.go
@@ -1,0 +1,155 @@
+package probe_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vibewarden/vibewarden/internal/app/probe"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// updateGolden controls whether golden files are regenerated. Run with:
+//
+//	UPDATE_GOLDEN=1 go test ./internal/app/probe/...
+var updateGolden = os.Getenv("UPDATE_GOLDEN") == "1"
+
+func goldenPath(t *testing.T, name string) string {
+	t.Helper()
+	return filepath.Join("testdata", name+".golden")
+}
+
+func runGolden(t *testing.T, name string, result probe.Result, err error) {
+	t.Helper()
+	var buf bytes.Buffer
+	probe.Render(&buf, result, err)
+	got := buf.String()
+
+	path := goldenPath(t, name)
+	if updateGolden {
+		if err2 := os.WriteFile(path, []byte(got), 0o644); err2 != nil {
+			t.Fatalf("writing golden %s: %v", path, err2)
+		}
+		t.Logf("updated golden: %s", path)
+		return
+	}
+
+	want, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("reading golden %s: %v — run UPDATE_GOLDEN=1 go test to regenerate", path, readErr)
+	}
+	if got != string(want) {
+		t.Errorf("golden mismatch for %q:\ngot:\n%s\nwant:\n%s", name, got, string(want))
+	}
+}
+
+func TestRender_DevOK(t *testing.T) {
+	result := probe.Result{
+		URL:     "https://localhost:8443/_vibewarden/health",
+		EnvName: "",
+		Doc: ports.HealthDocument{
+			Status:  "ok",
+			Version: "0.18.4",
+			Components: map[string]string{
+				"sidecar":  "ok",
+				"upstream": "ok",
+			},
+		},
+	}
+	runGolden(t, "dev_ok", result, nil)
+}
+
+func TestRender_EnvOK(t *testing.T) {
+	result := probe.Result{
+		URL:     "https://app.example.com/_vibewarden/health",
+		EnvName: "production",
+		Doc: ports.HealthDocument{
+			Status:  "ok",
+			Version: "0.18.4",
+			Components: map[string]string{
+				"sidecar":  "ok",
+				"upstream": "ok",
+			},
+		},
+	}
+	runGolden(t, "env_ok", result, nil)
+}
+
+func TestRender_BootGapExhausted(t *testing.T) {
+	result := probe.Result{
+		URL:     "https://localhost:8443/_vibewarden/health",
+		EnvName: "",
+		Doc: ports.HealthDocument{
+			Status:  "degraded",
+			Version: "0.18.4",
+			Components: map[string]string{
+				"sidecar":  "ok",
+				"upstream": "unknown",
+			},
+		},
+	}
+	runGolden(t, "boot_gap_exhausted", result, probe.ErrBootGapExhausted)
+}
+
+func TestRender_Refused(t *testing.T) {
+	result := probe.Result{
+		URL:     "https://localhost:8443/_vibewarden/health",
+		EnvName: "",
+	}
+	runGolden(t, "refused", result, ports.ErrProbeRefused)
+}
+
+func TestRender_Non200(t *testing.T) {
+	result := probe.Result{
+		URL:     "https://app.example.com/_vibewarden/health",
+		EnvName: "production",
+	}
+	err := &ports.ProbeNon200Error{StatusCode: 502, Body: "Bad Gateway"}
+	runGolden(t, "non_200", result, err)
+}
+
+func TestRender_Malformed(t *testing.T) {
+	result := probe.Result{
+		URL:     "https://app.example.com/_vibewarden/health",
+		EnvName: "production",
+	}
+	runGolden(t, "malformed", result, fmt.Errorf("%w: unexpected field", ports.ErrProbeMalformed))
+}
+
+// TestRender_FailingUpstream checks that a "failing" upstream renders the
+// degraded block with the correct DEGRADED summary (not boot-gap message).
+func TestRender_FailingUpstream(t *testing.T) {
+	result := probe.Result{
+		URL:     "https://localhost:8443/_vibewarden/health",
+		EnvName: "",
+		Doc: ports.HealthDocument{
+			Status:  "degraded",
+			Version: "0.18.4",
+			Components: map[string]string{
+				"sidecar":  "ok",
+				"upstream": "failing",
+			},
+		},
+	}
+	var buf bytes.Buffer
+	probe.Render(&buf, result, nil)
+	got := buf.String()
+	if !strings.Contains(got, "DEGRADED") {
+		t.Errorf("expected DEGRADED in output, got: %q", got)
+	}
+	if strings.Contains(got, "boot gap") || strings.Contains(got, "converged") {
+		t.Errorf("failing upstream should not show boot-gap message, got: %q", got)
+	}
+}
+
+// TestRender_Non200_Unwrap verifies that errors.Is works for wrapped ErrProbeNon200.
+func TestRender_Non200_Unwrap(t *testing.T) {
+	ne := &ports.ProbeNon200Error{StatusCode: 404, Body: "not found"}
+	if !errors.Is(ne, ports.ErrProbeNon200) {
+		t.Error("ProbeNon200Error should satisfy errors.Is(err, ErrProbeNon200)")
+	}
+}

--- a/internal/app/probe/service.go
+++ b/internal/app/probe/service.go
@@ -1,0 +1,144 @@
+// Package probe implements the vibew probe use case: HTTPS health probe of
+// /_vibewarden/health with a boot-gap retry policy.
+package probe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// ErrBootGapExhausted is returned by Service.Run when the boot-gap retry
+// budget is exhausted with upstream still in "unknown" state. The caller
+// receives the last observed Result alongside this error so it can render
+// the degraded output block before exiting 1.
+var ErrBootGapExhausted = errors.New("upstream probe has not converged within boot-gap window")
+
+// Options is the parameter object for Service.Run. All duration fields have
+// safe defaults applied by DefaultOptions.
+type Options struct {
+	// URL is the fully-qualified HTTPS URL to probe, e.g.
+	// "https://localhost:8443/_vibewarden/health".
+	URL string
+
+	// EnvName is the --env flag value passed by the CLI. It is echoed in the
+	// Result so the renderer can customise the summary line. Empty for the
+	// default (dev) probe.
+	EnvName string
+
+	// BootGapWait is the total budget for waiting on a soft "upstream:unknown"
+	// state before declaring boot-gap exhaustion. Default: 10s.
+	//
+	// This window matches ADR-098's stated boot-gap range. If a future change
+	// to the background probe lengthens that window, this constant must grow
+	// with it — flagged as a maintenance dependency per ADR-102.
+	BootGapWait time.Duration
+
+	// BootGapPoll is the interval between retries during the boot-gap wait.
+	// Default: 1s.
+	BootGapPoll time.Duration
+
+	// PerProbe is the per-request timeout forwarded to the prober via the
+	// context. Not currently used to set a per-probe deadline (the HTTP client
+	// timeout set at construction handles that), but kept for future use.
+	PerProbe time.Duration
+}
+
+// DefaultOptions returns Options with the production defaults.
+func DefaultOptions(url, envName string) Options {
+	return Options{
+		URL:         url,
+		EnvName:     envName,
+		BootGapWait: 10 * time.Second,
+		BootGapPoll: 1 * time.Second,
+		PerProbe:    3 * time.Second,
+	}
+}
+
+// Result is what the CLI renders. The URL is kept separate from Doc so the
+// renderer can print the URL even on hard-error paths where Doc is empty.
+type Result struct {
+	// URL is the target that was probed.
+	URL string
+
+	// Doc is the parsed health document. Zero-value when a hard error occurred.
+	Doc ports.HealthDocument
+
+	// EnvName is the environment name (from --env), empty for dev/default.
+	EnvName string
+}
+
+// Service orchestrates the probe use case: single-shot probe + boot-gap retry.
+// Construct with NewService.
+type Service struct {
+	prober ports.HealthProber
+	sleep  func(d time.Duration) // injectable for tests; defaults to time.Sleep
+}
+
+// NewService constructs a Service backed by the given prober.
+// The sleep function defaults to time.Sleep; inject a no-op for tests.
+func NewService(prober ports.HealthProber) *Service {
+	return &Service{
+		prober: prober,
+		sleep:  time.Sleep,
+	}
+}
+
+// WithSleep returns a copy of the service with the sleep function replaced.
+// Used in tests to avoid real sleeps.
+func (s *Service) WithSleep(fn func(time.Duration)) *Service {
+	return &Service{prober: s.prober, sleep: fn}
+}
+
+// Run probes opts.URL once. If the first probe's components.upstream is
+// "unknown", it retries every opts.BootGapPoll until either the upstream
+// reports a non-unknown state or opts.BootGapWait elapses. On budget
+// exhaustion it returns the last observed Result alongside ErrBootGapExhausted.
+//
+// Hard errors (ErrProbeRefused, ErrProbeMalformed, *ProbeNon200Error) are
+// returned immediately without retry.
+func (s *Service) Run(ctx context.Context, opts Options) (Result, error) {
+	result := Result{URL: opts.URL, EnvName: opts.EnvName}
+
+	doc, err := s.prober.Probe(ctx, opts.URL)
+	if err != nil {
+		// Hard errors: do not retry.
+		return result, err
+	}
+
+	result.Doc = doc
+
+	// Upstream is in a definitive state — return immediately.
+	if doc.Components["upstream"] != "unknown" {
+		return result, nil
+	}
+
+	// Boot-gap retry: upstream is "unknown". Keep polling until it clears or
+	// the budget is exhausted.
+	deadline := time.Now().Add(opts.BootGapWait)
+	for time.Now().Before(deadline) {
+		s.sleep(opts.BootGapPoll)
+
+		// Re-check context before each retry.
+		if err := ctx.Err(); err != nil {
+			return result, fmt.Errorf("probe context cancelled during boot-gap wait: %w", err)
+		}
+
+		doc, err = s.prober.Probe(ctx, opts.URL)
+		if err != nil {
+			// Hard error during retry — propagate immediately.
+			return result, err
+		}
+		result.Doc = doc
+
+		if doc.Components["upstream"] != "unknown" {
+			return result, nil
+		}
+	}
+
+	// Budget exhausted with upstream still unknown.
+	return result, ErrBootGapExhausted
+}

--- a/internal/app/probe/service_test.go
+++ b/internal/app/probe/service_test.go
@@ -1,0 +1,215 @@
+package probe_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/vibewarden/vibewarden/internal/app/probe"
+	"github.com/vibewarden/vibewarden/internal/ports"
+)
+
+// fakeProber is a test fake that returns pre-programmed responses in order.
+// When the queue is exhausted it repeats the last entry indefinitely.
+type fakeProber struct {
+	responses []fakeResponse
+	callCount int
+}
+
+type fakeResponse struct {
+	doc ports.HealthDocument
+	err error
+}
+
+func (f *fakeProber) Probe(_ context.Context, _ string) (ports.HealthDocument, error) {
+	idx := f.callCount
+	if idx >= len(f.responses) {
+		idx = len(f.responses) - 1
+	}
+	f.callCount++
+	r := f.responses[idx]
+	return r.doc, r.err
+}
+
+// okDoc returns a healthy HealthDocument.
+func okDoc() ports.HealthDocument {
+	return ports.HealthDocument{
+		Status:  "ok",
+		Version: "0.18.4",
+		Components: map[string]string{
+			"sidecar":  "ok",
+			"upstream": "ok",
+		},
+	}
+}
+
+// unknownDoc returns a degraded HealthDocument with upstream=unknown.
+func unknownDoc() ports.HealthDocument {
+	return ports.HealthDocument{
+		Status:  "degraded",
+		Version: "0.18.4",
+		Components: map[string]string{
+			"sidecar":  "ok",
+			"upstream": "unknown",
+		},
+	}
+}
+
+// failingDoc returns a degraded HealthDocument with upstream=failing.
+func failingDoc() ports.HealthDocument {
+	return ports.HealthDocument{
+		Status:  "degraded",
+		Version: "0.18.4",
+		Components: map[string]string{
+			"sidecar":  "ok",
+			"upstream": "failing",
+		},
+	}
+}
+
+// noSleep is an injectable sleep that does nothing, so tests run instantly.
+func noSleep(_ time.Duration) {}
+
+func opts(url string) probe.Options {
+	return probe.Options{
+		URL:         url,
+		BootGapWait: 5 * time.Second,
+		BootGapPoll: 100 * time.Millisecond,
+		PerProbe:    3 * time.Second,
+	}
+}
+
+func TestService_FirstProbeOK_NoRetry(t *testing.T) {
+	prober := &fakeProber{responses: []fakeResponse{{doc: okDoc()}}}
+	svc := probe.NewService(prober).WithSleep(noSleep)
+
+	result, err := svc.Run(context.Background(), opts("https://localhost:8443/_vibewarden/health"))
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if prober.callCount != 1 {
+		t.Errorf("callCount = %d, want 1 (no retry expected)", prober.callCount)
+	}
+	if result.Doc.Components["upstream"] != "ok" {
+		t.Errorf("upstream = %q, want %q", result.Doc.Components["upstream"], "ok")
+	}
+}
+
+func TestService_FirstProbeUnknown_ThenOK(t *testing.T) {
+	prober := &fakeProber{responses: []fakeResponse{
+		{doc: unknownDoc()},
+		{doc: unknownDoc()},
+		{doc: okDoc()},
+	}}
+	svc := probe.NewService(prober).WithSleep(noSleep)
+
+	result, err := svc.Run(context.Background(), opts("https://localhost:8443/_vibewarden/health"))
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if prober.callCount != 3 {
+		t.Errorf("callCount = %d, want 3", prober.callCount)
+	}
+	if result.Doc.Components["upstream"] != "ok" {
+		t.Errorf("upstream = %q, want ok", result.Doc.Components["upstream"])
+	}
+}
+
+func TestService_AllRetriesUnknown_ReturnsBootGapExhausted(t *testing.T) {
+	// All probes return unknown. The service should exhaust the budget and
+	// return ErrBootGapExhausted along with the last unknown Result.
+	prober := &fakeProber{responses: []fakeResponse{
+		{doc: unknownDoc()},
+	}}
+	svc := probe.NewService(prober).WithSleep(noSleep)
+
+	// Use a very short BootGapWait to avoid looping forever in tests.
+	o := probe.Options{
+		URL:         "https://localhost:8443/_vibewarden/health",
+		BootGapWait: 200 * time.Millisecond,
+		BootGapPoll: 100 * time.Millisecond,
+		PerProbe:    3 * time.Second,
+	}
+	result, err := svc.Run(context.Background(), o)
+	if err == nil {
+		t.Fatal("expected ErrBootGapExhausted, got nil")
+	}
+	if !errors.Is(err, probe.ErrBootGapExhausted) {
+		t.Errorf("expected ErrBootGapExhausted, got: %v", err)
+	}
+	if result.Doc.Components["upstream"] != "unknown" {
+		t.Errorf("last doc upstream = %q, want unknown", result.Doc.Components["upstream"])
+	}
+}
+
+func TestService_HardErrorOnFirstProbe_NoRetry(t *testing.T) {
+	prober := &fakeProber{responses: []fakeResponse{
+		{err: ports.ErrProbeRefused},
+	}}
+	svc := probe.NewService(prober).WithSleep(noSleep)
+
+	_, err := svc.Run(context.Background(), opts("https://localhost:8443/_vibewarden/health"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ports.ErrProbeRefused) {
+		t.Errorf("expected ErrProbeRefused, got: %v", err)
+	}
+	if prober.callCount != 1 {
+		t.Errorf("callCount = %d, want 1 (no retry on hard error)", prober.callCount)
+	}
+}
+
+func TestService_HardErrorDuringRetry_PropagatesImmediately(t *testing.T) {
+	prober := &fakeProber{responses: []fakeResponse{
+		{doc: unknownDoc()},            // first call → boot gap
+		{err: ports.ErrProbeMalformed}, // second call → hard error during retry
+	}}
+	svc := probe.NewService(prober).WithSleep(noSleep)
+
+	_, err := svc.Run(context.Background(), opts("https://localhost:8443/_vibewarden/health"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ports.ErrProbeMalformed) {
+		t.Errorf("expected ErrProbeMalformed, got: %v", err)
+	}
+	if prober.callCount != 2 {
+		t.Errorf("callCount = %d, want 2", prober.callCount)
+	}
+}
+
+func TestService_FailingUpstream_NoRetry(t *testing.T) {
+	// "failing" is not "unknown" — no boot-gap retry.
+	prober := &fakeProber{responses: []fakeResponse{{doc: failingDoc()}}}
+	svc := probe.NewService(prober).WithSleep(noSleep)
+
+	result, err := svc.Run(context.Background(), opts("https://localhost:8443/_vibewarden/health"))
+	if err != nil {
+		t.Fatalf("expected no error (failing is not retried), got: %v", err)
+	}
+	if prober.callCount != 1 {
+		t.Errorf("callCount = %d, want 1", prober.callCount)
+	}
+	if result.Doc.Components["upstream"] != "failing" {
+		t.Errorf("upstream = %q, want failing", result.Doc.Components["upstream"])
+	}
+}
+
+func TestService_ResultURL_PreservedOnError(t *testing.T) {
+	targetURL := "https://localhost:8443/_vibewarden/health"
+	prober := &fakeProber{responses: []fakeResponse{
+		{err: ports.ErrProbeRefused},
+	}}
+	svc := probe.NewService(prober).WithSleep(noSleep)
+
+	result, _ := svc.Run(context.Background(), probe.Options{
+		URL:         targetURL,
+		BootGapWait: 100 * time.Millisecond,
+		BootGapPoll: 50 * time.Millisecond,
+	})
+	if result.URL != targetURL {
+		t.Errorf("result.URL = %q, want %q", result.URL, targetURL)
+	}
+}

--- a/internal/app/probe/testdata/boot_gap_exhausted.golden
+++ b/internal/app/probe/testdata/boot_gap_exhausted.golden
@@ -1,0 +1,7 @@
+https://localhost:8443/_vibewarden/health
+  status:               degraded
+  version:              0.18.4
+  components.sidecar:   ok
+  components.upstream:  unknown
+
+DEGRADED — upstream probe has not converged within 10s. Check `vibew logs vibewarden`.

--- a/internal/app/probe/testdata/dev_ok.golden
+++ b/internal/app/probe/testdata/dev_ok.golden
@@ -1,0 +1,7 @@
+https://localhost:8443/_vibewarden/health
+  status:               ok
+  version:              0.18.4
+  components.sidecar:   ok
+  components.upstream:  ok
+
+OK — dev stack healthy.

--- a/internal/app/probe/testdata/env_ok.golden
+++ b/internal/app/probe/testdata/env_ok.golden
@@ -1,0 +1,7 @@
+https://app.example.com/_vibewarden/health
+  status:               ok
+  version:              0.18.4
+  components.sidecar:   ok
+  components.upstream:  ok
+
+OK — production stack healthy.

--- a/internal/app/probe/testdata/malformed.golden
+++ b/internal/app/probe/testdata/malformed.golden
@@ -1,0 +1,2 @@
+ERROR: https://app.example.com/_vibewarden/health
+Malformed response body — not the VibeWarden health wire format.

--- a/internal/app/probe/testdata/non_200.golden
+++ b/internal/app/probe/testdata/non_200.golden
@@ -1,0 +1,5 @@
+https://app.example.com/_vibewarden/health
+  http_status:  502
+  body:         Bad Gateway
+
+ERROR: non-2xx response from health endpoint.

--- a/internal/app/probe/testdata/refused.golden
+++ b/internal/app/probe/testdata/refused.golden
@@ -1,0 +1,2 @@
+ERROR: https://localhost:8443/_vibewarden/health
+Stack is not running. Start with: vibew dev

--- a/internal/app/promptkickoff/testdata/deploy.golden
+++ b/internal/app/promptkickoff/testdata/deploy.golden
@@ -69,9 +69,15 @@ vibewarden.production.yaml.
 
 ## Step 8 — Verify deployment
 
+  vibew probe --env production
+
+Expected output ends with `OK — production stack healthy.`
+If `components.upstream` is `"unknown"`, the first health probe has not yet
+completed — vibew probe retries automatically for up to 10s.
+If it is `"failing"`, the upstream container is not accepting connections.
+
+Fallback (when vibew binary is not available on the operator machine):
+
   curl -fsSL https://demo.example.com/_vibewarden/health
 
-Expected: HTTP 200 with JSON body containing `"status":"ok"` and
-`"components":{"upstream":"ok"}`. If `components.upstream` is `"unknown"`,
-the first health probe has not yet completed — wait 10 seconds and retry.
-If it is `"failing"`, the upstream container is not accepting connections.
+Expected: HTTP 200 with JSON body `"status":"ok"`, `"components":{"upstream":"ok"}`.

--- a/internal/app/promptkickoff/testdata/dev.golden
+++ b/internal/app/promptkickoff/testdata/dev.golden
@@ -36,3 +36,12 @@ rate-limiting, or security logic — VibeWarden handles those at the sidecar lay
   vibew dev
 
 The sidecar starts on localhost. Your app is proxied through it automatically.
+
+## Step 6 — Verify the stack
+
+  vibew probe
+
+Expected output ends with `OK — dev stack healthy.`
+On macOS, vibew probe bypasses system curl's LibreSSL limitation by using Go's
+TLS stack directly. If the output shows `upstream: unknown`, wait 10s — the
+first upstream probe cycle has not completed yet (vibew probe retries automatically).

--- a/internal/cli/cmd/probe.go
+++ b/internal/cli/cmd/probe.go
@@ -34,8 +34,11 @@ func NewProbeCmd() *cobra.Command {
 	var envName string
 
 	cmd := &cobra.Command{
-		Use:   "probe [--env <name>]",
-		Short: "Probe the sidecar's /_vibewarden/health endpoint",
+		Use:           "probe [--env <name>]",
+		Short:         "Probe the sidecar's /_vibewarden/health endpoint",
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  true,
 		Long: `Probe the VibeWarden sidecar's /_vibewarden/health endpoint over HTTPS.
 
 Uses Go's stdlib TLS stack, bypassing macOS LibreSSL friction with self-signed

--- a/internal/cli/cmd/probe.go
+++ b/internal/cli/cmd/probe.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	healthadapter "github.com/vibewarden/vibewarden/internal/adapters/health"
+	envapp "github.com/vibewarden/vibewarden/internal/app/env"
+	probeapp "github.com/vibewarden/vibewarden/internal/app/probe"
+	"github.com/vibewarden/vibewarden/internal/config"
+)
+
+const (
+	probeHealthPath = "/_vibewarden/health"
+	probeTimeout    = 3 * time.Second
+)
+
+// NewProbeCmd creates the "vibew probe" subcommand.
+//
+// The command performs an HTTPS GET against the sidecar's /_vibewarden/health
+// endpoint using Go's stdlib HTTP client, bypassing the host's TLS stack
+// (and the macOS LibreSSL friction documented in #1224). When --env is given,
+// the command resolves the named production override config, reads
+// tls.domain, and probes the remote endpoint with full TLS verification.
+//
+// Exit codes:
+//   - 0: components.upstream == "ok" (stack is fully healthy)
+//   - 1: any other state (refused, malformed, non-200, boot-gap exhausted, failing)
+func NewProbeCmd() *cobra.Command {
+	var envName string
+
+	cmd := &cobra.Command{
+		Use:   "probe [--env <name>]",
+		Short: "Probe the sidecar's /_vibewarden/health endpoint",
+		Long: `Probe the VibeWarden sidecar's /_vibewarden/health endpoint over HTTPS.
+
+Uses Go's stdlib TLS stack, bypassing macOS LibreSSL friction with self-signed
+dev certificates (see #1224 for the advisory background).
+
+Default (no --env flag):
+  Reads server.port from vibewarden.yaml.
+  Probes https://localhost:<port>/_vibewarden/health with InsecureSkipVerify=true.
+  Suitable for verifying a running vibew dev stack.
+
+With --env <name>:
+  Loads vibewarden.<name>.yaml (must exist in the project directory).
+  Reads tls.domain from the merged config.
+  Probes https://<tls.domain>/_vibewarden/health with full TLS verification.
+  Suitable for verifying a production deployment.
+
+Boot-gap handling:
+  When components.upstream is "unknown" (the sidecar has not yet completed its
+  first upstream probe cycle), vibew probe retries every 1s for up to 10s.
+  If the upstream does not converge within that window, the command exits 1.
+
+Examples:
+  vibew probe
+  vibew probe --env production
+  vibew probe --env staging`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runProbe(cmd, envName)
+		},
+	}
+
+	cmd.Flags().StringVar(&envName, "env", "", "environment name; loads vibewarden.<name>.yaml and probes tls.domain")
+
+	return cmd
+}
+
+// runProbe implements the probe command logic. It returns nil on exit-0 paths
+// and a non-nil error on exit-1 paths. The error message is suppressed (caller
+// prints nothing) because all user-visible output is written to cmd.OutOrStdout()
+// by the renderer.
+func runProbe(cmd *cobra.Command, envName string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting working directory: %w", err)
+	}
+
+	w := cmd.OutOrStdout()
+
+	if envName == "" {
+		// Dev path: load base config, probe localhost.
+		cfg, err := config.Load("")
+		if err != nil {
+			return fmt.Errorf("loading config: %w", err)
+		}
+
+		port := cfg.Server.Port
+		if port == 0 {
+			port = 8443
+		}
+		targetURL := fmt.Sprintf("https://localhost:%d%s", port, probeHealthPath)
+
+		prober := healthadapter.NewLocalhostProber(probeTimeout)
+		svc := probeapp.NewService(prober)
+
+		opts := probeapp.DefaultOptions(targetURL, "")
+		result, probeErr := svc.Run(cmd.Context(), opts)
+		probeapp.Render(w, result, probeErr)
+
+		return exitCode(result, probeErr)
+	}
+
+	// Named-env path: resolve the env, read tls.domain, probe with strict TLS.
+	resolver := envapp.NewFileResolver(cwd)
+	resolved, err := resolver.Resolve(envName)
+	if err != nil {
+		if errors.Is(err, envapp.ErrOverrideConfigMissing) {
+			return fmt.Errorf("config file not found: vibewarden.%s.yaml", envName)
+		}
+		if errors.Is(err, envapp.ErrBaseConfigMissing) {
+			return fmt.Errorf("config file not found: vibewarden.yaml")
+		}
+		return fmt.Errorf("resolving env %q: %w", envName, err)
+	}
+
+	domain := resolved.Cfg.TLS.Domain
+	if domain == "" {
+		return fmt.Errorf("tls.domain is empty in merged config; cannot resolve probe target for --env %q", envName)
+	}
+
+	targetURL := fmt.Sprintf("https://%s%s", domain, probeHealthPath)
+
+	prober := healthadapter.NewStrictProber(probeTimeout)
+	svc := probeapp.NewService(prober)
+
+	opts := probeapp.DefaultOptions(targetURL, envName)
+	result, probeErr := svc.Run(cmd.Context(), opts)
+	probeapp.Render(w, result, probeErr)
+
+	return exitCode(result, probeErr)
+}
+
+// exitCode maps a probe result + error to a cobra-compatible return value.
+//
+// Cobra exits 0 when RunE returns nil. To signal exit 1 without printing the
+// cobra error message, we call os.Exit(1) directly after rendering — but to
+// keep RunE testable, we instead return a sentinel that the caller can
+// intercept in tests. In production (main → Execute), cobra prints any
+// non-nil error returned from RunE to stderr; we suppress that by returning a
+// special value that the CLI command checks after Render.
+//
+// The simplest approach: return nil on success, return a wrapped error on
+// failure so cobra exits 1. The rendered output is already on stdout — cobra's
+// error line goes to stderr and doesn't interfere with the rendered output.
+func exitCode(result probeapp.Result, err error) error {
+	if err == nil && result.Doc.Components["upstream"] == "ok" {
+		return nil
+	}
+	// Return a sentinel that causes cobra to exit 1. We don't need cobra to
+	// print this — the renderer already wrote the user-facing message. But
+	// cobra always prints the error from RunE; we use an empty string trick
+	// via a silent error type.
+	return errSilentExit
+}
+
+// errSilentExit is a sentinel error that causes the cobra command to exit
+// with code 1 without printing an error message. The probe renderer has
+// already written all user-facing output.
+var errSilentExit = silentError{}
+
+// silentError is an error type that cobra's Execute() will exit-1 on but
+// whose Error() returns an empty string so cobra's default stderr print is
+// invisible.
+type silentError struct{}
+
+func (silentError) Error() string { return "" }
+
+// Compile-time assertion that silentError implements error.
+var _ error = silentError{}

--- a/internal/cli/cmd/probe_test.go
+++ b/internal/cli/cmd/probe_test.go
@@ -46,6 +46,9 @@ func execProbe(t *testing.T, args []string) (string, string, error) {
 }
 
 func TestProbeCmd_DefaultPath_OK(t *testing.T) {
+	// httptest.NewTLSServer binds to 127.0.0.1. NewLocalhostProber probes
+	// https://localhost:<port> with InsecureSkipVerify=true, so the self-signed
+	// cert is accepted and the round-trip succeeds end-to-end.
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/_vibewarden/health" {
 			http.NotFound(w, r)
@@ -60,8 +63,8 @@ func TestProbeCmd_DefaultPath_OK(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// We need a vibewarden.yaml that points to our test server port.
-	// Extract the port from the test server URL.
+	// Point vibewarden.yaml at the test server's port so the prober resolves
+	// the right target.
 	addr := srv.Listener.Addr().String()
 	port := portFromAddr(t, addr)
 
@@ -69,25 +72,25 @@ func TestProbeCmd_DefaultPath_OK(t *testing.T) {
 	writeYAML(t, filepath.Join(dir, "vibewarden.yaml"),
 		"server:\n  port: "+port+"\n")
 
-	// Change into the temp dir so config.Load("") finds the file.
 	origWd, _ := os.Getwd()
 	_ = os.Chdir(dir)
 	t.Cleanup(func() { _ = os.Chdir(origWd) })
 
-	// We can't easily redirect the probe to our test server without a flag,
-	// because the prober always hits localhost:<port>. Since this test is an
-	// integration test we skip the actual network call and test via --env
-	// path separately. This test validates the command wires up correctly.
-	//
-	// However, to make this a meaningful end-to-end test, we test the --env
-	// path below where we control the target URL.
-	//
-	// For the default path we just verify that the command runs without a
-	// panic and the output contains something meaningful (the URL).
-	// The actual network result will be a refused error since localhost:<port>
-	// is not running in tests.
-	stdout, _, _ := execProbe(t, nil)
-	_ = stdout // connection refused is expected; test verifies no panic
+	stdout, _, err := execProbe(t, nil)
+	if err != nil {
+		t.Errorf("expected exit 0 for healthy stack, got error: %v", err)
+	}
+	// Rendered output must contain the URL, the upstream component line, and the
+	// dev-ok summary line.
+	if !strings.Contains(stdout, "/_vibewarden/health") {
+		t.Errorf("output missing URL; got: %q", stdout)
+	}
+	if !strings.Contains(stdout, "components.upstream:") {
+		t.Errorf("output missing components.upstream line; got: %q", stdout)
+	}
+	if !strings.Contains(stdout, "OK — dev stack healthy.") {
+		t.Errorf("output missing OK summary; got: %q", stdout)
+	}
 }
 
 func TestProbeCmd_EnvPath_OK(t *testing.T) {
@@ -189,6 +192,14 @@ func TestProbeCmd_Help(t *testing.T) {
 	}
 	if !strings.Contains(help, "--env") {
 		t.Errorf("help text should mention --env flag, got: %q", help)
+	}
+}
+
+func TestProbeCmd_RejectsPositionalArgs(t *testing.T) {
+	// cobra.NoArgs must reject any positional argument; no config file needed.
+	_, _, err := execProbe(t, []string{"accidental-arg"})
+	if err == nil {
+		t.Error("expected non-nil error when positional argument is passed, got nil")
 	}
 }
 

--- a/internal/cli/cmd/probe_test.go
+++ b/internal/cli/cmd/probe_test.go
@@ -1,0 +1,221 @@
+package cmd_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vibewarden/vibewarden/internal/cli/cmd"
+)
+
+// healthResponse is a helper to create a /_vibewarden/health JSON response body.
+func healthResponse(status, version string, components map[string]string) []byte {
+	b, _ := json.Marshal(map[string]any{
+		"status":     status,
+		"version":    version,
+		"components": components,
+	})
+	return b
+}
+
+// newProbeRoot wraps NewProbeCmd inside a temporary root so cobra can dispatch.
+func newProbeRoot() *cobra.Command {
+	root := &cobra.Command{Use: "vibew"}
+	root.AddCommand(cmd.NewProbeCmd())
+	return root
+}
+
+// execProbe runs "vibew probe [args...]" and returns the captured stdout,
+// stderr and the cobra error.
+func execProbe(t *testing.T, args []string) (string, string, error) {
+	t.Helper()
+	root := newProbeRoot()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs(append([]string{"probe"}, args...))
+	err := root.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+func TestProbeCmd_DefaultPath_OK(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/_vibewarden/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(healthResponse("ok", "0.18.4", map[string]string{
+			"sidecar":  "ok",
+			"upstream": "ok",
+		}))
+	}))
+	defer srv.Close()
+
+	// We need a vibewarden.yaml that points to our test server port.
+	// Extract the port from the test server URL.
+	addr := srv.Listener.Addr().String()
+	port := portFromAddr(t, addr)
+
+	dir := t.TempDir()
+	writeYAML(t, filepath.Join(dir, "vibewarden.yaml"),
+		"server:\n  port: "+port+"\n")
+
+	// Change into the temp dir so config.Load("") finds the file.
+	origWd, _ := os.Getwd()
+	_ = os.Chdir(dir)
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	// We can't easily redirect the probe to our test server without a flag,
+	// because the prober always hits localhost:<port>. Since this test is an
+	// integration test we skip the actual network call and test via --env
+	// path separately. This test validates the command wires up correctly.
+	//
+	// However, to make this a meaningful end-to-end test, we test the --env
+	// path below where we control the target URL.
+	//
+	// For the default path we just verify that the command runs without a
+	// panic and the output contains something meaningful (the URL).
+	// The actual network result will be a refused error since localhost:<port>
+	// is not running in tests.
+	stdout, _, _ := execProbe(t, nil)
+	_ = stdout // connection refused is expected; test verifies no panic
+}
+
+func TestProbeCmd_EnvPath_OK(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/_vibewarden/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(healthResponse("ok", "0.18.4", map[string]string{
+			"sidecar":  "ok",
+			"upstream": "ok",
+		}))
+	}))
+	defer srv.Close()
+
+	// The --env path uses strict TLS verification. Since httptest.NewTLSServer
+	// uses a self-signed cert, we need to use a NewLocalhostProber-equivalent.
+	// We can't inject that from the CLI layer, so instead we test with a
+	// non-TLS test server using a workaround: we can't easily override the
+	// prober in the production CLI path. So this test validates that:
+	// 1. The --env flag is parsed correctly.
+	// 2. The env resolver is invoked and finds the override config.
+	// 3. A missing tls.domain produces the expected error message.
+	dir := t.TempDir()
+	addr := srv.Listener.Addr().String()
+	host := hostFromAddr(t, addr)
+	_ = host
+
+	writeYAML(t, filepath.Join(dir, "vibewarden.yaml"),
+		"server:\n  port: 8443\n")
+	// Production override: provide tls.domain pointing at our test server host.
+	// The strict prober will fail TLS verification, but we test error handling.
+	writeYAML(t, filepath.Join(dir, "vibewarden.production.yaml"),
+		"tls:\n  enabled: true\n  domain: 127.0.0.1\n")
+
+	origWd, _ := os.Getwd()
+	_ = os.Chdir(dir)
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	stdout, _, _ := execProbe(t, []string{"--env", "production"})
+	// The probe will fail with a TLS error (self-signed cert with strict verify)
+	// or connection refused. Either way the URL should appear in output.
+	_ = stdout // we just verify no panic
+}
+
+func TestProbeCmd_EnvPath_MissingOverride(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, filepath.Join(dir, "vibewarden.yaml"),
+		"server:\n  port: 8443\n")
+	// No vibewarden.production.yaml created.
+
+	origWd, _ := os.Getwd()
+	_ = os.Chdir(dir)
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	_, stderr, err := execProbe(t, []string{"--env", "production"})
+	if err == nil {
+		t.Error("expected error for missing override, got nil")
+	}
+	combined := stderr + err.Error()
+	if !strings.Contains(combined, "vibewarden.production.yaml") {
+		t.Errorf("expected vibewarden.production.yaml in error output, got stderr=%q err=%v", stderr, err)
+	}
+}
+
+func TestProbeCmd_EnvPath_EmptyDomain(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, filepath.Join(dir, "vibewarden.yaml"),
+		"server:\n  port: 8443\n")
+	// Production override with no tls.domain.
+	writeYAML(t, filepath.Join(dir, "vibewarden.production.yaml"),
+		"tls:\n  enabled: true\n")
+
+	origWd, _ := os.Getwd()
+	_ = os.Chdir(dir)
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	_, stderr, err := execProbe(t, []string{"--env", "production"})
+	if err == nil {
+		t.Error("expected error for empty tls.domain, got nil")
+	}
+	combined := stderr + err.Error()
+	if !strings.Contains(combined, "tls.domain") {
+		t.Errorf("expected tls.domain in error output, got stderr=%q err=%v", stderr, err)
+	}
+}
+
+func TestProbeCmd_Help(t *testing.T) {
+	root := newProbeRoot()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetArgs([]string{"probe", "--help"})
+	_ = root.Execute()
+	help := buf.String()
+	if !strings.Contains(help, "/_vibewarden/health") {
+		t.Errorf("help text should mention /_vibewarden/health, got: %q", help)
+	}
+	if !strings.Contains(help, "--env") {
+		t.Errorf("help text should mention --env flag, got: %q", help)
+	}
+}
+
+// writeYAML creates a YAML file at path with the given content.
+func writeYAML(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writeYAML(%q): %v", path, err)
+	}
+}
+
+// portFromAddr extracts the port string from a "host:port" address.
+func portFromAddr(t *testing.T, addr string) string {
+	t.Helper()
+	idx := strings.LastIndex(addr, ":")
+	if idx == -1 {
+		t.Fatalf("invalid addr: %q", addr)
+	}
+	return addr[idx+1:]
+}
+
+// hostFromAddr extracts the host string from a "host:port" address.
+func hostFromAddr(t *testing.T, addr string) string {
+	t.Helper()
+	idx := strings.LastIndex(addr, ":")
+	if idx == -1 {
+		t.Fatalf("invalid addr: %q", addr)
+	}
+	return addr[:idx]
+}

--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -52,6 +52,7 @@ Zero-to-secure in minutes.`,
 	root.AddCommand(NewBundleCmd())
 	root.AddCommand(NewTLSCmd())
 	root.AddCommand(NewPromptTemplateCmd())
+	root.AddCommand(NewProbeCmd())
 
 	return root
 }

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -30,7 +30,7 @@ VibeWarden is language-agnostic — `vibew init` does not scaffold app code, a D
 - **Serve `GET /health` returning HTTP 200** on that same port. Any response body is acceptable — vibew checks the status code only. Without this endpoint the sidecar container never leaves the "Created" state and `vibew dev` hangs.
 - **Do not implement TLS, auth, rate-limiting, WAF, or security headers in app code** — the sidecar owns all of those (see §Security boundary rule).
 
-`vibew doctor` validates this contract statically: `EXPOSE` vs `upstream.port` match, Dockerfile structure, and TLS state. Run it before `vibew dev` if you hit a connection-refused loop. For runtime upstream health, query `_vibewarden/health` after `vibew dev` is up.
+`vibew doctor` validates this contract statically: `EXPOSE` vs `upstream.port` match, Dockerfile structure, and TLS state. Run it before `vibew dev` if you hit a connection-refused loop. For runtime upstream health, run `vibew probe` after `vibew dev` is up (preferred on macOS; bypasses LibreSSL friction).
 
 ## Sidecar-injected headers
 
@@ -70,7 +70,9 @@ vibew down           # Stop the dev stack (preserves volumes; -v also removes vo
 vibew build && vibew dev  # Incremental rebuild — apply code changes without full recreate
 vibew obs up         # Start Prometheus + Grafana observability stack (after vibew dev)
 vibew obs down       # Stop Prometheus + Grafana observability stack
-vibew status         # Check component health
+vibew probe          # One-shot HTTPS health check (bypasses macOS LibreSSL friction — preferred over curl on macOS)
+vibew probe --env production  # Health check against a named environment overlay (reads tls.domain from merged config)
+vibew status         # Check component health (richer dev-stack overview; probe is for one-shot HTTPS verification)
 vibew doctor         # Diagnose issues
 ```
 
@@ -92,7 +94,9 @@ app port directly — it has no security.
 | `vibew build` | Build Docker image |
 | `vibew build --platform linux/amd64` | Build for a specific architecture |
 | `vibew bundle` | Produce a self-contained Docker Compose bundle under `.vibewarden/bundle/`; transfer with tar pipe + `docker compose up -d` |
-| `vibew status` | Show component health (OK / OFF / FAIL labels; OFF means disabled in config and not probed) |
+| `vibew probe` | One-shot HTTPS GET against `/_vibewarden/health` using Go's stdlib TLS stack. Uses `InsecureSkipVerify=true` for localhost (bypasses macOS LibreSSL friction). Boot-gap retry: up to 10s when `upstream=unknown`. Exit 0 on healthy, exit 1 otherwise. Canonical health check after `vibew dev` — preferred over curl on macOS. |
+| `vibew probe --env <name>` | Probe named env overlay. Loads `vibewarden.<name>.yaml`, reads merged `tls.domain`, probes with full TLS verification. |
+| `vibew status` | Show component health (OK / OFF / FAIL labels; OFF means disabled in config and not probed). Richer dev-stack overview than `vibew probe`; use probe for one-shot HTTPS endpoint verification. |
 | `vibew logs [<service>...]` | Stream local dev-stack logs (`--tail N`, `-f`/`--follow`, `--since <duration>`); scope with service name args (`vibewarden`, `app`, `kratos`, `postgres`, `mailslurper`) |
 | `vibew doctor` | Diagnose issues |
 | `vibew token` | Generate dev JWT |
@@ -115,7 +119,7 @@ For now: keep one site per project. Revisit when #1169 lands.
 ## Known limitations
 
 - WAF is in `detect` mode by default (logs but does not block). Set `waf.mode: block` in vibewarden.yaml to enforce blocking.
-- `vibew doctor` checks config, Docker, ports, ACME email, image tag, and (when the dev stack is running) generated files and local TLS cert validity. It does not probe runtime container health — use `curl https://<your-domain>/_vibewarden/health` after `vibew dev` is up for that. Pre-stack, the generated-files and TLS rows are silently skipped to avoid misleading WARNs. When a `Dockerfile` is present in the project root, `vibew doctor` also lints it against the contract: alpine base, `EXPOSE` matches `upstream.port`, no `HEALTHCHECK` directive, non-root `USER` (warn, non-blocking), multi-stage build for compiled languages, and builder image major.minor matches the project toolchain manifest (`go.mod`, `.nvmrc`, `pyproject.toml`). When no `Dockerfile` is present, the Dockerfile section is omitted entirely.
+- `vibew doctor` checks config, Docker, ports, ACME email, image tag, and (when the dev stack is running) generated files and local TLS cert validity. It does not probe runtime container health — use `vibew probe` after `vibew dev` is up for that (preferred on macOS; bypasses LibreSSL friction). For non-vibew tooling, fall back to `curl https://<your-domain>/_vibewarden/health`. Pre-stack, the generated-files and TLS rows are silently skipped to avoid misleading WARNs. When a `Dockerfile` is present in the project root, `vibew doctor` also lints it against the contract: alpine base, `EXPOSE` matches `upstream.port`, no `HEALTHCHECK` directive, non-root `USER` (warn, non-blocking), multi-stage build for compiled languages, and builder image major.minor matches the project toolchain manifest (`go.mod`, `.nvmrc`, `pyproject.toml`). When no `Dockerfile` is present, the Dockerfile section is omitted entirely.
 - Multi-site local dev works; production deploy is post-v1 (see https://github.com/VibeWarden/vibewarden/issues/1169).
 - `vibew init` does not accept `--tls` or `--domain` flags — run `vibew add tls --domain <your-domain>` after init.
 - **Image identity check (v0.18.3+):** `vibew dev` verifies the app image's `org.vibewarden.project-root-hash` label before starting the stack. If the label is missing (image built before v0.18.3) or belongs to a different project, `vibew dev` exits 1 with an actionable message. Recovery: `vibew dev --rebuild`. This catches the silent-image-collision bug where two projects with the same directory name share a `:latest` tag. TRAP: if you reused a directory name from a prior vibew project, run `vibew dev --rebuild` — the old image blocks immediately. Custom images set via `app.image:` in vibewarden.yaml bypass this check.
@@ -178,7 +182,11 @@ The bundle is just files. The contract is in `.vibewarden/bundle/README.md`:
    ```
 5. On the host, in the bundle directory: load `image.tar` (skip in
    registry-pull mode), then `docker compose up -d`.
-6. Verify against the public URL: `curl https://yourdomain/_vibewarden/health`.
+6. Verify against the public URL:
+   ```bash
+   vibew probe --env production
+   ```
+   Falls back to: `curl https://yourdomain/_vibewarden/health` for non-vibew tooling.
    Port **443** in production (TLS), not the dev port 8443.
 
 `vibew bundle` is the canonical path. Before writing any files it inspects

--- a/internal/cli/templates/prompts/deploy.tmpl
+++ b/internal/cli/templates/prompts/deploy.tmpl
@@ -69,9 +69,15 @@ vibewarden.production.yaml.
 
 ## Step 8 — Verify deployment
 
+  vibew probe --env production
+
+Expected output ends with `OK — production stack healthy.`
+If `components.upstream` is `"unknown"`, the first health probe has not yet
+completed — vibew probe retries automatically for up to 10s.
+If it is `"failing"`, the upstream container is not accepting connections.
+
+Fallback (when vibew binary is not available on the operator machine):
+
   curl -fsSL https://{{.Domain}}/_vibewarden/health
 
-Expected: HTTP 200 with JSON body containing `"status":"ok"` and
-`"components":{"upstream":"ok"}`. If `components.upstream` is `"unknown"`,
-the first health probe has not yet completed — wait 10 seconds and retry.
-If it is `"failing"`, the upstream container is not accepting connections.
+Expected: HTTP 200 with JSON body `"status":"ok"`, `"components":{"upstream":"ok"}`.

--- a/internal/cli/templates/prompts/dev.tmpl
+++ b/internal/cli/templates/prompts/dev.tmpl
@@ -36,3 +36,12 @@ rate-limiting, or security logic — VibeWarden handles those at the sidecar lay
   vibew dev
 
 The sidecar starts on localhost. Your app is proxied through it automatically.
+
+## Step 6 — Verify the stack
+
+  vibew probe
+
+Expected output ends with `OK — dev stack healthy.`
+On macOS, vibew probe bypasses system curl's LibreSSL limitation by using Go's
+TLS stack directly. If the output shows `upstream: unknown`, wait 10s — the
+first upstream probe cycle has not completed yet (vibew probe retries automatically).

--- a/internal/ports/health_prober.go
+++ b/internal/ports/health_prober.go
@@ -1,0 +1,71 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// HealthProber issues an HTTPS GET against a sidecar's /_vibewarden/health
+// endpoint and returns the parsed wire-format response.
+//
+// Implementations choose how strictly to verify the TLS cert chain — the
+// localhost adapter sets InsecureSkipVerify=true; the production adapter uses
+// the stdlib default (full chain verification). Callers express the difference
+// by selecting the adapter, not via flags on the port.
+type HealthProber interface {
+	// Probe performs a single HTTPS GET against url and returns the parsed
+	// body. Returns ErrProbeRefused when the connection is refused (stack not
+	// running). Returns ErrProbeMalformed when the body cannot be parsed as
+	// the expected wire format. Returns a *ProbeNon200Error (which wraps
+	// ErrProbeNon200) when the server returns a non-2xx status.
+	Probe(ctx context.Context, url string) (HealthDocument, error)
+}
+
+// HealthDocument is the parsed shape of /_vibewarden/health (ADR-098).
+// It mirrors the JSON wire format emitted by the HealthHandler in the caddy adapter.
+type HealthDocument struct {
+	// Status is the aggregate status: "ok" or "degraded".
+	Status string
+	// Version is the sidecar version, e.g. "0.18.4".
+	Version string
+	// Site is the multisite scope; empty for single-site deployments.
+	Site string
+	// Components maps component names to their status strings.
+	// Known keys: "sidecar" ("ok"), "upstream" ("ok"|"failing"|"unknown").
+	Components map[string]string
+}
+
+// Sentinel errors for HealthProber implementations.
+var (
+	// ErrProbeRefused is returned when the connection to the health endpoint
+	// is refused, indicating the stack is not running.
+	ErrProbeRefused = errors.New("connection refused — stack is not running")
+
+	// ErrProbeMalformed is returned when the response body cannot be parsed
+	// as the expected /_vibewarden/health wire format.
+	ErrProbeMalformed = errors.New("malformed health response body")
+
+	// ErrProbeNon200 is the sentinel wrapped by ProbeNon200Error. Callers
+	// may use errors.Is to detect any non-2xx response regardless of the
+	// status code.
+	ErrProbeNon200 = errors.New("non-2xx response from health endpoint")
+)
+
+// ProbeNon200Error wraps ErrProbeNon200 with the HTTP status code and a
+// bounded snippet of the response body so the CLI layer can render a useful
+// message without re-issuing the request.
+type ProbeNon200Error struct {
+	// StatusCode is the HTTP status code returned by the server.
+	StatusCode int
+	// Body is a truncated snippet of the response body (up to ~512 bytes).
+	Body string
+}
+
+// Error implements the error interface.
+func (e *ProbeNon200Error) Error() string {
+	return fmt.Sprintf("non-2xx response (%d): %s", e.StatusCode, e.Body)
+}
+
+// Unwrap returns ErrProbeNon200 so callers can use errors.Is(err, ErrProbeNon200).
+func (e *ProbeNon200Error) Unwrap() error { return ErrProbeNon200 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1212,8 +1212,9 @@ Step 7 — Ship and start. The bundle is just files; the contract is in README.m
     ssh root@<server-ip> "cd /opt/myapp && docker load -i image.tar && docker compose up -d"
 
 Step 8 — Verify against the public URL (port 443, TLS):
-    curl https://demo.yourdomain.com/_vibewarden/health && echo OK
-    # OK
+    vibew probe --env production
+    # Expected: OK — production stack healthy.
+    # Fallback (non-vibew tooling): curl https://demo.yourdomain.com/_vibewarden/health && echo OK
 
 Step 9 — Subsequent deploys (after code or config changes):
     vibew bundle
@@ -1355,7 +1356,9 @@ VibeWarden is operated via the `vibew` CLI. Below is the complete command list.
 | `vibew obs down` | Stop the observability stack (`-v` removes volumes; `--yes` skips confirmation) |
 | `vibew down` | Stop the local dev stack (preserves data volumes; pass `-v` to also remove volumes; pass `--yes` to skip confirmation prompt in CI/scripts) |
 | `vibew bundle` | Produce a self-contained Docker Compose deploy bundle under `.vibewarden/bundle/`. The bundle's `README.md` describes the deploy contract; operators copy the directory to a host and run `docker compose up -d`. |
-| `vibew status` | Show health of all components. Rows use three text labels: OK (healthy), OFF (disabled in config — probe suppressed), FAIL (enabled but check failed). A legend line is printed below the header. TLS: KindSelfSignedLocal and KindExpiringSoon → OK with annotation; only KindFailing → FAIL. |
+| `vibew status` | Show health of all components. Rows use three text labels: OK (healthy), OFF (disabled in config — probe suppressed), FAIL (enabled but check failed). A legend line is printed below the header. TLS: KindSelfSignedLocal and KindExpiringSoon → OK with annotation; only KindFailing → FAIL. Note: `vibew status` gives a richer dev-stack overview; `vibew probe` is for one-shot HTTPS verification of the health endpoint — use probe when system curl cannot handshake the dev cert. |
+| `vibew probe` | One-shot HTTPS GET against `/_vibewarden/health` using Go's stdlib TLS stack (bypasses macOS LibreSSL friction by construction). Default: reads `server.port` from `vibewarden.yaml`, probes `https://localhost:<port>/_vibewarden/health` with `InsecureSkipVerify=true`. With `--env <name>`: loads `vibewarden.<name>.yaml`, reads `tls.domain`, probes `https://<domain>/_vibewarden/health` with full TLS verification. Boot-gap retry: when `components.upstream` is `"unknown"` (first probe cycle not yet complete), retries every 1s for up to 10s. Exit 0 when `upstream=ok`; exit 1 otherwise. Use after `vibew dev` as the canonical health check on macOS instead of `curl`. |
+| `vibew probe --env <name>` | Probe a named environment overlay. Loads `vibewarden.<name>.yaml` (must exist), reads merged `tls.domain`, probes the production endpoint with full cert verification. Exit 1 when the override file is missing or `tls.domain` is empty. |
 | `vibew doctor` | Diagnose common issues; includes LE rate-limit preflight (crt.sh CT log query) when tls.provider=letsencrypt; --skip-le-preflight suppresses it |
 | `vibew logs [<service>...]` | Stream local dev-stack logs; all services interleaved by default. Positional args scope output (e.g. `vibew logs vibewarden app`). `--tail N` (default 100), `--follow` / `-f` for continuous streaming, `--since <duration\|RFC3339>`. Stack-not-running exits 1; unknown service exits 1; Docker unavailable exits 3. |
 | `vibew migrate` | Apply all pending database migrations (alias for migrate up) |
@@ -1648,11 +1651,16 @@ vibew doctor flags:
   local-CA ECC intermediate. Linux system curl (OpenSSL) accepts it.
   vibew doctor prints this advisory automatically on darwin after the check table.
 
-  Fix 1 — Homebrew curl (recommended):
+  Primary fix — vibew probe (no external tools required):
+    vibew probe
+  vibew probe uses Go's stdlib TLS stack and bypasses LibreSSL entirely.
+  This is the recommended health-check command on macOS after vibew dev.
+
+  Fallback fix 1 — Homebrew curl (when non-vibew tooling needs to hit the endpoint):
     brew install curl
     /opt/homebrew/opt/curl/bin/curl --insecure https://localhost:8443/_vibewarden/health
 
-  Fix 2 — Python ssl module (no Homebrew required):
+  Fallback fix 2 — Python ssl module (no Homebrew required):
     python3 -c '
     import ssl, urllib.request
     ctx = ssl._create_unverified_context()
@@ -1908,13 +1916,23 @@ rate-limiting, or security logic — VibeWarden handles those at the sidecar lay
   vibew dev
 
 The sidecar starts on localhost. Your app is proxied through it automatically.
+
+## Step 6 — Verify the stack
+
+  vibew probe
+
+Expected output ends with `OK — dev stack healthy.`
+On macOS, vibew probe bypasses system curl's LibreSSL limitation by using Go's
+TLS stack directly. If the output shows `upstream: unknown`, wait 10s — the
+first upstream probe cycle has not completed yet (vibew probe retries automatically).
 ```
 
---deploy adds Steps 6–8:
+--deploy adds Steps 6–9 (replacing the dev Step 6 above):
 - Step 6: vibew bundle (with arch mismatch guard — see note below)
 - Step 7: tar pipe transfer (dotfile-safe) + ssh + docker load -i image.tar + docker compose up -d
-- Step 8: curl healthcheck expecting HTTP 200, `"status":"ok"`,
-  `"components":{"upstream":"ok"}`
+- Step 8: `vibew probe --env production` — canonical verification step. Falls back to
+  curl healthcheck expecting HTTP 200, `"status":"ok"`, `"components":{"upstream":"ok"}`
+- Step 9 (dev only): `vibew probe` — health check after `vibew dev` (avoids LibreSSL on macOS)
 
 --domain is required when --deploy is set.
 

--- a/llms.txt
+++ b/llms.txt
@@ -54,6 +54,12 @@ cd my-app && vibew wrap --upstream 3000 && vibew dev
   under `.vibewarden/bundle/`. Transfer with tar pipe (dotfile-safe) and run
   `docker compose up -d` on the target host.
   Example: `vibew bundle`
+- `vibew probe` — one-shot HTTPS health check of `/_vibewarden/health` using Go's TLS stack.
+  Bypasses macOS LibreSSL friction — use after `vibew dev` instead of curl on macOS.
+  `--env <name>` loads `vibewarden.<name>.yaml` and probes the production domain with full cert verification.
+  Examples:
+    `vibew probe`
+    `vibew probe --env production`
 - `vibew doctor` — diagnose common configuration and runtime issues.
   Example: `vibew doctor`
 - `vibew validate` — validate `vibewarden.yaml` against the config schema.


### PR DESCRIPTION
Closes #1233

## Summary

- Adds `vibew probe [--env <name>]` CLI verb (ADR-102)
- New `HealthProber` port + `HealthDocument` value object + sentinel errors in `internal/ports/health_prober.go`
- `HTTPProber` adapter in `internal/adapters/health/prober.go` — `NewLocalhostProber` (InsecureSkipVerify) and `NewStrictProber` (full chain), both pure stdlib
- Env-resolver package `internal/app/env/` — canonical `Resolver` / `FileResolver` / `Resolved` for all future `--env`-flag verbs; delegates deep-merge to existing `bundleapp.LoadMergedConfig`
- Probe service `internal/app/probe/` — boot-gap retry (10s / 1s) at app layer, injectable sleep for test isolation
- Render package with six golden-pinned output branches (dev-ok, env-ok, boot-gap-exhausted, refused, non-200, malformed)
- Root wired: `NewProbeCmd()` added to `cmd/root.go`

## Resolves the macOS LibreSSL friction (#1224 complement)

The #1224 advisory documented a workaround (`python3 -c "import ssl..."`). `vibew probe` eliminates the need for it: Go's TLS stack handshakes the dev self-signed cert without complaint.

## Dev-ok output (pinned by golden test)

```
https://localhost:8443/_vibewarden/health
  status:               ok
  version:              0.18.4
  components.sidecar:   ok
  components.upstream:  ok

OK — dev stack healthy.
```

## Env-ok output (pinned by golden test)

```
https://app.example.com/_vibewarden/health
  status:               ok
  version:              0.18.4
  components.sidecar:   ok
  components.upstream:  ok

OK — production stack healthy.
```

## Test plan

- [ ] `go test -race ./internal/app/probe/... ./internal/adapters/health/... ./internal/app/env/... ./internal/cli/cmd/...` — all pass
- [ ] `golangci-lint run ./...` — 0 issues
- [ ] `gofmt -l .` — empty
- [ ] All 6 golden branches verified (dev-ok, env-ok, boot-gap-exhausted, refused, non-200, malformed)
- [ ] `make check` passes (pre-push hook confirmed on push)

## ADR

ADR-102: `decisions/adr-102-vibew-probe-go-stdlib-health-probe-and-env-resolver.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)