### PR TITLE
fix(#1371): remove phantom NameGrafana constant and fix plugin-activation docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ### Documentation
 
-- **fix(#1371): remove phantom `NameGrafana` domain constant and fix plugin-activation docs.** Grafana is a Docker Compose service in the `observability` profile, not a plugin. The unused `NameGrafana = "grafana"` constant has been removed from `internal/domain/plugin/names.go`. The `CLAUDE.md` "Plugin model" section and `names.go` godoc now describe the real flat top-level key activation model (no `plugins:` wrapper — the strict loader rejects unknown top-level keys). `internal/plugins/usermgmt/config.go` godoc now names the actual source keys (`admin.enabled`, `admin.token`, `kratos.admin_url`, `database.url`). `NameFleet` kept as reserved roadmap placeholder per locked decision. ADR-105.
+- **fix(#1371): remove phantom `NameGrafana` domain constant and fix plugin-activation docs.** Grafana is a Docker Compose service in the `observability` profile, not a plugin. The unused `NameGrafana = "grafana"` constant has been removed from `internal/domain/plugin/names.go`. The `CLAUDE.md` "Plugin model" section and `names.go` godoc now describe the real flat top-level key activation model (no `plugins:` wrapper — the strict loader rejects unknown top-level keys). `internal/plugins/usermgmt/config.go` godoc now names the actual source keys (`admin.enabled`, `admin.token`, `kratos.admin_url`, `database.url`). `NameFleet` kept as reserved roadmap placeholder per locked decision. ADR-105. Also fixed residual `plugins:` wrapper drift in `docs/identity-providers.md` and `docs/websockets.md` runnable examples — both now use real flat top-level keys (`admin:`, `database:`, `rate_limit:`) that pass `vibew validate`.
 
 ## [v0.19.0] — 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 - chore(lint): allow G124 in test files; reflect.Ptr → reflect.Pointer in internal/config
 
+### Documentation
+
+- **fix(#1371): remove phantom `NameGrafana` domain constant and fix plugin-activation docs.** Grafana is a Docker Compose service in the `observability` profile, not a plugin. The unused `NameGrafana = "grafana"` constant has been removed from `internal/domain/plugin/names.go`. The `CLAUDE.md` "Plugin model" section and `names.go` godoc now describe the real flat top-level key activation model (no `plugins:` wrapper — the strict loader rejects unknown top-level keys). `internal/plugins/usermgmt/config.go` godoc now names the actual source keys (`admin.enabled`, `admin.token`, `kratos.admin_url`, `database.url`). `NameFleet` kept as reserved roadmap placeholder per locked decision. ADR-105.
+
 ## [v0.19.0] — 2026-05-07
 
 Theme: audit-driven stabilization. Closes the 2026-05-03 cross-cutting audit (15 critical+high findings) plus 8 follow-up bugs surfaced by 4 smoke tests against demo.vibewarden.dev. Two breaking changes — see Migration below.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,30 +39,41 @@ Target: vibe coders who need zero-to-secure in minutes.
 
 ## Plugin model
 
-All plugins ship inside the official binary. Users activate them in `vibewarden.yaml`:
+All plugins ship inside the official binary. Activation is via **flat top-level keys**
+in `vibewarden.yaml` — there is no `plugins:` wrapper. The strict loader (`vibew validate`
+/ `vibew bundle`) rejects any unknown top-level key, so each block below must match the
+real schema. See `vibewarden.reference.yaml` for the full annotated reference.
 
 ```yaml
-plugins:
-  tls:
-    enabled: true
-    provider: letsencrypt   # or: external (Cloudflare, registrar, etc.), self-signed (dev)
-  user-management:
-    enabled: true
-    adapter: postgres
-  rate-limiting:
-    enabled: true
-  grafana:
-    enabled: false
-  fleet:
-    enabled: false          # opt-in: send telemetry to app.vibewarden.dev (Pro feature)
-    endpoint: https://app.vibewarden.dev
-    api_key: ${VIBEWARDEN_FLEET_KEY}
+tls:
+  enabled: true
+  provider: letsencrypt   # or: zerossl, buypass, self-signed, external (Cloudflare/registrar/ACM)
+
+# User management (admin API + Ory Kratos). Activated by admin.enabled;
+# it reads kratos.admin_url and database.url.
+admin:
+  enabled: true
+  token: ${VIBEWARDEN_ADMIN_TOKEN}
+kratos:
+  admin_url: http://127.0.0.1:4434
+database:
+  url: postgres://<user>:<pass>@localhost:5432/vibewarden?sslmode=disable
+
+rate_limit:
+  enabled: true
+
+# Grafana is NOT a plugin — it is a Docker Compose service under the
+# "observability" profile, switched on by observability.enabled.
+observability:
+  enabled: false
 ```
 
 `provider: external` is the escape hatch for users who already manage TLS via Cloudflare,
 their domain registrar, AWS ACM, etc.
 
-`fleet` plugin is the bridge to the Pro tier — always opt-in, never on by default.
+Fleet (the bridge to the Pro tier) is a **reserved roadmap item**, not yet a loadable
+config plugin. The only current surface is `vibew secret generate --fleet-key`, which
+emits a `VIBEWARDEN_FLEET_KEY` for future use. It will never be on by default.
 
 ---
 

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -91,6 +91,7 @@ Results applied 2026-05-04:
 | [102](adr-102-vibew-probe-go-stdlib-health-probe-and-env-resolver.md) | `vibew probe [--env <name>]` — Go-stdlib HTTPS probe of `/_vibewarden/health` and a generalisable env-resolver | #1233 | |
 | [103](adr-103-wire-api-key-auth-mode-into-caddy-handler-chain.md) | Wire `api-key` auth mode into Caddy handler chain | #1302 | |
 | [104](adr-104-openbao-prod-init-unseal-via-seed-secrets.md) | OpenBao prod init+unseal via seed-secrets init container | #1345 | |
+| [105](adr-105-remove-grafana-plugin-name-constant.md) | Remove unused grafana plugin-name constant; grafana is a compose service | #1371 | |
 | [497](adr-497-graceful-shutdown-connection-draining.md) | Graceful Shutdown / Connection Draining | — | Removed 2026-05-04 — see tombstone (anomalous number, paste of issue #497) |
 
 ## Numbering

--- a/decisions/adr-105-remove-grafana-plugin-name-constant.md
+++ b/decisions/adr-105-remove-grafana-plugin-name-constant.md
@@ -1,0 +1,72 @@
+# ADR-105: Remove unused grafana plugin-name constant; grafana is a compose service
+
+**Date**: 2026-06-05
+**Issue**: [#1371](https://github.com/vibewarden/vibewarden/issues/1371)
+**Status**: Accepted
+
+---
+
+## Context
+
+`internal/domain/plugin/names.go` defined a `NameGrafana = "grafana"` constant
+alongside the other well-known plugin-name constants (`NameTLS`, `NameUserManagement`,
+`NameRateLimiting`, `NameFleet`).
+
+Grafana is not a plugin. It is a Docker Compose service in the `observability` profile,
+gated by `observability.enabled` in `vibewarden.yaml`. It has no plugin lifecycle, no
+`Plugin` interface implementation, and no entry in the plugin registry
+(`internal/plugins/builtin.go`). The constant was unused in all production code — the
+only reference was in the test file that asserted the constant was non-empty.
+
+Simultaneously, `CLAUDE.md`'s "Plugin model" section showed a fictional `plugins:`
+wrapper block with a `grafana: enabled: false` entry. The strict loader
+(`internal/config/strict.go`) rejects any unknown top-level key, so this example would
+fail validation if copied verbatim. It also showed a `fleet:` entry as a loadable
+config plugin, which is not implemented. This phantom documentation taught LLM agents
+and human contributors an incorrect model of how plugin activation works.
+
+The real activation surface is flat top-level keys: `tls:`, `admin:` + `kratos:` +
+`database:` for user management, `rate_limit:`, `observability:`, etc. Verified against
+`internal/config/config.go:14-143` and `vibewarden.reference.yaml`.
+
+### What about `NameFleet`?
+
+`NameFleet` is also unused in production code but is kept. Fleet is a locked decision
+("fleet is the bridge to the Pro tier" — CLAUDE.md Locked decisions table). It is a
+deliberate roadmap placeholder and must not be removed without a new ADR that explicitly
+revisits that locked decision. The constant is annotated as reserved/roadmap.
+
+---
+
+## Decision
+
+1. **Remove `NameGrafana`** from `internal/domain/plugin/names.go`. Grafana is delivered
+   as a compose service, never as a plugin. A `plugin.Name` constant for a non-plugin
+   entity is a domain-model lie that causes downstream drift.
+
+2. **Keep `NameFleet`**, annotated with a comment marking it as a reserved roadmap
+   placeholder per the locked decision in CLAUDE.md.
+
+3. **Update the package godoc** in `names.go` to describe the real flat top-level key
+   activation model instead of the phantom `plugins:` wrapper.
+
+4. **Update `CLAUDE.md` "Plugin model" section** to show the real flat-key activation
+   pattern, cross-checked against `vibewarden.reference.yaml`. The "Locked decisions"
+   table is not modified.
+
+5. **Update `internal/plugins/usermgmt/config.go`** godoc to name the real source keys
+   (`admin.enabled`, `admin.token`, `kratos.admin_url`, `database.url`) instead of the
+   phantom `plugins.user-management` section.
+
+6. **Drop `plugin.NameGrafana` from `names_test.go`** so the test compiles and passes.
+
+---
+
+## Consequences
+
+- The domain model accurately reflects reality: grafana is a compose service, not a plugin.
+- LLM agents reading `CLAUDE.md` or `names.go` will no longer be taught a config
+  shape that fails strict validation.
+- No production behaviour changes — the constant was never loaded or evaluated at runtime.
+- `NameFleet` remains as a reserved placeholder; its removal is deferred until the Pro-tier
+  fleet roadmap decision is revisited.

--- a/docs/identity-providers.md
+++ b/docs/identity-providers.md
@@ -529,10 +529,12 @@ kratos:
   admin_url: "http://127.0.0.1:4434"
   # external: false  — VibeWarden starts Kratos for you (default)
 
-plugins:
-  user-management:
-    enabled: true
-    adapter: postgres
+admin:
+  enabled: true
+  token: ${VIBEWARDEN_ADMIN_TOKEN}
+
+database:
+  url: postgres://<user>:<pass>@localhost:5432/vibewarden?sslmode=disable
 ```
 
 No cloud accounts, no API keys, no internet access required.

--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -77,11 +77,15 @@ No special configuration is needed. A standard reverse-proxy setup works:
 upstream:
   url: "http://localhost:3000"
 
-plugins:
-  rate-limiting:
-    enabled: true
-  user-management:
-    enabled: true
+rate_limit:
+  enabled: true
+
+admin:
+  enabled: true
+  token: ${VIBEWARDEN_ADMIN_TOKEN}
+
+database:
+  url: postgres://<user>:<pass>@localhost:5432/vibewarden?sslmode=disable
 ```
 
 With the config above, WebSocket connections to VibeWarden are automatically

--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -84,6 +84,9 @@ admin:
   enabled: true
   token: ${VIBEWARDEN_ADMIN_TOKEN}
 
+kratos:
+  admin_url: http://127.0.0.1:4434
+
 database:
   url: postgres://<user>:<pass>@localhost:5432/vibewarden?sslmode=disable
 ```

--- a/internal/domain/plugin/names.go
+++ b/internal/domain/plugin/names.go
@@ -21,12 +21,18 @@ func NewName(name string) (Name, error) {
 // String returns the string representation of the plugin name.
 func (n Name) String() string { return n.value }
 
-// Well-known plugin name constants. These are the canonical identifiers
-// used in vibewarden.yaml under the plugins: key.
+// Well-known plugin name constants. These are the canonical plugin
+// identifiers. Plugins are activated by flat top-level keys in
+// vibewarden.yaml (e.g. tls:, rate_limit:, admin: + kratos: for
+// user-management) — there is no `plugins:` wrapper key.
 const (
 	NameTLS            = "tls"
 	NameUserManagement = "user-management"
 	NameRateLimiting   = "rate-limiting"
-	NameGrafana        = "grafana"
-	NameFleet          = "fleet"
+
+	// NameFleet is reserved for the Pro-tier fleet plugin (CLAUDE.md locked
+	// decision: "fleet is the bridge to the Pro tier"). It is a roadmap
+	// placeholder — there is no fleet plugin or config key yet; the only
+	// current surface is `vibew secret generate --fleet-key`.
+	NameFleet = "fleet"
 )

--- a/internal/domain/plugin/names_test.go
+++ b/internal/domain/plugin/names_test.go
@@ -64,7 +64,6 @@ func TestNameConstants(t *testing.T) {
 		plugin.NameTLS,
 		plugin.NameUserManagement,
 		plugin.NameRateLimiting,
-		plugin.NameGrafana,
 		plugin.NameFleet,
 	}
 	for _, c := range constants {

--- a/internal/plugins/usermgmt/config.go
+++ b/internal/plugins/usermgmt/config.go
@@ -7,8 +7,10 @@
 // the internal server after the admin auth handler validates the bearer token.
 package usermgmt
 
-// Config holds all settings for the user-management plugin.
-// It maps to the plugins.user-management section of vibewarden.yaml.
+// Config holds all settings for the user-management plugin. Its fields are
+// populated from flat top-level keys in vibewarden.yaml: admin.enabled →
+// Enabled, admin.token → AdminToken, kratos.admin_url → KratosAdminURL, and
+// database.url → DatabaseURL. There is no `plugins:` wrapper key.
 type Config struct {
 	// Enabled toggles the user-management plugin. When false all methods are no-ops.
 	Enabled bool


### PR DESCRIPTION
Closes #1371

## Summary

- Removes unused `NameGrafana = "grafana"` domain constant from `internal/domain/plugin/names.go`. Grafana is a Docker Compose service in the `observability` profile — never a plugin. The constant was unreferenced in all production code.
- Updates `names.go` package godoc: removes the phantom `plugins:` wrapper reference; describes the real flat top-level key activation model.
- Annotates `NameFleet` as a reserved roadmap placeholder per the CLAUDE.md locked decision ("fleet is the bridge to the Pro tier").
- Updates `CLAUDE.md` "Plugin model" section to show the real flat-key activation YAML (`tls:`, `admin:` + `kratos:` + `database:` for user management, `rate_limit:`, `observability:`). The strict loader rejects unknown top-level keys — the old `plugins:` wrapper example would fail validation if copied verbatim.
- Updates `internal/plugins/usermgmt/config.go` godoc to name the real source keys (`admin.enabled`, `admin.token`, `kratos.admin_url`, `database.url`).
- Drops `plugin.NameGrafana` from `names_test.go` so the test compiles and passes.
- Adds `decisions/adr-105-remove-grafana-plugin-name-constant.md`.
- Updates `decisions/README.md` index with ADR-105 row.
- Adds CHANGELOG entry.

**CLAUDE.md Locked-decisions table (lines 14-38) was NOT modified** — only the "Plugin model" section changed. Confirmed via `git diff --cached CLAUDE.md`.

## Grep proof: NameGrafana was unused in production

```
internal/domain/plugin/names_test.go:67:    plugin.NameGrafana,   ← test only
internal/domain/plugin/names.go:30:    NameGrafana = "grafana"   ← the constant itself
```
No hits in `internal/` or `cmd/` production code.

## Test plan

- `go test ./internal/domain/plugin/... ./internal/plugins/usermgmt/...` — all pass
- `golangci-lint run ./internal/domain/plugin/... ./internal/plugins/usermgmt/...` — 0 issues
- `go build ./...` — clean
- Testcontainers (postgres/ratelimit) fail due to Docker daemon version mismatch — pre-existing known baseline, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)