### PR TITLE
docs(#1234): AGENTS-VIBEWARDEN Dockerfile contract — frozen-install lockfile bullet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 - **Release artifacts: `agent-kickoff-dev.txt` and `agent-kickoff-deploy.txt`** (#1232, ADR-101). Goreleaser now emits both flavors of the canonical agent kickoff prompt as release assets, with `{{prjname}}`, `{{description}}`, and `{{domain}}` two-brace placeholders for consumers to substitute. Stable URL: `https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-dev.txt`. The website (vibewarden/vibewarden.dev) will fetch these at build time, replacing the hand-rolled JS template literal that drifted across three retros (vibewarden.dev#95). Forensic CI test asserts both artifacts contain the post-#1138 deploy contract (`docker load -i image.tar && docker compose up -d`), include the post-#1217 tar pipe transfer, and do NOT contain `bash deploy.sh` or the buggy `scp -r .vibewarden/bundle/*` glob form.
 
+### Documentation
+
+- **docs(#1234): AGENTS-VIBEWARDEN.md Dockerfile contract gains a "frozen-install lockfiles" bullet.** Catches the v0.18.3 retro friction where an agent's `npm ci` Dockerfile failed at build time because no `package-lock.json` was shipped. Language-agnostic by examples (npm/pnpm/yarn/bun/pip-sync/cargo --locked). Mirrored across the AGENTS template, the docs example, and llms-full.txt.
+
 ### Fixed
 
 - **fixed:** bundle stdout, bundle README, `vibew prompt-template --deploy` output, and `llms-full.txt § Agent Kickoff Prompt` all switch from `scp -r .vibewarden/bundle/* user@host:/path/` (which silently drops dotfiles like `.env`, `.credentials`, `.env.template` because shells don't include dotfiles in `*` glob) to a POSIX tar pipe: `tar -czf - -C .vibewarden/bundle . | ssh user@host 'tar -xzf - -C /opt/<app>/'`. Three retros (v0.18.1, v0.18.2, v0.18.3) flagged this; the v0.18.3 deploy shipped a "successful" stack that was missing `.env` and required manual recovery. Tar pipe is dotfile-safe by construction, single ssh connection, POSIX baseline. Forensic alignment test extended to enforce the new transfer command across all four surfaces and forbid the buggy form. (#1217)

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -148,6 +148,7 @@ component is disabled in config and was not probed.
 - [ ] **App responds to `GET /health` with HTTP 200** on that port. The sidecar waits on this endpoint before accepting traffic; a missing or 404 `/health` hangs the stack.
 - [ ] **Multi-stage build for compiled languages** (Go, Rust, Java, etc.). Pin the **builder** image's `major.minor` to the project toolchain manifest above. The final stage copies only the compiled binary onto Alpine — no source, no toolchain.
 - [ ] **No `HEALTHCHECK` directive.** Compose owns the healthcheck (already declared in the generated `docker-compose.yml`). A Dockerfile `HEALTHCHECK` is redundant, fights compose's view of container state, and will be flagged by `vibew doctor`.
+- [ ] **Frozen-install commands need lockfiles in the build context.** If your Dockerfile runs a frozen-install command (`npm ci`, `pnpm install --frozen-lockfile`, `yarn install --frozen-lockfile`, `bun install --frozen-lockfile`, `pip-sync`, `cargo build --locked`, etc.), the corresponding lockfile (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lockb`, `requirements.txt`, `Cargo.lock`) must exist in the build context. Without it, `vibew build` fails on the first run.
 
 **Strongly recommended (warned, not blocked):**
 

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -272,6 +272,7 @@ source of user friction. Running `vibew deploy` today prints cobra's
 - [ ] **App responds to `GET /health` with HTTP 200** on that port. The sidecar waits on this endpoint before accepting traffic; a missing or 404 `/health` hangs the stack.
 - [ ] **Multi-stage build for compiled languages** (Go, Rust, Java, etc.). Pin the **builder** image's `major.minor` to the project toolchain manifest above. The final stage copies only the compiled binary onto Alpine — no source, no toolchain.
 - [ ] **No `HEALTHCHECK` directive.** Compose owns the healthcheck (already declared in the generated `docker-compose.yml`). A Dockerfile `HEALTHCHECK` is redundant, fights compose's view of container state, and will be flagged by `vibew doctor`.
+- [ ] **Frozen-install commands need lockfiles in the build context.** If your Dockerfile runs a frozen-install command (`npm ci`, `pnpm install --frozen-lockfile`, `yarn install --frozen-lockfile`, `bun install --frozen-lockfile`, `pip-sync`, `cargo build --locked`, etc.), the corresponding lockfile (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lockb`, `requirements.txt`, `Cargo.lock`) must exist in the build context. Without it, `vibew build` fails on the first run.
 
 **Strongly recommended (warned, not blocked):**
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1598,6 +1598,13 @@ vibew doctor checks (in order):
       the project manifest go.mod/nvmrc/pyproject.toml (FAIL on mismatch; OFF when
       tag is "latest" or unrecognised, or when no manifest is found)
      All 6 checks are omitted when no Dockerfile is present in the project root.
+  Dockerfile contract — additional invariant (not a doctor check, enforced at build time):
+  - Frozen-install commands need lockfiles in the build context. If your Dockerfile
+    runs a frozen-install command (npm ci, pnpm install --frozen-lockfile,
+    yarn install --frozen-lockfile, bun install --frozen-lockfile, pip-sync,
+    cargo build --locked, etc.), the corresponding lockfile (package-lock.json,
+    pnpm-lock.yaml, yarn.lock, bun.lockb, requirements.txt, Cargo.lock) must exist
+    in the build context. Without it, vibew build fails on the first run.
   Runtime container health is NOT checked by doctor — query /_vibewarden/health
   after vibew dev is up for live runtime status.
 


### PR DESCRIPTION
Closes #1234.

## Summary

Adds one bullet to the `## Dockerfile contract` MUST list in three surfaces:

- `docs/examples/AGENTS-VIBEWARDEN.md` — the static reference copy
- `internal/cli/templates/agents/agents-vibewarden.md.tmpl` — so every `vibew init` generates the contract into new projects
- `llms-full.txt` § Dockerfile contract — the LLM-consumable reference

The new bullet:

> **Frozen-install commands need lockfiles in the build context.** If your Dockerfile runs a frozen-install command (`npm ci`, `pnpm install --frozen-lockfile`, `yarn install --frozen-lockfile`, `bun install --frozen-lockfile`, `pip-sync`, `cargo build --locked`, etc.), the corresponding lockfile (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lockb`, `requirements.txt`, `Cargo.lock`) must exist in the build context. Without it, `vibew build` fails on the first run.

## Context

v0.18.3 retro: an agent's `npm ci` Dockerfile would have failed on `vibew build` because no `package-lock.json` was shipped. The agent self-corrected, but the contract was silent on this case. A doctor check for lockfile presence was considered and rejected (see #1234) — it would compromise vibew's language-agnostic positioning. Expanding the contract document is the right fix.

Language coverage is intentionally wide (npm/pnpm/yarn/bun/pip-sync/cargo) so the bullet applies regardless of stack.

## No code change

Pure documentation. No new doctor check, no scaffold change, no binary behaviour change.

## Test plan

- [x] `make check` clean (golangci-lint + tests)
- [x] `vibew init --name foo --describe "x" --non-interactive` → generated `AGENTS-VIBEWARDEN.md` contains the new bullet
- [x] `grep -rn "Frozen-install" docs/ internal/cli/templates/agents/ llms-full.txt` returns exactly 3 hits