### PR TITLE
chore: release v0.18.4 — v0.18.3 retro fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+## [v0.18.4] — 2026-04-30
+
+Theme: v0.18.3 retrospective fixes. Four retro-tagged pipelines (#1217 #1232 #1233 #1234) covering the dotfile-safe deploy contract (tar pipe replaces buggy scp glob across four surfaces — three retros flagged this), the systemic agent-kickoff-artifact pattern that makes vibewarden.dev's `/start` page fetch from main repo's release tag (eliminating drift by construction), the new `vibew probe` verb that bypasses macOS LibreSSL via Go's stdlib HTTP, and a Dockerfile-contract docs bullet about frozen-install lockfiles. Two small companion patches (#1237 release-artifacts dist path, #1238 dry-run workflow follow-up tracked separately). One ADR landed: ADR-101 (kickoff release artifacts, content authority) plus ADR-102 (vibew probe + reusable env-resolver pattern). Companion website work tracked at vibewarden/vibewarden.dev#95 — fetches the new artifacts at build time once this release is tagged.
+
 ### Added
 
 - **`vibew probe [--env <name>]`** (#1233, ADR-102) — Go-stdlib HTTPS probe of `_vibewarden/health`. Default probes `https://localhost:<server.port>` with `InsecureSkipVerify` (bypasses macOS LibreSSL friction by construction). `--env <name>` resolves `vibewarden.<name>.yaml`, reads merged `tls.domain`, probes the production endpoint with full cert verification. Boot-gap retry: up to 10s when `components.upstream:"unknown"`. Generalizable env-resolver in `internal/app/env/` is available for future verbs to adopt (`vibew status --env prod`, `vibew validate --env prod`, etc.); migration of existing verbs is out of scope here.


### PR DESCRIPTION
## Summary

Release PR for v0.18.4: 4 retro-tagged pipelines (#1217 #1232 #1233 #1234) + 2 companion patches (#1237 #1238).

## Smoke test

End-to-end smoke against `demo.vibewarden.dev` with a fresh `vw184` project:

```
$ curl https://demo.vibewarden.dev/_vibewarden/health
{"status":"ok","version":"0.18.4-smoke","components":{"sidecar":"ok","upstream":"ok"}}

$ vibew probe --env production
https://demo.vibewarden.dev/_vibewarden/health
  status:               ok
  version:              0.18.4-smoke
  components.sidecar:   ok
  components.upstream:  ok

OK — production stack healthy.
```

The dotfile-safety smoke (the actual #1217 bug) verified end-to-end: tar pipe transfer placed `.env`, `.credentials`, and `.env.template` on the remote (the v0.18.3 retro shipped a deploy missing these).

## Companion

- vibewarden/vibewarden.dev#95 — website fetches kickoff artifacts at build time once this release ships and the artifacts exist at https://github.com/vibewarden/vibewarden/releases/latest/download/agent-kickoff-{dev,deploy}.txt.

## Test plan
- [x] `make check` clean on main
- [x] All 4 retro-pipeline PRs merged + non-dry-run CI green
- [x] Pre-existing dry-run workflow still failing (tracked at #1238 — broken since 2026-04-20)
- [x] Smoke test on demo.vibewarden.dev passing
- [ ] Tag v0.18.4 after merge (goreleaser publishes binaries + ghcr image + new kickoff artifacts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)