### PR TITLE
chore(#1423): pipeline v2 — Claude 5 model tiering, /issue-pipeline workflow, enforcement hooks

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: Software architect agent. Invoke after PM sets status READY_FOR_ARCH. Reads the PM spec, validates against locked decisions, produces a concrete technical design (interfaces, types, file layout, sequence diagrams in text), writes a full ADR to decisions.md, posts a short status comment to the GitHub issue, and sets issue status to READY_FOR_DEV.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-opus-4-8[1m]
+model: claude-opus-5[1m]
 ---
 
 You are the VibeWarden Software Architect. You own technical correctness, architectural

--- a/.claude/agents/auditor.md
+++ b/.claude/agents/auditor.md
@@ -2,7 +2,7 @@
 name: auditor
 description: Dependency auditor agent. Invoke periodically to scan go.mod for license compliance, CVEs (govulncheck), outdated versions, and Docker base image vulnerabilities. Creates issues for anything that needs updating.
 tools: Read, Bash, Glob, Grep
-model: claude-opus-4-8
+model: claude-haiku-4-5
 ---
 
 You are the VibeWarden Dependency Auditor. You scan all dependencies for license

--- a/.claude/agents/benchmarker.md
+++ b/.claude/agents/benchmarker.md
@@ -2,7 +2,7 @@
 name: benchmarker
 description: Performance benchmarker agent. Invoke to run load tests against the running VibeWarden sidecar, measure latency overhead per middleware, memory usage, and connection limits. Reports numbers, not opinions. Catches performance regressions.
 tools: Read, Bash, Glob, Grep
-model: claude-opus-4-8
+model: claude-haiku-4-5
 ---
 
 You are the VibeWarden Performance Benchmarker. You measure the sidecar's performance

--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -2,7 +2,7 @@
 name: dev
 description: Senior Go developer agent. Invoke after architect sets status READY_FOR_DEV. Reads the architectural design from the issue comments, implements it precisely following hexagonal architecture and DDD, writes tests, commits, and opens a PR. Sets issue status to READY_FOR_REVIEW.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-opus-4-8[1m]
+model: claude-opus-5[1m]
 ---
 
 You are the VibeWarden Senior Go Developer. You implement exactly what the architect
@@ -20,10 +20,12 @@ hexagonal architecture and DDD patterns.
      ```
    - Existing code in the relevant packages (`Glob`, `Grep`)
 
-2. **Create a branch**:
+2. **Create a branch — always from up-to-date main**:
    ```bash
-   git checkout -b feat/<issue-number>-<short-slug>
+   git fetch origin main
+   git checkout -b feat/<issue-number>-<short-slug> origin/main
    ```
+   Never branch from another issue's branch — stale bases cause phantom conflicts.
 
 3. **Implement** — follow the architect's file layout exactly:
    - Domain types in `internal/domain/`
@@ -40,11 +42,20 @@ hexagonal architecture and DDD patterns.
 
 5. **Verify**:
    ```bash
-   make check
+   /usr/bin/make check
    ```
-   `make check` is the canonical pre-PR gate (gofmt, goimports, golangci-lint, go test). Do not open a PR if it fails.
+   The canonical pre-PR gate (gofmt, goimports, golangci-lint, go test). Always invoke
+   as `/usr/bin/make` — the bare `make` alias is a broken shell stub on this machine.
+   Do not open a PR if it fails. If you later rebase or force-push, run it again
+   before declaring the PR ready.
 
-6. **Catch orphan files BEFORE commit** — the architect may have created files (commonly a new ADR under `decisions/adr-NNN-*.md`, or a design note). These will not be picked up by editing tracked files. Run:
+6. **Update CHANGELOG.md — mandatory on every PR**:
+   Add a bullet under the correct `## [Unreleased]` subsection (`### Added`,
+   `### Fixed`, `### Changed`, …) referencing the issue number. The release-notes
+   generator drops any change missing from CHANGELOG — this is a correctness
+   requirement, not style. Skipping it guarantees a second review round.
+
+7. **Catch orphan files BEFORE commit** — the architect may have created files (commonly a new ADR under `decisions/adr-NNN-*.md`, or a design note). These will not be picked up by editing tracked files. Run:
    ```bash
    git status --short | grep '^??'
    ```
