### PR TITLE
chore(#1316): publish llms files as release assets (content-authority fix)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -158,9 +158,17 @@ release:
   # these to release-artifacts/ in the before.hooks step above.
   # NOTE: must NOT use dist/ — goreleaser --clean wipes dist before hooks run,
   # then fails when hooks re-populate it ("dist is not empty").
+  #
+  # Content-authority files (issue #1316): llms-full.txt, llms.txt, and
+  # vibewarden.reference.yaml live at the repo root and are uploaded as release
+  # assets so the website (vibewarden.dev) can curl them at build time, eliminating
+  # the silent drift that bit v0.18.7. Mirrors the ADR-101 pattern.
   extra_files:
     - glob: release-artifacts/agent-kickoff-dev.txt
     - glob: release-artifacts/agent-kickoff-deploy.txt
+    - glob: llms-full.txt
+    - glob: llms.txt
+    - glob: vibewarden.reference.yaml
   header: |
     ## VibeWarden {{ .Version }}
 

--- a/test/architecture/release_assets_test.go
+++ b/test/architecture/release_assets_test.go
@@ -1,0 +1,57 @@
+// Package architecture_test — release-asset presence invariant (issue #1316).
+//
+// This file guards the content-authority pipeline established by issue #1316:
+// llms-full.txt, llms.txt, and vibewarden.reference.yaml must exist at the repo
+// root and be non-empty so that goreleaser can publish them as GitHub Release
+// assets. If any of these files is absent or empty, the website (vibewarden.dev)
+// will get a 404 when it curls the release at build time — reproducing the silent
+// drift that bit v0.18.7.
+//
+// These are not generated files. They are checked-in content that must be present
+// and non-empty for every release. This test ensures that no future housekeeping
+// PR accidentally deletes or truncates them.
+package architecture_test
+
+import (
+	"go/build"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReleaseAssets_ContentAuthorityFilesExistAndNonEmpty asserts that the three
+// content-authority files referenced in .goreleaser.yml's release.extra_files
+// block (#1316) exist at the repo root and contain at least one byte.
+func TestReleaseAssets_ContentAuthorityFilesExistAndNonEmpty(t *testing.T) {
+	// Resolve repo root by locating a known package (internal/ports always exists)
+	// and climbing two directories up: <root>/internal/ports → <root>/internal → <root>.
+	sentinel, err := build.Default.Import("github.com/vibewarden/vibewarden/internal/ports", "", build.FindOnly)
+	if err != nil {
+		t.Fatalf("locating module root via internal/ports: %v", err)
+	}
+	repoRoot := filepath.Dir(filepath.Dir(sentinel.Dir))
+
+	files := []string{
+		"llms-full.txt",
+		"llms.txt",
+		"vibewarden.reference.yaml",
+	}
+
+	for _, name := range files {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(repoRoot, name)
+			info, statErr := os.Stat(path)
+			if statErr != nil {
+				t.Fatalf("release-asset file %q missing from repo root: %v\n"+
+					"(.goreleaser.yml publishes this file as a GitHub Release asset — "+
+					"vibewarden.dev will 404 without it)", name, statErr)
+			}
+			if info.Size() == 0 {
+				t.Errorf("release-asset file %q is empty (zero bytes).\n"+
+					"goreleaser will upload an empty file as a release asset — "+
+					"vibewarden.dev fetches this at build time and will serve stale content.",
+					name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1316

## Summary

- Adds `llms-full.txt`, `llms.txt`, and `vibewarden.reference.yaml` to `.goreleaser.yml`'s `release.extra_files` block so the next GitHub Release publishes them as downloadable assets.
- Mirrors the ADR-101 pattern already used for `agent-kickoff-{dev,deploy}.txt`.
- Adds `test/architecture/release_assets_test.go` — a new architecture invariant test that fails the build if any of the three files is absent or empty at the repo root, preventing silent future deletions.
- CHANGELOG `[Unreleased] ### Changed` entry documents the change.

This is the permanent fix for the silent drift that caused the v0.18.7 incident. The manual sync was already done in vibewarden.dev#97. This PR closes the structural gap that allowed it.

## Dependency note

PR 2 (on `vibewarden/vibewarden.dev`) removes the checked-in copies of these files and replaces them with `curl` fetches at site-build time. That PR should only be merged **after** this PR is merged AND the next main-repo release ships (so `releases/latest/download/llms-full.txt` actually exists). Until then, the website falls back to its checked-in copies harmlessly.

## Test plan

- `make check` passes locally (includes the new `TestReleaseAssets_ContentAuthorityFilesExistAndNonEmpty` test).
- On next `goreleaser release`, the three files will appear as release assets alongside the binaries and kickoff artifacts.
- Delete `llms-full.txt` from the repo root and run `go test ./test/architecture/` — the test fails with a descriptive message. Restore the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)