### PR TITLE
chore: pin golangci-lint to v2.11.4 in CI (stop the ratchet)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.11.4
 
   build-and-test:
     name: Build & Test


### PR DESCRIPTION
## Summary

CI's `golangci-lint-action@v9` was set to `version: latest`, so the linter silently upgraded between the last green main run (5 days ago) and now. The new version flags 49 issues across previously-clean code — none introduced by current PRs:

- 45× gosec G124 (`http.Cookie missing or has insecure Secure/HttpOnly/SameSite`) — all in `internal/middleware/auth_test.go` test fixtures
- 4× govet inline warnings (`reflect.Ptr` should be inlined as `reflect.Pointer`) — in `internal/config/strict.go` and `internal/config/resolve_secrets.go`

Local `golangci-lint v2.11.4` reports 0 issues against current main. Pinning CI to the same version stops the ratchet and unblocks PR #1261.

## Follow-up

Will file a separate issue to upgrade the linter deliberately and fix the 49 issues in one focused PR (audit-tagged).

## Test plan
- [x] CI lint passes against current main on this branch (verifies the pin works)
- [ ] Merge → PR #1261 re-runs CI and gets through

🤖 Generated with [Claude Code](https://claude.com/claude-code)