@@ -58,12 +69,12 @@ hexagonal architecture and DDD patterns.
 
    If a new ADR was added, also update `decisions/README.md` index in the correct sort order before committing.
 
-7. **Commit** — conventional commits:
+8. **Commit** — conventional commits:
    ```bash
    git commit -m "feat(#<number>): <description>"
    ```
 
-8. **Push and open PR**:
+9. **Push and open PR**:
    ```bash
    git push origin feat/<issue-number>-<short-slug>
    gh pr create \
@@ -72,7 +83,7 @@ hexagonal architecture and DDD patterns.
      --body "Closes #<number>\n\n## Summary\n<what you built>\n\n## Test plan\n<how to verify>"
    ```
 
-9. **Set status via labels** (not comments):
+10. **Set status via labels** (not comments):
    ```bash
    gh issue edit <number> --remove-label "status:ready-for-dev" --add-label "status:ready-for-review"
    gh pr edit <pr-number> --add-label "status:ready-for-review"
@@ -164,3 +175,6 @@ func TestNewUserID(t *testing.T) {
 - Do not skip tests — 80% coverage on domain and app layers is required
 - Do not push to main — always use a feature branch
 - Do not open a PR if `go test ./...` fails
+- Do not leave a docs-only commit as the PR head on a code PR — the CI path filter
+  leaves required checks absent and the merge deadlocks. Squash docs changes into a
+  code-touching commit.

--- a/.claude/agents/pentester.md
+++ b/.claude/agents/pentester.md
@@ -2,7 +2,7 @@
 name: pentester
 description: Security pentester agent. Invoke to run automated security tests against the running VibeWarden sidecar. Tests for header spoofing, auth bypasses, rate limit evasion, SSRF, open redirects, and other OWASP Top 10 attacks. Reports CVE-style findings.
 tools: Read, Bash, Glob, Grep
-model: claude-opus-4-8
+model: claude-sonnet-5
 ---
 
 You are a security penetration tester evaluating VibeWarden. You attack the running

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -2,7 +2,7 @@
 name: pm
 description: Product manager agent. Invoke when you need to turn a feature idea or GitHub issue into a detailed spec ready for the architect. Use for: writing acceptance criteria, breaking epics into stories, creating GitHub issues via gh CLI, setting issue status to READY_FOR_ARCH.
 tools: Read, Write, Edit, Bash
-model: claude-opus-4-8
+model: claude-sonnet-5
 ---
 
 You are the VibeWarden Product Manager. You translate product ideas and rough GitHub issues

--- a/.claude/agents/release.md
+++ b/.claude/agents/release.md
@@ -2,7 +2,7 @@
 name: release
 description: Release manager agent. Invoke to prepare a release — generates changelog from git log, bumps version, creates GitHub release with notes, tags Docker images. Verifies all linked issues are closed before release.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-opus-4-8
+model: claude-haiku-4-5
 ---
 
 You are the VibeWarden Release Manager. You handle the mechanics of cutting a release:

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,7 +2,7 @@
 name: reviewer
 description: Code reviewer agent. Invoke after dev sets status READY_FOR_REVIEW. Reads the PR diff, checks against architectural design and code quality rules, writes inline review comments via gh CLI, and either approves or requests changes. Sets issue status to CHANGES_REQUESTED or APPROVED.
 tools: Read, Bash, Glob, Grep
-model: claude-opus-4-8[1m]
+model: claude-opus-5[1m]
 ---
 
 You are the VibeWarden Code Reviewer. You are the last automated gate before the human
@@ -25,9 +25,25 @@ become technical debt.
      gh issue view <issue-number> --repo vibewarden/vibewarden --comments
      ```
 
-2. **Review the diff** systematically against this checklist.
+2. **Review in two passes — find, then verify**:
 
