### PR TITLE
chore: release v0.18.5 — v0.18.4 retro fixes (first cross-vendor smoke)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+## [v0.18.5] — 2026-04-30
+
+Theme: v0.18.4 retrospective fixes — first cross-vendor smoke (Codex agent) surfaced LLM-shape assumptions that prior Claude smokes had absorbed implicitly. Six retro-tagged pipelines (#1242–#1247) covering: per-env error messages on `vibew probe` (CRITICAL — was telling production users to run `vibew dev`); ACME-aware TLS retry on `vibew probe --env <name>` (30s budget); SSH placeholder bracketing + new `deploy.host` config + Codex prompt preambles ("vibew init does not scaffold", "VibeWarden does not deploy for you"); `vibew bundle --print-deploy --host --user --path` ad-hoc override; `vibew doctor --preflight <env>` pre-deploy validation; AGENTS-VIBEWARDEN.md must-know checklist at the top. CLAUDE.md gains a §Architecture principles bullet locking cross-LLM literal-vs-template clarity. No new ADRs; all changes refine the v0.18.3/v0.18.4 architecture rather than establish new patterns.
+
 ### Added
 
 - **`vibew doctor --preflight <env>`** (#1246) — pre-deploy validation against a named env (e.g. `--preflight production` reads `vibewarden.production.yaml`). Five new checks: DNS resolves the merged `tls.domain`, `server.port` is 443 for production, `deploy.target_platform` is set, app image arch matches `deploy.target_platform`, `tls.email` is configured (Let's Encrypt warning only). Reuses the env-resolver from #1233 and the image-inspect path from #1219. Static config + Dockerfile checks still run; preflight section appends afterward.


### PR DESCRIPTION
## Summary

Release PR for v0.18.5: 6 retro-tagged pipelines (#1242–#1247) from the **first non-Claude (Codex) retro** on v0.18.4. Codex surfaced LLM-shape assumptions that prior Claude smokes absorbed.

## Smoke proof

End-to-end against `demo.vibewarden.dev` with a fresh `vw185` project:

```
$ vibew probe --env production
https://demo.vibewarden.dev/_vibewarden/health
  status:               ok
  version:              0.18.5-smoke
  components.sidecar:   ok
  components.upstream:  ok
OK — production stack healthy.
```

All 6 retro fixes verified locally:
- #1242 — `vibew probe --env production` BEFORE deploy emits per-env message (no `vibew dev` suggestion).
- #1243 — TLS retry exercised by deploying right after `docker compose up -d` (probe handled gracefully).
- #1244 — kickoff prompt now uses `<your-ssh-user>@<your-ssh-host>` placeholder + Codex preambles visible.
- #1245 — `vibew bundle --print-deploy --host 178.104.159.3 --user root --path /opt/vw185` substituted into stdout.
- #1246 — `vibew doctor --preflight production` ran all 5 checks with mixed outcomes (DNS ok, port ok, target_platform ok, image arch warn pre-build, TLS email warn).
- #1247 — generated `AGENTS-VIBEWARDEN.md` opens with the 6-line must-know checklist.

## Test plan
- [x] `make check` clean on main
- [x] All 6 sub-PRs merged + non-dry-run CI green
- [x] Smoke test on demo.vibewarden.dev passing
- [ ] Tag v0.18.5 after merge (goreleaser publishes binaries + ghcr image + regenerated kickoff artifacts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)