### PR TITLE
fix(#1334): bundle — remove disable_mlock from generated openbao config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Fixed
 
+- **fix(#1334): bundle — remove `disable_mlock = false` from generated `openbao/config.hcl`.** OpenBao 2.2.0+ rejects this directive ("OpenBao has dropped support for mlock"). Every Linux deploy with `secrets.provider: openbao` (i.e., every default deploy) failed at startup. Surfaced by the v0.19 smoke test on demo.vibewarden.dev (Hetzner).
+
 - **fix(#1304): cap TLS retry loop at a hard iteration ceiling.** Previously the retry path spun 500K–750K iterations on persistent failure with no cap, observable in the exhaustion test (the `noSleep` test seam removes the natural pacing of `time.Sleep`). New `MaxIterations(budget, poll)` helper returns `floor(budget/poll) + 2` and gates both `runTLSRetry` and the boot-gap loop. Production iteration counts stay in the low tens (30s budget / 2s poll → 17 max). Returns `ErrTLSRetryExhausted` cleanly after the cap is hit.
 
 ### Added

--- a/internal/app/generate/service_test.go
+++ b/internal/app/generate/service_test.go
@@ -2244,8 +2244,9 @@ func TestGenerate_OpenBaoConfigHCL_GeneratedForProd(t *testing.T) {
 	if !bytes.Contains(data, []byte("api_addr")) {
 		t.Errorf("openbao/config.hcl missing api_addr: %s", data)
 	}
-	if !bytes.Contains(data, []byte("disable_mlock")) {
-		t.Errorf("openbao/config.hcl missing disable_mlock: %s", data)
+	// OpenBao 2.2.0+ rejects the disable_mlock directive entirely; it must not appear.
+	if bytes.Contains(data, []byte("disable_mlock")) {
+		t.Errorf("openbao/config.hcl must not contain disable_mlock: OpenBao 2.2.0+ rejects this directive: %s", data)
 	}
 }
 

--- a/internal/config/templates/openbao-config.hcl.tmpl
+++ b/internal/config/templates/openbao-config.hcl.tmpl
@@ -10,5 +10,4 @@ listener "tcp" {
   tls_disable = 1
 }
 
-disable_mlock = false
-api_addr      = "http://openbao:8200"
+api_addr = "http://openbao:8200"


### PR DESCRIPTION
Closes #1334

## Summary

- Removes `disable_mlock = false` from `internal/config/templates/openbao-config.hcl.tmpl`. OpenBao 2.2.0+ treats this directive as a fatal error and refuses to start: `"OpenBao has dropped support for mlock. Please remove the line "disable_mlock" = false from your config"`.
- Flips the `TestGenerate_OpenBaoConfigHCL_GeneratedForProd` assertion from must-contain to must-not-contain `disable_mlock` — this is the regression test per the artifact-test pattern.
- Adds CHANGELOG entry under `[Unreleased] ### Fixed`.

## Root cause

The directive was originally added to disable memory-locking (mlock) on Linux systems where the container lacks `IPC_LOCK`. OpenBao 2.2.0 removed mlock support entirely rather than deprecating it, so the config key is now unrecognised and causes a startup failure. Since the generated compose already adds the `IPC_LOCK` capability to the openbao service in prod mode, removing the directive has no production impact — mlock would have been enabled, not disabled.

## Test plan

- `go test -race -run TestGenerate_OpenBaoConfigHCL ./internal/app/generate/...` — passes; the not-contains assertion catches any future regression where the directive is reintroduced.
- `make check` — clean (gofmt, golangci-lint, build, full test suite, demo-app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)