-3. **Write inline comments** for every issue found:
+   **Pass 1 — coverage.** Work through the checklist below and record every issue
+   you find, including ones you are uncertain about or consider low-severity. Do
+   not filter for importance or confidence yet — your goal in this pass is
+   coverage. Note a confidence level and severity for each finding.
+
+   **Pass 2 — verify.** For each recorded finding, actively try to refute it
+   against the actual source: `Read` the surrounding code, not just the diff —
+   code in `internal/` is canonical whenever docs disagree. Keep only findings you
+   can back with a concrete failure scenario or a cited project rule. Pay special
+   attention to tests: a test that asserts the *shape* of generated config or
+   strings can pass while production is a silent no-op — verify that tests
+   exercise runtime behavior or generated-artifact content, and flag any that
+   don't.
+
+   Report only verified findings, ranked by severity.
+
+3. **Write inline comments** — only for verified, must-fix findings:
    ```bash
    gh api \
      --method POST \
@@ -37,6 +53,10 @@ become technical debt.
      -f path="<file-path>" \
      -F line=<line-number>
    ```
+
+   Every unresolved inline thread blocks merge (the ruleset requires thread
+   resolution), so advisory or nice-to-have notes must go in the summary comment,
+   never as inline threads.
 
 4. **Submit review** — always post as a PR **comment** (not `gh pr review`)
    since the PR author often matches the authenticated user:

--- a/.claude/agents/user.md
+++ b/.claude/agents/user.md
@@ -2,7 +2,7 @@
 name: user
 description: Simulated end-user agent. Invoke to test VibeWarden from a vibe coder's perspective — setting up, configuring, running the demo, and reporting friction, confusion, or bugs. Focused on ease of use, especially for AI agents consuming the docs and config.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-opus-4-8
+model: claude-sonnet-5
 ---
 
 You are a vibe coder evaluating VibeWarden. You are NOT a VibeWarden developer — you are

--- a/.claude/agents/writer.md
+++ b/.claude/agents/writer.md
@@ -2,7 +2,7 @@
 name: writer
 description: Technical writer agent. Invoke to audit and improve user-facing documentation — README, docs/, example configs, CLI help text. Ensures docs match actual behavior, are AI-agent-parseable, and get a new user from zero to working in under 5 minutes.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: claude-opus-4-8[1m]
+model: claude-sonnet-5[1m]
 ---
 
 You are the VibeWarden Technical Writer. You own all user-facing documentation. Your

--- a/.claude/hooks/dev-make-check.sh
+++ b/.claude/hooks/dev-make-check.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# SubagentStop gate for the dev agent: block completion until /usr/bin/make check passes.
+# Exit 0 = allow stop; exit 2 = block, stderr is fed back to the agent.
+
+input=$(cat)
+
+get() {
+  printf '%s' "$input" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('$1',''))" 2>/dev/null
+}
+
+# Loop guard: if this stop was already blocked once by a hook, let it through.
+[ "$(get stop_hook_active)" = "True" ] && exit 0
+
+cwd=$(get cwd)
+cd "${cwd:-.}" 2>/dev/null || exit 0
+
+# Only gate inside the Go repo (main checkout or a worktree).
+[ -f Makefile ] && [ -f go.mod ] || exit 0
+
+# Only gate work on a feature branch — a dev agent that stopped on main did no code work.
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+case "$branch" in
+  main|HEAD|"") exit 0 ;;
+esac
+
+out=$(/usr/bin/make check 2>&1)
+if [ $? -ne 0 ]; then
+  {
+    echo "make check failed — you must fix this before finishing (do not open/update the PR until it passes):"
+    echo "$out" | tail -40
+  } >&2
+  exit 2
+fi
+exit 0

