### PR TITLE
fix(#1242): vibew probe --env emits per-env error messages on connection-refused / DNS failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+### Fixed
+
+- **fixed:** `vibew probe --env <name>` now emits a per-env error message on connection-refused. Default mode still says `Stack is not running. Start with: vibew dev`. With `--env <name>`: lists real causes (bundle not deployed, host down, DNS misconfig, sidecar exited) without suggesting `vibew dev`. New `ErrDNSFailure` sentinel surfaces DNS resolution failures separately with their own actionable message. Failure modes pinned by golden tests across all four variants. (#1242, retro-0.18.4 Codex finding)
+
 ## [v0.18.4] — 2026-04-30
 
 Theme: v0.18.3 retrospective fixes. Four retro-tagged pipelines (#1217 #1232 #1233 #1234) covering the dotfile-safe deploy contract (tar pipe replaces buggy scp glob across four surfaces — three retros flagged this), the systemic agent-kickoff-artifact pattern that makes vibewarden.dev's `/start` page fetch from main repo's release tag (eliminating drift by construction), the new `vibew probe` verb that bypasses macOS LibreSSL via Go's stdlib HTTP, and a Dockerfile-contract docs bullet about frozen-install lockfiles. Two small companion patches (#1237 release-artifacts dist path, #1238 dry-run workflow follow-up tracked separately). One ADR landed: ADR-101 (kickoff release artifacts, content authority) plus ADR-102 (vibew probe + reusable env-resolver pattern). Companion website work tracked at vibewarden/vibewarden.dev#95 — fetches the new artifacts at build time once this release is tagged.

--- a/internal/adapters/health/prober.go
+++ b/internal/adapters/health/prober.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -65,6 +67,7 @@ func NewStrictProber(timeout time.Duration) *HTTPProber {
 
 // Probe performs a single HTTPS GET against url and returns the parsed
 // HealthDocument. Error semantics follow ports.HealthProber:
+//   - ports.ErrDNSFailure    — hostname does not resolve
 //   - ports.ErrProbeRefused  — connection refused
 //   - ports.ErrProbeMalformed — body cannot be decoded
 //   - *ports.ProbeNon200Error — non-2xx HTTP status
@@ -76,6 +79,12 @@ func (p *HTTPProber) Probe(ctx context.Context, url string) (ports.HealthDocumen
 
 	resp, err := p.client.Do(req)
 	if err != nil {
+		// Classify DNS failures first: net.DNSError is wrapped inside *url.Error
+		// → *net.OpError → *net.DNSError. errors.As walks the full chain.
+		var dnsErr *net.DNSError
+		if errors.As(err, &dnsErr) {
+			return ports.HealthDocument{}, ports.ErrDNSFailure
+		}
 		if isConnectionRefused(err) {
 			return ports.HealthDocument{}, ports.ErrProbeRefused
 		}

--- a/internal/adapters/health/prober_test.go
+++ b/internal/adapters/health/prober_test.go
@@ -249,6 +249,19 @@ func TestHTTPProber_Probe_WithSite(t *testing.T) {
 	}
 }
 
+func TestHTTPProber_Probe_DNSFailure(t *testing.T) {
+	// nonexistent.invalid uses the RFC 6761 reserved .invalid TLD, which is
+	// guaranteed never to resolve. We expect ErrDNSFailure from the prober.
+	prober := NewStrictProber(2 * time.Second)
+	_, err := prober.Probe(context.Background(), "https://nonexistent.invalid/_vibewarden/health")
+	if err == nil {
+		t.Fatal("expected error for unresolvable hostname, got nil")
+	}
+	if !errors.Is(err, ports.ErrDNSFailure) {
+		t.Errorf("expected ErrDNSFailure, got: %v", err)
+	}
+}
+
 func TestHTTPProber_Probe_ContextCancelled(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Block until the request context is cancelled.

--- a/internal/app/probe/render.go
+++ b/internal/app/probe/render.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"text/tabwriter"
 
 	"github.com/vibewarden/vibewarden/internal/ports"
@@ -14,7 +15,10 @@ import (
 //
 //   - nil error, upstream=="ok"         → dev-ok or env-ok block + "OK" summary
 //   - ErrBootGapExhausted               → degraded block + "DEGRADED" summary
-//   - ErrProbeRefused                   → "ERROR:" URL + stack-not-running hint
+//   - ErrProbeRefused (EnvName=="")     → "ERROR:" URL + "Stack is not running" hint
+//   - ErrProbeRefused (EnvName!="")     → "ERROR:" URL + per-env causes list
+//   - ErrDNSFailure (EnvName=="")       → "ERROR:" URL + unexpected localhost hint
+//   - ErrDNSFailure (EnvName!="")       → "ERROR:" URL + tls.domain/DNS hint
 //   - *ProbeNon200Error                 → URL block + "ERROR: non-2xx" summary
 //   - ErrProbeMalformed                 → "ERROR:" URL + malformed hint
 //   - nil error, upstream!="ok"         → degraded block (failing/unknown) + "DEGRADED" summary
@@ -25,6 +29,8 @@ func Render(w io.Writer, result Result, err error) {
 	switch {
 	case errors.Is(err, ports.ErrProbeRefused):
 		renderRefused(w, result)
+	case errors.Is(err, ports.ErrDNSFailure):
+		renderDNSFailure(w, result)
 	case errors.Is(err, ports.ErrProbeMalformed):
 		renderMalformed(w, result)
 	case isNon200(err):
@@ -75,10 +81,46 @@ func renderDegradedSummary(w io.Writer, _ Result) {
 	fmt.Fprintf(w, "\nDEGRADED — upstream is not healthy. Check `vibew logs vibewarden`.\n")
 }
 
-// renderRefused writes the connection-refused error block.
+// renderRefused writes the connection-refused error block. When EnvName is
+// set (--env path) the message lists production-specific causes. For the
+// default local-dev path it keeps the familiar "vibew dev" hint.
 func renderRefused(w io.Writer, result Result) {
 	fmt.Fprintf(w, "ERROR: %s\n", result.URL)
-	fmt.Fprintf(w, "Stack is not running. Start with: vibew dev\n")
+	if result.EnvName == "" {
+		fmt.Fprintf(w, "Stack is not running. Start with: vibew dev\n")
+		return
+	}
+	domain := hostnameFromURL(result.URL)
+	fmt.Fprintf(w, "  connection refused\n")
+	fmt.Fprintf(w, "\nThe %s endpoint is not reachable. Possible causes:\n", result.EnvName)
+	fmt.Fprintf(w, "  - the bundle hasn't been deployed yet (see `vibew bundle` Next: block)\n")
+	fmt.Fprintf(w, "  - the remote host is down\n")
+	fmt.Fprintf(w, "  - DNS for %s doesn't resolve to the deploy host\n", domain)
+	fmt.Fprintf(w, "  - the sidecar container exited (ssh in and check `docker compose ps`)\n")
+}
+
+// renderDNSFailure writes the DNS-resolution-failure error block. When
+// EnvName is set it points the user at tls.domain in the env YAML file.
+// For the default local-dev path it flags an unexpected /etc/hosts problem.
+func renderDNSFailure(w io.Writer, result Result) {
+	domain := hostnameFromURL(result.URL)
+	fmt.Fprintf(w, "ERROR: %s\n", result.URL)
+	fmt.Fprintf(w, "  DNS does not resolve\n")
+	if result.EnvName == "" {
+		fmt.Fprintf(w, "\nUnexpected — localhost should always resolve. Check /etc/hosts.\n")
+		return
+	}
+	fmt.Fprintf(w, "\nCheck tls.domain in vibewarden.%s.yaml and the DNS A/AAAA records\nfor %s.\n", result.EnvName, domain)
+}
+
+// hostnameFromURL extracts the bare hostname (without port) from rawURL.
+// Falls back to rawURL itself if parsing fails.
+func hostnameFromURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	return u.Hostname()
 }
 
 // renderMalformed writes the malformed-body error block.

--- a/internal/app/probe/render_test.go
+++ b/internal/app/probe/render_test.go
@@ -153,3 +153,41 @@ func TestRender_Non200_Unwrap(t *testing.T) {
 		t.Error("ProbeNon200Error should satisfy errors.Is(err, ErrProbeNon200)")
 	}
 }
+
+// TestRender_RefusedEnv checks the per-env connection-refused message listing
+// production-specific causes (bundle not deployed, host down, DNS, sidecar).
+func TestRender_RefusedEnv(t *testing.T) {
+	result := probe.Result{
+		URL:     "https://demo.example.com/_vibewarden/health",
+		EnvName: "production",
+	}
+	runGolden(t, "refused_env", result, ports.ErrProbeRefused)
+}
+
+// TestRender_DNSFailureEnv checks the env-aware DNS-failure message pointing
+// to tls.domain in the env YAML and the A/AAAA records.
+func TestRender_DNSFailureEnv(t *testing.T) {
+	result := probe.Result{
+		URL:     "https://demo.example.com/_vibewarden/health",
+		EnvName: "production",
+	}
+	runGolden(t, "dns_failure_env", result, ports.ErrDNSFailure)
+}
+
+// TestRender_DNSFailureDefault checks the default-mode DNS-failure message
+// that flags an unexpected /etc/hosts problem (localhost always resolves).
+func TestRender_DNSFailureDefault(t *testing.T) {
+	result := probe.Result{
+		URL:     "https://localhost:8443/_vibewarden/health",
+		EnvName: "",
+	}
+	runGolden(t, "dns_failure_default", result, ports.ErrDNSFailure)
+}
+
+// TestRender_ErrDNSFailure_Sentinel is a smoke test that confirms ErrDNSFailure
+// is a properly exported sentinel that satisfies errors.Is with itself.
+func TestRender_ErrDNSFailure_Sentinel(t *testing.T) {
+	if !errors.Is(ports.ErrDNSFailure, ports.ErrDNSFailure) {
+		t.Error("ErrDNSFailure should satisfy errors.Is(err, ErrDNSFailure)")
+	}
+}

--- a/internal/app/probe/service_test.go
+++ b/internal/app/probe/service_test.go
@@ -144,20 +144,40 @@ func TestService_AllRetriesUnknown_ReturnsBootGapExhausted(t *testing.T) {
 }
 
 func TestService_HardErrorOnFirstProbe_NoRetry(t *testing.T) {
-	prober := &fakeProber{responses: []fakeResponse{
-		{err: ports.ErrProbeRefused},
-	}}
-	svc := probe.NewService(prober).WithSleep(noSleep)
+	tests := []struct {
+		name         string
+		sentinel     error
+		wantSentinel error
+	}{
+		{
+			name:         "connection refused",
+			sentinel:     ports.ErrProbeRefused,
+			wantSentinel: ports.ErrProbeRefused,
+		},
+		{
+			name:         "DNS failure",
+			sentinel:     ports.ErrDNSFailure,
+			wantSentinel: ports.ErrDNSFailure,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prober := &fakeProber{responses: []fakeResponse{
+				{err: tt.sentinel},
+			}}
+			svc := probe.NewService(prober).WithSleep(noSleep)
 
-	_, err := svc.Run(context.Background(), opts("https://localhost:8443/_vibewarden/health"))
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !errors.Is(err, ports.ErrProbeRefused) {
-		t.Errorf("expected ErrProbeRefused, got: %v", err)
-	}
-	if prober.callCount != 1 {
-		t.Errorf("callCount = %d, want 1 (no retry on hard error)", prober.callCount)
+			_, err := svc.Run(context.Background(), opts("https://localhost:8443/_vibewarden/health"))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(err, tt.wantSentinel) {
+				t.Errorf("expected %v, got: %v", tt.wantSentinel, err)
+			}
+			if prober.callCount != 1 {
+				t.Errorf("callCount = %d, want 1 (no retry on hard error)", prober.callCount)
+			}
+		})
 	}
 }
 

--- a/internal/app/probe/testdata/dns_failure_default.golden
+++ b/internal/app/probe/testdata/dns_failure_default.golden
@@ -1,0 +1,4 @@
+ERROR: https://localhost:8443/_vibewarden/health
+  DNS does not resolve
+
+Unexpected — localhost should always resolve. Check /etc/hosts.

--- a/internal/app/probe/testdata/dns_failure_env.golden
+++ b/internal/app/probe/testdata/dns_failure_env.golden
@@ -1,0 +1,5 @@
+ERROR: https://demo.example.com/_vibewarden/health
+  DNS does not resolve
+
+Check tls.domain in vibewarden.production.yaml and the DNS A/AAAA records
+for demo.example.com.

--- a/internal/app/probe/testdata/refused_env.golden
+++ b/internal/app/probe/testdata/refused_env.golden
@@ -1,0 +1,8 @@
+ERROR: https://demo.example.com/_vibewarden/health
+  connection refused
+
+The production endpoint is not reachable. Possible causes:
+  - the bundle hasn't been deployed yet (see `vibew bundle` Next: block)
+  - the remote host is down
+  - DNS for demo.example.com doesn't resolve to the deploy host
+  - the sidecar container exited (ssh in and check `docker compose ps`)

--- a/internal/ports/health_prober.go
+++ b/internal/ports/health_prober.go
@@ -15,7 +15,8 @@ import (
 // by selecting the adapter, not via flags on the port.
 type HealthProber interface {
 	// Probe performs a single HTTPS GET against url and returns the parsed
-	// body. Returns ErrProbeRefused when the connection is refused (stack not
+	// body. Returns ErrDNSFailure when the hostname cannot be resolved.
+	// Returns ErrProbeRefused when the connection is refused (stack not
 	// running). Returns ErrProbeMalformed when the body cannot be parsed as
 	// the expected wire format. Returns a *ProbeNon200Error (which wraps
 	// ErrProbeNon200) when the server returns a non-2xx status.
@@ -50,6 +51,13 @@ var (
 	// may use errors.Is to detect any non-2xx response regardless of the
 	// status code.
 	ErrProbeNon200 = errors.New("non-2xx response from health endpoint")
+
+	// ErrDNSFailure is returned when the health endpoint hostname cannot be
+	// resolved. This is distinct from ErrProbeRefused: the TCP stack was never
+	// reached because DNS lookup failed first. In production this typically
+	// means the tls.domain entry in vibewarden.<env>.yaml has no matching A/AAAA
+	// record; for localhost it indicates a broken /etc/hosts.
+	ErrDNSFailure = errors.New("DNS resolution failed")
 )
 
 // ProbeNon200Error wraps ErrProbeNon200 with the HTTP status code and a


### PR DESCRIPTION
Closes #1242

## Summary

Before this fix, `vibew probe --env production` on a connection-refused failure printed the local-dev message:

```
ERROR: https://demo.example.com/_vibewarden/health
Stack is not running. Start with: vibew dev
```

That message is wrong for the `--env` path — the user has nothing to start with `vibew dev` and the real causes are entirely different (bundle not deployed, host down, DNS misconfigured, sidecar exited).

After this fix:

```
ERROR: https://demo.example.com/_vibewarden/health
  connection refused

The production endpoint is not reachable. Possible causes:
  - the bundle hasn't been deployed yet (see `vibew bundle` Next: block)
  - the remote host is down
  - DNS for demo.example.com doesn't resolve to the deploy host
  - the sidecar container exited (ssh in and check `docker compose ps`)
```

The default local-dev path (`vibew probe` with no `--env`) is **unchanged** — still shows `Stack is not running. Start with: vibew dev` (regression-guarded by the existing `TestRender_Refused` golden).

New `ErrDNSFailure` sentinel added with its own actionable message variants (env-aware vs. default localhost fallback).

## Changes

- `internal/ports/health_prober.go` — `ErrDNSFailure` sentinel
- `internal/adapters/health/prober.go` — `errors.As(*net.DNSError)` classification before refused string-match
- `internal/adapters/health/prober_test.go` — `TestHTTPProber_Probe_DNSFailure` (probes `nonexistent.invalid` RFC 6761 TLD)
- `internal/app/probe/render.go` — split `renderRefused` by `EnvName`; add `renderDNSFailure`
- `internal/app/probe/render_test.go` — 3 new golden tests + sentinel smoke test
- `internal/app/probe/service_test.go` — `ErrDNSFailure` row in hard-error fail-fast table
- `internal/app/probe/testdata/refused_env.golden` — new
- `internal/app/probe/testdata/dns_failure_env.golden` — new
- `internal/app/probe/testdata/dns_failure_default.golden` — new
- `CHANGELOG.md` — Unreleased / Fixed entry

## Test plan

- [ ] `make check` clean (gofmt, golangci-lint, go build, go test -race — all green)
- [ ] `TestRender_Refused` still passes (default mode regression guard)
- [ ] `TestRender_RefusedEnv` passes against `refused_env.golden`
- [ ] `TestRender_DNSFailureEnv` passes against `dns_failure_env.golden`
- [ ] `TestRender_DNSFailureDefault` passes against `dns_failure_default.golden`
- [ ] `TestHTTPProber_Probe_DNSFailure` passes (adapter translates `*net.DNSError` → `ErrDNSFailure`)
- [ ] `TestService_HardErrorOnFirstProbe_NoRetry/DNS_failure` passes (no retry on `ErrDNSFailure`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)