### PR TITLE
docs(#1370): fix architecture.md + ai-log-schema.md drift (event types, health enum, Fleet, redis dir)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 - **Bump `golang.org/x/net` to v0.55.0 (GO-2026-5026) and `golang.org/x/crypto` to v0.52.0 (GO-2026-5018) — both HIGH-severity CVEs were reachable from our code.**
 
+### Documentation
+
+- **docs(#1370): fix four docs/code drift findings in `docs/architecture.md` and `docs/ai-log-schema.md`.**
+  - **A1:** Replaced the fabricated event-type table in `docs/architecture.md` (8 of 9 names were invented: `request.completed`, `auth.allowed`, `auth.blocked`, `rate_limit.blocked`, `waf.detected`, `waf.blocked`, `secret.injected`, `secret.fetch_failed`, `upstream.error`) with the real names emitted by `internal/domain/events/events.go`. Fixed the inline example event to use a canonical `auth.success` envelope (`severity`/`category`/`timestamp` instead of `level`/`time`).
+  - **A2:** Fixed `upstream.health_changed` state progression in `docs/ai-log-schema.md` from the incorrect `unknown → ok → failing` to the correct `unknown → healthy → unhealthy` (matching `internal/domain/health/health.go` and `schema/v1/event.json`).
+  - **A5:** Moved the Fleet plugin row out of the "Available plugins" table in `docs/architecture.md` into a clearly-labelled "Planned / Pro-tier (not yet implemented)" note. Fleet is a locked-decision roadmap item with no implementation in `internal/plugins/`.
+  - **A6:** Corrected the directory layout in `docs/architecture.md` — replaced non-existent `adapters/redis/` with `adapters/ratelimit/` (the actual location of the Redis rate-limit store: `internal/adapters/ratelimit/redis_adapter.go`).
+
 ### Changed
 
 - chore(lint): allow G124 in test files; reflect.Ptr → reflect.Pointer in internal/config

--- a/docs/ai-log-schema.md
+++ b/docs/ai-log-schema.md
@@ -356,7 +356,7 @@ Allowed `reason` values (v1 frozen set):
 |---|---|
 | `upstream.timeout` | Upstream did not respond within configured timeout; 504 returned. |
 | `upstream.retry` | Retry middleware re-sending a failed upstream request. |
-| `upstream.health_changed` | Upstream health status changed. States: `unknown` (boot gap) → `ok` → `failing`. |
+| `upstream.health_changed` | Upstream health status changed. States: `unknown` (boot gap) → `healthy` → `unhealthy`. |
 
 ### Circuit breaker (inbound)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,11 @@ plugin API.
 | Body size | `body_size` | Per-request body size enforcement |
 | Webhooks | `webhooks` | HMAC-signed audit event delivery |
 | Admin API | `admin` | User management endpoints |
-| Fleet | `fleet` | Pro tier telemetry bridge to `app.vibewarden.dev` |
+
+> **Planned / Pro-tier (not yet implemented):** The **Fleet** plugin (`fleet`) will
+> bridge telemetry to `app.vibewarden.dev` as the VibeWarden Pro tier feature.
+> It is a locked-decision roadmap item and is not available in the current binary.
+> See [CLAUDE.md locked decisions](../CLAUDE.md) for context.
 
 ---
 
@@ -127,7 +131,7 @@ internal/
     kratos/           # Ory Kratos adapter
     postgres/         # PostgreSQL adapter
     log/              # Log sink adapters (stdout, file, webhook)
-    redis/            # Redis rate-limit store adapter
+    ratelimit/        # Rate-limit store adapters (in-memory + Redis)
     openbao/          # OpenBao secrets adapter
 
   app/                # Application services (use cases)
@@ -194,16 +198,27 @@ Every security-relevant event produces a structured JSON log record:
 ```json
 {
   "schema_version": "v1",
-  "event_type": "request.completed",
-  "ai_summary": "GET /api/users 200 in 3ms",
-  "time": "2026-03-28T12:00:00Z",
-  "level": "INFO",
+  "event_type": "auth.success",
+  "timestamp": "2026-03-28T12:00:00Z",
+  "ai_summary": "Authenticated request allowed: GET /api/users (identity usr_abc123)",
+  "severity": "info",
+  "category": "auth",
+  "actor": {
+    "type": "user",
+    "id":   "usr_abc123",
+    "ip":   "203.0.113.42"
+  },
+  "resource": {
+    "type":   "http_endpoint",
+    "path":   "/api/users",
+    "method": "GET"
+  },
+  "outcome":      "allowed",
+  "triggered_by": "auth_middleware",
   "payload": {
-    "method": "GET",
-    "path": "/api/users",
-    "status_code": 200,
-    "duration_ms": 3,
-    "user_id": "usr_abc123"
+    "method":   "GET",
+    "path":     "/api/users",
+    "identity_id": "usr_abc123"
   }
 }
 ```
@@ -214,21 +229,27 @@ require a new `schema_version` value.
 
 ### Event types
 
+The table below lists the most commonly observed event types. For the full
+authoritative list — including payload schemas, severity levels, and example
+events — see [AI-Readable Log Schema](ai-log-schema.md).
+
 | Event type | Description |
 |------------|-------------|
-| `request.completed` | HTTP request forwarded to upstream and response returned |
-| `auth.allowed` | Authentication passed; user identity established |
-| `auth.blocked` | Authentication failed; request rejected |
-| `rate_limit.blocked` | Request blocked by rate limiter |
-| `rate_limit.store_fallback` | Redis unavailable; falling back to in-memory |
-| `rate_limit.store_recovered` | Redis recovered after a fallback |
-| `waf.detected` | WAF detected a suspicious pattern |
-| `waf.blocked` | WAF blocked a request |
-| `secret.injected` | Secret successfully injected into request headers |
-| `secret.fetch_failed` | Failed to fetch secret from OpenBao |
-| `upstream.error` | Upstream returned an error or was unreachable |
-| `circuit_breaker.opened` | Circuit breaker tripped to open state |
-| `circuit_breaker.closed` | Circuit breaker recovered to closed state |
+| `proxy.started` | Reverse proxy started and is ready to accept connections |
+| `auth.success` | Valid session or credential — request allowed through |
+| `auth.failed` | Missing, invalid, or expired credential — request rejected |
+| `rate_limit.hit` | Per-IP or per-user rate limit exceeded — request rejected |
+| `rate_limit.store_fallback` | Redis unavailable — rate limiter switched to in-memory store |
+| `rate_limit.store_recovered` | Redis available again — rate limiter switched back from in-memory |
+| `request.blocked` | Request blocked by a middleware policy (WAF, maintenance mode, etc.) |
+| `secret.rotated` | Dynamic secret rotated successfully |
+| `secret.rotation_failed` | Dynamic secret rotation failed; old credentials remain active |
+| `upstream.timeout` | Upstream did not respond within configured timeout; 504 returned |
+| `upstream.retry` | Retry middleware re-sending a failed upstream request |
+| `upstream.health_changed` | Upstream health status transitioned (unknown → healthy → unhealthy) |
+| `tls.certificate_issued` | TLS certificate obtained or renewed |
+| `config.reloaded` | Configuration reloaded and applied successfully |
+| `config.reload_failed` | Configuration reload failed; old config remains active |
 
 ### Log sinks
 


### PR DESCRIPTION
Closes #1370

## Summary

Four docs/code drift corrections found in the 2026-06-04 audit. All verified against canonical `internal/` source before writing.

- **A1 — event-type table rewritten** (`docs/architecture.md`): The previous table listed 8 invented event-type names (`request.completed`, `auth.allowed`, `auth.blocked`, `rate_limit.blocked`, `waf.detected`, `waf.blocked`, `secret.injected`, `secret.fetch_failed`, `upstream.error`) that do not exist in `internal/domain/events/events.go`. Replaced with the real names actually emitted by the codebase. The inline example event was also fixed to use the canonical envelope (`severity`/`category`/`timestamp`) instead of the non-canonical `level`/`time` fields.

- **A2 — upstream.health_changed enum corrected** (`docs/ai-log-schema.md:359`): Changed `unknown → ok → failing` to `unknown → healthy → unhealthy`, matching `internal/domain/health/health.go:27-34` (`StatusHealthy`/`StatusUnhealthy`) and `schema/v1/event.json`.

- **A5 — Fleet plugin moved to Planned note** (`docs/architecture.md:91`): Fleet was listed in the "Available plugins" table but `internal/plugins/` has no fleet directory. It is a locked-decision roadmap/Pro-tier item. Moved to a clearly-labelled "Planned / Pro-tier (not yet implemented)" callout block.

- **A6 — directory layout corrected** (`docs/architecture.md:130`): Replaced non-existent `adapters/redis/` with `adapters/ratelimit/` — the actual location of the Redis rate-limit store (`internal/adapters/ratelimit/redis_adapter.go` + `redis_factory.go`).

## Test plan

- [ ] `golangci-lint run ./...` — 0 issues
- [ ] `go build ./...` — succeeds
- [ ] `go test -race ./...` — all non-Docker tests pass (pre-existing Docker daemon unavailability causes `internal/adapters/postgres` and `internal/adapters/ratelimit` integration tests to fail on this machine; same failures exist on `main`)
- [ ] Every event-type name in the updated `docs/architecture.md` table verified against `internal/domain/events/events.go` via grep before writing

🤖 Generated with [Claude Code](https://claude.com/claude-code)