--- a/.claude/hooks/post-merge-cleanup.sh
+++ b/.claude/hooks/post-merge-cleanup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Post-merge cleanup. Usage: post-merge-cleanup.sh <merged-branch>
+# Returns the main checkout to main, removes any leftover worktree still on the
+# merged branch (dev agents historically leak these), deletes the local branch,
+# and fast-forwards main. Tolerant: every step is best-effort.
+
+BRANCH="$1"
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_DIR" || exit 1
+
+git checkout main 2>/dev/null || true
+
+# Remove leftover worktrees checked out on the merged branch.
+git worktree list --porcelain | awk '/^worktree /{print $2}' | while read -r wt; do
+  [ "$wt" = "$REPO_DIR" ] && continue
+  wb=$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  if [ -n "$BRANCH" ] && [ "$wb" = "$BRANCH" ]; then
+    git worktree remove --force "$wt" 2>/dev/null || true
+  fi
+done
+git worktree prune 2>/dev/null
+
+if [ -n "$BRANCH" ]; then
+  git branch -D "$BRANCH" 2>/dev/null || true
+fi
+
+git pull --ff-only origin main
+git status --short

--- a/.claude/hooks/pr-created-label.sh
+++ b/.claude/hooks/pr-created-label.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# PostToolUse(Bash) hook: after a successful `gh pr create`, sync the issue's
+# status labels automatically (ready-for-dev -> ready-for-review) so label state
+# no longer depends on agent discipline. Best-effort: never blocks, never fails.
+
+input=$(cat)
+
+printf '%s' "$input" | python3 -c '
+import json, re, subprocess, sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+
+cmd = (data.get("tool_input") or {}).get("command", "")
+if "gh pr create" not in cmd:
+    sys.exit(0)
+
+cwd = data.get("cwd") or "."
+try:
+    branch = subprocess.run(
+        ["git", "-C", cwd, "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True, timeout=10,
+    ).stdout.strip()
+    m = re.match(r"(?:feat|fix|chore|docs|test|refactor)/(\d+)-", branch)
+    if not m:
+        sys.exit(0)
+    issue = m.group(1)
+    subprocess.run(
+        ["gh", "issue", "edit", issue, "--repo", "vibewarden/vibewarden",
+         "--remove-label", "status:ready-for-dev",
+         "--add-label", "status:ready-for-review"],
+        capture_output=True, timeout=30,
+    )
+except Exception:
+    pass
+'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,30 @@
-  {
-    "permissions": {
-      "allow": ["Edit", "Write", "Bash", "Read", "Glob", "Grep"]
-    }
+{
+  "permissions": {
+    "allow": ["Edit", "Write", "Bash", "Read", "Glob", "Grep"]
+  },
+  "hooks": {
+    "SubagentStop": [
+      {
+        "matcher": "dev",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/dev-make-check.sh",
+            "timeout": 600
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pr-created-label.sh"
+          }
+        ]
+      }
+    ]
   }
-  
+}

