### PR TITLE
docs(#1382): fix observability port drift and demo-app Mailslurper claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 - **fix(#1368): delete `internal/schema/v1/event.json` (dead data) and add a real drift-guard test.** The internal copy was a stale 662-line subset (14 event types) of the canonical 2370-line `schema/v1/event.json` (47 constrained event types). No Go code, build script, or `//go:embed` directive read it — it was pure dead data. A false doc comment in `internal/schema/v1/schema_test.go` claimed the test "mirrors" the file, but no file comparison existed, making divergence undetectable. Fixed: deleted the internal duplicate; corrected the misleading doc comment to accurately describe the hand-encoded pattern check; repointed `docs/schema-evolution.md` to the canonical path; added `TestSchemaCoversAllEventTypes` to `schema/v1/schema_validate_test.go` which constructs a payload-violating instance for each of the 47 constrained event types and asserts the schema rejects it — this test fails if any if/then branch is removed from the canonical file.
 
+- **docs(#1382): fix observability port drift and demo-app Mailslurper claim.**
+  - **O1:** Corrected four occurrences of `localhost:8080` in `docs/observability.md` to `localhost:8443` (the real default `server.port`, `internal/config/config.go:307`). Reworked the Architecture mermaid diagram: VibeWarden now shows `:8443` and the Prometheus scrape arrow now points at `otel-collector:8889` — the actual target from `internal/config/templates/observability/prometheus.yml.tmpl` — with an added OTLP push edge from VibeWarden to the collector. The troubleshooting section was updated to name the correct scrape target (`otel-collector:8889`) and fix the Prometheus targets page reference.
+  - **O2:** Removed the false Mailslurper claim from `examples/demo-app/README.md:263`. The generated compose (`examples/demo-app/.vibewarden/generated/docker-compose.yml`) has no mail container; replaced with accurate behavior note.
+
 ### Documentation
 
 - **docs(#1372): fix three docs/code drift findings in `docs/index.md`, `README.md`, and `CHANGELOG.md` (audit P5, P7, P8).**

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -427,7 +427,7 @@ observability is enabled. It is loaded automatically by Grafana's provisioning c
 VibeWarden exposes all metrics at:
 
 ```
-http://localhost:8080/_vibewarden/metrics
+https://localhost:8443/_vibewarden/metrics
 ```
 
 The endpoint uses the standard Prometheus text exposition format.
@@ -458,15 +458,17 @@ Prometheus collectors:
 
 ```mermaid
 flowchart LR
-    App["Your App"] <--> VW["VibeWarden :8080"]
-    Prom["Prometheus :9090"] -. "scrape /_vibewarden/metrics" .-> VW
+    App["Your App"] <--> VW["VibeWarden :8443"]
+    VW -. "OTLP/HTTP" .-> OTel["OTel Collector :4318"]
+    Prom["Prometheus :9090"] -. "scrape :8889/metrics" .-> OTel
     Prom --> Grafana["Grafana :3000"]
     Logs["Docker container logs"] --> Promtail
     Promtail --> Loki["Loki :3100"]
     Loki --> Grafana
 ```
 
-Prometheus scrapes VibeWarden every 15 seconds. Promtail discovers all running Docker
+VibeWarden pushes metrics via OTLP to the OTel Collector, which exposes them at `:8889`
+for Prometheus to scrape every 15 seconds. Promtail discovers all running Docker
 containers via the Docker socket, tails their log files, and ships log entries to Loki.
 Grafana queries both Prometheus and Loki as data sources. All configs are generated
 under `.vibewarden/generated/observability/` by `vibewarden generate`.
@@ -549,10 +551,10 @@ Prometheus may not have scraped VibeWarden yet, or VibeWarden is not running.
    ```
 2. Verify VibeWarden's metrics endpoint is reachable:
    ```bash
-   curl http://localhost:8080/_vibewarden/metrics
+   curl https://localhost:8443/_vibewarden/metrics
    ```
 3. Check Prometheus targets at http://localhost:9090/targets — the
-   `vibewarden` target should show state `UP`.
+   `otel-collector` target should show state `UP`.
 
 ### Port conflicts
 
@@ -597,8 +599,10 @@ docker compose -f .vibewarden/generated/docker-compose.yml logs grafana
 
 ### Prometheus cannot reach VibeWarden
 
-Prometheus scrapes `vibewarden:8080` on the internal Docker network. If the
-VibeWarden container is not healthy, Prometheus will mark the target as `DOWN`.
+Prometheus scrapes `otel-collector:8889` on the internal Docker network; the OTel
+Collector receives metrics from VibeWarden via OTLP. If the VibeWarden container is
+not healthy, the OTel Collector will have no data and Prometheus will show the
+`otel-collector` target as stale or empty.
 Check VibeWarden logs:
 
 ```bash

--- a/examples/demo-app/README.md
+++ b/examples/demo-app/README.md
@@ -260,8 +260,10 @@ open https://localhost:8443/self-service/login/browser
 open https://localhost:8443/self-service/registration/browser
 ```
 
-Verification emails are captured by Mailslurper at http://localhost:4437 —
-no real email is sent.
+Verification emails are delivered to whichever SMTP address Kratos is configured
+with. The demo stack does not include a local mail catcher, so registration
+verification flows that require email will not complete without an external SMTP
+service or a Kratos config that disables verification.
 
 ## Security headers
 


### PR DESCRIPTION
Closes #1382

## Summary

- **O1 — `docs/observability.md` port drift:** Corrected four occurrences of the wrong port (`8080`) throughout the file:
  - Host-facing metrics URL: `http://localhost:8080/_vibewarden/metrics` → `https://localhost:8443/_vibewarden/metrics`
  - Mermaid Architecture diagram: `VibeWarden :8080` → `VibeWarden :8443`; replaced the direct Prometheus→VibeWarden scrape arrow with the accurate two-hop path: VibeWarden pushes OTLP to `otel-collector`, Prometheus scrapes `otel-collector:8889`
  - `curl` troubleshooting example: `http://localhost:8080/_vibewarden/metrics` → `https://localhost:8443/_vibewarden/metrics`; fixed Prometheus targets page reference from `vibewarden` target to `otel-collector` target
  - Troubleshooting prose: "Prometheus scrapes `vibewarden:8080`" → Prometheus scrapes `otel-collector:8889`; VibeWarden pushes via OTLP

- **O2 — `examples/demo-app/README.md` Mailslurper claim:** Removed false statement that verification emails are captured by Mailslurper at `localhost:4437`. The generated compose has no mail container. Replaced with accurate note about no bundled mail catcher.

## Verified internal scrape target

**`otel-collector:8889`** confirmed at two sources:
- `internal/config/templates/observability/prometheus.yml.tmpl` line 12: `- targets: ['otel-collector:8889']`
- `internal/config/templates/observability/otel-collector-config.yml.tmpl` line 20: `endpoint: 0.0.0.0:8889` (prometheus exporter)

Prometheus does NOT scrape VibeWarden directly. The internal scrape target (port 8889 on otel-collector) differs from the host-facing VibeWarden port (8443). Both are now correctly documented.

## Test plan

- [ ] `grep 8080 docs/observability.md` returns empty
- [ ] `grep -i mailslurper examples/demo-app/README.md` returns empty
- [ ] Mermaid diagram renders correctly in MkDocs with the new OTel Collector node
- [ ] `make check` passes — confirmed zero lint/format issues from this branch (all pre-existing lint issues are from stale cache pointing to other worktrees)
- [ ] `go test ./...` — only Docker/testcontainers integration tests fail (pre-existing baseline; no test changes in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)