### PR TITLE
chore(security): bump Go toolchain to 1.26.4 for GO-2026-5037/5039

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Run golangci-lint
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Build
@@ -133,7 +133,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Build VibeWarden Docker image (local test tag — never pushed)

--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Validate GoReleaser config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache: true
 
       - name: Set up QEMU

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -117,8 +117,11 @@ jobs:
           push: false
           load: true
           tags: vibewarden:scan
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # No build cache: the runtime stage runs `apk upgrade`, and a cached
+          # layer would pin tag-time package versions, hiding OS CVEs that were
+          # patched upstream after the layer was cached (e.g. libcrypto3/libssl3
+          # CVE-2026-45447). A fresh build each scan picks up current packages.
+          no-cache: true
 
       - name: Run Trivy image scan
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 - **Bump Go toolchain to go1.26.4 (GO-2026-5037, GO-2026-5039).** Both vulnerabilities affect the Go standard library and are fixed in go1.26.4. GO-2026-5037 is an inefficient candidate hostname parsing bug in `crypto/x509` (reachable via TLS dialing and certificate verification). GO-2026-5039 is an arbitrary-input inclusion bug in `net/textproto` (reachable via HTTP response reading in the OpenBao adapter). Pinned `toolchain go1.26.4` in `go.mod`, `golang:1.26.4-alpine` in `Dockerfile`, and `go-version: "1.26.4"` in all CI workflows. Unblocks the repo-wide Trivy and govulncheck CI gates.
 
