### PR TITLE
docs(#1372): fix secrets-backend, --profile demo, and missing add waf drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Documentation
 
+- **docs(#1372): fix three docs/code drift findings in `docs/index.md`, `README.md`, and `CHANGELOG.md` (audit P5, P7, P8).**
+  - **P5:** Secrets feature row in `docs/index.md` now reads "Built-in AES-256-GCM store (default) or OpenBao" — the default store is built-in (`internal/plugins/secrets/plugin.go:99`: `cfg.Store = "builtin"`), not OpenBao. Also updated the Comparison table (line 129) and the CLI table description for `vibew secret get` (line 152) to drop the OpenBao-only framing.
+  - **P7:** Removed non-existent `--profile demo` compose profile reference from `docs/index.md:81` and the historical `CHANGELOG.md` v0.17-era entry. Only the `observability` profile exists in `docker-compose.yml.tmpl`; the demo app starts via `vibew dev`.
+  - **P8:** Added `vibew add waf [--mode block|detect]` to CLI tables in both `README.md` and `docs/index.md`. Flag verified from `internal/cli/cmd/add_waf.go:59`: `cmd.Flags().StringVar(&mode, "mode", "detect", ...)`.
+
 - **docs(#1370): fix four docs/code drift findings in `docs/architecture.md` and `docs/ai-log-schema.md`.**
   - **A1:** Replaced the fabricated event-type table in `docs/architecture.md` (8 of 9 names were invented: `request.completed`, `auth.allowed`, `auth.blocked`, `rate_limit.blocked`, `waf.detected`, `waf.blocked`, `secret.injected`, `secret.fetch_failed`, `upstream.error`) with the real names emitted by `internal/domain/events/events.go`. Fixed the inline example event to use a canonical `auth.success` envelope (`severity`/`category`/`timestamp` instead of `level`/`time`).
   - **A2:** Fixed `upstream.health_changed` state progression in `docs/ai-log-schema.md` from the incorrect `unknown → ok → failing` to the correct `unknown → healthy → unhealthy` (matching `internal/domain/health/health.go` and `schema/v1/event.json`).
@@ -1075,7 +1080,7 @@ Single Go binary embedding Caddy. Zero-to-secure in minutes for vibe-coded apps.
   credential generation via `.env.template`
 - `vibewarden doctor` — pre-flight checks for config, TLS, and backend connectivity
 - `vibewarden secret get / list` — read secrets from OpenBao at runtime
-- Profile-based Docker Compose: `--profile observability`, `--profile demo`
+- Profile-based Docker Compose: `--profile observability`
 - Demo app with Vulnerability Lab (SQLi, XSS, path traversal, and more)
 - Production deployment guide, hardening checklist, and framework integration examples
 - Rate limiting at scale guide with annotated Redis config reference

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ features after the initial setup.
 | `vibew add rate-limiting` | Enable rate limiting |
 | `vibew add tls --domain app.yourcompany.com` | Enable TLS (use a domain you control; Let's Encrypt rejects `example.com`) |
 | `vibew add metrics` | Enable Prometheus metrics |
+| `vibew add waf [--mode block\|detect]` | Enable the Web Application Firewall (default mode: `detect`) |
 | `vibew add admin` | Enable admin API |
 | `vibew generate` | Regenerate `docker-compose.yml` from config |
 | `vibew build` | Build the Docker image for the app |

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,14 +71,14 @@ It is never hosted remotely.
 | Rate limiting | Token-bucket, per-IP and per-user; in-memory or Redis-backed |
 | WAF | Pattern detection for SQLi, XSS, path traversal; `block` or `detect` mode |
 | Security headers | HSTS, CSP, X-Frame-Options, Referrer-Policy, Permissions-Policy, CORS |
-| Secrets management | OpenBao (Apache 2.0 Vault fork) — inject secrets as headers or env vars |
+| Secrets management | Built-in AES-256-GCM store (default) or OpenBao — inject secrets as headers or env vars |
 | Egress proxy | Outbound HTTP with mTLS, circuit breaker, retry, SSRF protection, PII redaction |
 | Resilience | Circuit breaker, retry with jitter, timeout middleware, aggregate health endpoint |
 | Observability | Prometheus metrics, OpenTelemetry traces + logs, Grafana dashboards, Jaeger/Tempo |
 | AI-readable logs | Versioned JSON schema: `schema_version`, `event_type`, `ai_summary`, `payload` |
 | Audit log sinks | JSON file, OTel logs, webhook (HMAC-signed) with retry |
 | Admin API | User management at `/_vibewarden/admin/*` (bearer-token protected) |
-| Docker Compose | Profile-based: `vibew obs up` (observability), `--profile demo` |
+| Docker Compose | Profile-based: `vibew obs up` / `vibew obs down` (observability); demo app via `vibew dev` |
 
 ---
 
@@ -126,7 +126,7 @@ On public paths, these headers are present when the visitor has a valid session 
 | Setup time | 3 commands | Hours of config | Moderate | Minutes |
 | Auth out of the box | Yes (OIDC, Kratos, API key) | No | Partial (forward auth only) | No |
 | WAF | Yes | Paid (NGINX Plus) | No | Paid (Cloudflare WAF) |
-| Secrets management | Yes (OpenBao) | No | No | No |
+| Secrets management | Yes (built-in or OpenBao) | No | No | No |
 | AI-readable audit logs | Yes (versioned schema) | No | No | No |
 | Egress proxy + SSRF guard | Yes | No | No | No |
 | Self-hosted | Yes | Yes | Yes | No |
@@ -144,12 +144,13 @@ On public paths, these headers are present when the visitor has a valid session 
 | `vibew add rate-limiting` | Enable rate limiting |
 | `vibew add tls --domain app.yourcompany.com` | Enable TLS (use a domain you control; Let's Encrypt rejects `example.com`) |
 | `vibew add metrics` | Enable Prometheus metrics |
+| `vibew add waf [--mode block\|detect]` | Enable the Web Application Firewall (default mode: `detect`) |
 | `vibew generate` | Regenerate `docker-compose.yml` from config |
 | `vibew dev` | Start local dev environment |
 | `vibew status` | Show health of all components |
 | `vibew doctor` | Diagnose common issues |
 | `vibew logs` | Pretty-print structured logs |
-| `vibew secret get <alias-or-path>` | Read a secret from OpenBao |
+| `vibew secret get <alias-or-path>` | Read a secret from the configured store (built-in or OpenBao) |
 | `vibew secret list` | List all managed secret paths |
 | `vibew token` | Generate a signed dev JWT for local testing |
 | `vibew cert export` | Export the local CA certificate (for curl, Postman, …) |


### PR DESCRIPTION
Closes #1372

## Summary

- **P5 (secrets row):** `docs/index.md` feature table (line 74) now reads "Built-in AES-256-GCM store (default) or OpenBao — inject secrets as headers or env vars". Comparison table (line 129) updated from "Yes (OpenBao)" → "Yes (built-in or OpenBao)". CLI table description for `vibew secret get` (line 152) updated from "Read a secret from OpenBao" → "Read a secret from the configured store (built-in or OpenBao)". All verified against `internal/plugins/secrets/plugin.go:99` (`cfg.Store = "builtin"`) and `internal/cli/cmd/secret_get.go:98`.
- **P7 (--profile demo):** Removed non-existent `--profile demo` from `docs/index.md:81` and the historical CHANGELOG entry (v0.17-era line ~1080). Only the `observability` profile exists in `internal/config/templates/docker-compose.yml.tmpl`. The demo app starts via `vibew dev`, not a compose profile.
- **P8 (vibew add waf):** Added `vibew add waf [--mode block|detect]` to CLI tables in both `README.md` (~line 305) and `docs/index.md` (~line 147). Flag signature confirmed from `internal/cli/cmd/add_waf.go:59`: `cmd.Flags().StringVar(&mode, "mode", "detect", ...)`.

## Test plan

- [ ] `make check` passes (confirmed locally — all 54 test packages pass)
- [ ] `docs/index.md`: grep for "OpenBao" confirms no rows imply OpenBao-only for secrets
- [ ] `docs/index.md` and `README.md`: grep for "add waf" confirms both tables include the command
- [ ] No reference to `--profile demo` remains in docs or CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)