### PR TITLE
docs(#1373): document telemetry.traces, egress mtls, egress prompt_injection config keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
   - **A5:** Moved the Fleet plugin row out of the "Available plugins" table in `docs/architecture.md` into a clearly-labelled "Planned / Pro-tier (not yet implemented)" note. Fleet is a locked-decision roadmap item with no implementation in `internal/plugins/`.
   - **A6:** Corrected the directory layout in `docs/architecture.md` — replaced non-existent `adapters/redis/` with `adapters/ratelimit/` (the actual location of the Redis rate-limit store: `internal/adapters/ratelimit/redis_adapter.go`).
 
+### Documentation
+
+- **docs(#1373): document three previously undocumented config keys (`telemetry.traces.enabled`, `egress.routes[].mtls`, `egress.routes[].prompt_injection`).**
+  - **P9:** Added `telemetry.traces:` subsection to `vibewarden.reference.yaml` with `enabled: false` default. Added `v.SetDefault("telemetry.traces.enabled", false)` to `setDefaults()` so users without a `telemetry:` block get the opt-in default. Added `TestSetDefaults_EmptyYAML` assertion to pin it.
+  - **P10:** Added `mtls:` and `prompt_injection:` subsections to the `egress.routes` example block in `vibewarden.reference.yaml`. All keys derived from `EgressMTLSConfig` and `EgressPromptInjectionConfig` mapstructure tags — strict-loader valid.
+  - **P11:** Added `### Prompt Injection Detection` section to `docs/egress.md` with YAML example, field table, and link to the `llm.prompt_injection_blocked` event schema in `docs/ai-log-schema.md`.
+
 ### Changed
 
 - chore(lint): allow G124 in test files; reflect.Ptr → reflect.Pointer in internal/config

--- a/docs/egress.md
+++ b/docs/egress.md
@@ -301,6 +301,47 @@ routes:
 
 ---
 
+### Prompt Injection Detection
+
+When calling LLM APIs through the egress proxy, enable `prompt_injection` on the
+route to scan request bodies for prompt injection payloads before forwarding them
+upstream. When an injection is detected, the proxy either blocks the request with
+`400 Bad Request` or logs the event and passes the request through unchanged,
+depending on the `action` field.
+
+```yaml
+routes:
+  - name: openai-api
+    pattern: "https://api.openai.com/**"
+    prompt_injection:
+      enabled: true
+      # JSON path expressions used to extract text from the request body.
+      # Each expression must start with "." and may use array wildcards.
+      # When empty and enabled is true, the entire raw body is scanned.
+      content_paths:
+        - ".messages[].content"
+        - ".prompt"
+      # Additional regular expressions compiled with case-insensitive matching.
+      # These are applied alongside the built-in detection patterns.
+      extra_patterns: []
+      # What to do when an injection is detected.
+      # "block"  — reject the request with 400 Bad Request (default).
+      # "detect" — log the event and forward the request unchanged.
+      action: block
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | bool | Activate prompt injection scanning for this route |
+| `content_paths` | []string | JSON path expressions to extract text for scanning (e.g. `.messages[].content`, `.prompt`). When empty, the entire raw body is scanned |
+| `extra_patterns` | []string | Additional regex patterns applied alongside built-in detection patterns (case-insensitive) |
+| `action` | string | `"block"` (default) or `"detect"` |
+
+When an injection is detected, an `llm.prompt_injection_blocked` structured event
+is emitted. See [AI log schema](ai-log-schema.md) for the full event schema.
+
+---
+
 ### Request and Response Headers
 
 Inject static headers into every outbound request, strip internal request headers

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -382,6 +382,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("telemetry.otlp.interval", "30s")
 	v.SetDefault("telemetry.otlp.protocol", "http")
 	v.SetDefault("telemetry.logs.otlp", false)
+	v.SetDefault("telemetry.traces.enabled", false)
 	v.SetDefault("body_size.max", "1MB")
 	v.SetDefault("body_size.overrides", []BodySizeOverrideConfig{})
 	v.SetDefault("ip_filter.enabled", false)

--- a/internal/config/reference_yaml_test.go
+++ b/internal/config/reference_yaml_test.go
@@ -132,6 +132,9 @@ func TestSetDefaults_EmptyYAML(t *testing.T) {
 		{"resilience.retry.max_attempts", cfg.Resilience.Retry.MaxAttempts, 3},
 		{"resilience.retry.backoff", cfg.Resilience.Retry.InitialBackoff, "100ms"},
 		{"resilience.retry.max_backoff", cfg.Resilience.Retry.MaxBackoff, "10s"},
+
+		// telemetry.traces default — must be false so tracing is opt-in.
+		{"telemetry.traces.enabled", cfg.Telemetry.Traces.Enabled, false},
 	}
 
 	for _, tt := range tests {

--- a/vibewarden.reference.yaml
+++ b/vibewarden.reference.yaml
@@ -734,6 +734,13 @@ telemetry:
     # Requires telemetry.otlp.endpoint to be configured.
     otlp: false
 
+  # Distributed tracing settings
+  traces:
+    # Enable distributed tracing (default: false).
+    # When enabled, a span is created for each HTTP request and exported via OTLP.
+    # Requires telemetry.otlp.enabled to be true and telemetry.otlp.endpoint to be set.
+    enabled: false
+
 # CORS (Cross-Origin Resource Sharing)
 # Injects Access-Control-* headers and handles OPTIONS preflight requests.
 # Enable this when your app is served from a different origin than the browser app
@@ -971,6 +978,28 @@ egress:
   #   - name: internal-payments
   #     pattern: "http://payments.internal/**"
   #     allow_insecure: true
+  #
+  #   # mTLS route — present a client certificate to the upstream.
+  #   # cert_path and key_path are required; ca_path is optional (uses system roots when empty).
+  #   - name: payment-processor
+  #     pattern: "https://payments.example.com/**"
+  #     mtls:
+  #       cert_path: "/etc/vibewarden/certs/client.crt"
+  #       key_path:  "/etc/vibewarden/certs/client.key"
+  #       ca_path:   "/etc/vibewarden/certs/payments-ca.crt"
+  #
+  #   # Prompt injection detection — scan outbound LLM API request bodies.
+  #   # When enabled, request bodies are scanned before being forwarded upstream.
+  #   # Action "block" (default) rejects the request with 400; "detect" logs and passes through.
+  #   - name: openai-api
+  #     pattern: "https://api.openai.com/**"
+  #     prompt_injection:
+  #       enabled: true
+  #       content_paths:
+  #         - ".messages[].content"  # JSON path(s) to extract text for scanning
+  #         - ".prompt"
+  #       extra_patterns: []         # additional regex patterns (case-insensitive)
+  #       action: block              # "block" (default) or "detect"
 
 secrets:
   # Enable the secrets plugin (default: false)


### PR DESCRIPTION
Closes #1373

## Summary

- **P9 — `telemetry.traces.enabled`**: Added `telemetry.traces:` subsection to `vibewarden.reference.yaml` documenting `enabled: false` (opt-in default). Added `v.SetDefault("telemetry.traces.enabled", false)` to `setDefaults()` in `internal/config/config.go`. Extended `TestSetDefaults_EmptyYAML` to assert this default is registered.
- **P10 — egress `routes[].mtls` + `routes[].prompt_injection`**: Added `mtls:` and `prompt_injection:` subsections to the `egress.routes` example block in `vibewarden.reference.yaml`. All keys derived directly from `EgressMTLSConfig` and `EgressPromptInjectionConfig` mapstructure tags — strict-loader valid; `TestReferenceYAML_UnmarshalsCleanly` passes.
- **P11 — egress prompt-injection docs**: Added `### Prompt Injection Detection` section to `docs/egress.md` with a YAML example, field table, and link to `docs/ai-log-schema.md` for the `llm.prompt_injection_blocked` event schema.

## Test plan

- [x] `TestSetDefaults_EmptyYAML/telemetry.traces.enabled` passes
- [x] `TestReferenceYAML_UnmarshalsCleanly` passes (strict-loader validity of new reference YAML keys)
- [x] `go test -race ./internal/config/...` passes
- [x] `golangci-lint run ./...` passes (0 issues on our code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)