+- **Upgrade Alpine OpenSSL to >=3.5.7-r0 (CVE-2026-45447).** The runtime image shipped `libcrypto3`/`libssl3` 3.5.6-r0 from the `alpine:3.23` base, which Trivy flags HIGH for an OpenSSL heap use-after-free in `PKCS7_verify()`. Floored both packages at `3.5.7-r0` in `Dockerfile` and `Dockerfile.goreleaser`; the explicit version floor also busts the stale GHA `apk upgrade` build-cache layer that kept the vulnerable version. This was the second half of the repo-wide Trivy image-scan failure blocking all PRs.
+
 ## [v0.20.1] — 2026-06-06
 
 Theme: patch — pin the sidecar image to the CLI version (ADR-106), closing the silent CLI↔sidecar version-skew gap surfaced by the v0.20.0 release smoke test (#1385).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+### Security
+
+- **Bump Go toolchain to go1.26.4 (GO-2026-5037, GO-2026-5039).** Both vulnerabilities affect the Go standard library and are fixed in go1.26.4. GO-2026-5037 is an inefficient candidate hostname parsing bug in `crypto/x509` (reachable via TLS dialing and certificate verification). GO-2026-5039 is an arbitrary-input inclusion bug in `net/textproto` (reachable via HTTP response reading in the OpenBao adapter). Pinned `toolchain go1.26.4` in `go.mod`, `golang:1.26.4-alpine` in `Dockerfile`, and `go-version: "1.26.4"` in all CI workflows. Unblocks the repo-wide Trivy and govulncheck CI gates.
+
 ## [v0.20.1] — 2026-06-06
 
 Theme: patch — pin the sidecar image to the CLI version (ADR-106), closing the silent CLI↔sidecar version-skew gap surfaced by the v0.20.0 release smoke test (#1385).

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,15 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 FROM alpine:3.23
 
 # `apk upgrade` pulls the latest patch versions of the base packages so the
-# shipped image picks up CVE fixes released after the alpine:3.21 tag was
-# cut (e.g. libcrypto3/libssl3 CVE-2026-28390, musl CVE-2026-40200, zlib
-# CVE-2026-22184). Without this the image keeps the tag-time versions
-# indefinitely, which Trivy flags.
+# shipped image picks up CVE fixes released after the alpine:3.23 tag was
+# cut. libcrypto3/libssl3 are upgraded to >=3.5.7-r0 to close
+# CVE-2026-45447 (OpenSSL heap use-after-free in PKCS7_verify). The explicit
+# version floor also busts any stale `apk upgrade` build-cache layer that
+# predates the fix, so Trivy image scans stay green. Without this the image
+# keeps the tag-time versions indefinitely, which Trivy flags.
 RUN apk upgrade --no-cache \
-    && apk add --no-cache ca-certificates wget
+    && apk add --no-cache ca-certificates wget \
+       "libcrypto3>=3.5.7-r0" "libssl3>=3.5.7-r0"
 
 # Copy the statically linked binary.
 COPY --from=builder /vibewarden /vibewarden

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # ---------------------------------------------------------------------------
 # Stage 1: builder
 # ---------------------------------------------------------------------------
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 # Install git so `go mod download` can fetch VCS-based modules.
 RUN apk add --no-cache git ca-certificates

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -9,7 +9,12 @@
 
 FROM alpine:3.23
 
-RUN apk add --no-cache ca-certificates wget
+# `apk upgrade` pulls CVE fixes released after the alpine:3.23 tag was cut.
+# libcrypto3/libssl3 are floored at >=3.5.7-r0 to close CVE-2026-45447
+# (OpenSSL heap use-after-free in PKCS7_verify), which Trivy flags as HIGH.
+RUN apk upgrade --no-cache \
+    && apk add --no-cache ca-certificates wget \
+       "libcrypto3>=3.5.7-r0" "libssl3>=3.5.7-r0"
 
 # goreleaser injects the binary into the Docker build context at this path.
 COPY vibew /vibew

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/vibewarden/vibewarden
 
 go 1.26
 
+toolchain go1.26.4
+
 require (
 	github.com/caddyserver/caddy/v2 v2.11.3
 	github.com/fatih/color v1.19.0


### PR DESCRIPTION
## Summary

Fixes the repo-wide CI wall caused by two Go standard-library vulnerabilities, both patched in go1.26.4:

- **GO-2026-5037** (`crypto/x509`) — inefficient candidate hostname parsing; reachable via `tls.Dialer.DialContext` in `internal/app/ops/tls_handshake_fallback.go` and `x509.HostnameError.Error` in `internal/adapters/jwt/adapter.go`
- **GO-2026-5039** (`net/textproto`) — arbitrary inputs included in errors without escaping; reachable via `io.ReadAll` → `textproto.Reader.ReadMIMEHeader` in `internal/adapters/openbao/adapter.go`

The binary was compiled with go1.26.3, causing **Trivy Vulnerability Scan** and **Go Vulnerability Check** CI jobs to fail on every PR. This change unblocks the entire pipeline.

## Changes

- `/go.mod` — add `toolchain go1.26.4` directive (keeps `go 1.26` minimum compatibility line)
- `/Dockerfile` — pin builder stage to `golang:1.26.4-alpine`
- `/.github/workflows/ci.yml` — pin `go-version: "1.26.4"` (lint, build-and-test, integration jobs)
- `/.github/workflows/release.yml` — pin `go-version: "1.26.4"`
- `/.github/workflows/release-dryrun.yml` — pin `go-version: "1.26.4"`
- `/CHANGELOG.md` — add `[Unreleased] ### Security` entry

## govulncheck BEFORE (go1.26.3)

```
Vulnerability #1: GO-2026-5039
    Arbitrary inputs are included in errors without any escaping in net/textproto
    Found in: net/textproto@go1.26.3 | Fixed in: net/textproto@go1.26.4

Vulnerability #2: GO-2026-5037
    Inefficient candidate hostname parsing in crypto/x509
    Found in: crypto/x509@go1.26.3 | Fixed in: crypto/x509@go1.26.4

Your code is affected by 2 vulnerabilities from the Go standard library.
```

## govulncheck AFTER (go1.26.4)

```
No vulnerabilities found.
```

## Test plan

- [x] `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` — No vulnerabilities found
- [x] `go build ./...` — passes
- [x] `make check` — all checks passed (gofmt, golangci-lint 0 issues, full test suite)
- [ ] CI: Trivy Vulnerability Scan and Go Vulnerability Check should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)