### PR TITLE
feat(#1245): vibew bundle --print-deploy --host --user --path (ad-hoc deploy override)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+### Added
+
+- **`vibew bundle --print-deploy --host <h> --user <u> --path <p>`** (#1245) — ad-hoc, per-invocation override for the printed "Next: deploy" stdout block. All three sub-flags required when `--print-deploy` is set; flag wins over `deploy.host` from `vibewarden.production.yaml`. Bundle README is unaffected (config and placeholder paths only). Useful for one-off deploys and multi-host CI without mutating config. (retro-0.18.4 follow-up)
+
 ### Changed
 
 - **changed:** SSH target placeholder in vibew-emitted deploy commands is now `<your-ssh-user>@<your-ssh-host>` (was: `user@<domain>`). Codex agent followed the old form literally and hit auth failure on the v0.18.4 demo deploy. New `deploy.host` field in `vibewarden.production.yaml` (mirrors `deploy.target_platform`) — when set, `vibew bundle` stdout and bundle README substitute the configured host verbatim. Kickoff release artifacts (post-#1232) keep the bracketed placeholder forever (released-once, can't know any user's config). Two new prose preambles in the kickoff prompt clarify (a) `vibew init` does not scaffold app code/Dockerfile, (b) VibeWarden does not deploy for you. CLAUDE.md gains a §Architecture principles bullet locking the cross-LLM literal-vs-template clarity rule. (#1244, retro-0.18.4 Codex finding)

--- a/docs/examples/AGENTS-VIBEWARDEN.md
+++ b/docs/examples/AGENTS-VIBEWARDEN.md
@@ -205,6 +205,14 @@ The bundle is just files. The contract is in `.vibewarden/bundle/README.md`:
 
 1. Build for the target architecture: `vibew build --platform linux/amd64`.
 2. Produce the bundle: `vibew bundle`.
+   For CI or one-off deploys to a specific host without mutating config:
+   ```bash
+   vibew bundle --print-deploy --host <ssh-host> --user <ssh-user> --path /opt/myapp
+   ```
+   This substitutes the given SSH target and remote path into the printed "Next: deploy"
+   stdout block for this invocation only. Overrides `deploy.host` from
+   `vibewarden.production.yaml` for stdout; bundle README is unaffected.
+   All three sub-flags (`--host`, `--user`, `--path`) are required together.
 3. Make sure the remote directory exists (e.g. `ssh <your-ssh-user>@<your-ssh-host> mkdir -p
    /path/to/bundle`).
 4. Copy the bundle to the host using the tar pipe (dotfile-safe — `scp -r bundle/*`

--- a/docs/guide/bundle-to-vps.md
+++ b/docs/guide/bundle-to-vps.md
@@ -73,6 +73,15 @@ Flags you may want:
 | `--overwrite` | Replace an existing `.env` in the output dir. First run writes it; subsequent runs preserve the user's edits unless `--overwrite` is set. |
 | `--skip-image` | Do not package `image.tar`. Useful when `app.image` points at a registry the VPS can pull from. |
 | `--image <tag>` | Override the packaged image tag. Defaults to `<project>-app:latest`. |
+| `--print-deploy --host <h> --user <u> --path <p>` | Substitute an ad-hoc SSH target and remote path into the printed "Next: deploy" stdout block for this invocation only. Overrides `deploy.host` from `vibewarden.production.yaml` for stdout; the bundle README is unaffected. All three sub-flags are required together. Use this in CI pipelines or for one-off deploys to a different host without mutating config. |
+
+For a persistent single-host project, set `deploy.host` in `vibewarden.production.yaml` instead — it applies to both the stdout block and the bundle README and does not require repeating the flag on every invocation:
+
+```yaml
+# vibewarden.production.yaml
+deploy:
+  host: alice@vps.example.com
+```
 
 The command never opens an SSH connection, never calls docker on a remote
 host, and never touches files outside `--output`. Rerunning it with the

--- a/internal/cli/cmd/bundle.go
+++ b/internal/cli/cmd/bundle.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -46,6 +47,12 @@ const multiSiteErrorMessage = "multi-site bundle is post-v1; see #1169 for the N
 //   - --allow-stale        suppress the stale warning; bundle proceeds regardless
 //   - --target-platform    target deployment platform (default: linux/amd64)
 //
+// New flags (#1245):
+//   - --print-deploy        substitute --host/--user/--path into the stdout "Next: deploy" block
+//   - --host                SSH host for the stdout deploy block (requires --print-deploy)
+//   - --user                SSH user for the stdout deploy block (requires --print-deploy)
+//   - --path                remote deploy path for the stdout deploy block (requires --print-deploy)
+//
 // Exit codes:
 //   - 0: success (including warnings)
 //   - 1: generic / config failure
@@ -64,6 +71,10 @@ func NewBundleCmd() *cobra.Command {
 		build          bool
 		allowStale     bool
 		targetPlatform string
+		printDeploy    bool
+		deployHost     string
+		deployUser     string
+		deployPath     string
 	)
 
 	cmd := &cobra.Command{
@@ -110,9 +121,22 @@ Examples:
   vibew bundle --output build/deploy
   vibew bundle --skip-image
   vibew bundle --image ghcr.io/acme/myapp:v1.2.3
-  vibew bundle --overwrite`,
+  vibew bundle --overwrite
+  vibew bundle --print-deploy --host 1.2.3.4 --user root --path /opt/myapp   # ad-hoc deploy block (no config mutation)
+
+Deploy block precedence ("Next: deploy" stdout):
+  1. --print-deploy --host <h> --user <u> --path <p>  (ad-hoc; affects stdout only)
+  2. deploy.host in vibewarden.production.yaml         (persistent; affects stdout AND bundle README)
+  3. bracketed placeholder + hint paragraph            (default; nothing configured)
+
+The bundle README always reflects #2 or #3 — --print-deploy is stdout-only by design,
+since the README is a versioned artifact that ships with the bundle.
+
+--print-deploy overrides any deploy.host in vibewarden.production.yaml for the
+printed "Next: deploy" block. All three sub-flags (--host, --user, --path) must be
+supplied together. Paths with spaces in --path are not supported.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			code, err := runBundle(cmd, outputDir, imageTag, targetPlatform, overwrite, skipImage, build, allowStale)
+			code, err := runBundle(cmd, outputDir, imageTag, targetPlatform, overwrite, skipImage, build, allowStale, printDeploy, deployHost, deployUser, deployPath)
 			if err != nil {
 				// Set the process exit code for semantic exit codes (2, 3) while
 				// still surfacing the error message via cobra.
@@ -137,6 +161,11 @@ Examples:
 	cmd.Flags().BoolVar(&allowStale, "allow-stale", false, "suppress the stale-image warning (bundle proceeds regardless of freshness)")
 	cmd.Flags().StringVar(&targetPlatform, "target-platform", "",
 		"expected deployment platform, e.g. linux/arm64 (default: deploy.target_platform from vibewarden.production.yaml, or linux/amd64)")
+	cmd.Flags().BoolVar(&printDeploy, "print-deploy", false,
+		"substitute --host/--user/--path into the printed 'Next: deploy' block (overrides deploy.host from production.yaml)")
+	cmd.Flags().StringVar(&deployHost, "host", "", "SSH host to substitute into the printed deploy block (requires --print-deploy)")
+	cmd.Flags().StringVar(&deployUser, "user", "", "SSH user to substitute into the printed deploy block (requires --print-deploy)")
+	cmd.Flags().StringVar(&deployPath, "path", "", "remote deploy path to substitute into the printed deploy block, e.g. /opt/myapp (requires --print-deploy; paths with spaces are not supported)")
 
 	return cmd
 }
@@ -150,13 +179,19 @@ Examples:
 //	1: generic failure
 //	2: image missing (ErrImageMissing)
 //	3: docker daemon unreachable (ErrDockerUnavailable)
-func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, overwrite, skipImage, build, allowStale bool) (int, error) {
+func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, overwrite, skipImage, build, allowStale bool, printDeploy bool, deployHost, deployUser, deployPath string) (int, error) {
 	if err := requireScaffolding(); err != nil {
 		return 1, err
 	}
 
 	if outputDir == "" {
 		outputDir = defaultBundleOutputDir
+	}
+
+	// Validate --print-deploy flag combination BEFORE any config load or bundle
+	// work. Both invalid forms exit 1 with a clear error message.
+	if err := validatePrintDeployFlags(printDeploy, deployHost, deployUser, deployPath); err != nil {
+		return 1, err
 	}
 
 	cfg, err := loadAndResolve(cmd.Context(), "")
@@ -343,14 +378,24 @@ func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, o
 		domain = cfg.TLS.Domain
 	}
 
-	// Resolve the SSH target. When deploy.host is configured, use it verbatim.
-	// Otherwise use the bracketed placeholder — clearly not a real host — and
-	// append a hint paragraph so the user knows how to fill it in. This is the
-	// cross-LLM literal-vs-template clarity standard (#1244).
+	// Resolve the SSH target and remote path for the "Next: deploy" block.
+	// Three-way precedence (#1245):
+	//   1. --print-deploy flags (ad-hoc; stdout only — README unaffected)
+	//   2. deploy.host from config/production.yaml (persistent)
+	//   3. bracketed placeholder + hint paragraph (default)
 	const sshPlaceholder = "<your-ssh-user>@<your-ssh-host>"
 	sshTarget := sshPlaceholder
-	if cfg.Deploy.Host != "" {
+	remotePath := "/opt/" + appName // default implicit value — explicit for substitution
+	suppressHint := false
+
+	switch {
+	case printDeploy:
+		sshTarget = deployUser + "@" + deployHost
+		remotePath = deployPath
+		suppressHint = true
+	case cfg.Deploy.Host != "":
 		sshTarget = cfg.Deploy.Host
+		suppressHint = true
 	}
 
 	// Build the docker command for the "Next" block — omit docker load when
@@ -362,14 +407,14 @@ func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, o
 
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "Next: deploy")
-	fmt.Fprintf(out, "    ssh %s 'mkdir -p /opt/%s'\n", sshTarget, appName)
-	fmt.Fprintf(out, "    tar -czf - -C %q . | ssh %s 'tar -xzf - -C /opt/%s/'\n", absOut, sshTarget, appName)
-	fmt.Fprintf(out, "    ssh %s \"cd /opt/%s && %s\"\n", sshTarget, appName, dockerCmd)
+	fmt.Fprintf(out, "    ssh %s 'mkdir -p %s'\n", sshTarget, remotePath)
+	fmt.Fprintf(out, "    tar -czf - -C %q . | ssh %s 'tar -xzf - -C %s/'\n", absOut, sshTarget, remotePath)
+	fmt.Fprintf(out, "    ssh %s \"cd %s && %s\"\n", sshTarget, remotePath, dockerCmd)
 	fmt.Fprintf(out, "    curl -fsSL https://%s/_vibewarden/health\n", domain)
 	fmt.Fprintln(out, "")
-	// Hint paragraph — emitted only when deploy.host is unset (placeholder was
-	// used). When host is configured, the block is clean and self-explanatory.
-	if cfg.Deploy.Host == "" {
+	// Hint paragraph — emitted only when neither --print-deploy nor deploy.host
+	// resolved a real target. When a target is known, the block is self-explanatory.
+	if !suppressHint {
 		fmt.Fprintf(out, "Replace `%s` with your actual SSH target.\n", sshPlaceholder)
 		fmt.Fprintln(out, "  - Check `~/.ssh/config` for an existing alias.")
 		fmt.Fprintln(out, "  - Or set `deploy.host: user@host` in `vibewarden.production.yaml`")
@@ -378,6 +423,33 @@ func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, o
 	}
 	fmt.Fprintf(out, "See %s/README.md for context and read-only inspection commands.\n", absOut)
 	return 0, nil
+}
+
+// validatePrintDeployFlags enforces the all-or-nothing relationship between
+// --print-deploy and its three sub-flags. When --print-deploy is set, all
+// three of --host, --user, and --path must be non-empty. When --print-deploy
+// is unset, none of the three may be set.
+func validatePrintDeployFlags(printDeploy bool, host, user, path string) error {
+	if !printDeploy {
+		if host != "" || user != "" || path != "" {
+			return fmt.Errorf("--host/--user/--path require --print-deploy")
+		}
+		return nil
+	}
+	var missing []string
+	if host == "" {
+		missing = append(missing, "--host")
+	}
+	if user == "" {
+		missing = append(missing, "--user")
+	}
+	if path == "" {
+		missing = append(missing, "--path")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("--print-deploy requires --host, --user, --path (missing: %s)", strings.Join(missing, ", "))
+	}
+	return nil
 }
 
 // bundleListing walks dir and returns a sorted slice of relative file paths

--- a/internal/cli/cmd/bundle.go
+++ b/internal/cli/cmd/bundle.go
@@ -180,18 +180,20 @@ supplied together. Paths with spaces in --path are not supported.`,
 //	2: image missing (ErrImageMissing)
 //	3: docker daemon unreachable (ErrDockerUnavailable)
 func runBundle(cmd *cobra.Command, outputDir, imageTag, targetPlatform string, overwrite, skipImage, build, allowStale bool, printDeploy bool, deployHost, deployUser, deployPath string) (int, error) {
+	// Validate --print-deploy flag combination FIRST — pure function, no I/O.
+	// A user who types --host/--user/--path without --print-deploy anywhere
+	// (including outside a vibewarden directory) sees the relevant flag error,
+	// not the scaffolding error.
+	if err := validatePrintDeployFlags(printDeploy, deployHost, deployUser, deployPath); err != nil {
+		return 1, err
+	}
+
 	if err := requireScaffolding(); err != nil {
 		return 1, err
 	}
 
 	if outputDir == "" {
 		outputDir = defaultBundleOutputDir
-	}
-
-	// Validate --print-deploy flag combination BEFORE any config load or bundle
-	// work. Both invalid forms exit 1 with a clear error message.
-	if err := validatePrintDeployFlags(printDeploy, deployHost, deployUser, deployPath); err != nil {
-		return 1, err
 	}
 
 	cfg, err := loadAndResolve(cmd.Context(), "")

--- a/internal/cli/cmd/bundle_internal_test.go
+++ b/internal/cli/cmd/bundle_internal_test.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidatePrintDeployFlags is a pure unit test for the validatePrintDeployFlags
+// helper. The nine cases cover the full acceptance/rejection matrix: all flags
+// unset (ok), --print-deploy alone (error), each partial set of sub-flags with
+// --print-deploy (error), all four set (ok), and each sub-flag without
+// --print-deploy (error).
+func TestValidatePrintDeployFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		printDeploy bool
+		host        string
+		user        string
+		path        string
+		wantErr     bool
+		errContains []string // all strings must be present in the error message
+	}{
+		{
+			name:        "all empty — default behavior, no flags set",
+			printDeploy: false,
+			host:        "",
+			user:        "",
+			path:        "",
+			wantErr:     false,
+		},
+		{
+			name:        "--print-deploy only — missing all three sub-flags",
+			printDeploy: true,
+			host:        "",
+			user:        "",
+			path:        "",
+			wantErr:     true,
+			errContains: []string{"--print-deploy requires", "--host", "--user", "--path"},
+		},
+		{
+			name:        "--print-deploy + --host only — missing user and path",
+			printDeploy: true,
+			host:        "h.example",
+			user:        "",
+			path:        "",
+			wantErr:     true,
+			errContains: []string{"--print-deploy requires", "--user", "--path"},
+		},
+		{
+			name:        "--print-deploy + --host + --user — missing path",
+			printDeploy: true,
+			host:        "h.example",
+			user:        "alice",
+			path:        "",
+			wantErr:     true,
+			errContains: []string{"--print-deploy requires", "--path"},
+		},
+		{
+			name:        "all four set — valid",
+			printDeploy: true,
+			host:        "h.example",
+			user:        "alice",
+			path:        "/opt/myapp",
+			wantErr:     false,
+		},
+		{
+			name:        "--host without --print-deploy",
+			printDeploy: false,
+			host:        "h.example",
+			user:        "",
+			path:        "",
+			wantErr:     true,
+			errContains: []string{"require --print-deploy"},
+		},
+		{
+			name:        "--user without --print-deploy",
+			printDeploy: false,
+			host:        "",
+			user:        "alice",
+			path:        "",
+			wantErr:     true,
+			errContains: []string{"require --print-deploy"},
+		},
+		{
+			name:        "--path without --print-deploy",
+			printDeploy: false,
+			host:        "",
+			user:        "",
+			path:        "/opt/myapp",
+			wantErr:     true,
+			errContains: []string{"require --print-deploy"},
+		},
+		{
+			name:        "--host + --user + --path without --print-deploy",
+			printDeploy: false,
+			host:        "h.example",
+			user:        "alice",
+			path:        "/opt/myapp",
+			wantErr:     true,
+			errContains: []string{"require --print-deploy"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePrintDeployFlags(tt.printDeploy, tt.host, tt.user, tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validatePrintDeployFlags() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				for _, want := range tt.errContains {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error missing %q; got: %v", want, err)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/cmd/bundle_test.go
+++ b/internal/cli/cmd/bundle_test.go
@@ -699,10 +699,10 @@ func TestBundle_PrintDeploy_FlagValidationErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Validation runs before scaffolding checks (requireScaffolding comes
-			// first in runBundle, but validatePrintDeployFlags is called right
-			// after the outputDir default). Use a temp dir with scaffolding so the
-			// test can observe the validation error, not the scaffolding error.
+			// validatePrintDeployFlags is the first call in runBundle, so flag
+			// validation errors surface before scaffolding checks. The project
+			// directory is still set up so the test isolates the validation path
+			// without noise from other preconditions.
 			dir := setupBundleProject(t)
 			outDir := filepath.Join(dir, "out")
 

--- a/internal/cli/cmd/bundle_test.go
+++ b/internal/cli/cmd/bundle_test.go
@@ -517,6 +517,7 @@ func TestBundle_Stdout_PrintsLiteralDeployCommands(t *testing.T) {
 			// The three banned artifact forms are guarded here so a regression
 			// in bundle.go (stdout surface) is caught by this forensic check.
 			// The old unbracketed placeholder forms are also forbidden (#1244).
+			// The literal flag name "--print-deploy" must never leak into output (#1245).
 			wantAbsent: []string{
 				"docker load -i image.tar &&",
 				"scp -r .vibewarden/bundle/*", // dotfile-eating glob eliminated by #1217
@@ -524,6 +525,7 @@ func TestBundle_Stdout_PrintsLiteralDeployCommands(t *testing.T) {
 				"./deploy.sh",                 // ditto
 				"user@<",                      // old unbracketed placeholder form (#1244)
 				"user@host 'mkdir",            // pre-#1244 literal placeholder
+				"--print-deploy",              // flag name must not leak into output (#1245)
 			},
 		},
 		{
@@ -538,6 +540,7 @@ func TestBundle_Stdout_PrintsLiteralDeployCommands(t *testing.T) {
 				"bash deploy.sh",
 				"./deploy.sh",
 				"user@<",
+				"--print-deploy",
 			},
 		},
 		{
@@ -559,6 +562,7 @@ func TestBundle_Stdout_PrintsLiteralDeployCommands(t *testing.T) {
 				"bash deploy.sh",
 				"./deploy.sh",
 				"user@<",
+				"--print-deploy",
 			},
 		},
 		{
@@ -579,6 +583,7 @@ func TestBundle_Stdout_PrintsLiteralDeployCommands(t *testing.T) {
 				"bash deploy.sh",
 				"./deploy.sh",
 				"user@<",
+				"--print-deploy",
 			},
 		},
 	}
@@ -642,6 +647,325 @@ func TestBundle_Stdout_PrintsLiteralDeployCommands(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestBundle_PrintDeploy_FlagValidationErrors verifies that invalid --print-deploy
+// flag combinations exit 1 with a clear error message before any bundle work
+// runs. All seven invalid forms are driven through root.Execute() so the full
+// cobra dispatch path is exercised.
+func TestBundle_PrintDeploy_FlagValidationErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		errContains []string
+	}{
+		{
+			name:        "--print-deploy + --host + --user (missing --path)",
+			args:        []string{"bundle", "--skip-image", "--print-deploy", "--host", "h.example", "--user", "u"},
+			errContains: []string{"--print-deploy requires", "--path"},
+		},
+		{
+			name:        "--print-deploy + --host + --path (missing --user)",
+			args:        []string{"bundle", "--skip-image", "--print-deploy", "--host", "h.example", "--path", "/opt/x"},
+			errContains: []string{"--print-deploy requires", "--user"},
+		},
+		{
+			name:        "--print-deploy + --user + --path (missing --host)",
+			args:        []string{"bundle", "--skip-image", "--print-deploy", "--user", "u", "--path", "/opt/x"},
+			errContains: []string{"--print-deploy requires", "--host"},
+		},
+		{
+			name:        "--print-deploy only (all three missing)",
+			args:        []string{"bundle", "--skip-image", "--print-deploy"},
+			errContains: []string{"--print-deploy requires", "--host", "--user", "--path"},
+		},
+		{
+			name:        "--host without --print-deploy",
+			args:        []string{"bundle", "--skip-image", "--host", "h.example"},
+			errContains: []string{"require --print-deploy"},
+		},
+		{
+			name:        "--user without --print-deploy",
+			args:        []string{"bundle", "--skip-image", "--user", "alice"},
+			errContains: []string{"require --print-deploy"},
+		},
+		{
+			name:        "--path without --print-deploy",
+			args:        []string{"bundle", "--skip-image", "--path", "/opt/x"},
+			errContains: []string{"require --print-deploy"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Validation runs before scaffolding checks (requireScaffolding comes
+			// first in runBundle, but validatePrintDeployFlags is called right
+			// after the outputDir default). Use a temp dir with scaffolding so the
+			// test can observe the validation error, not the scaffolding error.
+			dir := setupBundleProject(t)
+			outDir := filepath.Join(dir, "out")
+
+			root := cmd.NewRootCmd("test")
+			args := append(tt.args, "--output", outDir)
+			root.SetArgs(args)
+			var out bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&out)
+
+			err := root.Execute()
+			if err == nil {
+				t.Fatalf("expected error for args %v, got nil\nstdout: %s", tt.args, out.String())
+			}
+			for _, want := range tt.errContains {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error missing %q; got: %v", want, err)
+				}
+			}
+		})
+	}
+}
+
+// TestBundle_PrintDeploy_StdoutSubstitution verifies the three substitution
+// scenarios for --print-deploy: all three values substituted, flag wins over
+// deploy.host from config, and the bundle README is unaffected (Option A).
+func TestBundle_PrintDeploy_StdoutSubstitution(t *testing.T) {
+	tests := []struct {
+		name       string
+		yaml       string
+		prodYAML   string // empty = no production.yaml
+		args       []string
+		wantStdout []string
+		wantAbsent []string
+		// readmeCheck: if non-empty, assert the README does NOT contain this string.
+		readmeNotContains []string
+		// readmeContains: if non-empty, assert README DOES contain these strings.
+		readmeContains []string
+	}{
+		{
+			name:     "all three values substituted in stdout",
+			yaml:     "name: myapp\ntls:\n  domain: myapp.example.com\nserver:\n  port: 8080\nupstream:\n  port: 3000\n",
+			prodYAML: "",
+			args:     []string{"bundle", "--skip-image", "--print-deploy", "--host", "h.example", "--user", "alice", "--path", "/custom/foo"},
+			wantStdout: []string{
+				"ssh alice@h.example 'mkdir -p /custom/foo'",
+				"| ssh alice@h.example 'tar -xzf - -C /custom/foo/'",
+				`ssh alice@h.example "cd /custom/foo`,
+				"curl -fsSL https://myapp.example.com/_vibewarden/health",
+			},
+			wantAbsent: []string{
+				"<your-ssh-user>@<your-ssh-host>",
+				"Replace `<your-ssh-user>",
+				"/opt/myapp",
+			},
+		},
+		{
+			name:     "flag overrides deploy.host from production.yaml",
+			yaml:     "name: myapp\ntls:\n  domain: myapp.example.com\nserver:\n  port: 8080\nupstream:\n  port: 3000\n",
+			prodYAML: "deploy:\n  host: root@configured.example\n",
+			args:     []string{"bundle", "--skip-image", "--print-deploy", "--host", "h.example", "--user", "alice", "--path", "/custom/foo"},
+			wantStdout: []string{
+				"ssh alice@h.example",
+				"/custom/foo",
+			},
+			wantAbsent: []string{
+				"root@configured.example",
+			},
+			// README uses cfg.Deploy.Host (Option A — README is config-driven, not flag-driven).
+			readmeNotContains: []string{"alice@h.example", "/custom/foo"},
+			readmeContains:    []string{"root@configured.example"},
+		},
+		{
+			name:     "README ignores flag (Option A) — placeholder when no production.yaml",
+			yaml:     "name: myapp\ntls:\n  domain: myapp.example.com\nserver:\n  port: 8080\nupstream:\n  port: 3000\n",
+			prodYAML: "",
+			args:     []string{"bundle", "--skip-image", "--print-deploy", "--host", "h.example", "--user", "alice", "--path", "/custom/foo"},
+			wantStdout: []string{
+				"ssh alice@h.example 'mkdir -p /custom/foo'",
+			},
+			// README should not have the flag-injected values; it uses the placeholder.
+			readmeNotContains: []string{"alice@h.example", "/custom/foo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := t.TempDir()
+			projDir := filepath.Join(base, "testproject")
+			if err := os.MkdirAll(projDir, 0o750); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			writeScaffoldingMarker(t, projDir)
+			if err := os.WriteFile(filepath.Join(projDir, "vibewarden.yaml"), []byte(tt.yaml), 0o644); err != nil {
+				t.Fatalf("writing vibewarden.yaml: %v", err)
+			}
+			if tt.prodYAML != "" {
+				if err := os.WriteFile(filepath.Join(projDir, "vibewarden.production.yaml"), []byte(tt.prodYAML), 0o644); err != nil {
+					t.Fatalf("writing vibewarden.production.yaml: %v", err)
+				}
+			}
+
+			origDir, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("getwd: %v", err)
+			}
+			if err := os.Chdir(projDir); err != nil {
+				t.Fatalf("chdir: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+			outDir := filepath.Join(projDir, "out")
+			root := cmd.NewRootCmd("test")
+			args := append(tt.args, "--output", outDir)
+			root.SetArgs(args)
+			var stdout bytes.Buffer
+			root.SetOut(&stdout)
+			root.SetErr(&stdout)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("bundle: %v\nstdout:\n%s", err, stdout.String())
+			}
+
+			out := stdout.String()
+			for _, want := range tt.wantStdout {
+				if !strings.Contains(out, want) {
+					t.Errorf("stdout missing %q\nstdout:\n%s", want, out)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(out, absent) {
+					t.Errorf("stdout must not contain %q\nstdout:\n%s", absent, out)
+				}
+			}
+
+			if len(tt.readmeNotContains) > 0 || len(tt.readmeContains) > 0 {
+				readmeBytes, readErr := os.ReadFile(filepath.Join(outDir, "README.md"))
+				if readErr != nil {
+					t.Fatalf("reading README.md: %v", readErr)
+				}
+				readme := string(readmeBytes)
+				for _, absent := range tt.readmeNotContains {
+					if strings.Contains(readme, absent) {
+						t.Errorf("README.md must not contain %q (README ignores --print-deploy flag)\nREADME:\n%s", absent, readme)
+					}
+				}
+				for _, want := range tt.readmeContains {
+					if !strings.Contains(readme, want) {
+						t.Errorf("README.md missing %q\nREADME:\n%s", want, readme)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestBundle_PrintDeploy_PathSubstitutesRemoteDir confirms that --path replaces
+// the /opt/<appname> segment in all three SSH lines and that the healthcheck
+// curl line (domain-based) is unaffected.
+func TestBundle_PrintDeploy_PathSubstitutesRemoteDir(t *testing.T) {
+	base := t.TempDir()
+	projDir := filepath.Join(base, "testproject")
+	if err := os.MkdirAll(projDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeScaffoldingMarker(t, projDir)
+	yaml := "name: myapp\ntls:\n  domain: myapp.example.com\nserver:\n  port: 8080\nupstream:\n  port: 3000\n"
+	if err := os.WriteFile(filepath.Join(projDir, "vibewarden.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatalf("writing vibewarden.yaml: %v", err)
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(projDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	outDir := filepath.Join(projDir, "out")
+	root := cmd.NewRootCmd("test")
+	root.SetArgs([]string{
+		"bundle", "--skip-image", "--output", outDir,
+		"--print-deploy", "--host", "h.example", "--user", "u", "--path", "/custom/dir",
+	})
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stdout)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("bundle: %v\nstdout:\n%s", err, stdout.String())
+	}
+
+	out := stdout.String()
+
+	// All three SSH lines must use /custom/dir.
+	for _, want := range []string{
+		"'mkdir -p /custom/dir'",
+		"'tar -xzf - -C /custom/dir/'",
+		`"cd /custom/dir`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q — --path did not substitute remote dir\nstdout:\n%s", want, out)
+		}
+	}
+
+	// The default path must not appear.
+	if strings.Contains(out, "/opt/myapp") {
+		t.Errorf("stdout still contains default /opt/myapp — --path substitution failed\nstdout:\n%s", out)
+	}
+
+	// The healthcheck curl line is domain-based, not path-based — must be unaffected.
+	if !strings.Contains(out, "curl -fsSL https://myapp.example.com/_vibewarden/health") {
+		t.Errorf("stdout missing healthcheck curl line\nstdout:\n%s", out)
+	}
+}
+
+// TestBundle_PrintDeploy_HintParagraphSuppressed confirms that the hint
+// paragraph ("Replace `<your-ssh-user>...`") is absent when --print-deploy
+// is used with valid sub-flags.
+func TestBundle_PrintDeploy_HintParagraphSuppressed(t *testing.T) {
+	base := t.TempDir()
+	projDir := filepath.Join(base, "testproject")
+	if err := os.MkdirAll(projDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeScaffoldingMarker(t, projDir)
+	yaml := "name: myapp\ntls:\n  domain: myapp.example.com\nserver:\n  port: 8080\nupstream:\n  port: 3000\n"
+	if err := os.WriteFile(filepath.Join(projDir, "vibewarden.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatalf("writing vibewarden.yaml: %v", err)
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(projDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	outDir := filepath.Join(projDir, "out")
+	root := cmd.NewRootCmd("test")
+	root.SetArgs([]string{
+		"bundle", "--skip-image", "--output", outDir,
+		"--print-deploy", "--host", "h.example", "--user", "alice", "--path", "/opt/myapp",
+	})
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stdout)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("bundle: %v\nstdout:\n%s", err, stdout.String())
+	}
+
+	out := stdout.String()
+	// The hint paragraph must be fully absent.
+	for _, absent := range []string{
+		"Replace `<your-ssh-user>",
+		"~/.ssh/config",
+		"deploy.host: user@host",
+	} {
+		if strings.Contains(out, absent) {
+			t.Errorf("stdout must not contain hint paragraph fragment %q when --print-deploy is set\nstdout:\n%s", absent, out)
+		}
 	}
 }
 

--- a/internal/cli/templates/agents/agents-vibewarden.md.tmpl
+++ b/internal/cli/templates/agents/agents-vibewarden.md.tmpl
@@ -94,6 +94,7 @@ app port directly — it has no security.
 | `vibew build` | Build Docker image |
 | `vibew build --platform linux/amd64` | Build for a specific architecture |
 | `vibew bundle` | Produce a self-contained Docker Compose bundle under `.vibewarden/bundle/`; transfer with tar pipe + `docker compose up -d` |
+| `vibew bundle --print-deploy --host <h> --user <u> --path <p>` | Substitute an ad-hoc SSH target and remote path into the printed "Next: deploy" stdout block for this invocation only. Overrides `deploy.host` for stdout; bundle README unaffected. All three sub-flags required together. For CI or one-off multi-host deploys without mutating config. |
 | `vibew probe` | One-shot HTTPS GET against `/_vibewarden/health` using Go's stdlib TLS stack. Uses `InsecureSkipVerify=true` for localhost (bypasses macOS LibreSSL friction). Boot-gap retry: up to 10s when `upstream=unknown`. Exit 0 on healthy, exit 1 otherwise. Canonical health check after `vibew dev` — preferred over curl on macOS. |
 | `vibew probe --env <name>` | Probe named env overlay. Loads `vibewarden.<name>.yaml`, reads merged `tls.domain`, probes with full TLS verification. |
 | `vibew status` | Show component health (OK / OFF / FAIL labels; OFF means disabled in config and not probed). Richer dev-stack overview than `vibew probe`; use probe for one-shot HTTPS endpoint verification. |
@@ -209,6 +210,7 @@ Key flags:
 - `--build` — build the image first (use when it's missing or stale)
 - `--allow-stale` — suppress STALE warning when you know the image is correct
 - `--target-platform linux/<arch>` — set when your VPS arch differs from your laptop
+- `--print-deploy --host <h> --user <u> --path <p>` — substitute ad-hoc SSH target and remote path into the stdout "Next: deploy" block for this invocation only; all three sub-flags required together; overrides `deploy.host` for stdout (bundle README unaffected)
 
 Exit codes: 0=success (with or without warnings), 1=image arch does not match target platform (rebuild with `vibew build --platform <target>`), 2=image missing, 3=docker daemon unreachable.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -805,6 +805,16 @@ Local observability stack (Grafana, Prometheus, Loki, Promtail).
   Typical values: linux/amd64 (most cloud VMs), linux/arm64 (Ampere/Graviton).
   Invalid values are caught as a mismatch at bundle time — no explicit validation.
 
+  deploy.host  string  ""  SSH target substituted into the "Next: deploy" stdout
+  block and bundle README. Accepts any value ssh(1) accepts: user@host, a
+  ~/.ssh/config alias, or an IP. When unset, the bracketed placeholder
+  `<your-ssh-user>@<your-ssh-host>` is used and a hint paragraph is appended.
+
+  The `--print-deploy --host/--user/--path` flags override deploy.host for
+  the stdout block only (bundle README remains config-driven or placeholder).
+  Use --print-deploy for per-invocation overrides (CI); use deploy.host for
+  persistent single-host projects.
+
 
 ### webhooks (outbound event delivery)
 
@@ -1442,9 +1452,26 @@ arch, created, size, target platform, freshness, warnings). Flags:
   > default linux/amd64. Bundle aborts (exit 1) on arch mismatch with an
   actionable rebuild command — this is the primary guard for Apple Silicon
   builds landing on amd64 VPS hosts without being noticed.
+- `--print-deploy` -- substitute `--host`, `--user`, and `--path` into the
+  printed "Next: deploy" stdout block for this invocation only. Overrides
+  `deploy.host` from vibewarden.production.yaml for stdout; bundle README is
+  unaffected (config-driven or placeholder). All three sub-flags are required
+  together when `--print-deploy` is set; any subset exits 1 with a clear error.
+  Passing `--host`/`--user`/`--path` without `--print-deploy` also exits 1.
+  Useful for one-off deploys and multi-host CI pipelines without mutating config.
+- `--host <ssh-host>` -- SSH host for the stdout deploy block (requires --print-deploy)
+- `--user <ssh-user>` -- SSH user for the stdout deploy block (requires --print-deploy)
+- `--path <remote-path>` -- remote deploy path for the stdout deploy block,
+  e.g. /opt/myapp (requires --print-deploy; paths with spaces are not supported)
+
+Deploy block precedence ("Next: deploy" stdout):
+  1. --print-deploy --host <h> --user <u> --path <p>  (ad-hoc; stdout only)
+  2. deploy.host in vibewarden.production.yaml         (persistent; stdout + README)
+  3. bracketed placeholder + hint paragraph            (default)
 
 Exit codes: 0=success (includes warnings), 1=generic failure (including arch
-mismatch), 2=image missing, 3=docker daemon unreachable.
+mismatch or invalid --print-deploy flag combination), 2=image missing, 3=docker
+daemon unreachable.
 
 Output layout:
 
@@ -1939,7 +1966,7 @@ first upstream probe cycle has not completed yet (vibew probe retries automatica
 
 --deploy adds Steps 6–9 (replacing the dev Step 6 above):
 - Step 6: vibew bundle (with arch mismatch guard — see note below)
-- Step 7: tar pipe transfer (dotfile-safe) + ssh `<your-ssh-user>@<your-ssh-host>` + docker load -i image.tar + docker compose up -d (set `deploy.host` in vibewarden.production.yaml to substitute your real SSH target)
+- Step 7: tar pipe transfer (dotfile-safe) + ssh `<your-ssh-user>@<your-ssh-host>` + docker load -i image.tar + docker compose up -d (set `deploy.host` in vibewarden.production.yaml to substitute your real SSH target persistently, or use `vibew bundle --print-deploy --host <h> --user <u> --path <p>` for a per-invocation override without mutating config)
 - Step 8: `vibew probe --env production` — canonical verification step. Falls back to
   curl healthcheck expecting HTTP 200, `"status":"ok"`, `"components":{"upstream":"ok"}`
 - Step 9 (dev only): `vibew probe` — health check after `vibew dev` (avoids LibreSSL on macOS)

--- a/vibewarden.reference.yaml
+++ b/vibewarden.reference.yaml
@@ -1075,5 +1075,10 @@ deploy:
   # When unset (default), the three ssh lines use the bracketed placeholder
   # `<your-ssh-user>@<your-ssh-host>` and a hint paragraph is appended.
   #
+  # Per-invocation override: `vibew bundle --print-deploy --host <h> --user <u>
+  # --path <p>` overrides this field for the stdout block only (bundle README is
+  # unaffected). Use --print-deploy for CI pipelines or one-off multi-host deploys
+  # without modifying this file.
+  #
   # Default: "" (use bracketed placeholder)
   # host: alice@vps.example.com


### PR DESCRIPTION
Closes #1245

## Summary

- Adds `--print-deploy` (bool), `--host`, `--user`, `--path` (strings) flags to `vibew bundle`
- When `--print-deploy` is set with all three sub-flags, the "Next: deploy" stdout block substitutes `<user>@<host>` and `--path` for the remote directory, overriding `deploy.host` from `vibewarden.production.yaml`
- Bundle README is unaffected (Option A: README is a versioned artifact, flag is stdout-only by design)
- Flag combination validation runs before any config load or bundle work — both invalid forms exit 1 with a clear error

## Before / after

**Ad-hoc invocation (no config, flag wins):**
```
vibew bundle --skip-image --print-deploy --host 1.2.3.4 --user deploy --path /opt/myapp

Next: deploy
    ssh deploy@1.2.3.4 'mkdir -p /opt/myapp'
    tar -czf - -C "/path/to/.vibewarden/bundle" . | ssh deploy@1.2.3.4 'tar -xzf - -C /opt/myapp/'
    ssh deploy@1.2.3.4 "cd /opt/myapp && docker compose up -d"
    curl -fsSL https://myapp.example.com/_vibewarden/health
```

**Config + flag override (flag wins):**
```yaml
# vibewarden.production.yaml
deploy:
  host: root@configured.example
```
```
vibew bundle --skip-image --print-deploy --host 1.2.3.4 --user deploy --path /opt/myapp
# stdout: deploy@1.2.3.4, NOT root@configured.example
```

**README unaffected (Option A):**
- README.md on disk still uses `root@configured.example` (from config) or the bracketed placeholder (when no config). The flag never touches the README.

**Validation error examples:**
```
vibew bundle --print-deploy --host h --user u
# Error: --print-deploy requires --host, --user, --path (missing: --path)

vibew bundle --host h --user u --path /opt/x
# Error: --host/--user/--path require --print-deploy
```

## Test plan

- `TestValidatePrintDeployFlags` (9 table cases, `package cmd` internal test) — unit tests the pure validation function covering all accept/reject combinations
- `TestBundle_PrintDeploy_FlagValidationErrors` (7 cases) — drives invalid combos through cobra and asserts exit 1 with correct error text
- `TestBundle_PrintDeploy_StdoutSubstitution` (3 cases) — all-three-substituted, flag-overrides-config, README-ignores-flag
- `TestBundle_PrintDeploy_PathSubstitutesRemoteDir` — confirms `--path` replaces `/opt/<appname>` in all three SSH lines; healthcheck curl unaffected
- `TestBundle_PrintDeploy_HintParagraphSuppressed` — hint paragraph absent when `--print-deploy` is set
- `TestBundle_Stdout_PrintsLiteralDeployCommands` extended — `"--print-deploy"` added to `wantAbsent` in all four existing cases (sanity: flag name never leaks into output)
- `make check` clean (gofmt, golangci-lint, build, `go test -race ./...`, demo-app) — verified by pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)