### PR TITLE
chore(#1290): upgrade oryd/kratos to v26.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Changed
 
+- **chore(#1290): upgrade Ory Kratos image v1.3.1 → v26.2.0.** Catches up on 24+ CalVer versions of security/bugfixes. Five files updated (docker-compose.yml, two templates, dev/kratos/kratos.yml, integration test image). All five REST endpoints we depend on are signature-stable; v25→v26 breaking changes are confined to self-service UI flow behavior we do not consume. Integration test migrate-first pattern added (`migrateKratos`) to handle v26.2.0's 338 migrations without exceeding the serve-container startup timeout.
 - **chore(#1316): publish `llms-full.txt`, `llms.txt`, and `vibewarden.reference.yaml` as GitHub Release assets.** The website (vibewarden.dev) will fetch these at build time, eliminating the silent drift that bit v0.18.7. Mirrors the ADR-101 pattern already used for `agent-kickoff-{dev,deploy}.txt`. A new architecture invariant test (`test/architecture/release_assets_test.go`) fails the build if any of these files is absent or empty from the repo root.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,12 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Changed
 
-- **chore(#1290): upgrade Ory Kratos image v1.3.1 → v26.2.0.** Catches up on 24+ CalVer versions of security/bugfixes. Five files updated (docker-compose.yml, two templates, dev/kratos/kratos.yml, integration test image). All five REST endpoints we depend on are signature-stable; v25→v26 breaking changes are confined to self-service UI flow behavior we do not consume. Integration test migrate-first pattern added (`migrateKratos`) to handle v26.2.0's 338 migrations without exceeding the serve-container startup timeout.
+- **chore(#1290): upgrade Ory Kratos image v1.3.1 → v26.2.0.** Catches up on 24+ CalVer versions of security/bugfixes. Five config/template files updated (docker-compose.yml, two templates, dev/kratos/kratos.yml, integration test image). The architect's pre-analysis suggested "no Go source changes" but four real breaking changes in the admin API required adapter fixes:
+  - `PATCH /admin/identities/:id` (used by `DeactivateUser`) now requires JSON Patch (RFC 6902) shape `[{"op":"replace","path":"/state","value":"inactive"}]` with `Content-Type: application/json-patch+json` (was a bare `{"state":"inactive"}` JSON object).
+  - `POST /admin/recovery/link` was removed; replaced with `POST /admin/recovery/code` (used by `generateRecoveryLink`).
+  - `GET /admin/identities` pagination switched to 0-indexed pages; the adapter now translates caller-facing `Page=N` to wire-level `page=N-1`.
+  - Session token detection: API-flow tokens (`ory_st_*` prefix) now use the `X-Session-Token` header on Kratos requests; browser cookies still use the `Cookie` header (auto-detected by prefix).
+  Operators upgrading: pull the new image; `kratos-migrate` handles schema migrations automatically. Direct callers of vibewarden's admin adapter are unaffected — the breaking changes are absorbed inside the adapter.
 - **chore(#1316): publish `llms-full.txt`, `llms.txt`, and `vibewarden.reference.yaml` as GitHub Release assets.** The website (vibewarden.dev) will fetch these at build time, eliminating the silent drift that bit v0.18.7. Mirrors the ADR-101 pattern already used for `agent-kickoff-{dev,deploy}.txt`. A new architecture invariant test (`test/architecture/release_assets_test.go`) fails the build if any of these files is absent or empty from the repo root.
 
 ### Removed

--- a/dev/kratos/kratos.yml
+++ b/dev/kratos/kratos.yml
@@ -13,7 +13,7 @@
 # hostname, but it can reach localhost:8080 which is the published VibeWarden
 # port.
 
-version: v1.3.1
+version: v26.2.0
 
 # DSN is overridden by the DSN environment variable in docker-compose.yml.
 # "memory" is the fallback for non-Docker usage (e.g. testcontainers tests).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
   # Kratos migrate — runs DB migrations once, then exits (service_completed_successfully)
   # --------------------------------------------------------------------------
   kratos-migrate:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     container_name: vibewarden-kratos-migrate
     environment:
       DSN: postgres://vibewarden:vibewarden@postgres:5432/vibewarden?sslmode=disable
@@ -75,7 +75,7 @@ services:
   # that the browser redirects go through the sidecar as the proxy.
   # --------------------------------------------------------------------------
   kratos:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     container_name: vibewarden-kratos
     environment:
       # DSN is overridden here; the kratos.yml carries a fallback of "memory"

--- a/docs/examples/django.md
+++ b/docs/examples/django.md
@@ -148,7 +148,7 @@ services:
       retries: 10
 
   kratos-migrate:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     container_name: myapp-kratos-migrate
     restart: on-failure
     environment:
@@ -163,7 +163,7 @@ services:
       - myapp
 
   kratos:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     container_name: myapp-kratos
     restart: unless-stopped
     environment:

--- a/docs/examples/express.md
+++ b/docs/examples/express.md
@@ -128,7 +128,7 @@ services:
       retries: 10
 
   kratos-migrate:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     container_name: myapp-kratos-migrate
     restart: on-failure
     environment:
@@ -143,7 +143,7 @@ services:
       - myapp
 
   kratos:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     container_name: myapp-kratos
     restart: unless-stopped
     environment:

--- a/docs/examples/nextjs.md
+++ b/docs/examples/nextjs.md
@@ -135,7 +135,7 @@ services:
       retries: 10
 
   kratos-migrate:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     container_name: myapp-kratos-migrate
     restart: on-failure
     environment:
@@ -150,7 +150,7 @@ services:
       - myapp
 
   kratos:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     container_name: myapp-kratos
     restart: unless-stopped
     environment:

--- a/docs/examples/rails.md
+++ b/docs/examples/rails.md
@@ -150,7 +150,7 @@ services:
       retries: 10
 
   kratos-migrate:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     container_name: myapp-kratos-migrate
     restart: on-failure
     environment:
@@ -165,7 +165,7 @@ services:
       - myapp
 
   kratos:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     container_name: myapp-kratos
     restart: unless-stopped
     environment:

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -57,7 +57,7 @@ services:
       retries: 10
 
   kratos-migrate:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     environment:
       DSN: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
     command: migrate sql -e --yes
@@ -66,7 +66,7 @@ services:
         condition: service_healthy
 
   kratos:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     environment:
       DSN: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
     depends_on:
@@ -126,13 +126,13 @@ services:
   # No local postgres service.
 
   kratos-migrate:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     environment:
       DSN: ${VIBEWARDEN_DATABASE_EXTERNAL_URL}
     command: migrate sql -e --yes
 
   kratos:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     environment:
       DSN: ${VIBEWARDEN_DATABASE_EXTERNAL_URL}
 ```

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -96,7 +96,7 @@ services:
       retries: 10
 
   kratos-migrate:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     container_name: myapp-kratos-migrate
     restart: on-failure
     environment:
@@ -111,7 +111,7 @@ services:
       - myapp
 
   kratos:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     container_name: myapp-kratos
     restart: unless-stopped
     environment:
@@ -308,7 +308,7 @@ Create `config/kratos/identity.schema.json`:
 Create `config/kratos/kratos.yml`:
 
 ```yaml
-version: v1.3.1
+version: v26.2.0
 
 dsn: memory   # overridden by DSN env var
 

--- a/internal/adapters/kratos/adapter.go
+++ b/internal/adapters/kratos/adapter.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/vibewarden/vibewarden/internal/domain/identity"
@@ -132,9 +133,13 @@ func (a *Adapter) Authenticate(ctx context.Context, r *http.Request) identity.Au
 	return identity.Success(ident)
 }
 
-// CheckSession calls the Kratos GET /sessions/whoami endpoint, passing the
-// session cookie in the Cookie request header, and maps the response to a
-// ports.Session. It is used internally by Authenticate.
+// CheckSession calls the Kratos GET /sessions/whoami endpoint and maps the
+// response to a ports.Session. It is used internally by Authenticate.
+//
+// sessionCookie can be either a cookie pair ("ory_kratos_session=<value>",
+// used by browser flows) or a raw API session token ("ory_st_*", used by
+// API flows). Kratos v25+ uses X-Session-Token for API tokens; cookie format
+// is used for browser sessions. The format is detected automatically.
 //
 // TODO(#1106): remove once no external caller depends on this method.
 //
@@ -153,8 +158,15 @@ func (a *Adapter) CheckSession(ctx context.Context, sessionCookie string) (*port
 	if err != nil {
 		return nil, fmt.Errorf("building whoami request: %w", err)
 	}
-	req.Header.Set("Cookie", sessionCookie)
 	req.Header.Set("Accept", "application/json")
+	// Detect whether the caller provided a cookie pair ("name=value") or a raw
+	// API session token. Kratos v25+ API tokens start with "ory_st_" and must
+	// be sent via X-Session-Token; browser session cookies use the Cookie header.
+	if strings.HasPrefix(sessionCookie, "ory_st_") {
+		req.Header.Set("X-Session-Token", sessionCookie)
+	} else {
+		req.Header.Set("Cookie", sessionCookie)
+	}
 
 	resp, err := a.client.Do(req)
 	if err != nil {

--- a/internal/adapters/kratos/adapter_integration_test.go
+++ b/internal/adapters/kratos/adapter_integration_test.go
@@ -16,53 +16,25 @@ import (
 	"time"
 
 	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/network"
 	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
-// startPostgres starts a Postgres container and returns the DSN.
-func startPostgres(ctx context.Context, t *testing.T) string {
-	t.Helper()
+// kratosImage is the Kratos container image used across all integration tests.
+const kratosImage = "oryd/kratos:v26.2.0"
 
-	pgContainer, err := postgres.Run(ctx,
-		"postgres:16-alpine",
-		postgres.WithDatabase("kratos"),
-		postgres.WithUsername("kratos"),
-		postgres.WithPassword("kratos"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(60*time.Second),
-		),
-	)
-	if err != nil {
-		t.Fatalf("starting postgres container: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := pgContainer.Terminate(ctx); err != nil {
-			t.Logf("terminating postgres container: %v", err)
-		}
-	})
+// kratosNetworkDSN is the network-internal Postgres DSN used by Kratos
+// containers when all services share the same Docker network.
+const kratosNetworkDSN = "postgres://kratos:kratos@postgres:5432/kratos?sslmode=disable"
 
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("getting postgres connection string: %v", err)
-	}
-
-	return connStr
-}
-
-// startKratos starts a Kratos container pointing at the given Postgres DSN.
-// Returns the Kratos public API base URL.
-func startKratos(ctx context.Context, t *testing.T, pgDSN string) string {
-	t.Helper()
-
-	// Minimal Kratos configuration using an in-memory database so we can
-	// avoid mounting files. In integration tests we override with env vars.
-	kratosConfig := `
-version: v1.3.0
+// kratosConfigYAML returns the minimal Kratos YAML configuration used by
+// integration tests. pgDSN is the DSN reachable from inside the Docker
+// network (i.e. the container-internal address, not the host-mapped port).
+func kratosConfigYAML(pgDSN string) string {
+	return `
+version: v26.2.0
 
 dsn: ` + pgDSN + `
 
@@ -108,9 +80,125 @@ courier:
   smtp:
     connection_uri: smtp://test:test@localhost:25/?skip_ssl_verify=true
 `
+}
+
+// testNetwork creates a named Docker network for a single test and registers
+// cleanup. Returns the network name.
+func testNetwork(ctx context.Context, t *testing.T) string {
+	t.Helper()
+
+	net, err := network.New(ctx)
+	if err != nil {
+		t.Fatalf("creating docker network: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := net.Remove(ctx); err != nil {
+			t.Logf("removing docker network: %v", err)
+		}
+	})
+	return net.Name
+}
+
+// startPostgres starts a Postgres container on the given Docker network with
+// the alias "postgres" so that Kratos containers on the same network can reach
+// it via hostname. Returns the network name (same as input) for convenience.
+func startPostgres(ctx context.Context, t *testing.T, netName string) {
+	t.Helper()
 
 	req := testcontainers.ContainerRequest{
-		Image:        "oryd/kratos:v1.3.0",
+		Image: "postgres:16-alpine",
+		Env: map[string]string{
+			"POSTGRES_DB":       "kratos",
+			"POSTGRES_USER":     "kratos",
+			"POSTGRES_PASSWORD": "kratos",
+		},
+		Networks: []string{netName},
+		NetworkAliases: map[string][]string{
+			netName: {"postgres"},
+		},
+		WaitingFor: wait.ForLog("database system is ready to accept connections").
+			WithOccurrence(2).
+			WithStartupTimeout(60 * time.Second),
+	}
+
+	pgContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatalf("starting postgres container: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := pgContainer.Terminate(ctx); err != nil {
+			t.Logf("terminating postgres container: %v", err)
+		}
+	})
+}
+
+// migrateKratos runs a one-shot Kratos migrate container on the given Docker
+// network and waits for it to exit. Must be called after startPostgres.
+//
+// v26.2.0 ships 338 SQL migrations. Running them inline during serve startup
+// (which Kratos does in --dev mode when the schema is absent) exceeds the
+// 120-second container readiness timeout. Running migrate as a dedicated step
+// — matching the docker-compose.yml pattern — keeps the serve container fast.
+func migrateKratos(ctx context.Context, t *testing.T, netName string) {
+	t.Helper()
+
+	cfg := kratosConfigYAML(kratosNetworkDSN)
+	req := testcontainers.ContainerRequest{
+		Image:    kratosImage,
+		Networks: []string{netName},
+		Env:      map[string]string{"DSN": kratosNetworkDSN},
+		Cmd:      []string{"migrate", "sql", "-e", "--yes"},
+		Files: []testcontainers.ContainerFile{
+			{
+				Reader:            strings.NewReader(cfg),
+				ContainerFilePath: "/etc/kratos/kratos.yml",
+				FileMode:          0o644,
+			},
+		},
+		WaitingFor: wait.ForExit().WithExitTimeout(180 * time.Second),
+	}
+
+	migrateContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatalf("starting kratos migrate container: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := migrateContainer.Terminate(ctx); err != nil {
+			t.Logf("terminating kratos migrate container: %v", err)
+		}
+	})
+}
+
+// kratosURLs holds the mapped public and admin base URLs for a running
+// Kratos container. Defined here (not in admin_integration_test.go) so both
+// test files share the same type.
+type kratosURLs struct {
+	public string
+	admin  string
+}
+
+// startKratos starts a Kratos container on the given Docker network.
+// Returns the host-accessible public and admin API base URLs. Runs database
+// migrations via a separate one-shot container before starting the serve
+// process so that startup is fast and the readiness check does not time out.
+func startKratos(ctx context.Context, t *testing.T, netName string) kratosURLs {
+	t.Helper()
+
+	// Run migrations before serving. v26.2.0 has 338 migrations; without this
+	// pre-migration step the serve startup exceeds the 120-second timeout.
+	migrateKratos(ctx, t, netName)
+
+	kratosConfig := kratosConfigYAML(kratosNetworkDSN)
+
+	req := testcontainers.ContainerRequest{
+		Image:        kratosImage,
+		Networks:     []string{netName},
 		ExposedPorts: []string{"4433/tcp", "4434/tcp"},
 		Env:          map[string]string{},
 		Cmd:          []string{"serve", "--config", "/etc/kratos/kratos.yml", "--dev", "--watch-courier"},
@@ -143,12 +231,19 @@ courier:
 	if err != nil {
 		t.Fatalf("getting kratos host: %v", err)
 	}
-	port, err := kratosContainer.MappedPort(ctx, "4433")
+	publicPort, err := kratosContainer.MappedPort(ctx, "4433")
 	if err != nil {
-		t.Fatalf("getting kratos mapped port: %v", err)
+		t.Fatalf("getting kratos public mapped port: %v", err)
+	}
+	adminPort, err := kratosContainer.MappedPort(ctx, "4434")
+	if err != nil {
+		t.Fatalf("getting kratos admin mapped port: %v", err)
 	}
 
-	return fmt.Sprintf("http://%s:%s", host, port.Port())
+	return kratosURLs{
+		public: fmt.Sprintf("http://%s:%s", host, publicPort.Port()),
+		admin:  fmt.Sprintf("http://%s:%s", host, adminPort.Port()),
+	}
 }
 
 // TestKratosAdapter_Integration_CheckSession_InvalidCookie verifies that the
@@ -157,10 +252,11 @@ courier:
 func TestKratosAdapter_Integration_CheckSession_InvalidCookie(t *testing.T) {
 	ctx := context.Background()
 
-	pgDSN := startPostgres(ctx, t)
-	kratosPublicURL := startKratos(ctx, t, pgDSN)
+	netName := testNetwork(ctx, t)
+	startPostgres(ctx, t, netName)
+	urls := startKratos(ctx, t, netName)
 
-	adapter := NewAdapter(kratosPublicURL, 10*time.Second, slog.Default())
+	adapter := NewAdapter(urls.public, 10*time.Second, slog.Default())
 
 	_, err := adapter.CheckSession(ctx, "ory_kratos_session=bogus-cookie-value")
 	if err == nil {
@@ -177,10 +273,11 @@ func TestKratosAdapter_Integration_CheckSession_InvalidCookie(t *testing.T) {
 func TestKratosAdapter_Integration_CheckSession_EmptyCookie(t *testing.T) {
 	ctx := context.Background()
 
-	pgDSN := startPostgres(ctx, t)
-	kratosPublicURL := startKratos(ctx, t, pgDSN)
+	netName := testNetwork(ctx, t)
+	startPostgres(ctx, t, netName)
+	urls := startKratos(ctx, t, netName)
 
-	adapter := NewAdapter(kratosPublicURL, 10*time.Second, slog.Default())
+	adapter := NewAdapter(urls.public, 10*time.Second, slog.Default())
 
 	_, err := adapter.CheckSession(ctx, "")
 	if err == nil {
@@ -198,20 +295,24 @@ func TestKratosAdapter_Integration_CheckSession_EmptyCookie(t *testing.T) {
 func TestKratosAdapter_Integration_CreateAndCheckSession(t *testing.T) {
 	ctx := context.Background()
 
-	pgDSN := startPostgres(ctx, t)
-	kratosPublicURL := startKratos(ctx, t, pgDSN)
+	netName := testNetwork(ctx, t)
+	startPostgres(ctx, t, netName)
+	urls := startKratos(ctx, t, netName)
 
-	// Derive admin URL from public URL (port 4434).
-	kratosAdminURL := deriveAdminURL(t, ctx, kratosPublicURL)
+	const (
+		testEmail    = "test@example.com"
+		testPassword = "test-password-123!"
+	)
 
-	// Create a test identity via the Kratos admin API.
-	identityID := createTestIdentity(t, ctx, kratosAdminURL, "test@example.com")
+	// Create a test identity with known password credentials via the admin API.
+	createTestIdentity(t, ctx, urls.admin, testEmail)
 
-	// Create a session for the identity via the Kratos admin API.
-	sessionCookie := createTestSession(t, ctx, kratosAdminURL, identityID)
+	// Obtain a session token via the self-service login flow.
+	// POST /admin/sessions was removed in Kratos v25; login is the only path.
+	sessionCookie := createTestSession(t, ctx, urls.public, testEmail, testPassword)
 
 	// Now validate the session using the adapter.
-	adapter := NewAdapter(kratosPublicURL, 10*time.Second, slog.Default())
+	adapter := NewAdapter(urls.public, 10*time.Second, slog.Default())
 
 	session, err := adapter.CheckSession(ctx, sessionCookie)
 	if err != nil {
@@ -232,31 +333,6 @@ func TestKratosAdapter_Integration_CreateAndCheckSession(t *testing.T) {
 // isSessionError reports whether the error is one of the expected session errors.
 func isSessionError(err error) bool {
 	return err == ports.ErrSessionInvalid || err == ports.ErrSessionNotFound
-}
-
-// deriveAdminURL converts a Kratos public URL to an admin URL.
-// In the container setup the admin port is 4434; we derive the mapped address
-// by querying the health endpoint on both ports.
-func deriveAdminURL(t *testing.T, ctx context.Context, publicURL string) string {
-	t.Helper()
-	// The testcontainers setup maps 4434/tcp to a random host port.
-	// We can't easily get that from here. For simplicity, derive it from
-	// the public URL by replacing the port. This works because our container
-	// setup uses the same host with consecutive mapped ports.
-	// In practice, integration tests accept that admin URL may not be reachable
-	// without port mapping; we skip identity/session creation if unavailable.
-	_ = ctx
-	// Replace the last port segment; this is best-effort for test purposes.
-	// If admin API is unreachable, skip the test.
-	adminURL := strings.Replace(publicURL, ":4433", ":4434", 1)
-	// Use a simple health probe to confirm reachability.
-	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Get(adminURL + "/health/ready")
-	if err != nil {
-		t.Skipf("Kratos admin API not reachable at %s: %v", adminURL, err)
-	}
-	resp.Body.Close()
-	return adminURL
 }
 
 // createTestIdentity creates a Kratos identity via the admin API and returns its ID.
@@ -304,42 +380,77 @@ func createTestIdentity(t *testing.T, ctx context.Context, adminURL, email strin
 	return result.ID
 }
 
-// createTestSession creates a Kratos session for the given identity ID via the
-// admin API, returning the session cookie string ready for use in HTTP requests.
-func createTestSession(t *testing.T, ctx context.Context, adminURL, identityID string) string {
+// createTestSession creates a Kratos session via the self-service login API flow
+// and returns the session token as a cookie string ready for use in HTTP requests.
+// The POST /admin/sessions endpoint was removed in Kratos v25; self-service login
+// is now the only programmatic path to obtain a session token.
+func createTestSession(t *testing.T, ctx context.Context, publicURL, email, password string) string {
 	t.Helper()
 
-	body := `{"identity_id": "` + identityID + `"}`
+	client := &http.Client{Timeout: 10 * time.Second}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		adminURL+"/admin/sessions",
-		strings.NewReader(body),
+	// Step 1: Initialise an API login flow.
+	initReq, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		publicURL+"/self-service/login/api", nil)
+	if err != nil {
+		t.Fatalf("building login flow init request: %v", err)
+	}
+
+	initResp, err := client.Do(initReq)
+	if err != nil {
+		t.Fatalf("initialising login flow: %v", err)
+	}
+	defer initResp.Body.Close()
+
+	if initResp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(initResp.Body)
+		t.Fatalf("login flow init status = %d, body = %s", initResp.StatusCode, b)
+	}
+
+	var flowResult struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(initResp.Body).Decode(&flowResult); err != nil {
+		t.Fatalf("decoding login flow response: %v", err)
+	}
+
+	// Step 2: Submit the login flow with password credentials.
+	submitBody := fmt.Sprintf(`{"method":"password","identifier":%q,"password":%q}`,
+		email, password)
+	submitReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		publicURL+"/self-service/login?flow="+flowResult.ID,
+		strings.NewReader(submitBody),
 	)
 	if err != nil {
-		t.Fatalf("building create session request: %v", err)
+		t.Fatalf("building login submit request: %v", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+	submitReq.Header.Set("Content-Type", "application/json")
+	submitReq.Header.Set("Accept", "application/json")
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
+	submitResp, err := client.Do(submitReq)
 	if err != nil {
-		t.Fatalf("creating session: %v", err)
+		t.Fatalf("submitting login flow: %v", err)
 	}
-	defer resp.Body.Close()
+	defer submitResp.Body.Close()
 
-	if resp.StatusCode != http.StatusCreated {
-		b, _ := io.ReadAll(resp.Body)
-		t.Fatalf("create session status = %d, body = %s", resp.StatusCode, b)
+	if submitResp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(submitResp.Body)
+		t.Fatalf("login submit status = %d, body = %s", submitResp.StatusCode, b)
 	}
 
-	var result struct {
+	var sessionResult struct {
 		SessionToken string `json:"session_token"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		t.Fatalf("decoding create session response: %v", err)
+	if err := json.NewDecoder(submitResp.Body).Decode(&sessionResult); err != nil {
+		t.Fatalf("decoding session response: %v", err)
 	}
 
-	// Return as a cookie string. Kratos also accepts the session token
-	// via the ory_kratos_session cookie.
-	return "ory_kratos_session=" + result.SessionToken
+	if sessionResult.SessionToken == "" {
+		t.Fatal("empty session_token in login response")
+	}
+
+	// Return the raw session token (ory_st_* prefix). CheckSession detects
+	// this prefix and uses X-Session-Token instead of Cookie, which is
+	// required for API-flow sessions in Kratos v25+.
+	return sessionResult.SessionToken
 }

--- a/internal/adapters/kratos/adapter_test.go
+++ b/internal/adapters/kratos/adapter_test.go
@@ -317,6 +317,68 @@ func TestCheckSession_MalformedJSONResponse(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// CheckSession — X-Session-Token vs Cookie routing (Kratos v25+)
+// ---------------------------------------------------------------------------
+
+// TestCheckSession_OrySessionToken verifies that tokens with the "ory_st_"
+// prefix are sent via X-Session-Token and NOT via the Cookie header. A
+// regression here would silently break all API-flow sessions on v25+.
+func TestCheckSession_OrySessionToken(t *testing.T) {
+	tests := []struct {
+		name         string
+		token        string
+		wantHeader   string
+		wantValue    string
+		unwantHeader string
+	}{
+		{
+			name:         "ory_st_ prefix uses X-Session-Token",
+			token:        "ory_st_abc123",
+			wantHeader:   "X-Session-Token",
+			wantValue:    "ory_st_abc123",
+			unwantHeader: "Cookie",
+		},
+		{
+			name:         "browser cookie uses Cookie header",
+			token:        "ory_kratos_session=some-browser-token",
+			wantHeader:   "Cookie",
+			wantValue:    "ory_kratos_session=some-browser-token",
+			unwantHeader: "X-Session-Token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				gotWantHeader   string
+				gotUnwantHeader string
+			)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotWantHeader = r.Header.Get(tt.wantHeader)
+				gotUnwantHeader = r.Header.Get(tt.unwantHeader)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(validSessionBody())
+			}))
+			defer srv.Close()
+
+			adapter := kratos.NewAdapter(srv.URL, 0, newTestLogger())
+			_, err := adapter.CheckSession(context.Background(), tt.token)
+			if err != nil {
+				t.Fatalf("CheckSession() error = %v, want nil", err)
+			}
+
+			if gotWantHeader != tt.wantValue {
+				t.Errorf("%s header = %q, want %q", tt.wantHeader, gotWantHeader, tt.wantValue)
+			}
+			if gotUnwantHeader != "" {
+				t.Errorf("%s header should be absent, got %q", tt.unwantHeader, gotUnwantHeader)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // IdentityProvider (Authenticate) tests
 // ---------------------------------------------------------------------------
 

--- a/internal/adapters/kratos/admin.go
+++ b/internal/adapters/kratos/admin.go
@@ -28,19 +28,24 @@ type kratosCreateIdentityRequest struct {
 	Traits   map[string]any `json:"traits"`
 }
 
-// kratosPatchIdentityRequest is the body sent to PATCH /admin/identities/:id.
-type kratosPatchIdentityRequest struct {
-	State string `json:"state"`
+// kratosPatchOp is a single JSON Patch operation as defined in RFC 6902.
+// Kratos v25+ requires JSON Patch format for PATCH /admin/identities/:id.
+type kratosPatchOp struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value"`
 }
 
-// kratosRecoveryLinkRequest is the body sent to POST /admin/recovery/link.
-type kratosRecoveryLinkRequest struct {
+// kratosRecoveryCodeRequest is the body sent to POST /admin/recovery/code.
+// This endpoint replaced POST /admin/recovery/link in Kratos v25.
+type kratosRecoveryCodeRequest struct {
 	IdentityID string `json:"identity_id"`
 }
 
-// kratosRecoveryLinkResponse mirrors the response from POST /admin/recovery/link.
-type kratosRecoveryLinkResponse struct {
+// kratosRecoveryCodeResponse mirrors the response from POST /admin/recovery/code.
+type kratosRecoveryCodeResponse struct {
 	RecoveryLink string `json:"recovery_link"`
+	RecoveryCode string `json:"recovery_code"`
 }
 
 // AdminAdapter implements ports.UserAdmin using the Ory Kratos admin API.
@@ -68,17 +73,22 @@ func NewAdminAdapter(adminURL string, timeout time.Duration, logger *slog.Logger
 
 // ListUsers implements ports.UserAdmin.
 // It calls GET /admin/identities with per_page and page query parameters.
+// Kratos v25+ uses 0-indexed pages; ports.Pagination.Page is 1-indexed, so
+// the adapter subtracts 1 before sending.
 func (a *AdminAdapter) ListUsers(ctx context.Context, pagination ports.Pagination) (*ports.PaginatedUsers, error) {
 	page := pagination.Page
 	if page < 1 {
 		page = 1
 	}
+	// Convert to 0-indexed page offset required by Kratos v25+.
+	kratosPage := page - 1
+
 	perPage := pagination.PerPage
 	if perPage < 1 {
 		perPage = 25
 	}
 
-	endpoint := fmt.Sprintf("%s/admin/identities?page=%d&per_page=%d", a.adminURL, page, perPage)
+	endpoint := fmt.Sprintf("%s/admin/identities?page=%d&per_page=%d", a.adminURL, kratosPage, perPage)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -148,7 +158,8 @@ func (a *AdminAdapter) GetUser(ctx context.Context, id string) (*user.User, erro
 
 // InviteUser implements ports.UserAdmin.
 // It calls POST /admin/identities to create the identity, then
-// POST /admin/recovery/link to obtain a one-time recovery link.
+// POST /admin/recovery/code to obtain a one-time recovery link.
+// The /admin/recovery/link endpoint was removed in Kratos v25.
 func (a *AdminAdapter) InviteUser(ctx context.Context, email string) (*ports.InviteResult, error) {
 	// Step 1: Create the identity.
 	createBody := kratosCreateIdentityRequest{
@@ -207,10 +218,14 @@ func (a *AdminAdapter) InviteUser(ctx context.Context, email string) (*ports.Inv
 }
 
 // DeactivateUser implements ports.UserAdmin.
-// It calls PATCH /admin/identities/:id with state=inactive.
+// It calls PATCH /admin/identities/:id with a JSON Patch payload (RFC 6902).
+// Kratos v25+ requires Content-Type: application/json-patch+json and a JSON
+// Patch array; the earlier plain-object body format returns 400.
 func (a *AdminAdapter) DeactivateUser(ctx context.Context, id string) error {
-	patchBody := kratosPatchIdentityRequest{State: "inactive"}
-	bodyBytes, err := json.Marshal(patchBody)
+	patchOps := []kratosPatchOp{
+		{Op: "replace", Path: "/state", Value: "inactive"},
+	}
+	bodyBytes, err := json.Marshal(patchOps)
 	if err != nil {
 		return fmt.Errorf("marshalling patch identity request: %w", err)
 	}
@@ -220,7 +235,7 @@ func (a *AdminAdapter) DeactivateUser(ctx context.Context, id string) error {
 	if err != nil {
 		return fmt.Errorf("building patch identity request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/json-patch+json")
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := a.client.Do(req)
@@ -240,39 +255,41 @@ func (a *AdminAdapter) DeactivateUser(ctx context.Context, id string) error {
 	return nil
 }
 
-// generateRecoveryLink calls POST /admin/recovery/link for the given identity ID
-// and returns the one-time link.
+// generateRecoveryLink calls POST /admin/recovery/code for the given identity
+// ID and returns the one-time recovery link. The /admin/recovery/link endpoint
+// was removed in Kratos v25; /admin/recovery/code is its replacement and
+// returns the same recovery_link field alongside a recovery_code.
 func (a *AdminAdapter) generateRecoveryLink(ctx context.Context, identityID string) (string, error) {
-	body := kratosRecoveryLinkRequest{IdentityID: identityID}
+	body := kratosRecoveryCodeRequest{IdentityID: identityID}
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
-		return "", fmt.Errorf("marshalling recovery link request: %w", err)
+		return "", fmt.Errorf("marshalling recovery code request: %w", err)
 	}
 
-	endpoint := fmt.Sprintf("%s/admin/recovery/link", a.adminURL)
+	endpoint := fmt.Sprintf("%s/admin/recovery/code", a.adminURL)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(bodyBytes))
 	if err != nil {
-		return "", fmt.Errorf("building recovery link request: %w", err)
+		return "", fmt.Errorf("building recovery code request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := a.client.Do(req)
 	if err != nil {
-		return "", a.wrapNetworkError(ctx, "recovery link", endpoint, err)
+		return "", a.wrapNetworkError(ctx, "recovery code", endpoint, err)
 	}
 	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // response body close error is not actionable
 
-	if err := a.checkAdminError(ctx, resp, "recovery link"); err != nil {
+	if err := a.checkAdminError(ctx, resp, "recovery code"); err != nil {
 		return "", err
 	}
 
-	var linkResp kratosRecoveryLinkResponse
-	if err := json.NewDecoder(resp.Body).Decode(&linkResp); err != nil {
-		return "", fmt.Errorf("decoding recovery link response: %w", err)
+	var codeResp kratosRecoveryCodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&codeResp); err != nil {
+		return "", fmt.Errorf("decoding recovery code response: %w", err)
 	}
 
-	return linkResp.RecoveryLink, nil
+	return codeResp.RecoveryLink, nil
 }
 
 // checkAdminError inspects resp.StatusCode and returns the appropriate sentinel

--- a/internal/adapters/kratos/admin_integration_test.go
+++ b/internal/adapters/kratos/admin_integration_test.go
@@ -20,71 +20,22 @@ import (
 	"github.com/vibewarden/vibewarden/internal/ports"
 )
 
-// kratosURLs holds the mapped public and admin base URLs for a running
-// Kratos container.
-type kratosURLs struct {
-	public string
-	admin  string
-}
-
-// startKratosWithAdmin starts a Kratos container connected to the given
-// Postgres DSN and returns both the public and admin API base URLs.
-// Port mapping is resolved from the container runtime so the URLs are always
-// correct regardless of host port assignment.
-func startKratosWithAdmin(ctx context.Context, t *testing.T, pgDSN string) kratosURLs {
+// startKratosWithAdmin starts a Kratos container on the given Docker network
+// and returns both the public and admin API base URLs. Database migrations are
+// run as a separate one-shot container before the serve container starts
+// (see migrateKratos in adapter_integration_test.go for rationale).
+func startKratosWithAdmin(ctx context.Context, t *testing.T, netName string) kratosURLs {
 	t.Helper()
 
-	kratosConfig := `
-version: v1.3.0
+	// Run migrations before serving to avoid startup timeout under v26.2.0's
+	// 338 SQL migrations.
+	migrateKratos(ctx, t, netName)
 
-dsn: ` + pgDSN + `
-
-serve:
-  public:
-    base_url: http://localhost:4433/
-  admin:
-    base_url: http://localhost:4434/
-
-selfservice:
-  default_browser_return_url: http://localhost:3000/
-  allowed_return_urls:
-    - http://localhost:3000
-
-  methods:
-    password:
-      enabled: true
-
-  flows:
-    registration:
-      enabled: true
-      ui_url: http://localhost:3000/auth/registration
-    login:
-      ui_url: http://localhost:3000/auth/login
-    logout:
-      after:
-        default_browser_return_url: http://localhost:3000/
-    verification:
-      enabled: false
-    recovery:
-      enabled: true
-      ui_url: http://localhost:3000/auth/recovery
-
-log:
-  level: error
-
-identity:
-  default_schema_id: default
-  schemas:
-    - id: default
-      url: base64://eyIkaWQiOiJodHRwczovL3NjaGVtYXMub3J5LnNoL3ByZXNldHMva3JhdG9zL3F1aWNrc3RhcnQvZW1haWwtcGFzc3dvcmQvaWRlbnRpdHkuc2NoZW1hLmpzb24iLCIkc2NoZW1hIjoiaHR0cDovL2pzb24tc2NoZW1hLm9yZy9kcmFmdC0wNy9zY2hlbWEjIiwidGl0bGUiOiJQZXJzb24iLCJ0eXBlIjoib2JqZWN0IiwicHJvcGVydGllcyI6eyJ0cmFpdHMiOnsidHlwZSI6Im9iamVjdCIsInByb3BlcnRpZXMiOnsiZW1haWwiOnsidHlwZSI6InN0cmluZyIsImZvcm1hdCI6ImVtYWlsIiwidGl0bGUiOiJFLU1haWwiLCJvcnkuc2gva3JhdG9zIjp7ImNyZWRlbnRpYWxzIjp7InBhc3N3b3JkIjp7ImlkZW50aWZpZXIiOnRydWV9fX19fX19fQ==
-
-courier:
-  smtp:
-    connection_uri: smtp://test:test@localhost:25/?skip_ssl_verify=true
-`
+	kratosConfig := kratosConfigYAML(kratosNetworkDSN)
 
 	req := testcontainers.ContainerRequest{
-		Image:        "oryd/kratos:v1.3.0",
+		Image:        kratosImage,
+		Networks:     []string{netName},
 		ExposedPorts: []string{"4433/tcp", "4434/tcp"},
 		Env:          map[string]string{},
 		Cmd:          []string{"serve", "--config", "/etc/kratos/kratos.yml", "--dev", "--watch-courier"},
@@ -139,8 +90,9 @@ courier:
 func TestAdminAdapter_Integration_ListUsers_ReturnsCreatedUsers(t *testing.T) {
 	ctx := context.Background()
 
-	pgDSN := startPostgres(ctx, t)
-	urls := startKratosWithAdmin(ctx, t, pgDSN)
+	netName := testNetwork(ctx, t)
+	startPostgres(ctx, t, netName)
+	urls := startKratosWithAdmin(ctx, t, netName)
 
 	adapter := NewAdminAdapter(urls.admin, 10*time.Second, slog.Default())
 
@@ -178,8 +130,9 @@ func TestAdminAdapter_Integration_ListUsers_ReturnsCreatedUsers(t *testing.T) {
 func TestAdminAdapter_Integration_GetUser_ByID(t *testing.T) {
 	ctx := context.Background()
 
-	pgDSN := startPostgres(ctx, t)
-	urls := startKratosWithAdmin(ctx, t, pgDSN)
+	netName := testNetwork(ctx, t)
+	startPostgres(ctx, t, netName)
+	urls := startKratosWithAdmin(ctx, t, netName)
 
 	adapter := NewAdminAdapter(urls.admin, 10*time.Second, slog.Default())
 
@@ -212,8 +165,9 @@ func TestAdminAdapter_Integration_GetUser_ByID(t *testing.T) {
 func TestAdminAdapter_Integration_InviteUser_CreatesIdentityInKratos(t *testing.T) {
 	ctx := context.Background()
 
-	pgDSN := startPostgres(ctx, t)
-	urls := startKratosWithAdmin(ctx, t, pgDSN)
+	netName := testNetwork(ctx, t)
+	startPostgres(ctx, t, netName)
+	urls := startKratosWithAdmin(ctx, t, netName)
 
 	adapter := NewAdminAdapter(urls.admin, 10*time.Second, slog.Default())
 
@@ -248,8 +202,9 @@ func TestAdminAdapter_Integration_InviteUser_CreatesIdentityInKratos(t *testing.
 func TestAdminAdapter_Integration_DeactivateUser_SetsStateInactive(t *testing.T) {
 	ctx := context.Background()
 
-	pgDSN := startPostgres(ctx, t)
-	urls := startKratosWithAdmin(ctx, t, pgDSN)
+	netName := testNetwork(ctx, t)
+	startPostgres(ctx, t, netName)
+	urls := startKratosWithAdmin(ctx, t, netName)
 
 	adapter := NewAdminAdapter(urls.admin, 10*time.Second, slog.Default())
 
@@ -288,8 +243,9 @@ func TestAdminAdapter_Integration_DeactivateUser_SetsStateInactive(t *testing.T)
 func TestAdminAdapter_Integration_GetUser_NonExistentID_ReturnsErrUserNotFound(t *testing.T) {
 	ctx := context.Background()
 
-	pgDSN := startPostgres(ctx, t)
-	urls := startKratosWithAdmin(ctx, t, pgDSN)
+	netName := testNetwork(ctx, t)
+	startPostgres(ctx, t, netName)
+	urls := startKratosWithAdmin(ctx, t, netName)
 
 	adapter := NewAdminAdapter(urls.admin, 10*time.Second, slog.Default())
 

--- a/internal/adapters/kratos/admin_test.go
+++ b/internal/adapters/kratos/admin_test.go
@@ -63,7 +63,8 @@ func TestAdminAdapter_ListUsers_Success(t *testing.T) {
 }
 
 func TestAdminAdapter_ListUsers_DefaultPagination(t *testing.T) {
-	// Verify that zero-value pagination is normalised to page=1 per_page=25.
+	// Verify that zero-value pagination sends page=0 (Kratos v25+ 0-indexed)
+	// and per_page=25 to the Kratos API.
 	var gotPage, gotPerPage string
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -79,8 +80,9 @@ func TestAdminAdapter_ListUsers_DefaultPagination(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListUsers() error = %v", err)
 	}
-	if gotPage != "1" {
-		t.Errorf("page = %q, want %q", gotPage, "1")
+	// Kratos v25+ uses 0-indexed pages; Pagination.Page=1 (normalised default) maps to page=0.
+	if gotPage != "0" {
+		t.Errorf("page = %q, want %q", gotPage, "0")
 	}
 	if gotPerPage != "25" {
 		t.Errorf("per_page = %q, want %q", gotPerPage, "25")
@@ -204,9 +206,10 @@ func TestAdminAdapter_InviteUser_Success(t *testing.T) {
 			w.WriteHeader(http.StatusCreated)
 			_ = json.NewEncoder(w).Encode(identityFixture(newID, "new@example.com", "active"))
 
-		case r.Method == http.MethodPost && r.URL.Path == "/admin/recovery/link":
+		case r.Method == http.MethodPost && r.URL.Path == "/admin/recovery/code":
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{"recovery_link": wantLink})
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"recovery_link": wantLink, "recovery_code": "123456"})
 
 		default:
 			http.NotFound(w, r)
@@ -243,7 +246,7 @@ func TestAdminAdapter_InviteUser_RecoveryLinkFailureIsNonFatal(t *testing.T) {
 			w.WriteHeader(http.StatusCreated)
 			_ = json.NewEncoder(w).Encode(identityFixture(newID, "fragile@example.com", "active"))
 
-		case r.Method == http.MethodPost && r.URL.Path == "/admin/recovery/link":
+		case r.Method == http.MethodPost && r.URL.Path == "/admin/recovery/code":
 			w.WriteHeader(http.StatusInternalServerError)
 
 		default:
@@ -307,13 +310,14 @@ func TestAdminAdapter_InviteUser_ServerError(t *testing.T) {
 func TestAdminAdapter_DeactivateUser_Success(t *testing.T) {
 	const identityID = "c1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
-	var gotMethod, gotPath string
-	var gotBody map[string]any
+	var gotMethod, gotPath, gotContentType string
+	var gotPatchOps []map[string]any
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
-		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		gotContentType = r.Header.Get("Content-Type")
+		_ = json.NewDecoder(r.Body).Decode(&gotPatchOps)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(identityFixture(identityID, "dave@example.com", "inactive"))
@@ -332,8 +336,20 @@ func TestAdminAdapter_DeactivateUser_Success(t *testing.T) {
 	if gotPath != "/admin/identities/"+identityID {
 		t.Errorf("path = %q, want /admin/identities/%s", gotPath, identityID)
 	}
-	if gotBody["state"] != "inactive" {
-		t.Errorf("body.state = %v, want \"inactive\"", gotBody["state"])
+	if gotContentType != "application/json-patch+json" {
+		t.Errorf("Content-Type = %q, want application/json-patch+json", gotContentType)
+	}
+	if len(gotPatchOps) != 1 {
+		t.Fatalf("patch ops count = %d, want 1", len(gotPatchOps))
+	}
+	if gotPatchOps[0]["op"] != "replace" {
+		t.Errorf("patch op = %q, want \"replace\"", gotPatchOps[0]["op"])
+	}
+	if gotPatchOps[0]["path"] != "/state" {
+		t.Errorf("patch path = %q, want \"/state\"", gotPatchOps[0]["path"])
+	}
+	if gotPatchOps[0]["value"] != "inactive" {
+		t.Errorf("patch value = %v, want \"inactive\"", gotPatchOps[0]["value"])
 	}
 }
 

--- a/internal/adapters/kratos/admin_test.go
+++ b/internal/adapters/kratos/admin_test.go
@@ -89,6 +89,49 @@ func TestAdminAdapter_ListUsers_DefaultPagination(t *testing.T) {
 	}
 }
 
+// TestAdminAdapter_ListUsers_PageOffset verifies the 0-indexed page translation
+// for several explicit page values. Caller-facing Page=N must produce Kratos
+// wire value page=N-1. This prevents a regression that reintroduces page=page.
+func TestAdminAdapter_ListUsers_PageOffset(t *testing.T) {
+	tests := []struct {
+		name        string
+		callerPage  int
+		callerPer   int
+		wantPage    string
+		wantPerPage string
+	}{
+		{"page 1 → wire 0", 1, 10, "0", "10"},
+		{"page 2 → wire 1", 2, 10, "1", "10"},
+		{"page 5 → wire 4", 5, 25, "4", "25"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPage, gotPerPage string
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPage = r.URL.Query().Get("page")
+				gotPerPage = r.URL.Query().Get("per_page")
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode([]map[string]any{})
+			}))
+			defer srv.Close()
+
+			adapter := kratos.NewAdminAdapter(srv.URL, 0, newTestLogger())
+			_, err := adapter.ListUsers(context.Background(), ports.Pagination{Page: tt.callerPage, PerPage: tt.callerPer})
+			if err != nil {
+				t.Fatalf("ListUsers() error = %v", err)
+			}
+			if gotPage != tt.wantPage {
+				t.Errorf("page = %q, want %q (caller Page=%d should map to wire page=%s)", gotPage, tt.wantPage, tt.callerPage, tt.wantPage)
+			}
+			if gotPerPage != tt.wantPerPage {
+				t.Errorf("per_page = %q, want %q", gotPerPage, tt.wantPerPage)
+			}
+		})
+	}
+}
+
 func TestAdminAdapter_ListUsers_ServerError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/app/ops/testdata/docker-compose.yml
+++ b/internal/app/ops/testdata/docker-compose.yml
@@ -9,6 +9,6 @@ services:
     ports:
       - "3000:3000"
   kratos:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     ports:
       - "4433:4433"

--- a/internal/config/templates/docker-compose.yml.tmpl
+++ b/internal/config/templates/docker-compose.yml.tmpl
@@ -166,7 +166,7 @@ services:
       retries: 10
 
   kratos-migrate:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     restart: "no"
     command: migrate sql -e --yes
     env_file:
@@ -183,7 +183,7 @@ services:
 {{- end }}
 
   kratos:
-    image: oryd/kratos:v1.3.1
+    image: oryd/kratos:v26.2.0
     restart: unless-stopped
     command: serve --config /etc/kratos/kratos.yml --dev
     env_file:

--- a/internal/config/templates/kratos.yml.tmpl
+++ b/internal/config/templates/kratos.yml.tmpl
@@ -2,7 +2,7 @@
 # Do not edit manually — re-run `vibewarden generate` to regenerate.
 # To customise, set overrides.kratos_config in vibewarden.yaml.
 
-version: v1.3.0
+version: v26.2.0
 
 # DSN is set via the DSN environment variable in docker-compose.yml.
 # Do not set it here — the env var takes precedence.


### PR DESCRIPTION
Closes #1290

## Summary

- Bumps `oryd/kratos` from `v1.3.1` to `v26.2.0` in `docker-compose.yml`, two templates, `dev/kratos/kratos.yml`, and integration tests
- Fixes three v25+ API breaking changes the architect flagged as discovered during testing:
  - `PATCH /admin/identities/:id` now requires JSON Patch (RFC 6902) with `Content-Type: application/json-patch+json` — plain object body returns 400
  - `POST /admin/recovery/link` removed; replaced with `POST /admin/recovery/code`
  - `GET /admin/identities` pagination switched to 0-indexed pages — `page=1&per_page=25` skipped the first 25 items, returning empty results
- `POST /admin/sessions` removed in v25; `TestKratosAdapter_Integration_CreateAndCheckSession` now uses the self-service login flow
- `CheckSession` updated to detect `ory_st_*` API session tokens and send them via `X-Session-Token` header instead of `Cookie`
- `startKratos` now returns both mapped public and admin ports, eliminating the broken string-replace `deriveAdminURL` helper
- Integration tests add a `migrateKratos` one-shot container to pre-run v26.2.0's 338 SQL migrations before serve startup (matching docker-compose.yml pattern)

## Test plan

- [ ] `make check` passes (unit tests, lint, build) — verified locally
- [ ] All 8 integration tests pass with `go test -tags integration ./internal/adapters/kratos/... -timeout 600s` — verified locally
- [ ] `docker-compose.yml` and both templates reference `oryd/kratos:v26.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)