### PR TITLE
chore: release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
-## [0.21.0] — 2026-08-05
+## [v0.21.0] — 2026-08-05
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This initial entry was written by hand to summarise the work leading up to v0.1.
 
 ## [Unreleased]
 
+## [0.21.0] — 2026-08-05
+
 ### Added
 
 - **feat(#1391): embedded user-management admin UI at `/_vibewarden/admin/ui` (ADR-107).** Adds a browser-based admin console for user management, served directly from the binary via `go:embed`. The UI (vanilla HTML/CSS/JS, no Node/npm, no CDN) is embedded under `internal/plugins/usermgmt/ui/assets/` and served by a new `AdminUIHandler` using stdlib `http.FileServerFS`. Static assets load without a token (carved out of the `AdminAuthMiddleware` token gate — matched against the cleaned path as an exact subtree so traversal/prefix-confusion cannot reach gated routes — while remaining hidden when `admin.enabled: false`); all data endpoints (`/_vibewarden/admin/users*`, `/events`, etc.) keep their `X-Admin-Key` requirement unchanged. The UI shows the official VibeWarden logo and a "Protected by VibeWarden" badge linking to vibewarden.dev. The JS prompts for the admin token, stores it in `sessionStorage` only, and sends it as `X-Admin-Key` per request. Works under `default-src 'self'` CSP with no policy change (no inline code, no external origins). No new dependencies.


### PR DESCRIPTION
## Summary
CHANGELOG updated: [Unreleased] → [0.21.0] (2026-08-05).

Staging release for v0.21.0 with:
- New embedded admin UI for user management (#1391, ADR-107)
- Security hardening: admin-auth bypass fix, OWASP A01/A03/A04/A05 fixes (#1393, #1281, #1274, #1276, #1279)
- Zero open Dependabot alerts (all 20 from backlog fixed or triaged)
- Go 1.26.5 + gRPC v1.82.1 + full `golang.org/x` module suite update
- Full docs/code drift audit completed (#1439)

All 17 referenced issues are closed. Build passes. No breaking changes.

Do NOT merge, tag, or publish — test release only.

Generated with Claude Fable 5