### PR TITLE
test(#1303): add 4 cross-cutting architecture invariants + consolidate docker error detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
-### Fixed
-
-- **fix(#1304): cap TLS retry loop at N iterations + exponential backoff.** Previously the retry path spun ~500K iterations on persistent failure with no cap, observable in the exhaustion test. New cap returns a clear error after exhaustion; backoff between attempts prevents CPU-melt under network instability.
-
 ### Documentation
 
 - **docs(#1270): vibewarden.reference.yaml — add 13 previously-missing top-level config sections.** Brings the reference file to full coverage of fields documented in llms-full.txt or defined in internal/config Go structs. Also fixes a class of latent default-bugs surfaced by the new TestReferenceYAML_UnmarshalsCleanly test: audit.enabled, audit.output, and resilience.circuit_breaker/retry fields now apply their documented defaults via setDefaults(), where previously they were silently zero.
@@ -34,7 +30,6 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Changed
 
-- **chore(#1290): upgrade Ory Kratos image v1.3.1 → v26.2.0.** Catches up on 24+ CalVer versions of security/bugfixes. Five files updated (docker-compose.yml, two templates, dev/kratos/kratos.yml, integration test image). All five REST endpoints we depend on are signature-stable; v25→v26 breaking changes are confined to self-service UI flow behavior we don't consume. Integration tests at `go test -tags integration ./internal/adapters/kratos/...` are the acceptance gate.
 - **chore(#1316): publish `llms-full.txt`, `llms.txt`, and `vibewarden.reference.yaml` as GitHub Release assets.** The website (vibewarden.dev) will fetch these at build time, eliminating the silent drift that bit v0.18.7. Mirrors the ADR-101 pattern already used for `agent-kickoff-{dev,deploy}.txt`. A new architecture invariant test (`test/architecture/release_assets_test.go`) fails the build if any of these files is absent or empty from the repo root.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+### Fixed
+
+- **fix(#1304): cap TLS retry loop at N iterations + exponential backoff.** Previously the retry path spun ~500K iterations on persistent failure with no cap, observable in the exhaustion test. New cap returns a clear error after exhaustion; backoff between attempts prevents CPU-melt under network instability.
+
 ### Documentation
 
 - **docs(#1270): vibewarden.reference.yaml — add 13 previously-missing top-level config sections.** Brings the reference file to full coverage of fields documented in llms-full.txt or defined in internal/config Go structs. Also fixes a class of latent default-bugs surfaced by the new TestReferenceYAML_UnmarshalsCleanly test: audit.enabled, audit.output, and resilience.circuit_breaker/retry fields now apply their documented defaults via setDefaults(), where previously they were silently zero.
@@ -24,8 +28,13 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 - **fix(#1269): reject env names containing path-traversal sequences in `vibew probe --env` and `vibew doctor --preflight`.** New `validateEnvName` (`^[a-zA-Z0-9_-]+$`) returns `ErrInvalidEnvName`; defense-in-depth: resolved path is verified inside project root after `filepath.EvalSymlinks` to block symlink-escape via legitimately-named override files.
 - **fix(#1264): caddy auth handlers — strip ALL X-User-* headers from incoming requests + fix public-path prefix matching.** Closes identity-spoofing via forged X-User-* values in JWT mode (notably X-User-Name) and public-path bypass via prefix-sibling paths (e.g. /auth-evil matching /auth/*). Both Caddy-layer (config_handlers.go x-user-* glob) and Go-layer (stripXUserHeaders defense-in-depth) defenses now active.
 
+### Added
+
+- **test(#1303): four cross-cutting architecture invariants now enforced in `test/architecture/`.** Previously these patterns were enforced by code review only. Tests cover: (1) `TestDomainPackages_NoExternalImports` — no domain file may import adapters/app/cli/ports/plugins/middleware (single pre-approved exception: `internal/domain/site/site.go → internal/config` per ADR-068); (2) `TestConfigPackage_NoOuterLayerImports` — `internal/config` must not import outer layers; (3) `TestDockerErrorDetection_OnlyInClassifyDockerError` — all docker error string matching lives exclusively in `ClassifyDockerError`; (4) `TestLoadMergedConfig_RestrictedCallers` — `LoadMergedConfig` callers restricted to the approved allow-list (definition, bundle.go, env/resolver.go; `validate.go` included with a `TODO(#1301)` until that bypass is migrated). Pre-work: inline `isDockerNotFound` check in `image_inspect.go:145` migrated into `ClassifyDockerError` in `docker_errors.go`, consolidating all docker binary-absent detection into the canonical seam.
+
 ### Changed
 
+- **chore(#1290): upgrade Ory Kratos image v1.3.1 → v26.2.0.** Catches up on 24+ CalVer versions of security/bugfixes. Five files updated (docker-compose.yml, two templates, dev/kratos/kratos.yml, integration test image). All five REST endpoints we depend on are signature-stable; v25→v26 breaking changes are confined to self-service UI flow behavior we don't consume. Integration tests at `go test -tags integration ./internal/adapters/kratos/...` are the acceptance gate.
 - **chore(#1316): publish `llms-full.txt`, `llms.txt`, and `vibewarden.reference.yaml` as GitHub Release assets.** The website (vibewarden.dev) will fetch these at build time, eliminating the silent drift that bit v0.18.7. Mirrors the ADR-101 pattern already used for `agent-kickoff-{dev,deploy}.txt`. A new architecture invariant test (`test/architecture/release_assets_test.go`) fails the build if any of these files is absent or empty from the repo root.
 
 ### Removed

--- a/internal/adapters/ops/docker_errors.go
+++ b/internal/adapters/ops/docker_errors.go
@@ -6,21 +6,28 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
-// ClassifyDockerError inspects stderr captured from a docker shell-out and
-// returns a *ports.DockerUnavailableError wrapping the most specific sentinel
-// when a known unavailability signature is detected, or originalErr unchanged
-// when no signature matches (including empty stderr or nil originalErr).
+// ClassifyDockerError inspects the error message and stderr captured from a
+// docker shell-out and returns a *ports.DockerUnavailableError wrapping the
+// most specific sentinel when a known unavailability signature is detected, or
+// originalErr unchanged when no signature matches (including empty stderr or
+// nil originalErr).
 //
-// Recognised signatures:
-//   - "permission denied while trying to connect to the docker api" →
+// This is the single canonical place where Docker error detection lives.
+// Do not add docker-binary-absent or daemon-unavailable string checks anywhere
+// else in the codebase — extend this function instead.
+//
+// Recognised signatures (checked in precedence order):
+//   - err.Error() contains "executable file not found" →
+//     ErrDockerUnavailable (docker binary absent from PATH)
+//   - stderr contains "permission denied while trying to connect to the docker api" →
 //     ErrDockerSocketPermission
-//   - "unix:///" AND "permission denied" →
+//   - stderr contains "unix:///" AND "permission denied" →
 //     ErrDockerSocketPermission (macOS user-socket path variant)
-//   - "cannot connect to the docker daemon" →
+//   - stderr contains "cannot connect to the docker daemon" →
 //     ErrDockerDaemonNotRunning
-//   - "is the docker daemon running" →
+//   - stderr contains "is the docker daemon running" →
 //     ErrDockerDaemonNotRunning (variant phrasing emitted by some Docker versions)
-//   - "docker: command not found" →
+//   - stderr contains "docker: command not found" →
 //     ErrDockerDaemonNotRunning (snap-installed Docker on Ubuntu; binary missing
 //     means the daemon is unreachable — same operator hint applies)
 //
@@ -34,6 +41,16 @@ import (
 func ClassifyDockerError(originalErr error, stderr string) error {
 	if originalErr == nil {
 		return nil
+	}
+
+	// Check the error message itself for binary-not-found before inspecting
+	// stderr — exec.ErrNotFound / LookPath embeds this signature in the error.
+	if strings.Contains(originalErr.Error(), "executable file not found") {
+		return &ports.DockerUnavailableError{
+			Sentinel: ports.ErrDockerUnavailable,
+			Stderr:   stderr,
+			Cause:    originalErr,
+		}
 	}
 
 	lower := strings.ToLower(stderr)

--- a/internal/adapters/ops/docker_errors_test.go
+++ b/internal/adapters/ops/docker_errors_test.go
@@ -148,6 +148,45 @@ func TestClassifyDockerError_NilOriginal(t *testing.T) {
 	}
 }
 
+// TestClassifyDockerError_BinaryNotFound verifies the consolidated binary-absent
+// path added in #1303. Previously this check lived in isDockerNotFound inside
+// image_inspect.go; it is now handled by ClassifyDockerError directly so that
+// the TestDockerErrorDetection_OnlyInClassifyDockerError invariant test can pass.
+func TestClassifyDockerError_BinaryNotFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		errMsg  string
+		wantErr error
+	}{
+		{
+			name:    "exec ErrNotFound phrasing",
+			errMsg:  `exec: "docker": executable file not found in $PATH`,
+			wantErr: ports.ErrDockerUnavailable,
+		},
+		{
+			name:    "shorter executable file not found",
+			errMsg:  "fork/exec /usr/bin/docker: executable file not found in $PATH",
+			wantErr: ports.ErrDockerUnavailable,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := errors.New(tt.errMsg)
+			err := ops.ClassifyDockerError(orig, "")
+			if err == nil {
+				t.Fatal("expected non-nil error")
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("errors.Is(err, %v) = false; got %v", tt.wantErr, err)
+			}
+			var typed *ports.DockerUnavailableError
+			if !errors.As(err, &typed) {
+				t.Fatal("errors.As(*DockerUnavailableError) = false")
+			}
+		})
+	}
+}
+
 func TestDockerUnavailableError_Is_Umbrella(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/adapters/ops/image_inspect.go
+++ b/internal/adapters/ops/image_inspect.go
@@ -54,17 +54,12 @@ func (a *ImageInspectAdapter) Inspect(ctx context.Context, tag string) (ports.Im
 	err := cmd.Run()
 	if err != nil {
 		stderrStr := stderr.String()
-		// Check for docker not being found (exec.ErrNotFound) or explicit
-		// "executable file not found" before checking stderr content.
-		if isDockerNotFound(err) {
-			return ports.ImageInfo{}, ports.ErrDockerUnavailable
-		}
 		if strings.Contains(stderrStr, "No such image") {
 			return ports.ImageInfo{}, ports.ErrImageNotFound
 		}
-		// Classify daemon-unavailable stderr (e.g. "Cannot connect to the Docker daemon",
-		// "permission denied while trying to connect to the docker API") via the
-		// shared helper. Falls through to a generic error when no signature matches.
+		// ClassifyDockerError is the single canonical seam for all docker error
+		// classification — binary-not-found (via err.Error()), daemon-unavailable,
+		// and socket-permission checks are all handled there.
 		classified := ClassifyDockerError(err, stderrStr)
 		if classified != err {
 			return ports.ImageInfo{}, classified
@@ -130,20 +125,4 @@ func parseInspectJSON(jsonBlob []byte) (ports.ImageInfo, error) {
 		SizeBytes:    out.Size,
 		Labels:       labels,
 	}, nil
-}
-
-// isDockerNotFound reports whether the error indicates the docker binary was
-// not found on PATH.
-func isDockerNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	if strings.Contains(err.Error(), "executable file not found") {
-		return true
-	}
-	// exec.ErrNotFound is set when LookPath fails.
-	if strings.Contains(err.Error(), "exec: \"docker\": executable file not found in $PATH") {
-		return true
-	}
-	return false
 }

--- a/test/architecture/config_seam_test.go
+++ b/test/architecture/config_seam_test.go
@@ -1,0 +1,90 @@
+// Package architecture_test — LoadMergedConfig restricted-callers invariant.
+//
+// TestLoadMergedConfig_RestrictedCallers enforces that bundleapp.LoadMergedConfig
+// (or bundle.LoadMergedConfig) is called only from the approved set of files. All
+// other callers must go through the env.Resolver seam (ADR-102).
+package architecture_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLoadMergedConfig_RestrictedCallers asserts that LoadMergedConfig is called
+// only from the approved allow-list of files. Any call site not in the list
+// bypasses the env.Resolver seam and will fail this test.
+//
+// Allow-list rationale:
+//   - internal/app/bundle/resolve.go — definition of LoadMergedConfig (allowed)
+//   - internal/app/bundle/bundle.go  — primary consumer inside the bundle use case
+//   - internal/app/env/resolver.go   — the ADR-102 canonical seam; all other code
+//     should call through this instead of LoadMergedConfig directly
+//   - internal/cli/cmd/validate.go   — TODO(#1301): this caller bypasses the env
+//     Resolver seam. It must be migrated to call env.Resolver instead. Until
+//     #1301 lands, it is included here so the build stays green; remove it from
+//     the allow-list when #1301 is complete.
+func TestLoadMergedConfig_RestrictedCallers(t *testing.T) {
+	// allowedCallers is the set of slash-relative paths (from module root) that
+	// are permitted to reference LoadMergedConfig. Any file outside this set that
+	// calls LoadMergedConfig (or bundleapp.LoadMergedConfig) fails the test.
+	allowedCallers := map[string]bool{
+		"internal/app/bundle/resolve.go": true, // definition
+		"internal/app/bundle/bundle.go":  true, // primary consumer
+		"internal/app/env/resolver.go":   true, // ADR-102 canonical seam
+		// TODO(#1301): migrate validate.go to call env.Resolver and remove this entry.
+		"internal/cli/cmd/validate.go": true,
+	}
+
+	moduleRootDir := resolveModuleRoot(t)
+
+	scanRoots := []string{"internal", "cmd"}
+	fset := token.NewFileSet()
+
+	for _, root := range scanRoots {
+		rootDir := filepath.Join(moduleRootDir, filepath.FromSlash(root))
+		err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+
+			relSlash := filepath.ToSlash(mustRel(moduleRootDir, path))
+			if allowedCallers[relSlash] {
+				return nil
+			}
+
+			f, parseErr := parser.ParseFile(fset, path, nil, 0)
+			if parseErr != nil {
+				t.Errorf("parsing %s: %v", path, parseErr)
+				return nil
+			}
+
+			ast.Inspect(f, func(n ast.Node) bool {
+				sel, ok := n.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				if sel.Sel.Name != "LoadMergedConfig" {
+					return true
+				}
+				t.Errorf("%s calls LoadMergedConfig — only the env.Resolver seam "+
+					"(internal/app/env/resolver.go) may call this function directly. "+
+					"Use env.Resolver instead, or add this file to the allow-list "+
+					"in this test with an ADR justification.",
+					relSlash)
+				return false // stop traversal for this file's violations
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+}

--- a/test/architecture/docker_errors_seam_test.go
+++ b/test/architecture/docker_errors_seam_test.go
@@ -1,0 +1,142 @@
+// Package architecture_test — docker error detection seam invariant.
+//
+// TestDockerErrorDetection_OnlyInClassifyDockerError enforces that
+// ClassifyDockerError in internal/adapters/ops/docker_errors.go is the single
+// canonical place where docker-specific error strings are matched. No other
+// non-test file may contain strings.Contains calls whose string literal contains
+// signatures that indicate docker binary absence or daemon unavailability.
+package architecture_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDockerErrorDetection_OnlyInClassifyDockerError asserts that docker error
+// detection string literals appear only in the canonical seam
+// (internal/adapters/ops/docker_errors.go). Any other non-test Go file that
+// contains a strings.Contains call whose string argument matches a docker-error
+// signature will fail this test.
+//
+// Background: prior to this invariant, image_inspect.go:145 contained an inline
+// check for "exec: \"docker\": executable file not found in $PATH". That check
+// was migrated into ClassifyDockerError as part of issue #1303. This test
+// prevents the pattern from re-appearing elsewhere.
+//
+// Exempt files:
+//   - internal/adapters/ops/docker_errors.go (the canonical seam — allowed)
+//   - internal/adapters/ops/docker_errors_test.go (test coverage — allowed)
+func TestDockerErrorDetection_OnlyInClassifyDockerError(t *testing.T) {
+	moduleRootDir := resolveModuleRoot(t)
+
+	// dockerErrSignatures are substrings that, when found inside a
+	// strings.Contains string-literal argument, indicate docker error detection
+	// logic that belongs exclusively in ClassifyDockerError.
+	dockerErrSignatures := []string{
+		"permission denied",
+		"daemon",
+		"cannot connect to the docker",
+		"docker: executable file not found",
+		`exec: "docker"`,
+		"executable file not found",
+	}
+
+	// exemptFiles are slash-relative paths from the module root that are
+	// permitted to contain these literals (the canonical seam and its test).
+	exemptFiles := map[string]bool{
+		"internal/adapters/ops/docker_errors.go":      true,
+		"internal/adapters/ops/docker_errors_test.go": true,
+	}
+
+	// scanRoots lists the directory subtrees to walk.
+	scanRoots := []string{"internal", "cmd"}
+
+	fset := token.NewFileSet()
+
+	for _, root := range scanRoots {
+		rootDir := filepath.Join(moduleRootDir, filepath.FromSlash(root))
+		err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+
+			relSlash := filepath.ToSlash(mustRel(moduleRootDir, path))
+			if exemptFiles[relSlash] {
+				return nil
+			}
+
+			f, parseErr := parser.ParseFile(fset, path, nil, 0)
+			if parseErr != nil {
+				t.Errorf("parsing %s: %v", path, parseErr)
+				return nil
+			}
+
+			ast.Inspect(f, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+
+				// Match calls of the form strings.Contains(x, <literal>)
+				// or strings.ContainsAny / strings.HasPrefix — we only care
+				// about strings.Contains here since that's the pattern used
+				// for docker error detection.
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				pkgIdent, ok := sel.X.(*ast.Ident)
+				if !ok {
+					return true
+				}
+				if pkgIdent.Name != "strings" || sel.Sel.Name != "Contains" {
+					return true
+				}
+				if len(call.Args) < 2 {
+					return true
+				}
+
+				lit, ok := call.Args[1].(*ast.BasicLit)
+				if !ok {
+					return true
+				}
+				// Strip surrounding quotes from the string literal.
+				litVal := strings.ToLower(strings.Trim(lit.Value, `"`))
+
+				for _, sig := range dockerErrSignatures {
+					if strings.Contains(litVal, strings.ToLower(sig)) {
+						t.Errorf("%s: strings.Contains call with docker error signature %q found outside the canonical seam "+
+							"(internal/adapters/ops/docker_errors.go). "+
+							"Migrate this check into ClassifyDockerError instead.",
+							relSlash, sig)
+						// Report only once per call site.
+						break
+					}
+				}
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+}
+
+// mustRel is filepath.Rel that panics on error (both paths are known-good
+// module-root-relative paths produced by WalkDir in this package).
+func mustRel(base, path string) string {
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		panic(err)
+	}
+	return rel
+}

--- a/test/architecture/domain_purity_test.go
+++ b/test/architecture/domain_purity_test.go
@@ -1,0 +1,176 @@
+// Package architecture_test — domain purity and config-layer isolation invariants.
+//
+// This file guards two boundaries:
+//
+//  1. TestDomainPackages_NoExternalImports — no file under internal/domain/ may
+//     import from the adapters, app, cli, ports, plugins, or middleware layers.
+//     The single pre-approved exception is internal/domain/site/site.go importing
+//     internal/config (ADR-068 boundary exception). Any new exception requires
+//     editing the allowedExceptions map and justifying the decision in an ADR.
+//
+//  2. TestConfigPackage_NoOuterLayerImports — no file under internal/config/ may
+//     import from adapters, app, cli, plugins, or middleware. Config is an
+//     inward-facing package used by all layers; it must not reach outward.
+package architecture_test
+
+import (
+	"go/build"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDomainPackages_NoExternalImports asserts that no non-test Go file under
+// internal/domain/ imports from the adapters, app, cli, ports, plugins, or
+// middleware layers. The domain layer must have zero external dependencies so
+// that use cases can be tested without any infrastructure (hexagonal
+// architecture, ADR-064).
+//
+// The single allowed exception — internal/domain/site/site.go importing
+// internal/config — is encoded as a (relPath, importPath) tuple. Adding a
+// second exception requires editing this test and justifying the decision.
+func TestDomainPackages_NoExternalImports(t *testing.T) {
+	const (
+		modulePrefix = "github.com/vibewarden/vibewarden/"
+		pkgRoot      = "internal/domain"
+	)
+
+	// bannedPrefixes are module-relative import prefixes that the domain layer
+	// must not reference.
+	bannedPrefixes := []string{
+		modulePrefix + "internal/adapters/",
+		modulePrefix + "internal/app/",
+		modulePrefix + "internal/cli/",
+		modulePrefix + "internal/ports/",
+		modulePrefix + "internal/plugins/",
+		modulePrefix + "internal/middleware/",
+	}
+
+	// allowedExceptions maps a file's path relative to the pkgRoot to the one
+	// import it is permitted to make into a banned prefix.
+	// Key:   slash-separated path relative to internal/domain (e.g. "site/site.go")
+	// Value: the exact import path that is allowed for that file
+	allowedExceptions := map[string]string{
+		// ADR-068: site domain depends on config for SiteConfig value objects.
+		// This is a pragmatic exception; all other domain files must be clean.
+		"site/site.go": modulePrefix + "internal/config",
+	}
+
+	moduleRootDir := resolveModuleRoot(t)
+	targetDir := filepath.Join(moduleRootDir, filepath.FromSlash(pkgRoot))
+
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(targetDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		rel, _ := filepath.Rel(targetDir, path)
+		relSlash := filepath.ToSlash(rel)
+
+		f, parseErr := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if parseErr != nil {
+			t.Errorf("parsing %s: %v", path, parseErr)
+			return nil
+		}
+
+		for _, imp := range f.Imports {
+			importPath := strings.Trim(imp.Path.Value, `"`)
+			for _, banned := range bannedPrefixes {
+				if !strings.HasPrefix(importPath, banned) {
+					continue
+				}
+				// Check whether this (file, import) pair is an allowed exception.
+				if allowed, ok := allowedExceptions[relSlash]; ok && allowed == importPath {
+					continue
+				}
+				t.Errorf("%s/%s imports %q — forbidden by ADR-064 (domain layer must have zero external deps). "+
+					"If this exception is intentional, add it to allowedExceptions in this test with an ADR reference.",
+					pkgRoot, relSlash, importPath)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", pkgRoot, err)
+	}
+}
+
+// TestConfigPackage_NoOuterLayerImports asserts that no non-test Go file under
+// internal/config/ imports from adapters, app, cli, plugins, or middleware.
+// Config is consumed by all layers; importing back into them creates cycles and
+// breaks the hexagonal architecture's dependency rule.
+func TestConfigPackage_NoOuterLayerImports(t *testing.T) {
+	const (
+		modulePrefix = "github.com/vibewarden/vibewarden/"
+		pkgRoot      = "internal/config"
+	)
+
+	bannedPrefixes := []string{
+		modulePrefix + "internal/adapters/",
+		modulePrefix + "internal/app/",
+		modulePrefix + "internal/cli/",
+		modulePrefix + "internal/plugins/",
+		modulePrefix + "internal/middleware/",
+	}
+
+	moduleRootDir := resolveModuleRoot(t)
+	targetDir := filepath.Join(moduleRootDir, filepath.FromSlash(pkgRoot))
+
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(targetDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		rel, _ := filepath.Rel(targetDir, path)
+
+		f, parseErr := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if parseErr != nil {
+			t.Errorf("parsing %s: %v", path, parseErr)
+			return nil
+		}
+
+		for _, imp := range f.Imports {
+			importPath := strings.Trim(imp.Path.Value, `"`)
+			for _, banned := range bannedPrefixes {
+				if strings.HasPrefix(importPath, banned) {
+					t.Errorf("%s/%s imports %q — forbidden (internal/config must not import outer layers). "+
+						"Config is consumed by all layers; importing back into them creates import cycles.",
+						pkgRoot, filepath.ToSlash(rel), importPath)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", pkgRoot, err)
+	}
+}
+
+// resolveModuleRoot returns the on-disk path of the module root by importing
+// the always-present internal/ports package and climbing two directories up.
+// Defined here for use by tests in this file; the shared helper in
+// ports_purity_test.go is unexported and in the same package so it cannot be
+// called — each file that needs it must inline it or use build.Default directly.
+func resolveModuleRoot(t *testing.T) string {
+	t.Helper()
+
+	sentinel, err := build.Default.Import("github.com/vibewarden/vibewarden/internal/ports", "", build.FindOnly)
+	if err != nil {
+		t.Fatalf("locating module root via internal/ports: %v", err)
+	}
+	// sentinel.Dir is <moduleRoot>/internal/ports — go up two levels.
+	return filepath.Dir(filepath.Dir(sentinel.Dir))
+}


### PR DESCRIPTION
Closes #1303

## Summary

**Pre-work:** migrated the inline `isDockerNotFound` check from `internal/adapters/ops/image_inspect.go:145` into `ClassifyDockerError` in `docker_errors.go`. This makes `ClassifyDockerError` the single canonical seam for all docker error detection (binary-absent via `err.Error()`, daemon-unavailable, and socket-permission checks).

**Four new invariant tests** added to `test/architecture/`:

1. `TestDomainPackages_NoExternalImports` (`domain_purity_test.go`) — walks `internal/domain/`, fails if any non-test file imports from `adapters/`, `app/`, `cli/`, `ports/`, `plugins/`, or `middleware/`. The single pre-approved exception (`internal/domain/site/site.go → internal/config`, ADR-068) is encoded as an explicit `(file, importPath)` tuple — any new exception requires editing the test.

2. `TestConfigPackage_NoOuterLayerImports` (`domain_purity_test.go`) — walks `internal/config/`, fails if any non-test file imports from outer layers (`adapters/`, `app/`, `cli/`, `plugins/`, `middleware/`). Currently green; adds a regression guard.

3. `TestDockerErrorDetection_OnlyInClassifyDockerError` (`docker_errors_seam_test.go`) — walks all non-test `.go` files under `internal/` and `cmd/`, fails if any `strings.Contains` call's string argument matches a docker-error signature (`permission denied`, `daemon`, `cannot connect to the docker`, `executable file not found`, etc.) outside the exempt files (`docker_errors.go` and its test).

4. `TestLoadMergedConfig_RestrictedCallers` (`config_seam_test.go`) — walks all non-test `.go` files under `internal/` and `cmd/`, fails if any `LoadMergedConfig` selector appears outside the allow-list (definition, `bundle.go`, `env/resolver.go`). `internal/cli/cmd/validate.go` is included in the allow-list with a `// TODO(#1301)` comment until that bypass is migrated to call through `env.Resolver`.

## #1301 coordination

`validate.go` is in the `TestLoadMergedConfig_RestrictedCallers` allow-list with a `TODO(#1301)` comment. The test will keep passing until #1301 lands, at which point `validate.go` should be removed from the allow-list to keep the invariant tight.

## Test plan

- `go test ./test/architecture/... -run "TestDomainPackages_NoExternalImports|TestConfigPackage_NoOuterLayerImports|TestDockerErrorDetection_OnlyInClassifyDockerError|TestLoadMergedConfig_RestrictedCallers"` — all 4 pass
- `go test ./internal/adapters/ops/... -run "TestClassifyDockerError"` — all pass including new `TestClassifyDockerError_BinaryNotFound`
- `make check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)