### PR TITLE
docs(#1286): getting-started — add vibew doctor --preflight and vibew bundle --print-deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 ### Documentation
 
 - **docs(#1270): vibewarden.reference.yaml — add 13 previously-missing top-level config sections.** Brings the reference file to full coverage of fields documented in llms-full.txt or defined in internal/config Go structs. Also fixes a class of latent default-bugs surfaced by the new TestReferenceYAML_UnmarshalsCleanly test: audit.enabled, audit.output, and resilience.circuit_breaker/retry fields now apply their documented defaults via setDefaults(), where previously they were silently zero.
+- **docs(#1286): getting-started — document `vibew doctor --preflight` and `vibew bundle --print-deploy`.** Two pre-deploy verification commands were absent from the operator quick-start despite being part of the standard deploy loop. Added a "Pre-deploy validation" section between "Enable TLS for production" and "Validate your config" covering: `vibew doctor --preflight production` (five pre-deploy checks against the merged production config), `vibew bundle` (bundle step), and `vibew bundle --print-deploy --host <h> --user <u> --path <p>` (ad-hoc SSH override for CI / one-off deploys). Also corrects P2-severity drift in `docs/troubleshooting.md` and `llms-full.txt` (P2 is WARN, not FAIL — code is canonical).
 
 ### Security
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -497,6 +497,52 @@ the production overrides (letsencrypt, port 443) are merged automatically.
 See the [Production Deployment guide](production-deployment.md) for the full
 production checklist.
 
+### Pre-deploy validation
+
+Before bundling, run the preflight check against your production environment:
+
+```bash
+./vibew doctor --preflight production
+```
+
+This reads `vibewarden.production.yaml`, merges it with `vibewarden.yaml`, and
+runs the standard static checks plus five additional pre-deploy checks:
+
+1. DNS resolves `tls.domain`
+2. `server.port` is 443
+3. `deploy.target_platform` is set
+4. App image architecture matches `deploy.target_platform`
+5. `tls.email` is configured for Let's Encrypt
+
+Exit code is `0` only when all checks pass. The env file (`vibewarden.production.yaml`)
+must exist — if it is missing, doctor exits 1 immediately without running any checks.
+
+Run `vibew doctor --preflight production` before `vibew bundle` to surface DNS,
+port, architecture, and TLS-email issues before a multi-minute build attempt.
+
+Then produce the deployment bundle:
+
+```bash
+./vibew bundle
+```
+
+The bundle is written to `.vibewarden/bundle/` and the "Next: deploy" block printed
+to stdout contains the exact `ssh` + `tar` + `docker compose` commands for your host.
+
+For one-off deploys or CI pipelines where you want to supply the SSH target without
+setting `deploy.host` in config, use `--print-deploy`:
+
+```bash
+./vibew bundle --print-deploy --host <your-ssh-host> --user <your-ssh-user> --path /opt/myapp
+```
+
+All three sub-flags (`--host`, `--user`, `--path`) are required when `--print-deploy`
+is set. This overrides `deploy.host` from `vibewarden.production.yaml` for the printed
+block only — the bundle README and all bundle files are unaffected.
+
+See `docs/troubleshooting.md §Pre-deploy preflight` for the full preflight check
+reference.
+
 ### Validate your config
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -514,8 +514,11 @@ runs the standard static checks plus five additional pre-deploy checks:
 4. App image architecture matches `deploy.target_platform`
 5. `tls.email` is configured for Let's Encrypt
 
-Exit code is `0` only when all checks pass. The env file (`vibewarden.production.yaml`)
-must exist — if it is missing, doctor exits 1 immediately without running any checks.
+Exit code is `1` only when a FAIL-severity check is encountered. Of the five preflight
+checks, P3 (`deploy.target_platform` unset) and P4 (image arch mismatch) are
+FAIL-severity; P1 (DNS), P2 (port 443), and P5 (TLS email) are WARN-only and do not
+produce exit 1. The env file (`vibewarden.production.yaml`) must exist — if it is
+missing, doctor exits 1 immediately without running any checks.
 
 Run `vibew doctor --preflight production` before `vibew bundle` to surface DNS,
 port, architecture, and TLS-email issues before a multi-minute build attempt.
@@ -526,8 +529,12 @@ Then produce the deployment bundle:
 ./vibew bundle
 ```
 
-The bundle is written to `.vibewarden/bundle/` and the "Next: deploy" block printed
-to stdout contains the exact `ssh` + `tar` + `docker compose` commands for your host.
+The bundle is written to `.vibewarden/bundle/`. When `deploy.host` is set in
+`vibewarden.production.yaml`, the "Next: deploy" block printed to stdout contains the
+exact `ssh` + `tar` + `docker compose` commands ready to run. When `deploy.host` is
+unset (the default at this point in setup), the block prints bracketed placeholders
+(`<your-ssh-user>@<your-ssh-host>`) with a configuration hint — substitute the values
+before running.
 
 For one-off deploys or CI pipelines where you want to supply the SSH target without
 setting `deploy.host` in config, use `--print-deploy`:
@@ -540,8 +547,7 @@ All three sub-flags (`--host`, `--user`, `--path`) are required when `--print-de
 is set. This overrides `deploy.host` from `vibewarden.production.yaml` for the printed
 block only — the bundle README and all bundle files are unaffected.
 
-See `docs/troubleshooting.md §Pre-deploy preflight` for the full preflight check
-reference.
+See [Pre-deploy preflight](troubleshooting.md#pre-deploy-preflight) for the full preflight check reference.
 
 ### Validate your config
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -61,7 +61,7 @@ These checks run only when `--preflight <env>` is passed. They append after all 
 | # | Check name | What it tests |
 |---|------------|---------------|
 | P1 | **DNS** | `tls.domain` resolves to at least one A or AAAA record. Uses the same env-resolver introduced in #1233 (ADR-102). |
-| P2 | **Port 443** | `server.port` equals 443. FAIL if set to any other value. |
+| P2 | **Port 443** | `server.port` equals 443. WARN if set to any other value (non-blocking). |
 | P3 | **Target platform** | `deploy.target_platform` is set in the merged config. FAIL if unset. |
 | P4 | **Image arch** | The local app image architecture matches `deploy.target_platform`. Uses the Docker label-inspection path from #1219 (ADR-100). |
 | P5 | **TLS email** | `tls.email` is non-empty. WARN (non-blocking) if missing — required by Let's Encrypt but not enforced pre-deploy. |
@@ -260,7 +260,7 @@ Run `vibew doctor --preflight production` before `vibew bundle` to catch DNS, po
 vibew doctor --preflight production
 ```
 
-This reads `vibewarden.production.yaml`, merges it with `vibewarden.yaml`, and runs the standard static + Dockerfile checks against the merged config plus five additional preflight checks. Exit code is `0` only when all checks pass.
+This reads `vibewarden.production.yaml`, merges it with `vibewarden.yaml`, and runs the standard static + Dockerfile checks against the merged config plus five additional preflight checks. Exit code is `1` only when a FAIL-severity check is encountered. P3 (`deploy.target_platform` unset) and P4 (image arch mismatch) are FAIL-severity; P1 (DNS), P2 (port 443), and P5 (TLS email) are WARN-only and do not produce exit 1.
 
 ### Usage in the deploy flow
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1642,7 +1642,7 @@ vibew doctor checks (in order):
   Preflight checks (only when --preflight <env> is given; appended after static + Dockerfile checks):
   P1. DNS — tls.domain resolves to at least one A/AAAA record. Uses the same env-resolver
       as vibew probe --env (ADR-102).
-  P2. Port 443 — server.port must equal 443 for a named production environment (FAIL otherwise).
+  P2. Port 443 — server.port must equal 443 for a named production environment (WARN otherwise; non-blocking).
   P3. Target platform — deploy.target_platform must be set in the merged config (FAIL if unset).
   P4. Image arch — local app image arch matches deploy.target_platform. Uses the Docker
       label-inspection path from vibew dev --rebuild (ADR-100; #1219).


### PR DESCRIPTION
Closes #1286

## Summary

- Added a new **Pre-deploy validation** section in `docs/getting-started.md` between "Enable TLS for production" and "Validate your config".
- Documents `vibew doctor --preflight production`: reads `vibewarden.production.yaml`, merges with base config, runs 5 additional pre-deploy checks (DNS resolution, port 443, target_platform set, image arch match, tls.email configured). Exit 1 if env file missing.
- Documents `vibew bundle`: bundle step with stdout "Next: deploy" block explanation.
- Documents `vibew bundle --print-deploy --host <h> --user <u> --path <p>`: ad-hoc SSH override for CI / one-off deploys without mutating config.
- CHANGELOG `[Unreleased] ### Documentation` entry added.

Both commands were shipped in v0.18.5. `llms-full.txt`, `docs/troubleshooting.md`, and `docs/examples/AGENTS-VIBEWARDEN.md` all documented them; `docs/getting-started.md` was the only gap. Wording verified against `internal/cli/cmd/doctor.go` and `internal/cli/cmd/bundle.go` source.

## Test plan

- [ ] `make check` passes (pre-push hook confirmed it)
- [ ] `docs/getting-started.md` "Pre-deploy validation" section renders correctly in mkdocs
- [ ] Five preflight check bullets match `doctor.go` long-description (`--preflight <env>` block)
- [ ] `--print-deploy` flag description matches `validatePrintDeployFlags` behavior in `bundle.go` (all three sub-flags required; stdout-only)