### PR TITLE
fix(#1304): cap TLS retry loop with hard iteration ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+### Fixed
+
+- **fix(#1304): cap TLS retry loop at N iterations + exponential backoff.** Previously the retry path spun ~500K iterations on persistent failure with no cap, observable in the exhaustion test. New cap returns a clear error after exhaustion; backoff between attempts prevents CPU-melt under network instability.
+
 ### Documentation
 
 - **docs(#1270): vibewarden.reference.yaml — add 13 previously-missing top-level config sections.** Brings the reference file to full coverage of fields documented in llms-full.txt or defined in internal/config Go structs. Also fixes a class of latent default-bugs surfaced by the new TestReferenceYAML_UnmarshalsCleanly test: audit.enabled, audit.output, and resilience.circuit_breaker/retry fields now apply their documented defaults via setDefaults(), where previously they were silently zero.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Fixed
 
-- **fix(#1304): cap TLS retry loop at N iterations + exponential backoff.** Previously the retry path spun ~500K iterations on persistent failure with no cap, observable in the exhaustion test. New cap returns a clear error after exhaustion; backoff between attempts prevents CPU-melt under network instability.
+- **fix(#1304): cap TLS retry loop at a hard iteration ceiling.** Previously the retry path spun 500K–750K iterations on persistent failure with no cap, observable in the exhaustion test (the `noSleep` test seam removes the natural pacing of `time.Sleep`). New `MaxIterations(budget, poll)` helper returns `floor(budget/poll) + 2` and gates both `runTLSRetry` and the boot-gap loop. Production iteration counts stay in the low tens (30s budget / 2s poll → 17 max). Returns `ErrTLSRetryExhausted` cleanly after the cap is hit.
 
 ### Documentation
 

--- a/internal/app/probe/service.go
+++ b/internal/app/probe/service.go
@@ -124,6 +124,25 @@ func (s *Service) WithSleep(fn func(time.Duration)) *Service {
 	return &Service{prober: s.prober, sleep: fn}
 }
 
+// MaxIterations computes a ceiling iteration count for a retry loop given the
+// total budget and the per-iteration poll interval. It always returns at least
+// 1, and adds a small safety margin so a production loop never terminates
+// slightly early due to scheduling jitter.
+//
+// This cap is the primary safeguard against busy-spinning when the sleep
+// function is a no-op (test seam). Without it, loops driven by wall-clock
+// time alone spin hundreds of thousands of times per 200ms test budget.
+func MaxIterations(budget, poll time.Duration) int {
+	if poll <= 0 {
+		return 1
+	}
+	n := int(budget/poll) + 2 // +2: rounding margin so production loops do not clip
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
 // Run probes opts.URL once. Two retry loops may engage in sequence:
 //
 //  1. TLS-retry loop (--env path only): if the first probe returns
@@ -174,8 +193,14 @@ func (s *Service) Run(ctx context.Context, opts Options) (Result, error) {
 
 	// Boot-gap retry: upstream is "unknown". Keep polling until it clears or
 	// the budget is exhausted.
+	//
+	// maxIter caps the loop so that injected no-op sleeps (test seam) do not
+	// cause busy-spinning. The wall-clock deadline is still the authoritative
+	// exit condition in production; the cap is a safety bound that makes the
+	// iteration count provable at code review.
 	deadline := time.Now().Add(opts.BootGapWait)
-	for time.Now().Before(deadline) {
+	maxIter := MaxIterations(opts.BootGapWait, opts.BootGapPoll)
+	for i := 0; i < maxIter && time.Now().Before(deadline); i++ {
 		s.sleep(opts.BootGapPoll)
 
 		// Re-check context before each retry.
@@ -205,14 +230,19 @@ func (s *Service) Run(ctx context.Context, opts Options) (Result, error) {
 //
 // Returns (doc, nil) on success, ErrTLSRetryExhausted on budget exhaustion, or
 // the new error immediately when the error class changes.
+//
+// The loop is bounded by both a wall-clock deadline and a maxIter cap. The cap
+// prevents busy-spinning when the sleep function is a no-op (test seam). In
+// production, time.Sleep keeps the iteration count in the low tens regardless.
 func (s *Service) runTLSRetry(ctx context.Context, opts Options, pw io.Writer) (ports.HealthDocument, error) {
 	retrySeconds := int(opts.TLSRetryWait.Seconds())
 	fmt.Fprintf(pw, "Waiting for ACME issuance... (TLS handshake failed; retrying %ds)\n", retrySeconds)
 
 	start := time.Now()
 	deadline := start.Add(opts.TLSRetryWait)
+	maxIter := MaxIterations(opts.TLSRetryWait, opts.TLSRetryPoll)
 
-	for {
+	for i := 0; i < maxIter; i++ {
 		s.sleep(opts.TLSRetryPoll)
 
 		elapsed := int(time.Since(start).Seconds())
@@ -234,8 +264,11 @@ func (s *Service) runTLSRetry(ctx context.Context, opts Options, pw io.Writer) (
 		}
 
 		if !time.Now().Before(deadline) {
-			// Budget exhausted.
+			// Budget exhausted by wall clock.
 			return ports.HealthDocument{}, ErrTLSRetryExhausted
 		}
 	}
+
+	// Budget exhausted by iteration cap.
+	return ports.HealthDocument{}, ErrTLSRetryExhausted
 }

--- a/internal/app/probe/service_test.go
+++ b/internal/app/probe/service_test.go
@@ -390,3 +390,117 @@ func TestService_TLSRetry_EnvMode_ErrorClassChange(t *testing.T) {
 		t.Errorf("callCount = %d, want 3 (1 initial + 2 retries)", prober.callCount)
 	}
 }
+
+// TestMaxIterations verifies the MaxIterations helper used to cap retry loops.
+func TestMaxIterations(t *testing.T) {
+	tests := []struct {
+		name    string
+		budget  time.Duration
+		poll    time.Duration
+		wantMin int
+		wantMax int
+	}{
+		{
+			name:    "production TLS defaults 30s/2s",
+			budget:  30 * time.Second,
+			poll:    2 * time.Second,
+			wantMin: 15, // floor(30/2)=15, +2 margin = 17
+			wantMax: 20,
+		},
+		{
+			name:    "production boot-gap defaults 10s/1s",
+			budget:  10 * time.Second,
+			poll:    1 * time.Second,
+			wantMin: 10, // floor(10/1)=10, +2 margin = 12
+			wantMax: 15,
+		},
+		{
+			name:    "test budget 200ms/2s (poll larger than budget)",
+			budget:  200 * time.Millisecond,
+			poll:    2 * time.Second,
+			wantMin: 1,
+			wantMax: 5,
+		},
+		{
+			name:    "zero poll returns 1",
+			budget:  10 * time.Second,
+			poll:    0,
+			wantMin: 1,
+			wantMax: 1,
+		},
+		{
+			name:    "equal budget and poll",
+			budget:  5 * time.Second,
+			poll:    5 * time.Second,
+			wantMin: 1,
+			wantMax: 5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := probe.MaxIterations(tt.budget, tt.poll)
+			if got < tt.wantMin {
+				t.Errorf("MaxIterations(%v, %v) = %d, want >= %d", tt.budget, tt.poll, got, tt.wantMin)
+			}
+			if got > tt.wantMax {
+				t.Errorf("MaxIterations(%v, %v) = %d, want <= %d", tt.budget, tt.poll, got, tt.wantMax)
+			}
+		})
+	}
+}
+
+// TestService_TLSRetry_IterationCapEnforced verifies that with a no-op sleep
+// the TLS retry loop terminates after a bounded number of probe calls.
+// Before the fix, ~750,000 iterations were observed for a 200ms budget.
+func TestService_TLSRetry_IterationCapEnforced(t *testing.T) {
+	prober := &fakeProber{responses: []fakeResponse{{err: tlsErr()}}}
+	svc := probe.NewService(prober).WithSleep(noSleep)
+
+	// budget=200ms, poll=2s → MaxIterations returns floor(0.1)+2 = 2
+	_, err := svc.Run(context.Background(), probe.Options{
+		URL:          "https://example.com/_vibewarden/health",
+		EnvName:      "production",
+		TLSRetryWait: 200 * time.Millisecond,
+		TLSRetryPoll: 2 * time.Second,
+		BootGapWait:  10 * time.Second,
+		BootGapPoll:  1 * time.Second,
+	})
+
+	if !errors.Is(err, probe.ErrTLSRetryExhausted) {
+		t.Fatalf("expected ErrTLSRetryExhausted, got: %v", err)
+	}
+
+	// 1 initial probe + at most MaxIterations(200ms, 2s) loop probes = at most 3.
+	// Without the iteration cap this would be ~750,000.
+	const maxExpectedCalls = 20
+	if prober.callCount > maxExpectedCalls {
+		t.Errorf("callCount = %d, want <= %d (iteration cap not enforced — busy-spin bug)", prober.callCount, maxExpectedCalls)
+	}
+}
+
+// TestService_BootGap_IterationCapEnforced verifies that with a no-op sleep
+// the boot-gap loop terminates after a bounded number of probe calls.
+// Before the fix, ~500,000 iterations were observed for a 200ms budget.
+func TestService_BootGap_IterationCapEnforced(t *testing.T) {
+	prober := &fakeProber{responses: []fakeResponse{{doc: unknownDoc()}}}
+	svc := probe.NewService(prober).WithSleep(noSleep)
+
+	// budget=200ms, poll=100ms → MaxIterations returns floor(2)+2 = 4
+	_, err := svc.Run(context.Background(), probe.Options{
+		URL:         "https://example.com/_vibewarden/health",
+		BootGapWait: 200 * time.Millisecond,
+		BootGapPoll: 100 * time.Millisecond,
+		PerProbe:    3 * time.Second,
+	})
+
+	if !errors.Is(err, probe.ErrBootGapExhausted) {
+		t.Fatalf("expected ErrBootGapExhausted, got: %v", err)
+	}
+
+	// 1 initial probe + at most MaxIterations(200ms, 100ms) loop probes = at most 5.
+	// Without the iteration cap this would be ~500,000.
+	const maxExpectedCalls = 20
+	if prober.callCount > maxExpectedCalls {
+		t.Errorf("callCount = %d, want <= %d (iteration cap not enforced — busy-spin bug)", prober.callCount, maxExpectedCalls)
+	}
+}


### PR DESCRIPTION
Closes #1304

## Summary

- `runTLSRetry` and the boot-gap loop in `internal/app/probe/service.go` relied solely on wall-clock time to exit. With the `noSleep` test seam, they busy-spun ~750K (TLS) and ~500K (boot-gap) iterations per 200ms test budget, burning a full CPU core per test.
- Added `MaxIterations(budget, poll time.Duration) int` — returns `floor(budget/poll)+2`. Both loops now exit on whichever fires first: wall-clock deadline or iteration cap.
- Production behavior unchanged: `time.Sleep(2s)` keeps real iteration counts to single digits regardless.

**Before:** `TestService_TLSRetry_EnvMode_Exhausted` spun ~750,000 iterations in 200ms.
**After:** same test exits after 2 iterations (MaxIterations(200ms, 2s) = 2).

## Files changed

- `/private/tmp/vw-1304/internal/app/probe/service.go` — `MaxIterations` helper + iteration cap in both loops
- `/private/tmp/vw-1304/internal/app/probe/service_test.go` — 3 new tests: `TestMaxIterations`, `TestService_TLSRetry_IterationCapEnforced`, `TestService_BootGap_IterationCapEnforced`
- `CHANGELOG.md` — entry under `[Unreleased] ### Fixed`

## Test plan

- [ ] `go test -count=1 -v ./internal/app/probe/...` — all 31 tests pass, suite completes in <1s
- [ ] `make check` — all checks pass (gofmt, golangci-lint, go build, go test -race ./...)
- [ ] `TestService_TLSRetry_IterationCapEnforced` asserts `callCount <= 20` with noSleep + 200ms budget
- [ ] `TestService_BootGap_IterationCapEnforced` asserts `callCount <= 20` with noSleep + 200ms budget
- [ ] Existing exhaustion tests still pass (error sentinel unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)