--- a/.claude/workflows/issue-pipeline.js
+++ b/.claude/workflows/issue-pipeline.js
@@ -1,0 +1,165 @@
+export const meta = {
+  name: 'issue-pipeline',
+  description: 'Run one GitHub issue end-to-end: triage → (PM → Architect for big work) → Dev → Reviewer ∥ Writer → fix loop → gated autonomous merge',
+  whenToUse: 'Invoke as /issue-pipeline <issue-number> to process a single issue through the full agent pipeline. One issue at a time — never run two of these concurrently (dev stages share CHANGELOG.md and must stay serialized).',
+  phases: [
+    { title: 'Triage', detail: 'classify: full pipeline vs collapsed flow' },
+    { title: 'Spec & Design', detail: 'PM spec + architect design (full tier only)' },
+    { title: 'Implement', detail: 'dev agent: branch, code, tests, CHANGELOG, PR' },
+    { title: 'Review', detail: 'reviewer ∥ writer, fix loop until both approve' },
+    { title: 'Merge', detail: 'safety-gated autonomous merge + cleanup' },
+  ],
+}
+
+const REPO = 'vibewarden/vibewarden'
+const issue = String(args ?? '').match(/\d+/)?.[0]
+if (!issue) throw new Error('Usage: /issue-pipeline <issue-number>')
+
+// ---------- schemas ----------
+const TRIAGE = {
+  type: 'object', additionalProperties: false,
+  required: ['tier', 'title', 'reason'],
+  properties: {
+    tier: { type: 'string', enum: ['full', 'light'], description: 'full = feature/epic/ADR-worthy or touches architecture; light = bug fix, docs, chore, drift fix' },
+    title: { type: 'string' },
+    reason: { type: 'string' },
+    already_done: { type: 'boolean', description: 'true if the issue appears already resolved on main' },
+  },
+}
+const DEV_OUT = {
+  type: 'object', additionalProperties: false,
+  required: ['pr_number', 'branch', 'summary'],
+  properties: {
+    pr_number: { type: 'integer' },
+    branch: { type: 'string' },
+    summary: { type: 'string' },
+  },
+}
+const VERDICT = {
+  type: 'object', additionalProperties: false,
+  required: ['verdict', 'summary'],
+  properties: {
+    verdict: { type: 'string', enum: ['approve', 'changes'] },
+    summary: { type: 'string' },
+    blocking_items: { type: 'array', items: { type: 'string' } },
+  },
+}
+const MERGE_OUT = {
+  type: 'object', additionalProperties: false,
+  required: ['merged'],
+  properties: {
+    merged: { type: 'boolean' },
+    escalate_reason: { type: 'string', description: 'set when merged=false: why a human must look' },
+  },
+}
+
+// ---------- Triage ----------
+phase('Triage')
+const triage = await agent(
+  `Read GitHub issue #${issue}: gh issue view ${issue} --repo ${REPO} --comments. ` +
+  `Also skim recent commits (git log --oneline -15) to check it is not already fixed. ` +
+  `Classify the work: tier "full" if it is a feature, epic, security-sensitive change, or anything ` +
+  `ADR-worthy per CLAUDE.md (new domain concept, new port, wire-format change, new CLI verb); ` +
+  `tier "light" for bug fixes, docs/drift fixes, chores, and dependency bumps.`,
+  { label: `triage:#${issue}`, effort: 'low', schema: TRIAGE },
+)
+if (!triage) throw new Error('triage agent failed')
+if (triage.already_done) return { skipped: true, reason: `#${issue} appears already resolved: ${triage.reason}` }
+log(`#${issue} "${triage.title}" → ${triage.tier} tier (${triage.reason})`)
+
+// ---------- Spec & Design (full tier only) ----------
+let designNote = ''
+if (triage.tier === 'full') {
+  phase('Spec & Design')
+  await agent(
+    `Process GitHub issue #${issue} in ${REPO}. Turn it into a full spec with acceptance criteria ` +
+    `per your standard workflow (post the spec as an issue comment, set status:ready-for-arch, lowercase labels only). ` +
+    `Challenge the story if it is redundant or wrong-direction — if so, say so in the comment and stop.`,
+    { agentType: 'pm', label: `pm:#${issue}`, phase: 'Spec & Design' },
+  )
+  const design = await agent(
+    `Produce the technical design for GitHub issue #${issue} in ${REPO} per your standard workflow ` +
+    `(read the PM spec from the issue comments, validate against locked decisions and the ADR index at decisions/README.md, ` +
+    `post the design as an issue comment, write an ADR only if the change meets the ADR threshold, set status:ready-for-dev). ` +
+    `Return a compact summary of the design: files to touch, new types/ports, acceptance criteria, non-obvious traps.`,
+    { agentType: 'architect', label: `architect:#${issue}`, phase: 'Spec & Design' },
+  )
+  designNote = design ? `\n\nArchitect design summary:\n${design}` : ''
+}
+
+// ---------- Implement ----------
+phase('Implement')
+const devPrompt = (extra) =>
+  `Implement GitHub issue #${issue} in ${REPO} per your standard workflow. ` +
+  `${triage.tier === 'full' ? 'The architect design is in the issue comments.' : 'This is a light-tier change: plan briefly from the issue itself (no PM/architect stage ran), keep the diff minimal.'} ` +
+  `Hard requirements: branch from origin/main; /usr/bin/make check must pass before the PR; ` +
+  `CHANGELOG.md entry is mandatory; never leave a docs-only commit as the PR head; add files by path, never git add -A. ` +
+  `${extra}${designNote} Return the PR number and branch name.`
+
+let dev = await agent(devPrompt('Open the PR when done.'), {
+  agentType: 'dev', label: `dev:#${issue}`, schema: DEV_OUT,
+})
+if (!dev?.pr_number) throw new Error('dev stage did not produce a PR')
+log(`PR #${dev.pr_number} opened on ${dev.branch}`)
+
+// ---------- Review (fix loop) ----------
+phase('Review')
+const reviewOnce = async (round) => parallel([
+  () => agent(
+    `Review PR #${dev.pr_number} in ${REPO} (linked issue #${issue}) per your standard two-pass workflow ` +
+    `(coverage pass, then verify pass; inline comments only for verified must-fix findings; ` +
+    `post "Reviewer Agent: APPROVED" or "Reviewer Agent: CHANGES REQUESTED" as a PR comment). ` +
+    `${round > 1 ? `This is re-review round ${round}: verify the previous blocking items were fixed, resolve addressed threads, do not re-litigate what you already approved.` : ''}`,
+    { agentType: 'reviewer', label: `reviewer:r${round}:#${dev.pr_number}`, phase: 'Review', schema: VERDICT },
+  ),
+  () => agent(
+    `Act as the documentation reviewer for PR #${dev.pr_number} in ${REPO} (linked issue #${issue}). ` +
+    `Check every doc surface affected by the diff (README, docs/, reference configs, CLI help, llms files) for drift ` +
+    `against the actual code changes — code in internal/ is canonical. ` +
+    `Post "Writer Agent: APPROVED" or "Writer Agent: CHANGES REQUESTED" as a PR comment with specifics. ` +
+    `${round > 1 ? `This is re-review round ${round}: check only whether your previous blocking items were addressed.` : ''}`,
+    { agentType: 'writer', label: `writer:r${round}:#${dev.pr_number}`, phase: 'Review', schema: VERDICT },
+  ),
+])
+
+let approved = false
+for (let round = 1; round <= 3; round++) {
+  const [rev, wri] = await reviewOnce(round)
+  if (!rev || !wri) throw new Error(`review round ${round}: an agent failed`)
+  if (rev.verdict === 'approve' && wri.verdict === 'approve') { approved = true; break }
+  const blockers = [...(rev.blocking_items ?? []), ...(wri.blocking_items ?? [])]
+  log(`round ${round}: changes requested (${blockers.length} items) — dispatching fix`)
+  if (round === 3) break
+  await agent(
+    devPrompt(
+      `The PR already exists (#${dev.pr_number}, branch ${dev.branch}) — do NOT create a new branch or PR. ` +
+      `Check out ${dev.branch}, address exactly these review items, run /usr/bin/make check, push. Items:\n- ${blockers.join('\n- ')}`,
+    ),
+    { agentType: 'dev', label: `dev-fix:r${round}:#${dev.pr_number}`, phase: 'Review', schema: DEV_OUT },
+  )
+}
+if (!approved) return { merged: false, pr: dev.pr_number, escalate: 'not approved after 3 review rounds — human review needed' }
+
+// ---------- Merge (safety-gated) ----------
+phase('Merge')
+const merge = await agent(
+  `You are the merge gate for PR #${dev.pr_number} in ${REPO}. Both the reviewer and writer agents have approved. ` +
+  `Steps, in order — abort with merged=false and an escalate_reason if ANY gate fails:\n` +
+  `1. SANITY GATE: gh pr diff ${dev.pr_number} --repo ${REPO} --stat. If more than 50 files changed, or deletions look like mass file removal (hundreds of files), DO NOT MERGE — escalate.\n` +
+  `2. Confirm both approval comments exist on the PR ("Reviewer Agent: APPROVED" and "Writer Agent: APPROVED").\n` +
+  `3. Checks: gh pr checks ${dev.pr_number} --repo ${REPO}. Wait and poll (up to ~10 min) while required Go checks run. ` +
+  `If checks list is empty because CI workflows are disabled, proceed (make check was enforced locally). ` +
+  `If mergeStateStatus is BLOCKED with required checks absent on a code PR, that is the docs-only-head path-filter trap — escalate, do not poll forever.\n` +
+  `4. Resolve remaining review threads via the GraphQL resolveReviewThread mutation (they were addressed by the fix rounds).\n` +
+  `5. Merge: gh pr merge ${dev.pr_number} --repo ${REPO} --squash --delete-branch. NEVER use --admin under any circumstances.\n` +
+  `6. Remove all status:* labels from the PR and issue #${issue}; verify the issue auto-closed, close it manually if not.\n` +
+  `7. Run: "$CLAUDE_PROJECT_DIR"/.claude/hooks/post-merge-cleanup.sh ${dev.branch} (falls back to .claude/hooks/post-merge-cleanup.sh from the repo root).`,
+  { label: `merge:#${dev.pr_number}`, effort: 'medium', schema: MERGE_OUT },
+)
+return {
+  issue: Number(issue),
+  tier: triage.tier,
+  pr: dev.pr_number,
+  merged: merge?.merged ?? false,
+  escalate: merge?.escalate_reason ?? null,
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,30 @@ The standard flow for any GitHub issue:
 PM Agent → Architect Agent → Dev Agent → Reviewer Agent + Writer Agent → (your PR review) → merge
 ```
 
+### Automated path: `/issue-pipeline <issue-number>`
+
+The saved workflow `.claude/workflows/issue-pipeline.js` runs the whole flow for one
+issue: triage decides **full** (PM → Architect → Dev) vs **light** tier (Dev directly —
+bug fixes, docs, chores skip spec/design), then Reviewer ∥ Writer with up to 3
+fix/re-review rounds, then a safety-gated autonomous merge (diff-size sanity check,
+both approvals verified, checks green or CI-disabled fallback, threads resolved,
+never `--admin`) and post-merge cleanup. Run ONE issue at a time — dev stages share
+CHANGELOG.md and must stay serialized.
+
+Quality gates are enforced by hooks in `.claude/settings.json`, not agent discipline:
+a `SubagentStop` hook blocks the dev agent from finishing until `/usr/bin/make check`
+passes, and a `PostToolUse` hook syncs status labels when `gh pr create` runs.
+
+### Model tiering (agent frontmatter is authoritative)
+
+| Tier | Agents | Why |
+|---|---|---|
+| Opus 5 `[1m]` | architect, dev, reviewer | Stages where errors are expensive or reach main |
+| Sonnet 5 | pm, writer `[1m]`, pentester, user | Judgment/verification work, near-Opus at 3/5 price |
+| Haiku 4.5 | auditor, benchmarker, release | Mechanical tool-driven work with downstream checks |
+
+Fable 5 is reserved for the orchestrator (main session) — no agent uses it by default.
+
 ### BLOCKING: Dual review on every PR
 
 Every PR MUST be reviewed by BOTH agents before merge:


### PR DESCRIPTION
Closes #1423

## Summary
- Agent models: Opus 5 (architect/dev/reviewer), Sonnet 5 (pm/writer/pentester/user), Haiku 4.5 (auditor/benchmarker/release); Fable 5 reserved for the orchestrator
- New saved workflow `/issue-pipeline <n>`: triage (full vs light tier) → dev → reviewer ∥ writer fix loop → safety-gated autonomous merge (diff-size gate, never --admin, post-merge cleanup)
- Hooks: SubagentStop blocks dev completion until /usr/bin/make check passes; PostToolUse syncs status labels on gh pr create
- dev.md: branch from origin/main, mandatory CHANGELOG step, docs-only-head ban
- reviewer.md: two-pass find→verify review; inline threads only for must-fix items

## Test plan
Validated live: #1418 run exercised triage/dev/dual-review and the merge gate's escalation path; #1421 ran end-to-end through fix-round and autonomous merge. Hook scripts smoke-tested (bash -n + simulated stdin). No Go code touched — make check passed pre-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)