### PR TITLE
fix(#1244): bracket SSH placeholder + add deploy.host config + Codex preambles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+### Changed
+
+- **changed:** SSH target placeholder in vibew-emitted deploy commands is now `<your-ssh-user>@<your-ssh-host>` (was: `user@<domain>`). Codex agent followed the old form literally and hit auth failure on the v0.18.4 demo deploy. New `deploy.host` field in `vibewarden.production.yaml` (mirrors `deploy.target_platform`) — when set, `vibew bundle` stdout and bundle README substitute the configured host verbatim. Kickoff release artifacts (post-#1232) keep the bracketed placeholder forever (released-once, can't know any user's config). Two new prose preambles in the kickoff prompt clarify (a) `vibew init` does not scaffold app code/Dockerfile, (b) VibeWarden does not deploy for you. CLAUDE.md gains a §Architecture principles bullet locking the cross-LLM literal-vs-template clarity rule. (#1244, retro-0.18.4 Codex finding)
+
 ### Fixed
 
 - **fixed:** `vibew probe --env <name>` now emits a per-env error message on connection-refused. Default mode still says `Stack is not running. Start with: vibew dev`. With `--env <name>`: lists real causes (bundle not deployed, host down, DNS misconfig, sidecar exited) without suggesting `vibew dev`. New `ErrDNSFailure` sentinel surfaces DNS resolution failures separately with their own actionable message. Failure modes pinned by golden tests across all four variants. (#1242, retro-0.18.4 Codex finding)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,12 @@ their domain registrar, AWS ACM, etc.
   explicit error handling over panics.
 - **No global state**: everything passed via dependency injection.
 - **Artifact policy: real or pure-instruction, never example-shaped.** Every artifact vibew produces is either (a) **real** — validated, kept current, owned by vibew (the merged `vibewarden.yaml` inside the bundle, the deterministic `docker-compose.yml`, the cert files); or (b) **pure instruction** — documented in `AGENTS-VIBEWARDEN.md` or `docs/` as a contract or checklist the agent satisfies (the Dockerfile contract, the deploy recipe). Forbidden: example-shaped middle-ground artifacts that read like real code but rot — placeholder Dockerfiles, commented-out config stanzas, mostly-correct shell scripts. Stale generated content teaches agents the wrong thing; a sharp spec lets them get it right against current reality. Surfaced by the qr-dali deploy retro on v0.17.0.
+- **Cross-LLM literal-vs-template clarity.** Every literal-looking command
+  in a vibew-emitted artifact must either be runnable as written OR clearly
+  bracketed as a template (`<your-foo>`). LLM agents differ in how aggressively
+  they treat unbracketed identifiers as stand-ins; the safe default is to bracket.
+  Surfaced by the qr-code-azulejos retro on v0.18.4 (Codex agent followed
+  `user@<domain>` literally and got auth failure).
 
 ### Directory layout
 

--- a/docs/agent-kickoff.md
+++ b/docs/agent-kickoff.md
@@ -67,6 +67,9 @@ Verify: `vibew --version` should print a version string.
 
 ## Step 2 — Scaffold the project
 
+NOTE: `vibew init` does not create app code or a Dockerfile. You must
+provide both. AGENTS-VIBEWARDEN.md describes the contract.
+
   mkdir <your-project> && cd <your-project>
   vibew init --name <your-project> --describe "<your description>"
 

--- a/docs/deploy-reference.md
+++ b/docs/deploy-reference.md
@@ -16,8 +16,8 @@ is touched.
 | Before (removed) | After (supported) |
 |------------------|-------------------|
 | `vibew deploy --target ssh://user@host --config vibewarden.production.yaml` | `vibew bundle` → copy `.vibewarden/bundle/` to the host → `docker compose up -d` (see the bundle's `README.md` for the full contract) |
-| `vibew deploy status --target ssh://user@host` | `ssh user@host 'cd ~/vibewarden-bundle && docker compose ps'` |
-| `vibew deploy logs --target ssh://user@host --lines 50` | `ssh user@host 'cd ~/vibewarden-bundle && docker compose logs --tail=50'` |
+| `vibew deploy status --target ssh://user@host` | `ssh <your-ssh-user>@<your-ssh-host> 'cd ~/vibewarden-bundle && docker compose ps'` |
+| `vibew deploy logs --target ssh://user@host --lines 50` | `ssh <your-ssh-user>@<your-ssh-host> 'cd ~/vibewarden-bundle && docker compose logs --tail=50'` |
 | `vibew deploy --dry-run` | `vibew bundle` (bundle is always written locally; inspect `.vibewarden/bundle/`) |
 
 ---

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -205,12 +205,12 @@ The bundle is just files. The contract is in `.vibewarden/bundle/README.md`:
 
 1. Build for the target architecture: `vibew build --platform linux/amd64`.
 2. Produce the bundle: `vibew bundle`.
-3. Make sure the remote directory exists (e.g. `ssh user@host mkdir -p
+3. Make sure the remote directory exists (e.g. `ssh <your-ssh-user>@<your-ssh-host> mkdir -p
    /path/to/bundle`).
 4. Copy the bundle to the host using the tar pipe (dotfile-safe — `scp -r bundle/*`
    silently drops `.env` and `.credentials` due to POSIX glob):
    ```bash
-   tar -czf - -C .vibewarden/bundle . | ssh user@host 'tar -xzf - -C /path/to/bundle/'
+   tar -czf - -C .vibewarden/bundle . | ssh <your-ssh-user>@<your-ssh-host> 'tar -xzf - -C /path/to/bundle/'
    ```
 5. On the host, in the bundle directory: load `image.tar` (in
    registry-pull mode the image is already published — skip this step

--- a/docs/guide/bundle-to-vps.md
+++ b/docs/guide/bundle-to-vps.md
@@ -41,7 +41,7 @@ On the VPS:
 - Docker Engine 20.10+ and the Docker Compose v2 plugin installed and
   runnable by the SSH user.
 - A directory writable by the SSH user where the bundle will land. Create
-  it before copying — `ssh user@host mkdir -p /path/to/bundle` works.
+  it before copying — `ssh <your-ssh-user>@<your-ssh-host> mkdir -p /path/to/bundle` works.
 
 ---
 
@@ -85,16 +85,16 @@ same inputs produces byte-identical output (deterministic).
 The bundle is just files. The contract is described in
 `.vibewarden/bundle/README.md` and reproduced here:
 
-1. Make sure the remote directory exists (e.g. `ssh user@host mkdir -p
+1. Make sure the remote directory exists (e.g. `ssh <your-ssh-user>@<your-ssh-host> mkdir -p
    /path/to/bundle`). The transfer step below cannot create missing
    parent directories.
 2. Copy the bundle to the host using the tar pipe form — it transfers
    dotfiles (`.env`, `.credentials`) that `scp -r bundle/*` silently
    drops due to POSIX glob expansion:
    ```bash
-   tar -czf - -C .vibewarden/bundle . | ssh user@host 'tar -xzf - -C /path/to/bundle/'
+   tar -czf - -C .vibewarden/bundle . | ssh <your-ssh-user>@<your-ssh-host> 'tar -xzf - -C /path/to/bundle/'
    ```
-   For redeploys with delta transfer, `rsync -av --delete .vibewarden/bundle/ user@host:/path/to/bundle/` also works (rsync is dotfile-safe by default).
+   For redeploys with delta transfer, `rsync -av --delete .vibewarden/bundle/ <your-ssh-user>@<your-ssh-host>:/path/to/bundle/` also works (rsync is dotfile-safe by default).
 3. On the host, in the bundle directory: load `image.tar` into Docker
    (or, in registry-pull mode built with `--skip-image`, ensure the
    image referenced by `docker-compose.yml` is published and reachable).
@@ -118,10 +118,10 @@ Once the bundle is on the VPS, all subsequent operations use standard
 `docker compose`:
 
 ```bash
-ssh user@host 'cd ~/vibewarden-bundle && docker compose ps'                 # status
-ssh user@host 'cd ~/vibewarden-bundle && docker compose logs --tail=100 -f' # logs
-ssh user@host 'cd ~/vibewarden-bundle && docker compose restart vibewarden' # restart
-ssh user@host 'cd ~/vibewarden-bundle && docker compose pull && docker compose up -d'  # update
+ssh <your-ssh-user>@<your-ssh-host> 'cd ~/vibewarden-bundle && docker compose ps'                 # status
+ssh <your-ssh-user>@<your-ssh-host> 'cd ~/vibewarden-bundle && docker compose logs --tail=100 -f' # logs
+ssh <your-ssh-user>@<your-ssh-host> 'cd ~/vibewarden-bundle && docker compose restart vibewarden' # restart
+ssh <your-ssh-user>@<your-ssh-host> 'cd ~/vibewarden-bundle && docker compose pull && docker compose up -d'  # update
 ```
 
 Redeploys are `vibew bundle` → repeat the copy + `docker compose up -d`. The bundle
@@ -140,7 +140,7 @@ changed (config, image tag, overlay).
 - **TLS certificates.** `vibew bundle` emits whatever TLS config the
   merged `vibewarden.yaml` specifies. Let's Encrypt flows run on first
   container start. Verify with
-  `ssh user@host 'cd ~/vibewarden-bundle && docker compose logs vibewarden | grep -i acme'`.
+  `ssh <your-ssh-user>@<your-ssh-host> 'cd ~/vibewarden-bundle && docker compose logs vibewarden | grep -i acme'`.
 
 - **Strict config validation failures before any files are written.**
   `vibew bundle` calls `config.LoadStrict`, so unknown keys abort the

--- a/internal/app/bundle/bundle_extras.go
+++ b/internal/app/bundle/bundle_extras.go
@@ -29,6 +29,12 @@ const appPlaceholder = "<your-app>"
 // domainPlaceholder is used in README and stdout when domain is empty.
 const domainPlaceholder = "<your-domain>"
 
+// sshPlaceholder is used in README and stdout when deploy.host is unset.
+// It is clearly bracketed so LLM agents do not treat it as a literal SSH
+// target — the bracketed form is the cross-LLM literal-vs-template clarity
+// standard locked by #1244 and CLAUDE.md §Architecture principles.
+const sshPlaceholder = "<your-ssh-user>@<your-ssh-host>"
+
 // manifestVersion is set at build time via ldflags in production; defaults to
 // "dev" so unit tests produce stable deterministic output (excluding the header).
 var manifestVersion = "dev"
@@ -137,8 +143,16 @@ func (s *Service) writeBundleExtras(ctx context.Context, opts BundleOptions, out
 		domain = opts.Config.TLS.Domain
 	}
 
+	// Resolve the SSH deploy host from config. When set, the literal value is
+	// substituted verbatim into the README deploy block. When empty, the
+	// bracketed placeholder is used and a hint paragraph is appended.
+	sshHost := ""
+	if opts.Config != nil {
+		sshHost = opts.Config.Deploy.Host
+	}
+
 	// README.md — always overwrite.
-	readmeBody := renderBundleReadme(projectName, domain, opts.SkipImage)
+	readmeBody := renderBundleReadme(projectName, domain, sshHost, opts.SkipImage)
 	readmePath := filepath.Join(outDir, fileReadme)
 	if err := s.bundleFS.WriteFile(readmePath, []byte(readmeBody), 0o600); err != nil {
 		return fmt.Errorf("writing %s: %w", fileReadme, err)
@@ -294,8 +308,13 @@ func renderDotEnv(imageTag string, templateKeys []string) string {
 // It is exported so tests can call it directly to verify placeholder
 // substitution without going through the full Bundle pipeline.
 // See renderBundleReadme for the implementation.
-func RenderBundleReadme(appName, domain string, skipImage bool) string {
-	return renderBundleReadme(appName, domain, skipImage)
+//
+// sshHost is the SSH deploy target (e.g. "alice@host.example" or a
+// ~/.ssh/config alias). When empty, the bracketed placeholder
+// "<your-ssh-user>@<your-ssh-host>" is used and a hint paragraph is appended
+// after the deploy fenced block.
+func RenderBundleReadme(appName, domain, sshHost string, skipImage bool) string {
+	return renderBundleReadme(appName, domain, sshHost, skipImage)
 }
 
 // renderBundleReadme produces the README.md shipped inside the bundle.
@@ -303,10 +322,13 @@ func RenderBundleReadme(appName, domain string, skipImage bool) string {
 // fenced deploy block so agents have a literal command sequence immediately.
 //
 // appName and domain are substituted into the command block. Empty values
-// produce safe placeholders (<your-app>, <your-domain>). When skipImage is
-// true, the `docker load -i image.tar &&` clause is omitted from the deploy
-// block so the printed sequence remains valid for registry-pull mode.
-func renderBundleReadme(appName, domain string, skipImage bool) string {
+// produce safe placeholders (<your-app>, <your-domain>). When sshHost is
+// non-empty, it is substituted verbatim into all three ssh lines; otherwise
+// the bracketed placeholder "<your-ssh-user>@<your-ssh-host>" is used and a
+// hint paragraph is appended after the fenced block. When skipImage is true,
+// the `docker load -i image.tar &&` clause is omitted from the deploy block
+// so the printed sequence remains valid for registry-pull mode.
+func renderBundleReadme(appName, domain, sshHost string, skipImage bool) string {
 	app := appName
 	if app == "" {
 		app = appPlaceholder
@@ -314,6 +336,14 @@ func renderBundleReadme(appName, domain string, skipImage bool) string {
 	dom := domain
 	if dom == "" {
 		dom = domainPlaceholder
+	}
+
+	// Resolve the SSH target. When empty, use the bracketed placeholder so
+	// agents never mistake it for a real host. The hint paragraph is emitted
+	// below (outside the fenced block) only when the placeholder was chosen.
+	sshTarget := sshHost
+	if sshTarget == "" {
+		sshTarget = sshPlaceholder
 	}
 
 	// Build the deploy command block. When skipImage is true, the docker load
@@ -331,12 +361,22 @@ func renderBundleReadme(appName, domain string, skipImage bool) string {
 	b.WriteString("## Deploy\n")
 	b.WriteString("\n")
 	b.WriteString("```bash\n")
-	b.WriteString("ssh user@host 'mkdir -p /opt/" + app + "'\n")
-	b.WriteString("tar -czf - -C .vibewarden/bundle . | ssh user@host 'tar -xzf - -C /opt/" + app + "/'\n")
-	b.WriteString("ssh user@host \"cd /opt/" + app + " && " + dockerCmd + "\"\n")
+	b.WriteString("ssh " + sshTarget + " 'mkdir -p /opt/" + app + "'\n")
+	b.WriteString("tar -czf - -C .vibewarden/bundle . | ssh " + sshTarget + " 'tar -xzf - -C /opt/" + app + "/'\n")
+	b.WriteString("ssh " + sshTarget + " \"cd /opt/" + app + " && " + dockerCmd + "\"\n")
 	b.WriteString("curl -fsSL https://" + dom + "/_vibewarden/health\n")
 	b.WriteString("```\n")
 	b.WriteString("\n")
+
+	// Hint paragraph — emitted only when the placeholder was used (host unset).
+	// It is omitted when deploy.host is configured so the block is clean.
+	if sshHost == "" {
+		b.WriteString("Replace `<your-ssh-user>@<your-ssh-host>` with your actual SSH target.\n")
+		b.WriteString("  - Check `~/.ssh/config` for an existing alias.\n")
+		b.WriteString("  - Or set `deploy.host: user@host` in `vibewarden.production.yaml`\n")
+		b.WriteString("    (vibew will substitute it into the bundle stdout next time).\n")
+		b.WriteString("\n")
+	}
 
 	// Section: What this is.
 	b.WriteString("## What this is\n")
@@ -379,8 +419,8 @@ func renderBundleReadme(appName, domain string, skipImage bool) string {
 	b.WriteString("## Read-only inspection\n")
 	b.WriteString("\n")
 	b.WriteString("```bash\n")
-	b.WriteString("ssh user@host docker compose -f /opt/" + app + "/docker-compose.yml logs --tail 50\n")
-	b.WriteString("ssh user@host docker compose -f /opt/" + app + "/docker-compose.yml ps\n")
+	b.WriteString("ssh " + sshTarget + " docker compose -f /opt/" + app + "/docker-compose.yml logs --tail 50\n")
+	b.WriteString("ssh " + sshTarget + " docker compose -f /opt/" + app + "/docker-compose.yml ps\n")
 	b.WriteString("curl -fsSL https://" + dom + "/_vibewarden/health\n")
 	b.WriteString("```\n")
 	b.WriteString("\n")

--- a/internal/app/bundle/bundle_extras_test.go
+++ b/internal/app/bundle/bundle_extras_test.go
@@ -573,13 +573,13 @@ func TestBundle_Extras_Readme_FencedDeployBlock(t *testing.T) {
 		wantAbsent []string
 	}{
 		{
-			name:      "full deploy sequence",
+			name:      "full deploy sequence — no sshHost uses bracketed placeholder",
 			appName:   "myapp",
 			domain:    "example.com",
 			skipImage: false,
 			wantCmds: []string{
-				"ssh user@host 'mkdir -p /opt/myapp'",
-				"tar -czf - -C .vibewarden/bundle . | ssh user@host 'tar -xzf - -C /opt/myapp/'",
+				"ssh <your-ssh-user>@<your-ssh-host> 'mkdir -p /opt/myapp'",
+				"tar -czf - -C .vibewarden/bundle . | ssh <your-ssh-user>@<your-ssh-host> 'tar -xzf - -C /opt/myapp/'",
 				"docker load -i image.tar && docker compose up -d",
 				"curl -fsSL https://example.com/_vibewarden/health",
 			},
@@ -590,8 +590,8 @@ func TestBundle_Extras_Readme_FencedDeployBlock(t *testing.T) {
 			domain:    "example.com",
 			skipImage: true,
 			wantCmds: []string{
-				"ssh user@host 'mkdir -p /opt/myapp'",
-				"tar -czf - -C .vibewarden/bundle . | ssh user@host 'tar -xzf - -C /opt/myapp/'",
+				"ssh <your-ssh-user>@<your-ssh-host> 'mkdir -p /opt/myapp'",
+				"tar -czf - -C .vibewarden/bundle . | ssh <your-ssh-user>@<your-ssh-host> 'tar -xzf - -C /opt/myapp/'",
 				"docker compose up -d",
 				"curl -fsSL https://example.com/_vibewarden/health",
 			},
@@ -721,7 +721,7 @@ func TestBundle_Extras_Readme_PlaceholdersWhenAppOrDomainMissing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			body := bundleapp.RenderBundleReadme(tt.appName, tt.domain, true)
+			body := bundleapp.RenderBundleReadme(tt.appName, tt.domain, "", true)
 
 			// The body must contain /opt/<wantApp> in the deploy block.
 			if !strings.Contains(body, "/opt/"+tt.wantApp) {
@@ -879,17 +879,15 @@ func TestBundle_Readme_AlignsWithDeployTmpl(t *testing.T) {
 	}
 	readmeBody := string(mem.files[filepath.Join(outDir, "README.md")])
 
-	// normalise replaces template variables and domain-as-host with the
-	// canonical forms used in the bundle README:
+	// normalise replaces template variables with concrete values so deploy.tmpl
+	// commands can be compared against the bundle README. Post-#1244 the ssh
+	// lines use the bracketed placeholder "<your-ssh-user>@<your-ssh-host>"
+	// (not the old "user@{{.Domain}}" form), so no ssh-host substitution is
+	// needed — both surfaces carry the same placeholder string verbatim.
 	//   - {{.Name}} → testApp
-	//   - user@{{.Domain}} → user@host (README never resolves the host)
-	//   - user@<testDomain> → user@host (template after first normalise)
-	//   - {{.Domain}} → testDomain (for non-host occurrences like curl URL)
-	// Order matters: replace the host patterns before the bare domain.
+	//   - {{.Domain}} → testDomain (for curl URL lines)
 	normalise := func(s string) string {
 		s = strings.ReplaceAll(s, "{{.Name}}", testApp)
-		s = strings.ReplaceAll(s, "user@{{.Domain}}", "user@host")
-		s = strings.ReplaceAll(s, "user@"+testDomain, "user@host")
 		s = strings.ReplaceAll(s, "{{.Domain}}", testDomain)
 		return s
 	}
@@ -943,11 +941,16 @@ func TestBundle_Readme_AlignsWithDeployTmpl(t *testing.T) {
 	required := []string{
 		"tar -czf - -C",
 		"tar -xzf - -C",
+		// #1244: bracketed placeholder must appear on all surfaces (when no deploy.host).
+		"<your-ssh-user>@<your-ssh-host>",
 	}
 	forbidden := []string{
 		"scp -r .vibewarden/bundle/*", // the dotfile-eating glob this issue eliminates
 		"bash deploy.sh",              // already-removed artifact (#1138)
 		"./deploy.sh",                 // ditto
+		// #1244: old unbracketed placeholder forms — Codex agents followed these literally.
+		"user@<domain>", // the original soft placeholder form
+		"user@<",        // catches any remaining unbracketed user@<...> form
 	}
 
 	for surfaceName, surfaceContent := range surfaces {
@@ -961,6 +964,75 @@ func TestBundle_Readme_AlignsWithDeployTmpl(t *testing.T) {
 				t.Errorf("forensic[%s]: forbidden pattern %q found — must not appear", surfaceName, ban)
 			}
 		}
+	}
+}
+
+// TestRenderBundleReadme_PlaceholderPath verifies that when sshHost is empty,
+// the README deploy block uses the bracketed placeholder and the hint paragraph
+// is appended after the fenced block (#1244).
+func TestRenderBundleReadme_PlaceholderPath(t *testing.T) {
+	body := bundleapp.RenderBundleReadme("myapp", "example.com", "", false)
+
+	// The bracketed placeholder must appear in all three ssh lines.
+	wantSSH := []string{
+		"ssh <your-ssh-user>@<your-ssh-host> 'mkdir -p /opt/myapp'",
+		"| ssh <your-ssh-user>@<your-ssh-host> 'tar -xzf - -C /opt/myapp/'",
+		`ssh <your-ssh-user>@<your-ssh-host> "cd /opt/myapp`,
+	}
+	for _, want := range wantSSH {
+		if !strings.Contains(body, want) {
+			t.Errorf("README missing %q in deploy block\nbody:\n%s", want, body)
+		}
+	}
+
+	// Hint paragraph must be present.
+	wantHint := []string{
+		"Replace `<your-ssh-user>@<your-ssh-host>` with your actual SSH target.",
+		"~/.ssh/config",
+		"deploy.host: user@host",
+	}
+	for _, hint := range wantHint {
+		if !strings.Contains(body, hint) {
+			t.Errorf("README missing hint %q\nbody:\n%s", hint, body)
+		}
+	}
+
+	// Old unbracketed form must not appear.
+	forbidden := []string{"user@<domain>", "user@<"}
+	for _, ban := range forbidden {
+		if strings.Contains(body, ban) {
+			t.Errorf("README must not contain %q\nbody:\n%s", ban, body)
+		}
+	}
+}
+
+// TestRenderBundleReadme_SubstitutedPath verifies that when sshHost is set,
+// the README deploy block substitutes it verbatim, no placeholder appears, and
+// no hint paragraph is emitted (#1244).
+func TestRenderBundleReadme_SubstitutedPath(t *testing.T) {
+	const host = "root@1.2.3.4"
+	body := bundleapp.RenderBundleReadme("myapp", "example.com", host, false)
+
+	// The configured host must appear in all three ssh lines.
+	wantSSH := []string{
+		"ssh root@1.2.3.4 'mkdir -p /opt/myapp'",
+		"| ssh root@1.2.3.4 'tar -xzf - -C /opt/myapp/'",
+		`ssh root@1.2.3.4 "cd /opt/myapp`,
+	}
+	for _, want := range wantSSH {
+		if !strings.Contains(body, want) {
+			t.Errorf("README missing %q in deploy block\nbody:\n%s", want, body)
+		}
+	}
+
+	// No placeholder must appear.
+	if strings.Contains(body, "<your-ssh-user>@<your-ssh-host>") {
+		t.Errorf("README must not contain bracketed placeholder when sshHost is set\nbody:\n%s", body)
+	}
+
+	// Hint paragraph must be absent.
+	if strings.Contains(body, "Replace `<your-ssh-user>") {
+		t.Errorf("README must not contain hint paragraph when sshHost is set\nbody:\n%s", body)
 	}
 }
 

--- a/internal/app/promptkickoff/testdata/deploy.golden
+++ b/internal/app/promptkickoff/testdata/deploy.golden
@@ -15,6 +15,9 @@ Verify: `vibew --version` should print a version string.
 
 ## Step 2 — Scaffold the project
 
+NOTE: `vibew init` does not create app code or a Dockerfile. You must
+provide both. AGENTS-VIBEWARDEN.md describes the contract.
+
   # Skip if you're already in the project directory:
   mkdir foo && cd foo
   vibew init --name foo --describe "bar"
@@ -59,13 +62,22 @@ vibewarden.production.yaml.
 
 ## Step 7 — Deploy to your server
 
+NOTE: VibeWarden does not deploy for you. `vibew bundle` produces a
+self-contained bundle and prints the exact ssh / scp / docker commands.
+You run them with your own SSH target.
+
 # NOTE: this is the canonical deploy recipe defined in ADR-099.
 # The bundle README opens with this same fenced block (app.name and tls.domain substituted).
 # Run these commands directly — no shell script wrapper.
 
-  ssh user@demo.example.com 'mkdir -p /opt/foo'
-  tar -czf - -C .vibewarden/bundle . | ssh user@demo.example.com 'tar -xzf - -C /opt/foo/'
-  ssh user@demo.example.com "cd /opt/foo && docker load -i image.tar && docker compose up -d"
+  ssh <your-ssh-user>@<your-ssh-host> 'mkdir -p /opt/foo'
+  tar -czf - -C .vibewarden/bundle . | ssh <your-ssh-user>@<your-ssh-host> 'tar -xzf - -C /opt/foo/'
+  ssh <your-ssh-user>@<your-ssh-host> "cd /opt/foo && docker load -i image.tar && docker compose up -d"
+
+Replace `<your-ssh-user>@<your-ssh-host>` with your actual SSH target.
+  - Check `~/.ssh/config` for an existing alias.
+  - Or set `deploy.host: user@host` in `vibewarden.production.yaml`
+    (vibew will substitute it into the bundle stdout next time).
 
 ## Step 8 — Verify deployment
 

--- a/internal/app/promptkickoff/testdata/dev.golden
+++ b/internal/app/promptkickoff/testdata/dev.golden
@@ -15,6 +15,9 @@ Verify: `vibew --version` should print a version string.
 
 ## Step 2 — Scaffold the project
 
+NOTE: `vibew init` does not create app code or a Dockerfile. You must
+provide both. AGENTS-VIBEWARDEN.md describes the contract.
+
   # Skip if you're already in the project directory:
   mkdir foo && cd foo
   vibew init --name foo --describe "bar"

--- a/internal/cli/cmd/bundle.go
+++ b/internal/cli/cmd/bundle.go
@@ -264,6 +264,16 @@ func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, o
 			cfg.TLS.Domain = prodDomain
 		}
 	}
+
+	// Mirror the same pattern for deploy.host. When set in production.yaml,
+	// vibew bundle substitutes it verbatim into the stdout block and the
+	// bundle README; otherwise, the bracketed placeholder is used with a hint
+	// paragraph. No auto-resolve from ~/.ssh/config; explicit is better.
+	if cfg.Deploy.Host == "" {
+		if prodHost := readProdDeployHost(prodConfigPath); prodHost != "" {
+			cfg.Deploy.Host = prodHost
+		}
+	}
 	bundleErr := svc.Bundle(cmd.Context(), bundleapp.BundleOptions{
 		Config:         cfg,
 		ConfigPath:     absConfig,
@@ -333,6 +343,16 @@ func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, o
 		domain = cfg.TLS.Domain
 	}
 
+	// Resolve the SSH target. When deploy.host is configured, use it verbatim.
+	// Otherwise use the bracketed placeholder — clearly not a real host — and
+	// append a hint paragraph so the user knows how to fill it in. This is the
+	// cross-LLM literal-vs-template clarity standard (#1244).
+	const sshPlaceholder = "<your-ssh-user>@<your-ssh-host>"
+	sshTarget := sshPlaceholder
+	if cfg.Deploy.Host != "" {
+		sshTarget = cfg.Deploy.Host
+	}
+
 	// Build the docker command for the "Next" block — omit docker load when
 	// --skip-image was set so the printed sequence stays valid.
 	dockerCmd := "docker load -i image.tar && docker compose up -d"
@@ -342,11 +362,20 @@ func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, o
 
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "Next: deploy")
-	fmt.Fprintf(out, "    ssh user@host 'mkdir -p /opt/%s'\n", appName)
-	fmt.Fprintf(out, "    tar -czf - -C %q . | ssh user@host 'tar -xzf - -C /opt/%s/'\n", absOut, appName)
-	fmt.Fprintf(out, "    ssh user@host \"cd /opt/%s && %s\"\n", appName, dockerCmd)
+	fmt.Fprintf(out, "    ssh %s 'mkdir -p /opt/%s'\n", sshTarget, appName)
+	fmt.Fprintf(out, "    tar -czf - -C %q . | ssh %s 'tar -xzf - -C /opt/%s/'\n", absOut, sshTarget, appName)
+	fmt.Fprintf(out, "    ssh %s \"cd /opt/%s && %s\"\n", sshTarget, appName, dockerCmd)
 	fmt.Fprintf(out, "    curl -fsSL https://%s/_vibewarden/health\n", domain)
 	fmt.Fprintln(out, "")
+	// Hint paragraph — emitted only when deploy.host is unset (placeholder was
+	// used). When host is configured, the block is clean and self-explanatory.
+	if cfg.Deploy.Host == "" {
+		fmt.Fprintf(out, "Replace `%s` with your actual SSH target.\n", sshPlaceholder)
+		fmt.Fprintln(out, "  - Check `~/.ssh/config` for an existing alias.")
+		fmt.Fprintln(out, "  - Or set `deploy.host: user@host` in `vibewarden.production.yaml`")
+		fmt.Fprintln(out, "    (vibew will substitute it into the bundle stdout next time).")
+		fmt.Fprintln(out, "")
+	}
 	fmt.Fprintf(out, "See %s/README.md for context and read-only inspection commands.\n", absOut)
 	return 0, nil
 }
@@ -420,4 +449,29 @@ func readProdTLSDomain(prodConfigPath string) string {
 		return ""
 	}
 	return tree.TLS.Domain
+}
+
+// readProdDeployHost reads deploy.host from a production override YAML without
+// merging the rest of the file. This mirrors readProdTLSDomain — both helpers
+// are intentionally near-identical rather than generalised into a single
+// config-driven function (YAGNI for two fields; if a third lands the refactor
+// is one commit per the architect's decision in #1244).
+// Returns "" when the file does not exist, is unreadable, or has no host.
+func readProdDeployHost(prodConfigPath string) string {
+	if prodConfigPath == "" {
+		return ""
+	}
+	data, err := os.ReadFile(prodConfigPath) //nolint:gosec // path is the resolved production config path
+	if err != nil {
+		return ""
+	}
+	var tree struct {
+		Deploy struct {
+			Host string `yaml:"host"`
+		} `yaml:"deploy"`
+	}
+	if err := yaml.Unmarshal(data, &tree); err != nil {
+		return ""
+	}
+	return tree.Deploy.Host
 }

--- a/internal/cli/cmd/bundle_test.go
+++ b/internal/cli/cmd/bundle_test.go
@@ -499,24 +499,31 @@ func TestBundle_Stdout_PrintsLiteralDeployCommands(t *testing.T) {
 		spacedOutDir bool // when true, outDir path contains a space to exercise %q quoting
 	}{
 		{
-			name: "app name and domain substituted in next block",
+			name: "app name and domain substituted in next block — no deploy.host uses bracketed placeholder",
 			yaml: "name: myapp\ntls:\n  domain: myapp.example.com\nserver:\n  port: 8080\nupstream:\n  port: 3000\n",
 			wantCmds: []string{
 				"Next: deploy",
-				"ssh user@host 'mkdir -p /opt/myapp'",
+				"ssh <your-ssh-user>@<your-ssh-host> 'mkdir -p /opt/myapp'",
 				"tar -czf - -C",
-				"| ssh user@host 'tar -xzf - -C /opt/myapp/'",
+				"| ssh <your-ssh-user>@<your-ssh-host> 'tar -xzf - -C /opt/myapp/'",
 				"docker compose up -d",
 				"curl -fsSL https://myapp.example.com/_vibewarden/health",
+				// Hint paragraph must be present when deploy.host is unset.
+				"Replace `<your-ssh-user>@<your-ssh-host>` with your actual SSH target.",
+				"~/.ssh/config",
+				"deploy.host: user@host",
 			},
 			// --skip-image is always passed; docker load must not appear.
 			// The three banned artifact forms are guarded here so a regression
 			// in bundle.go (stdout surface) is caught by this forensic check.
+			// The old unbracketed placeholder forms are also forbidden (#1244).
 			wantAbsent: []string{
 				"docker load -i image.tar &&",
 				"scp -r .vibewarden/bundle/*", // dotfile-eating glob eliminated by #1217
 				"bash deploy.sh",              // already-removed artifact (#1138)
 				"./deploy.sh",                 // ditto
+				"user@<",                      // old unbracketed placeholder form (#1244)
+				"user@host 'mkdir",            // pre-#1244 literal placeholder
 			},
 		},
 		{
@@ -530,6 +537,7 @@ func TestBundle_Stdout_PrintsLiteralDeployCommands(t *testing.T) {
 				"scp -r .vibewarden/bundle/*",
 				"bash deploy.sh",
 				"./deploy.sh",
+				"user@<",
 			},
 		},
 		{
@@ -550,6 +558,27 @@ func TestBundle_Stdout_PrintsLiteralDeployCommands(t *testing.T) {
 				"scp -r .vibewarden/bundle/*",
 				"bash deploy.sh",
 				"./deploy.sh",
+				"user@<",
+			},
+		},
+		{
+			// deploy.host set in yaml substitutes verbatim; hint paragraph absent.
+			name: "deploy.host set — substituted into Next block, hint absent",
+			yaml: "name: myapp\ntls:\n  domain: myapp.example.com\nserver:\n  port: 8080\nupstream:\n  port: 3000\ndeploy:\n  host: alice@host.example\n",
+			wantCmds: []string{
+				"Next: deploy",
+				"ssh alice@host.example 'mkdir -p /opt/myapp'",
+				"| ssh alice@host.example 'tar -xzf - -C /opt/myapp/'",
+				`ssh alice@host.example "cd /opt/myapp`,
+				"curl -fsSL https://myapp.example.com/_vibewarden/health",
+			},
+			wantAbsent: []string{
+				"<your-ssh-user>@<your-ssh-host>",
+				"Replace `<your-ssh-user>",
+				"scp -r .vibewarden/bundle/*",
+				"bash deploy.sh",
+				"./deploy.sh",
+				"user@<",
 			},
 		},
 	}

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -173,12 +173,12 @@ The bundle is just files. The contract is in `.vibewarden/bundle/README.md`:
 
 1. Build for the target architecture: `vibew build --platform linux/amd64`.
 2. Produce the bundle: `vibew bundle`.
-3. Make sure the remote directory exists (`ssh user@host mkdir -p
+3. Make sure the remote directory exists (`ssh <your-ssh-user>@<your-ssh-host> mkdir -p
    /path/to/bundle`).
 4. Copy the bundle to the host using the tar pipe (dotfile-safe — `scp -r bundle/*`
    silently drops `.env` and `.credentials` due to POSIX glob):
    ```bash
-   tar -czf - -C .vibewarden/bundle . | ssh user@host 'tar -xzf - -C /path/to/bundle/'
+   tar -czf - -C .vibewarden/bundle . | ssh <your-ssh-user>@<your-ssh-host> 'tar -xzf - -C /path/to/bundle/'
    ```
 5. On the host, in the bundle directory: load `image.tar` (skip in
    registry-pull mode), then `docker compose up -d`.
@@ -243,9 +243,9 @@ the dev port 8443.
 Day-two operations are standard docker compose against the copied bundle:
 
 ```bash
-ssh user@host 'cd /path/to/bundle && docker compose ps'
-ssh user@host 'cd /path/to/bundle && docker compose logs --tail=100 vibewarden'
-ssh user@host 'cd /path/to/bundle && docker compose restart vibewarden'
+ssh <your-ssh-user>@<your-ssh-host> 'cd /path/to/bundle && docker compose ps'
+ssh <your-ssh-user>@<your-ssh-host> 'cd /path/to/bundle && docker compose logs --tail=100 vibewarden'
+ssh <your-ssh-user>@<your-ssh-host> 'cd /path/to/bundle && docker compose restart vibewarden'
 ```
 
 There is no all-in-one remote-deploy command. `vibew bundle` is the only

--- a/internal/cli/templates/init-vibewarden.production.yaml.tmpl
+++ b/internal/cli/templates/init-vibewarden.production.yaml.tmpl
@@ -10,5 +10,8 @@ deploy:
   # Target platform for `vibew bundle`. The bundle aborts if the image arch
   # does not match. Hetzner and most cloud VMs are linux/amd64.
   target_platform: linux/amd64
+  # host: user@host  # SSH target for `vibew bundle` deploy commands.
+                     # Resolves into the printed deploy block when set.
+                     # Accepts a literal user@host or an alias from ~/.ssh/config.
 
 # Add overrides below.

--- a/internal/cli/templates/production_yaml_test.go
+++ b/internal/cli/templates/production_yaml_test.go
@@ -113,6 +113,50 @@ func TestInitProject_ProductionYAML_NoCommentedStubs(t *testing.T) {
 	})
 }
 
+// TestInitProject_ProductionYAML_HasDeployHostHint verifies that the rendered
+// init-vibewarden.production.yaml.tmpl contains the commented-out deploy.host
+// hint introduced in #1244. The hint must be a comment (not an active yaml key)
+// so fresh projects are not accidentally broken by an unpopulated host field.
+func TestInitProject_ProductionYAML_HasDeployHostHint(t *testing.T) {
+	renderer := templateadapter.NewRenderer(templates.FS)
+
+	data := domainscaffold.InitProjectData{
+		ProjectName: "myapp",
+		Port:        3000,
+		Name:        "myapp",
+	}
+
+	rendered, err := renderer.Render("init-vibewarden.production.yaml.tmpl", data)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	content := string(rendered)
+
+	// Must contain the commented hint somewhere.
+	t.Run("has_deploy_host_hint", func(t *testing.T) {
+		if !strings.Contains(content, "# host: user@host") {
+			t.Errorf("rendered production.yaml missing deploy.host hint comment\n\nContent:\n%s", content)
+		}
+	})
+
+	// The hint must be a comment (leading # after optional whitespace), not
+	// an active yaml key. An active "host:" key would break strict validation
+	// for users who never fill it in — empty value passes but "user@host"
+	// would be forwarded verbatim as the SSH target.
+	t.Run("host_hint_is_comment_not_active_key", func(t *testing.T) {
+		lines := strings.Split(content, "\n")
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			// Active key: line starts with "host:" (no leading #).
+			if trimmed == "host:" || strings.HasPrefix(trimmed, "host: ") {
+				if !strings.HasPrefix(trimmed, "#") {
+					t.Errorf("deploy.host appears as active yaml key — must be commented out\nLine: %q\n\nContent:\n%s", line, content)
+				}
+			}
+		}
+	})
+}
+
 // TestInitProject_ProductionYAML_HasDeployTargetPlatform verifies that the
 // rendered init-vibewarden.production.yaml.tmpl contains deploy.target_platform
 // as an actual yaml mapping (not a comment) — guard for #1200.

--- a/internal/cli/templates/prompts/deploy.tmpl
+++ b/internal/cli/templates/prompts/deploy.tmpl
@@ -15,6 +15,9 @@ Verify: `vibew --version` should print a version string.
 
 ## Step 2 — Scaffold the project
 
+NOTE: `vibew init` does not create app code or a Dockerfile. You must
+provide both. AGENTS-VIBEWARDEN.md describes the contract.
+
   # Skip if you're already in the project directory:
   mkdir {{.Name}} && cd {{.Name}}
   vibew init --name {{.Name}} --describe "{{.Describe}}"
@@ -59,13 +62,22 @@ vibewarden.production.yaml.
 
 ## Step 7 — Deploy to your server
 
+NOTE: VibeWarden does not deploy for you. `vibew bundle` produces a
+self-contained bundle and prints the exact ssh / scp / docker commands.
+You run them with your own SSH target.
+
 # NOTE: this is the canonical deploy recipe defined in ADR-099.
 # The bundle README opens with this same fenced block (app.name and tls.domain substituted).
 # Run these commands directly — no shell script wrapper.
 
-  ssh user@{{.Domain}} 'mkdir -p /opt/{{.Name}}'
-  tar -czf - -C .vibewarden/bundle . | ssh user@{{.Domain}} 'tar -xzf - -C /opt/{{.Name}}/'
-  ssh user@{{.Domain}} "cd /opt/{{.Name}} && docker load -i image.tar && docker compose up -d"
+  ssh <your-ssh-user>@<your-ssh-host> 'mkdir -p /opt/{{.Name}}'
+  tar -czf - -C .vibewarden/bundle . | ssh <your-ssh-user>@<your-ssh-host> 'tar -xzf - -C /opt/{{.Name}}/'
+  ssh <your-ssh-user>@<your-ssh-host> "cd /opt/{{.Name}} && docker load -i image.tar && docker compose up -d"
+
+Replace `<your-ssh-user>@<your-ssh-host>` with your actual SSH target.
+  - Check `~/.ssh/config` for an existing alias.
+  - Or set `deploy.host: user@host` in `vibewarden.production.yaml`
+    (vibew will substitute it into the bundle stdout next time).
 
 ## Step 8 — Verify deployment
 

--- a/internal/cli/templates/prompts/dev.tmpl
+++ b/internal/cli/templates/prompts/dev.tmpl
@@ -15,6 +15,9 @@ Verify: `vibew --version` should print a version string.
 
 ## Step 2 — Scaffold the project
 
+NOTE: `vibew init` does not create app code or a Dockerfile. You must
+provide both. AGENTS-VIBEWARDEN.md describes the contract.
+
   # Skip if you're already in the project directory:
   mkdir {{.Name}} && cd {{.Name}}
   vibew init --name {{.Name}} --describe "{{.Describe}}"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3510,3 +3510,64 @@ func TestLoad_DeployBlock_MissingEntirelyUsesDefault(t *testing.T) {
 		t.Errorf("Deploy.TargetPlatform = %q, want %q", cfg.Deploy.TargetPlatform, "linux/amd64")
 	}
 }
+
+// TestLoad_DeployHost_DefaultIsEmpty verifies that when no yaml contains
+// deploy.host the field defaults to the empty string (no SSH target assumed).
+func TestLoad_DeployHost_DefaultIsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "vibewarden.yaml")
+	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8443\n"), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Deploy.Host != "" {
+		t.Errorf("Deploy.Host = %q, want empty string (no default)", cfg.Deploy.Host)
+	}
+}
+
+// TestLoad_DeployHost_FromYAML verifies that deploy.host is populated when
+// the yaml carries the field, and that an explicit empty string in the yaml
+// returns empty (mirrors the target_platform behaviour documented above).
+func TestLoad_DeployHost_FromYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHost string
+	}{
+		{
+			name:     "literal user@host from yaml",
+			yaml:     "deploy:\n  host: root@1.2.3.4\n",
+			wantHost: "root@1.2.3.4",
+		},
+		{
+			name:     "ssh alias (no @) from yaml",
+			yaml:     "deploy:\n  host: myserver\n",
+			wantHost: "myserver",
+		},
+		{
+			name:     "empty string in yaml returns empty",
+			yaml:     "deploy:\n  host: \"\"\n",
+			wantHost: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "vibewarden.yaml")
+			if err := os.WriteFile(cfgPath, []byte(tt.yaml), 0o600); err != nil {
+				t.Fatalf("writing config: %v", err)
+			}
+			cfg, err := config.Load(cfgPath)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if cfg.Deploy.Host != tt.wantHost {
+				t.Errorf("Deploy.Host = %q, want %q", cfg.Deploy.Host, tt.wantHost)
+			}
+		})
+	}
+}

--- a/internal/config/deploy.go
+++ b/internal/config/deploy.go
@@ -11,4 +11,17 @@ type DeployConfig struct {
 	//
 	// Default: "linux/amd64" (Hetzner and most cloud VMs).
 	TargetPlatform string `mapstructure:"target_platform"`
+
+	// Host is the SSH target used in the "Next: deploy" block printed by
+	// `vibew bundle` and in the bundle README fenced deploy block. When set,
+	// the literal value (e.g. "alice@host.example" or a ~/.ssh/config alias)
+	// is substituted verbatim into all three ssh lines. When empty (the
+	// default), the bracketed placeholder "<your-ssh-user>@<your-ssh-host>"
+	// is used and a hint paragraph is appended.
+	//
+	// VibeWarden does not validate the shape of this value — any string the
+	// user wrote is passed through. SSH will surface auth or DNS failure with
+	// its own clear message. This also means ~/.ssh/config aliases (which
+	// contain no "@") are accepted without modification.
+	Host string `mapstructure:"host"`
 }

--- a/internal/config/strict_test.go
+++ b/internal/config/strict_test.go
@@ -269,3 +269,28 @@ func TestLoadStrict_DeployUnknownKey_Rejected(t *testing.T) {
 		t.Errorf("UnknownKeyError.Keys = %v, want to contain %q", unknown.Keys, "deploy.foo")
 	}
 }
+
+// TestLoadStrict_DeployHost_Accepted verifies that the new deploy.host field
+// is accepted by LoadStrict and does not trigger an UnknownKeyError. Production
+// yaml files that carry this field must load cleanly.
+func TestLoadStrict_DeployHost_Accepted(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "vibewarden.yaml")
+	if err := os.WriteFile(basePath, []byte("server:\n  port: 8443\n"), 0o600); err != nil {
+		t.Fatalf("writing base: %v", err)
+	}
+	prodPath := filepath.Join(dir, "vibewarden.production.yaml")
+	prodYAML := "server:\n  port: 443\ndeploy:\n  target_platform: linux/amd64\n  host: alice@host.example\n"
+	if err := os.WriteFile(prodPath, []byte(prodYAML), 0o600); err != nil {
+		t.Fatalf("writing prod: %v", err)
+	}
+
+	// LoadStrict validates the schema but only loads values from the base yaml
+	// via config.Load (the prod yaml is only schema-checked, not merged into
+	// cfg). The important assertion here is that LoadStrict does NOT return an
+	// UnknownKeyError for deploy.host — the field is known and must be accepted.
+	_, err := config.LoadStrict(basePath, prodPath)
+	if err != nil {
+		t.Fatalf("LoadStrict() error = %v (deploy.host must be accepted)", err)
+	}
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1161,7 +1161,7 @@ Step 2 — Point DNS. Add A record: demo.yourdomain.com -> <server-ip>.
     # must return <server-ip>
 
 Step 3 — Install Docker on the server:
-    ssh root@<server-ip> 'curl -fsSL https://get.docker.com | sh'
+    ssh <your-ssh-user>@<your-ssh-host> 'curl -fsSL https://get.docker.com | sh'
 
 Step 4 — Set up project locally:
     curl -fsSL https://vibewarden.dev/install.sh | sh
@@ -1207,9 +1207,9 @@ Step 7 — Ship and start. The bundle is just files; the contract is in README.m
     you copy, and the production healthcheck port is 443 (TLS), not the
     dev port 8443.
 
-    ssh root@<server-ip> "mkdir -p /opt/myapp"
-    tar -czf - -C .vibewarden/bundle . | ssh root@<server-ip> 'tar -xzf - -C /opt/myapp/'
-    ssh root@<server-ip> "cd /opt/myapp && docker load -i image.tar && docker compose up -d"
+    ssh <your-ssh-user>@<your-ssh-host> "mkdir -p /opt/myapp"
+    tar -czf - -C .vibewarden/bundle . | ssh <your-ssh-user>@<your-ssh-host> 'tar -xzf - -C /opt/myapp/'
+    ssh <your-ssh-user>@<your-ssh-host> "cd /opt/myapp && docker load -i image.tar && docker compose up -d"
 
 Step 8 — Verify against the public URL (port 443, TLS):
     vibew probe --env production
@@ -1218,8 +1218,8 @@ Step 8 — Verify against the public URL (port 443, TLS):
 
 Step 9 — Subsequent deploys (after code or config changes):
     vibew bundle
-    rsync -av --delete .vibewarden/bundle/ root@<server-ip>:/opt/myapp/
-    ssh root@<server-ip> "cd /opt/myapp && docker load -i image.tar && docker compose up -d"
+    rsync -av --delete .vibewarden/bundle/ <your-ssh-user>@<your-ssh-host>:/opt/myapp/
+    ssh <your-ssh-user>@<your-ssh-host> "cd /opt/myapp && docker load -i image.tar && docker compose up -d"
 
 Note: the legacy `vibew deploy` command (one-shot SSH orchestration) was removed
 in ADR-086. The bundle pipeline above is the only supported remote workflow.
@@ -1237,10 +1237,10 @@ in ADR-086. The bundle pipeline above is the only supported remote workflow.
     Wait 1 hour. Use tls.provider: self-signed to test the rest of the stack.
 
   Container fails to start:
-    ssh root@<server-ip> 'cd /opt/myapp && docker compose logs vibewarden --tail 100'
+    ssh <your-ssh-user>@<your-ssh-host> 'cd /opt/myapp && docker compose logs vibewarden --tail 100'
 
   Full doctor output from the server:
-    ssh root@<server-ip> 'docker run --rm \
+    ssh <your-ssh-user>@<your-ssh-host> 'docker run --rm \
       -v /opt/myapp/vibewarden.production.yaml:/vibewarden.yaml:ro \
       ghcr.io/vibewarden/vibewarden:latest vibew doctor --json'
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1903,6 +1903,9 @@ Verify: `vibew --version` should print a version string.
 
 ## Step 2 — Scaffold the project
 
+NOTE: `vibew init` does not create app code or a Dockerfile. You must
+provide both. AGENTS-VIBEWARDEN.md describes the contract.
+
   mkdir <your-project> && cd <your-project>
   vibew init --name <your-project> --describe "<your description>"
 
@@ -1936,7 +1939,7 @@ first upstream probe cycle has not completed yet (vibew probe retries automatica
 
 --deploy adds Steps 6–9 (replacing the dev Step 6 above):
 - Step 6: vibew bundle (with arch mismatch guard — see note below)
-- Step 7: tar pipe transfer (dotfile-safe) + ssh + docker load -i image.tar + docker compose up -d
+- Step 7: tar pipe transfer (dotfile-safe) + ssh `<your-ssh-user>@<your-ssh-host>` + docker load -i image.tar + docker compose up -d (set `deploy.host` in vibewarden.production.yaml to substitute your real SSH target)
 - Step 8: `vibew probe --env production` — canonical verification step. Falls back to
   curl healthcheck expecting HTTP 200, `"status":"ok"`, `"components":{"upstream":"ok"}`
 - Step 9 (dev only): `vibew probe` — health check after `vibew dev` (avoids LibreSSL on macOS)

--- a/vibewarden.reference.yaml
+++ b/vibewarden.reference.yaml
@@ -1065,3 +1065,15 @@ deploy:
   #
   # Default: linux/amd64
   target_platform: linux/amd64
+
+  # SSH target substituted verbatim into the "Next: deploy" block printed by
+  # `vibew bundle` and into the bundle README's fenced deploy commands.
+  # Accepts any value ssh(1) accepts: user@host, a ~/.ssh/config alias, or an IP.
+  # VibeWarden does not validate this value — SSH surfaces auth or DNS failure
+  # with its own message.
+  #
+  # When unset (default), the three ssh lines use the bracketed placeholder
+  # `<your-ssh-user>@<your-ssh-host>` and a hint paragraph is appended.
+  #
+  # Default: "" (use bracketed placeholder)
+  # host: alice@vps.example.com


### PR DESCRIPTION
Closes #1244

## Summary

- **Bracketed SSH placeholder** — all four code-emitted surfaces (`vibew bundle` stdout, bundle README, `prompts/dev.tmpl`, `prompts/deploy.tmpl`) now use `<your-ssh-user>@<your-ssh-host>` instead of the old `user@<domain>` / `user@host` forms that Codex agents followed literally.
- **`deploy.host` config field** — new field in `DeployConfig` (mirrors `deploy.target_platform`). When set in `vibewarden.production.yaml`, `vibew bundle` substitutes it verbatim into the stdout block and bundle README. When unset, the bracketed placeholder + hint paragraph is emitted.
- **`readProdDeployHost` helper** — sibling to `readProdTLSDomain` in `bundle.go`; intentionally near-identical (YAGNI per architect).
- **Hint paragraph** — appended on all dynamic surfaces when `deploy.host` is empty, pointing users to `~/.ssh/config` or the `deploy.host` config key.
- **Codex #1 preamble** (`prompts/dev.tmpl` + `prompts/deploy.tmpl` Step 2): "vibew init does not create app code or a Dockerfile."
- **Codex #3 preamble** (`prompts/deploy.tmpl` Step 7): "VibeWarden does not deploy for you."
- **Golden files regenerated** (`testdata/dev.golden`, `testdata/deploy.golden`).
- **Forensic alignment test extended** — `TestBundle_Readme_AlignsWithDeployTmpl` now requires `<your-ssh-user>@<your-ssh-host>` and forbids `user@<domain>` / `user@<` across all surfaces.
- **`CLAUDE.md`** gains the Cross-LLM literal-vs-template clarity bullet under §Architecture principles.

## Before / after

**Bundle stdout — deploy.host unset (placeholder + hint):**
```
Next: deploy
    ssh <your-ssh-user>@<your-ssh-host> 'mkdir -p /opt/myapp'
    tar -czf - -C "/path/to/.vibewarden/bundle" . | ssh <your-ssh-user>@<your-ssh-host> 'tar -xzf - -C /opt/myapp/'
    ssh <your-ssh-user>@<your-ssh-host> "cd /opt/myapp && docker compose up -d"
    curl -fsSL https://myapp.example.com/_vibewarden/health

Replace `<your-ssh-user>@<your-ssh-host>` with your actual SSH target.
  - Check `~/.ssh/config` for an existing alias.
  - Or set `deploy.host: user@host` in `vibewarden.production.yaml`
    (vibew will substitute it into the bundle stdout next time).
```

**Bundle stdout — deploy.host: alice@host.example (substituted, no hint):**
```
Next: deploy
    ssh alice@host.example 'mkdir -p /opt/myapp'
    tar -czf - -C "/path/to/.vibewarden/bundle" . | ssh alice@host.example 'tar -xzf - -C /opt/myapp/'
    ssh alice@host.example "cd /opt/myapp && docker compose up -d"
    curl -fsSL https://myapp.example.com/_vibewarden/health
```

**Kickoff prompt Step 2 (with Codex #1 preamble):**
```
## Step 2 — Scaffold the project

NOTE: `vibew init` does not create app code or a Dockerfile. You must
provide both. AGENTS-VIBEWARDEN.md describes the contract.

  # Skip if you're already in the project directory:
  mkdir myapp && cd myapp
  vibew init --name myapp --describe "..."
```

**Kickoff prompt Step 7 (with Codex #3 preamble + bracketed placeholder + hint):**
```
## Step 7 — Deploy to your server

NOTE: VibeWarden does not deploy for you. `vibew bundle` produces a
self-contained bundle and prints the exact ssh / scp / docker commands.
You run them with your own SSH target.

  ssh <your-ssh-user>@<your-ssh-host> 'mkdir -p /opt/myapp'
  tar -czf - -C .vibewarden/bundle . | ssh <your-ssh-user>@<your-ssh-host> 'tar -xzf - -C /opt/myapp/'
  ssh <your-ssh-user>@<your-ssh-host> "cd /opt/myapp && docker load -i image.tar && docker compose up -d"

Replace `<your-ssh-user>@<your-ssh-host>` with your actual SSH target.
  - Check `~/.ssh/config` for an existing alias.
  - Or set `deploy.host: user@host` in `vibewarden.production.yaml`
    (vibew will substitute it into the bundle stdout next time).
```

## Test plan

- `make check` passes (gofmt, golangci-lint, go build, go test -race ./...)
- `TestLoad_DeployHost_DefaultIsEmpty` — no yaml → empty host
- `TestLoad_DeployHost_FromYAML` — three cases: literal `user@host`, alias, explicit empty
- `TestLoadStrict_DeployHost_Accepted` — deploy.host in prod yaml does not trigger UnknownKeyError
- `TestInitProject_ProductionYAML_HasDeployHostHint` — rendered template has commented hint, not active key
- `TestRenderBundleReadme_PlaceholderPath` — empty sshHost → bracketed placeholder + hint
- `TestRenderBundleReadme_SubstitutedPath` — sshHost set → verbatim substitution, no hint
- `TestBundle_Stdout_PrintsLiteralDeployCommands` — new case: host set substitutes; unset uses placeholder + hint; forbidden `user@<` pattern enforced
- `TestBundle_Readme_AlignsWithDeployTmpl` — forensic alignment: `<your-ssh-user>@<your-ssh-host>` required, `user@<domain>` / `user@<` forbidden across bundle README + deploy.tmpl + llms-full.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)